### PR TITLE
Setting `PYTHON_UDF_X86_PRPR_TOP_LEVEL_PACKAGES_FROZEN_SOLVE_VERSIONS='{}'` when running UDF test

### DIFF
--- a/test/integ/scala/test_udf_suite.py
+++ b/test/integ/scala/test_udf_suite.py
@@ -51,6 +51,15 @@ def setup(session_cnx, resources_path):
         session._run_query(f"insert into {table1} values(1),(2),(3)")
         Utils.create_table(session, table2, "a int, b int")
         session._run_query(f"insert into {table2} values(1, 2),(2, 3),(3, 4)")
+        # TODO: remove this snippet (don't need to set this parameter for Python UDF)
+        #  after prpr
+        current_sf_version = float(
+            session._run_query("select current_version()")[0][0][:4]
+        )
+        if current_sf_version >= 5.35:
+            session._run_query(
+                "alter session set PYTHON_UDF_X86_PRPR_TOP_LEVEL_PACKAGES_FROZEN_SOLVE_VERSIONS='{}'"
+            )
         yield
         Utils.drop_table(session, tmp_table_name)
         Utils.drop_table(session, table1)

--- a/test/integ/test_udf.py
+++ b/test/integ/test_udf.py
@@ -43,6 +43,15 @@ tmp_stage_name = Utils.random_stage_name()
 def setup(session_cnx):
     with session_cnx() as session:
         Utils.create_stage(session, tmp_stage_name, is_temporary=True)
+        # TODO: remove this snippet (don't need to set this parameter for Python UDF)
+        #  after prpr
+        current_sf_version = float(
+            session._run_query("select current_version()")[0][0][:4]
+        )
+        if current_sf_version >= 5.35:
+            session._run_query(
+                "alter session set PYTHON_UDF_X86_PRPR_TOP_LEVEL_PACKAGES_FROZEN_SOLVE_VERSIONS='{}'"
+            )
 
 
 def test_basic_udf(session_cnx):


### PR DESCRIPTION
After this change https://github.com/snowflakedb/snowflake/commit/4c821ad37cb98f7f4b963f10b9866bb3f4f515ec, Python UDF will require setting this parameter so that XP will not validate what packages are downloaded (they are hardcoded for prpr phase 1). I will remove it after it's not needed. 