### PR TITLE
SNOW-541495: Use `_internal_collect_with_tag()` instead of `collect()` for all methods

### DIFF
--- a/src/snowflake/snowpark/file_operation.py
+++ b/src/snowflake/snowpark/file_operation.py
@@ -94,7 +94,9 @@ class FileOperation:
             Utils.normalize_remote_file_or_dir(stage_location),
             options,
         )
-        put_result = snowflake.snowpark.DataFrame(self._session, plan).collect()
+        put_result = snowflake.snowpark.DataFrame(
+            self._session, plan
+        )._internal_collect_with_tag()
         return [PutResult(**file_result.asDict()) for file_result in put_result]
 
     def get(
@@ -155,7 +157,9 @@ class FileOperation:
         try:
             # JDBC auto-creates directory but python-connector doesn't. So create the folder here.
             os.makedirs(Utils.get_local_file_path(target_directory), exist_ok=True)
-            get_result = snowflake.snowpark.DataFrame(self._session, plan).collect()
+            get_result = snowflake.snowpark.DataFrame(
+                self._session, plan
+            )._internal_collect_with_tag()
             return [GetResult(**file_result.asDict()) for file_result in get_result]
         # connector raises IndexError when no file is downloaded from python connector.
         # TODO: https://snowflakecomputing.atlassian.net/browse/SNOW-499333. Discuss with python connector whether

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -538,7 +538,9 @@ class Session:
             if stage_location
             else self.__session_stage
         )
-        file_list = self.sql(f"ls {normalized}").select('"name"').collect()
+        file_list = (
+            self.sql(f"ls {normalized}").select('"name"')._internal_collect_with_tag()
+        )
         prefix_length = Utils.get_stage_file_prefix_length(stage_location)
         return {str(row[0])[prefix_length:] for row in file_list}
 

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -352,7 +352,7 @@ class Table(DataFrame):
                 else None,
             )
         )
-        return _get_update_result(new_df.collect())
+        return _get_update_result(new_df._internal_collect_with_tag())
 
     def delete(
         self,
@@ -397,7 +397,7 @@ class Table(DataFrame):
                 else None,
             )
         )
-        return _get_delete_result(new_df.collect())
+        return _get_delete_result(new_df._internal_collect_with_tag())
 
     def merge(
         self,
@@ -458,5 +458,8 @@ class Table(DataFrame):
             )
         )
         return _get_merge_result(
-            new_df.collect(), inserted=inserted, updated=updated, deleted=deleted
+            new_df._internal_collect_with_tag(),
+            inserted=inserted,
+            updated=updated,
+            deleted=deleted,
         )


### PR DESCRIPTION
When executing a DataFrame in any method of snowpark (either public or private), we should always call this method instead of collect(), to make sure the query tag is set properly.