### PR TITLE
SNOW-512907: fix doc typos and add links

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -251,7 +251,7 @@ class DataFrame:
 
     def toPandas(self, **kwargs) -> "pandas.DataFrame":
         """
-        Returns the contents of this DataFrame as a Pandas DataFrame.
+        Returns the contents of this DataFrame as a `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`__.
 
         Note:
             1. This method is only available if Pandas is installed and available.
@@ -440,7 +440,7 @@ class DataFrame:
 
         Examples::
 
-            df_filtered = df.filter(col("A") > 1 && col("B") < 100)
+            df_filtered = df.filter(col("A") > 1 & col("B") < 100)
 
             # The following two result in the same SQL query:
             prices_df.filter(col("price") > 100)

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -24,13 +24,13 @@ The following examples demonstrate the use of some of these functions::
     # Call system-defined functions that have no corresponding function in the functions
     # object. This example calls the RADIANS() SQL function, passing in values from the
     # column "e".
-    df.select(callBuiltin("radians", col("e")))
+    df.select(call_builtin("radians", col("e")))
 
     # Call a user-defined function (UDF) by name.
     df.select(call_udf("some_func", col("c")))
 
-    # Evaluate an SQL expression
-    df.select(sqlExpr("c + 1"))
+    # Evaluate a SQL expression
+    df.select(sql_expr("c + 1"))
 """
 import functools
 from random import randint
@@ -1270,7 +1270,7 @@ def udf(
 
         from snowflake.snowpark.types import IntegerType
         # register a temporary udf
-        add_one = udf(lambda x: x+1, return_types=IntegerType(), input_types=[IntegerType()])
+        add_one = udf(lambda x: x+1, return_type=IntegerType(), input_types=[IntegerType()])
 
         # register a permanent udf by setting is_permanent to True
         @udf(name="minus_one", is_permanent=True, stage_location="@mystage")

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -124,6 +124,7 @@ class _UDFColumn(NamedTuple):
 class UDFRegistration:
     """
     Provides methods to register lambdas and functions as UDFs in the Snowflake database.
+    For more information about Snowflake Python UDFs, see `Python UDFs <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python.html>`__.
 
     :attr:`session.udf <snowflake.snowpark.Session.udf>` returns an object of this class.
     You can use this object to register UDFs that you plan to use in the current session.


### PR DESCRIPTION
SNOW-512907     Doc: fix example in Snowpark Python API reference for DataFrame.filter
SNOW-507753    Documentation of Snowpark has typos in function descriptions 
SNOW-503356   Documentation of Snowpark has a typo
SNOW-496368   Doc: Return type for dataframe.py toPandas() needs clarification
SNOW-475980   Doc: In the Python Snowpark API docs, add a link to the Python UDF docs

This PR is to fix various small typos in the Python Snowpark API documentation.