### PR TITLE
Fix two UDF tests on preprod

### DIFF
--- a/tests/integ/scala/test_permanent_udf_suite.py
+++ b/tests/integ/scala/test_permanent_udf_suite.py
@@ -51,7 +51,6 @@ def test_mix_temporary_and_permanent_udf(session, new_session):
                 df2.select(call_udf(temp_func_name, "a")), [Row(2), Row(3)]
             )
         assert "SQL compilation error" in str(ex_info)
-        assert "does not exist or not authorized" in str(ex_info)
     finally:
         session._run_query(f"drop function if exists {temp_func_name}(int)")
         session._run_query(f"drop function if exists {perm_func_name}(int)")
@@ -112,7 +111,6 @@ def test_support_fully_qualified_udf_name(session, new_session):
                 df2.select(call_udf(temp_func_name, "a")), [Row(2), Row(3)]
             )
         assert "SQL compilation error" in str(ex_info)
-        assert "does not exist or not authorized" in str(ex_info)
     finally:
         session._run_query(f"drop function if exists {temp_func_name}(int)")
         session._run_query(f"drop function if exists {perm_func_name}(int)")


### PR DESCRIPTION
It looks like when we try to access the temporary function in another session, the previous error message is something like `... does not exist or not authorized`, but now it changes to `found function ..., but ... can't be resolved`. Actually the latter is more clear and we should remove this assertion in the test.

https://jenkins.int.snowflakecomputing.com/job/SnowparkPythonClientRegressRunner/249/