### PR TITLE
SNOW-515012 Skip IMPORTS when all_imports is empty

### DIFF
--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -397,6 +397,7 @@ def {_DEFAULT_HANDLER_NAME}({args}):
         sql_func_args = ",".join(
             [f"{a.name} {t}" for a, t in zip(input_args, input_sql_types)]
         )
+        imports_in_sql = f"IMPORTS=({all_imports})" if all_imports else ""
         inline_python_code_in_sql = (
             f"""
 AS $$
@@ -413,7 +414,7 @@ CREATE {"OR REPLACE " if replace else ""}
 RETURNS {return_sql_type}
 LANGUAGE PYTHON
 RUNTIME_VERSION=3.8
-IMPORTS=({all_imports})
+{imports_in_sql}
 HANDLER='{handler}'
 {inline_python_code_in_sql}
 """


### PR DESCRIPTION
Description
Currently we will not face this issue because we always have
cloudpickle. But once cloudpickle is handled by server and udf
is inlined, it is possible for all_imports to be empty.

Testing
Existing tests