### PR TITLE
Fix handling of common expr_to_alias values.

### DIFF
--- a/src/snowflake/snowpark/internal/analyzer_obj.py
+++ b/src/snowflake/snowpark/internal/analyzer_obj.py
@@ -302,7 +302,9 @@ class Analyzer:
         # let (df1.join(df2)).join(df2.join(df3)).select(df2) report error
         for k, v in resolved_children.items():
             if v.expr_to_alias:
-                use_maps.update({p:q for p,q in v.expr_to_alias.items() if counts[p]<2})
+                use_maps.update(
+                    {p: q for p, q in v.expr_to_alias.items() if counts[p] < 2}
+                )
 
         self.alias_maps_to_use = use_maps
         return self.do_resolve_inner(logical_plan, resolved_children)

--- a/test/integ/scala/test_column_suite.py
+++ b/test/integ/scala/test_column_suite.py
@@ -72,9 +72,7 @@ def test_alias(session):
 
 def test_equal_and_not_equal(session):
     test_data1 = TestData.test_data1(session)
-    assert test_data1.where(test_data1["BOOL"] == True).collect() == [
-        Row(1, True, "a")
-    ]
+    assert test_data1.where(test_data1["BOOL"] == True).collect() == [Row(1, True, "a")]
     assert test_data1.where(test_data1["BOOL"] == lit(True)).collect() == [
         Row(1, True, "a")
     ]
@@ -97,9 +95,7 @@ def test_gt_and_lt(session):
         Row(2, False, "b")
     ]
     assert test_data1.where(test_data1["NUM"] < 2).collect() == [Row(1, True, "a")]
-    assert test_data1.where(test_data1["NUM"] < lit(2)).collect() == [
-        Row(1, True, "a")
-    ]
+    assert test_data1.where(test_data1["NUM"] < lit(2)).collect() == [Row(1, True, "a")]
 
 
 def test_leq_and_geq(session):

--- a/test/integ/scala/test_complex_dataframe_suite.py
+++ b/test/integ/scala/test_complex_dataframe_suite.py
@@ -124,5 +124,3 @@ def test_combination_of_multiple_data_sources(session, resources_path):
     finally:
         Utils.drop_table(session, tmp_table_name)
         Utils.drop_stage(session, tmp_stage_name)
-
-

--- a/test/integ/scala/test_dataframe_join_suite.py
+++ b/test/integ/scala/test_dataframe_join_suite.py
@@ -44,6 +44,7 @@ def test_join_using_multiple_columns(session):
         Row(3, 4, "3", "4"),
     ]
 
+
 def test_full_outer_join_followed_by_inner_join(session):
 
     a = session.createDataFrame([[1, 2], [2, 3]]).toDF(["a", "b"])
@@ -187,7 +188,6 @@ def test_join_using_multiple_columns_and_specifying_join_type(session, db_parame
         res = df.join(df2, ["int", "str"], "outer").collect()
         res.sort(key=lambda x: x[0])
         assert res == [
-
             Row(1, "1", 2, 3),
             Row(3, "3", 4, None),
             Row(5, "5", None, 6),
@@ -443,7 +443,7 @@ def test_using_joins(session):
         ]
 
         with pytest.raises(SnowparkClientException) as ex_info:
-             lhs.join(rhs, ['intcol'], join_type).select('negcol').collect()
+            lhs.join(rhs, ["intcol"], join_type).select("negcol").collect()
         assert "reference to the column 'NEGCOL' is ambiguous" in ex_info.value.message
 
         res = lhs.join(rhs, ["intcol"], join_type).select("intcol").collect()
@@ -484,7 +484,7 @@ def test_columns_with_and_without_quotes(session):
     assert res == []
 
     with pytest.raises(SnowparkClientException) as ex_info:
-         lhs.join(rhs, col('intcol') == col('"INTCOL"')).collect()
+        lhs.join(rhs, col("intcol") == col('"INTCOL"')).collect()
     assert "reference to the column 'INTCOL' is ambiguous." in ex_info.value.message
 
 

--- a/test/integ/scala/test_function_suite.py
+++ b/test/integ/scala/test_function_suite.py
@@ -72,14 +72,26 @@ def test_kurtosis(session_cnx):
         )
         Utils.check_answer(
             df,
-            [Row(Decimal("-3.333333333333"), Decimal("5.0"), Decimal("3.613736609956"))]
+            [
+                Row(
+                    Decimal("-3.333333333333"),
+                    Decimal("5.0"),
+                    Decimal("3.613736609956"),
+                )
+            ],
         )
 
         # same as above, but pass str instead of Column
         df = TestData.xyz(session).select(kurtosis("X"), kurtosis("Y"), kurtosis("Z"))
         Utils.check_answer(
             df,
-            [Row(Decimal("-3.333333333333"), Decimal("5.0"), Decimal("3.613736609956"))],
+            [
+                Row(
+                    Decimal("-3.333333333333"),
+                    Decimal("5.0"),
+                    Decimal("3.613736609956"),
+                )
+            ],
         )
 
 
@@ -125,10 +137,10 @@ def test_variance(session_cnx):
             [
                 Row(Decimal(1), Decimal(0.00), Decimal(1.0), Decimal(2.0)),
                 Row(
-                        Decimal(2),
-                        Decimal("0.333333"),
-                        Decimal("14.888889"),
-                        Decimal("22.333333"),
+                    Decimal(2),
+                    Decimal("0.333333"),
+                    Decimal("14.888889"),
+                    Decimal("22.333333"),
                 ),
             ],
         )
@@ -144,10 +156,10 @@ def test_variance(session_cnx):
             [
                 Row(Decimal(1), Decimal(0.00), Decimal(1.0), Decimal(2.0)),
                 Row(
-                        Decimal(2),
-                        Decimal("0.333333"),
-                        Decimal("14.888889"),
-                        Decimal("22.333333"),
+                    Decimal(2),
+                    Decimal("0.333333"),
+                    Decimal("14.888889"),
+                    Decimal("22.333333"),
                 ),
             ],
         )

--- a/test/integ/test_column.py
+++ b/test/integ/test_column.py
@@ -7,7 +7,6 @@
 import pytest
 
 from snowflake.snowpark.row import Row
-
 from snowflake.snowpark.snowpark_client_exception import SnowparkClientException
 
 


### PR DESCRIPTION
- Fix handling of common expr_to_alias values, for resolving columns during `JOIN` operations.
- uncomment test parts that were pending on `wrapException`