### PR TITLE
SNOW-530705 Test improvements for integ/scala

### DIFF
--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -9,6 +9,7 @@ import re
 import pytest
 
 from snowflake.snowpark import DataFrame, Row
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import (
     SnowparkJoinException,
     SnowparkSQLAmbiguousJoinException,
@@ -158,7 +159,7 @@ def test_join_with_ambiguous_column_in_condidtion(session_cnx):
         assert "The reference to the column 'A' is ambiguous." in ex_info.value.message
 
 
-def test_join_using_multiple_columns_and_specifying_join_type(session, db_parameters):
+def test_join_using_multiple_columns_and_specifying_join_type(session):
     table_name1 = Utils.random_name()
     table_name2 = Utils.random_name()
     try:
@@ -866,8 +867,8 @@ def test_dont_throw_analysis_exception_in_check_cartesian(session):
 
 
 def test_name_alias_on_multiple_join(session):
-    table_trips = Utils.random_name()
-    table_stations = Utils.random_name()
+    table_trips = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_stations = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temp table {table_trips} (starttime timestamp, "
@@ -908,8 +909,8 @@ def test_name_alias_on_multiple_join(session):
 
 def test_name_alias_on_multiple_join_unnormalized_name(session):
 
-    table_trips = Utils.random_name()
-    table_stations = Utils.random_name()
+    table_trips = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_stations = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temp table {table_trips} (starttime timestamp, "

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -12,6 +12,7 @@ import pytest
 import snowflake.connector
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark import Row, Session
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import (
     SnowparkColumnException,
     SnowparkDataframeException,
@@ -220,7 +221,7 @@ def test_show(session):
 
 
 def test_non_select_query_composition(session):
-    table_name = Utils.random_name()
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temporary table {table_name} (num int)"
@@ -240,7 +241,7 @@ def test_non_select_query_composition(session):
 
 
 def test_non_select_query_composition_union(session):
-    table_name = Utils.random_name()
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temporary table {table_name} (num int)"
@@ -257,7 +258,7 @@ def test_non_select_query_composition_union(session):
 
 
 def test_non_select_query_composition_unionall(session):
-    table_name = Utils.random_name()
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temporary table {table_name} (num int)"
@@ -274,7 +275,7 @@ def test_non_select_query_composition_unionall(session):
 
 
 def test_non_select_query_composition_self_union(session):
-    table_name = Utils.random_name()
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temporary table {table_name} (num int)"
@@ -290,7 +291,7 @@ def test_non_select_query_composition_self_union(session):
 
 
 def test_non_select_query_composition_self_unionall(session):
-    table_name = Utils.random_name()
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(
             f"create or replace temporary table {table_name} (num int)"
@@ -332,7 +333,7 @@ def test_df_stat_corr(session):
     assert TestData.null_data2(session).stat.corr("a", "b") is None
     assert TestData.double4(session).stat.corr("a", "b") is None
     assert math.isnan(TestData.double3(session).stat.corr("a", "b"))
-    assert TestData.double2(session).stat.corr("a", "b") == 0.9999999999999991
+    math.isclose(TestData.double2(session).stat.corr("a", "b"), 0.9999999999999991)
 
 
 def test_df_stat_cov(session):
@@ -343,7 +344,7 @@ def test_df_stat_cov(session):
     assert TestData.null_data2(session).stat.cov("a", "b") == 0
     assert TestData.double4(session).stat.cov("a", "b") is None
     assert math.isnan(TestData.double3(session).stat.cov("a", "b"))
-    assert TestData.double2(session).stat.cov("a", "b") == 0.010000000000000037
+    math.isclose(TestData.double2(session).stat.cov("a", "b"), 0.010000000000000037)
 
 
 def test_df_stat_approxQuantile(session):
@@ -368,8 +369,9 @@ def test_df_stat_approxQuantile(session):
         assert session.table(table_name).stat.approxQuantile("num", [0.5])[0] is None
 
         res = TestData.double2(session).stat.approxQuantile(["a", "b"], [0, 0.1, 0.6])
-        assert res[0] == [0.05, 0.15000000000000002, 0.25]
-        assert res[1] == [0.45, 0.55, 0.6499999999999999]
+        Utils.assert_rows(
+            res, [[0.05, 0.15000000000000002, 0.25], [0.45, 0.55, 0.6499999999999999]]
+        )
 
         # ApproxNumbers2 contains a column called T, which conflicts with tmpColumnName.
         # This test demos that the query still works.
@@ -1321,7 +1323,7 @@ def test_createDataFrame_with_given_schema_time(session):
 
 def test_show_collect_with_misc_commands(session, resources_path, tmpdir):
     object_name = Utils.random_name()
-    stage_name = Utils.random_stage_name()
+    stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
     # In scala, they create a temp JAR file, here we just upload an existing CSV file
     filepath = TestFiles(resources_path).test_file_csv
     escaped_filepath = Utils.escape_path(filepath)

--- a/tests/integ/scala/test_result_attributes_suite.py
+++ b/tests/integ/scala/test_result_attributes_suite.py
@@ -112,9 +112,7 @@ def test_array_type(session):
     assert type(attributes[0].datatype) == ArrayType
 
 
-def test_describe_schema_matches_execute_schema_for_show_queries(
-    session, db_parameters
-):
+def test_describe_schema_matches_execute_schema_for_show_queries(session):
     objs = [
         "tables",
         "transactions",

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -6,6 +6,7 @@ from snowflake.snowpark import Row
 from snowflake.snowpark._internal.analyzer.analyzer_package import AnalyzerPackage
 from snowflake.snowpark._internal.analyzer.sf_attribute import Attribute
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.functions import col
 from snowflake.snowpark.types import IntegerType, LongType
 from tests.utils import Utils
@@ -37,7 +38,7 @@ def test_single_query(session_cnx):
 def test_multiple_queries(session_cnx):
     with session_cnx() as session:
         # unary query
-        table_name1 = Utils.random_name()
+        table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         queries = [
             Query(
                 f"create or replace temporary table {table_name1} as select * from values(1::INT, 'a'::STRING),(2::INT, 'b'::STRING) as T(A,B)"
@@ -67,7 +68,7 @@ def test_multiple_queries(session_cnx):
             Utils.drop_table(session, table_name1)
 
         # binary query
-        table_name2 = Utils.random_name()
+        table_name2 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         queries2 = [
             Query(
                 f"create or replace temporary table {table_name2} as select * from values(3::INT),(4::INT) as T(A)"

--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -7,6 +7,7 @@ import pytest
 
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark import Row
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.functions import col
 from snowflake.snowpark.types import LongType, StructField, StructType
 from tests.utils import TestFiles, Utils
@@ -14,7 +15,7 @@ from tests.utils import TestFiles, Utils
 
 def test_non_select_queries(session):
     try:
-        stage_name = Utils.random_name()
+        stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
         Utils.create_stage(session, stage_name)
         res = session.sql(f"show stages like '{stage_name}'").collect()
         assert len(res) == 1
@@ -45,7 +46,7 @@ def test_put_get_should_not_be_performed_when_preparing(
     path = test_files.test_file_csv
     file_name = "testCSV.csv"
 
-    tmp_stage_name = Utils.random_stage_name()
+    tmp_stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
 
     # add spaces to the query
     put_query = f"put file:///{path} @{tmp_stage_name}"
@@ -111,7 +112,7 @@ def test_create_table(session):
 
         # assert the table is not created before collect
         with pytest.raises(ProgrammingError) as ex_info:
-            session.sql(f"select from {table_name}").collect()
+            session.sql(f"select * from {table_name}").collect()
 
         table.collect()
 

--- a/tests/integ/scala/test_view_suite.py
+++ b/tests/integ/scala/test_view_suite.py
@@ -9,6 +9,7 @@ import pytest
 
 from snowflake.snowpark import Row
 from snowflake.snowpark._internal.analyzer.analyzer_package import AnalyzerPackage
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkCreateViewException
 from snowflake.snowpark.functions import col, sql_expr, sum
 from snowflake.snowpark.types import LongType
@@ -58,7 +59,7 @@ def test_only_works_on_select(session):
 
 
 def test_consistent_view_name_behaviors(session):
-    view_name = Utils.random_name()
+    view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
     sc = session.getCurrentSchema()
     db = session.getCurrentDatabase()
 
@@ -133,8 +134,8 @@ def test_consistent_view_name_behaviors(session):
 
 
 def test_create_temp_view_on_functions(session):
-    table_name = Utils.random_name()
-    view_name = Utils.random_name()
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
 
     try:
         Utils.create_table(session, table_name, "id int, val int")

--- a/tests/integ/scala/test_window_spec_suite.py
+++ b/tests/integ/scala/test_window_spec_suite.py
@@ -9,6 +9,7 @@ import pytest
 
 from snowflake.connector.errors import ProgrammingError
 from snowflake.snowpark import Row, Window
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.functions import (
     avg,
     col,
@@ -194,7 +195,8 @@ def test_empty_over_spec(session):
     df = session.createDataFrame([("a", 1), ("a", 1), ("a", 2), ("b", 2)]).toDF(
         "key", "value"
     )
-    df.createOrReplaceTempView("window_table")
+    view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
+    df.createOrReplaceTempView(view_name)
     Utils.check_answer(
         df.select("key", "value", sum_("value").over(), avg("value").over()),
         [
@@ -206,7 +208,7 @@ def test_empty_over_spec(session):
     )
     Utils.check_answer(
         session.sql(
-            "select key, value, sum(value) over(), avg(value) over() from window_table"
+            f"select key, value, sum(value) over(), avg(value) over() from {view_name}"
         ),
         [
             Row("a", 1, 6, 1.5),


### PR DESCRIPTION
Description
This includes the following changes to help with stored proc tests:

- Use correct temp object name pattern for stored procs
- Remove unnecessary db_parameters
- Fix one query syntax error
- Float comparison

Testing
existing tests