### PR TITLE
SNOW-476839: Run doctest with pytest

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -14,7 +14,6 @@ from snowflake.snowpark import Session
 def add_snowpark_session(doctest_namespace):
     with open("tests/parameters.py", encoding="utf-8") as f:
         exec(f.read(), globals())
-    print(globals()["CONNECTION_PARAMETERS"])
     with Session.builder.configs(
         globals()["CONNECTION_PARAMETERS"]
     ).create() as session:

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --doctest-modules

--- a/tox.ini
+++ b/tox.ini
@@ -108,3 +108,4 @@ markers =
     unit: unit tests
     # Other markers
     timeout: tests that need a timeout time
+addopts = --doctest-modules


### PR DESCRIPTION
To run the doctest with pytest, change directory to the project root folder `.../snowpark-python`, then run `pytest src`.
A snowpark session is created in the namespace so the doctest can use the session object.

Then we can easily verify all sample code with a single command.