### PR TITLE
SNOW-524578 Support upload stream for stored proc

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -263,9 +263,7 @@ class ServerConnection:
         if self._is_stored_proc:
             file_name = os.path.basename(path)
             target_path = self.__build_target_path(stage_location, dest_prefix)
-            self._conn.cursor().upload_stream(
-                open(path, "rb"), f"{target_path}/{file_name}"
-            )
+            self._cursor.upload_stream(open(path, "rb"), f"{target_path}/{file_name}")
         else:
             uri = f"file://{path}"
             self.run_query(
@@ -297,7 +295,7 @@ class ServerConnection:
             if self._is_stored_proc:
                 input_stream.seek(0)
                 target_path = self.__build_target_path(stage_location, dest_prefix)
-                self._conn.cursor().upload_stream(
+                self._cursor.upload_stream(
                     input_stream, f"{target_path}/{dest_filename}"
                 )
             else:


### PR DESCRIPTION
Description
Stored proc python connector currently does not support PUT/GET command.
Instead, they provide upload_stream in the cursor. This change
would adopt the stored proc connector change to support upload
stream in stored proc.

Testing
regression test

This is the [precommit](https://buwa.c1.us-west-2.aws-dev.app.snowflake.com/builds/precommit/ci43.int.snowflakecomputing.com/27550) run with this change together with regression test change in https://github.com/snowflakedb/snowflake/commit/a98eb91f196319f0ab1c0968eae4599784988d1b and https://github.com/snowflakedb/snowflake/pull/44265