### PR TITLE
SNOW-520110 Drop temporary file format for post action

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_package.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_package.py
@@ -1194,6 +1194,16 @@ class AnalyzerPackage:
     def drop_table_if_exists_statement(self, table_name: str) -> str:
         return self._Drop + self._Table + self._If + self._Exists + table_name
 
+    def drop_file_format_if_exists_statement(self, format_name: str) -> str:
+        return (
+            self._Drop
+            + self._File
+            + self._Format
+            + self._If
+            + self._Exists
+            + format_name
+        )
+
     def attribute_to_schema_string(self, attributes: List[Attribute]) -> str:
         return self._Comma.join(
             attr.name + self._Space + convert_to_sf_type(attr.datatype)

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -622,7 +622,7 @@ class SnowflakePlanBuilder:
             return SnowflakePlan(
                 queries,
                 pkg.schema_value_statement(schema),
-                [],
+                [pkg.drop_file_format_if_exists_statement(temp_file_format_name)],
                 {},
                 self.__session,
                 None,


### PR DESCRIPTION
Description
While working on transaction for python stored proc, I found we
do not drop the temp file format after using it, which is
different from Scala. And it makes sense to drop it.

Testing
existing tests