### PR TITLE
SNOW-450052 Row class extends `tuple` and allows duplidate fields

### DIFF
--- a/src/snowflake/snowpark/row.py
+++ b/src/snowflake/snowpark/row.py
@@ -15,7 +15,7 @@ def _restore_row_from_pickle(values, named_values, fields):
     else:
         row = Row(*values)
     row.__fields__ = fields
-    return Row(*values)
+    return row
 
 
 class Row(tuple):

--- a/test/unit/test_row.py
+++ b/test/unit/test_row.py
@@ -162,6 +162,8 @@ def test_row_pickle(row):
     pickled = pickle.dumps(row)
     restored = pickle.loads(pickled)
     assert row == restored
+    assert row._named_values == restored._named_values
+    assert row.__fields__ == restored.__fields__
 
 
 def test_dunder_call():


### PR DESCRIPTION
1. `Row` class extending `tuple` can re-use APIs of `tuple` so we maintain less code. The same test code still passes.
2. It's possible that a user use an sql to get duplicate names, for instance, "select a, a from a_table". DataFrame allows this to happen so the Row class need to support this exceptional case. Some subsequent DataFrame APIs will raise exceptions, for instance, `saveAsTable`, if there are duplicate column names in the DataFrame. 