### PR TITLE
SNOW-565682: Fix `create_dataframe` when pandas is not installed

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1078,8 +1078,9 @@ class Session:
         if isinstance(data, Row):
             raise TypeError("create_dataframe() function does not accept a Row object.")
 
-        if not isinstance(data, (list, tuple)) or (
-            installed_pandas and not isinstance(data, pandas.DataFrame)
+        if not isinstance(data, (list, tuple)) and (
+            not installed_pandas
+            or (installed_pandas and not isinstance(data, pandas.DataFrame))
         ):
             raise TypeError(
                 "create_dataframe() function only accepts data as a list, tuple or a pandas DataFrame."


### PR DESCRIPTION
Similar to https://github.com/snowflakedb/snowpark-python/commit/a395c39d1b2ce3af6ead12d29c13d3374481968b, `create_dataframe` will not work if pandas is not installed. We should make sure that it can still be used if pandas is not available. 