### PR TITLE
SNOW-572423: Support empty dataframe

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -2005,20 +2005,24 @@ class DataFrame:
 
         def row_to_string(row: List[str]) -> str:
             tokens = []
-            for segment, size in zip(row, col_width):
-                if len(segment) > max_width:
-                    # if truncated, add ... to the end
-                    formatted = (segment[: max_width - 3] + "...").ljust(size, " ")
-                else:
-                    formatted = segment.ljust(size, " ")
-                tokens.append(formatted)
+            if row:
+                for segment, size in zip(row, col_width):
+                    if len(segment) > max_width:
+                        # if truncated, add ... to the end
+                        formatted = (segment[: max_width - 3] + "...").ljust(size, " ")
+                    else:
+                        formatted = segment.ljust(size, " ")
+                    tokens.append(formatted)
+            else:
+                tokens = [" " * size for size in col_width]
             return f"|{'|'.join(tok for tok in tokens)}|\n"
 
         return (
             line
             + row_to_string(header)
             + line
-            + "".join(row_to_string(b) for b in body)
+            # `body` of an empty df is empty
+            + ("".join(row_to_string(b) for b in body) if body else row_to_string([]))
             + line
         )
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1076,14 +1076,13 @@ class Session:
                 create_temp_table=True,
             )
 
-        if not data:
-            raise ValueError("data cannot be empty.")
-
         # infer the schema based on the data
         names = None
         if isinstance(schema, StructType):
             new_schema = schema
         else:
+            if not data:
+                raise ValueError("Cannot infer schema from empty data")
             if isinstance(schema, list):
                 names = schema
             new_schema = reduce(


### PR DESCRIPTION
It aligns with pyspark: we allow to create an empty dataframe if the schema is given (i.e., column name and data type), but won't support creating an empty dataframe if the schema is not provided (i.e., `session.createDataFrame([])`). Previously there is a bug when analyzing the plan of an empty dataframe, but fortunately our refactoring change #284 fixes this issue 😅, so in this PR I just made the change to support `show()` on the empty dataframe and added some tests . 