### PR TITLE
SNOW-550792 Use environment variable for build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: {{ os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_BUILD_NUMBER', 0) }}
   noarch: python
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vvv


### PR DESCRIPTION
Description

This would be useful for precommit style testing, where we want
each package to have different build number to avoid overwriting
each other in S3 bucket.

Testing
```
> conda build recipe/
...
TEST END: /home/sfan/conda-bld/noarch/snowflake-snowpark-python-0.4.0-py_0.tar.bz2
...
> export SNOWFLAKE_SNOWPARK_PYTHON_BUILD_NUMBER=12345
> conda build recipe/
...
TEST END: /home/sfan/conda-bld/noarch/snowflake-snowpark-python-0.4.0-py_12345.tar.bz2
...
```