### PR TITLE
SNOW-541425 Use temp object name for random_stage_name

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -69,7 +69,7 @@ class Utils:
 
     @staticmethod
     def random_stage_name() -> str:
-        return f"SN_TEST_Stage_{abs(random.randint(0, 2 ** 31))}".upper()
+        return Utils.random_name_for_temp_object(TempObjectType.STAGE)
 
     @staticmethod
     def create_table(


### PR DESCRIPTION
Description
We should use stage name that uses the temp object naming
convention for random_stage_name so it would work in
stored proc

Testing
existing test