### PR TITLE
SNOW-557067: Don't support `OrderedDict` and `defaultdict` in UDF type hints

### DIFF
--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -7,7 +7,6 @@
 # existing code originally distributed by the Apache Software Foundation as part of the
 # Apache Spark project, under the Apache License, Version 2.0.
 import ast
-import collections
 import ctypes
 import datetime
 import decimal
@@ -15,20 +14,7 @@ import re
 import sys
 import typing  # type: ignore
 from array import array
-from collections import OrderedDict
-from typing import (
-    Any,
-    DefaultDict,
-    Dict,
-    List,
-    Optional,
-    OrderedDict,
-    Tuple,
-    Type,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args, get_origin
 
 import snowflake.snowpark.types  # type: ignore
 from snowflake.snowpark.types import (
@@ -333,8 +319,6 @@ def _python_type_str_to_object(tp_str: str) -> Type:
         return datetime.time
     elif tp_str == "datetime":
         return datetime.datetime
-    elif tp_str == "defaultdict":
-        return collections.defaultdict
     else:
         return eval(tp_str)
 
@@ -373,15 +357,8 @@ def _python_type_to_snow_type(tp: Union[str, Type]) -> Tuple[DataType, bool]:
         )
         return ArrayType(element_type), False
 
-    # typing.Dict, typing.DefaultDict, typing.OrderDict, dict, defaultdict, OrderedDict
-    dict_tps = [
-        dict,
-        collections.defaultdict,
-        collections.OrderedDict,
-        OrderedDict,
-        Dict,
-        DefaultDict,
-    ]
+    # typing.Dict, dict
+    dict_tps = [dict, Dict]
     if tp in dict_tps or (tp_origin and tp_origin in dict_tps):
         key_type = _python_type_to_snow_type(tp_args[0])[0] if tp_args else StringType()
         value_type = (

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -6,7 +6,7 @@
 import os
 import typing
 from array import array
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from datetime import date, datetime, time
 from decimal import Decimal
 
@@ -332,36 +332,6 @@ def test_python_type_to_snow_type():
         MapType(StringType(), StringType()),
         False,
     )
-    check_type(
-        typing.DefaultDict[str, int],
-        MapType(StringType(), LongType()),
-        False,
-    )
-    check_type(
-        typing.DefaultDict,
-        MapType(StringType(), StringType()),
-        False,
-    )
-    check_type(
-        defaultdict,
-        MapType(StringType(), StringType()),
-        False,
-    )
-    check_type(
-        typing.OrderedDict[str, int],
-        MapType(StringType(), LongType()),
-        False,
-    )
-    check_type(
-        typing.OrderedDict,
-        MapType(StringType(), StringType()),
-        False,
-    )
-    check_type(
-        OrderedDict,
-        MapType(StringType(), StringType()),
-        False,
-    )
     check_type(Variant, VariantType(), False)
     check_type(Geography, GeographyType(), False)
 
@@ -409,6 +379,10 @@ def test_python_type_to_snow_type():
         _python_type_to_snow_type(typing.Set)
     with pytest.raises(TypeError):
         _python_type_to_snow_type(set)
+    with pytest.raises(TypeError):
+        _python_type_to_snow_type(typing.OrderedDict)
+    with pytest.raises(TypeError):
+        _python_type_to_snow_type(defaultdict)
     with pytest.raises(TypeError):
         _python_type_to_snow_type(typing.Union[str, int, None])
     with pytest.raises(TypeError):


### PR DESCRIPTION
Per discussion here https://github.com/snowflakedb/snowpark-python/pull/238#discussion_r821907403, we shouldn't support `OrderedDict` and `defaultdict` in UDF type hints. 