### PR TITLE
Fix the build issue of use2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     license="Apache License, Version 2.0",
     keywords="Snowflake db database cloud analytics warehouse",
     url="https://www.snowflake.com/",
-    use_2to3=False,
     project_urls={
         "Documentation": "https://docs.snowflake.com/",
         # TODO: update it when we have documentation


### PR DESCRIPTION
Currently our build is failing: 
https://github.com/snowflakedb/snowpark-python/pull/67/checks?check_run_id=3537697365

There is a very recent change of `setuptools` that breaks our build: https://github.com/pypa/setuptools/blob/main/CHANGES.rst#misc

Basically, we don't need to set this flag anymore, and there is a corresponding fix in Python connector https://github.com/snowflakedb/snowflake-connector-python/pull/855. 