### PR TITLE
SNOW-490668: Fix link in API docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,14 +1,14 @@
 Snowpark API Reference (Python)
 ===========================================================
 
-.. sidebar:: Preview Feature ---  Private
+.. sidebar:: Preview Feature --- Private
 
    Support for this feature is currently not in production and is available only to selected accounts.
 
 Snowpark is a new developer experience that provides an intuitive API for querying and handling data.
 Snowpark simplifies the process of building complex data pipelines and allows you to interact with
 Snowflake directly without moving data to the system where your application code runs. For more
-information, see the `Snowpark Developer Guide <https://docs.snowflake.com/en/developer-guide/snowpark/index.html>`_.
+information, see the `Snowpark Developer Guide for Python <https://docs.snowflake.com/en/LIMITEDACCESS/snowpark-python.html>`_.
 
 .. rubric:: Modules
 


### PR DESCRIPTION
In the index.html file, this PR fixes a link that should be:
Snowpark Developer Guide for Python https://docs.snowflake.com/en/LIMITEDACCESS/snowpark-python.html
Note: The link will be broken until the Developer Guide is published when 5.39 ships. 
