### PR TITLE
SNOW-508063: Add new type `ColumnOrSQLExpression` and `ColumnOrLiteralStr`

### DIFF
--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -13,7 +13,18 @@ import re
 import sys
 import typing  # type: ignore
 from array import array
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args, get_origin
+from typing import (
+    Any,
+    Dict,
+    List,
+    NewType,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+)
 
 import snowflake.snowpark.types  # type: ignore
 from snowflake.connector.options import installed_pandas, pandas
@@ -490,10 +501,14 @@ def type_string_to_type_object(type_str: str) -> DataType:
 
 
 # Type hints
-ColumnOrName = typing.NewType(
-    "ColumnOrName", Union["snowflake.snowpark.column.Column", str]
+ColumnOrName = NewType("ColumnOrName", Union["snowflake.snowpark.column.Column", str])
+ColumnOrLiteralStr = NewType(
+    "ColumnOrLiteralStr", Union["snowflake.snowpark.column.Column", str]
 )
-LiteralType = typing.NewType("LiteralType", Union[VALID_PYTHON_TYPES_FOR_LITERAL_VALUE])
-ColumnOrLiteral = typing.NewType(
+ColumnOrSqlExpr = NewType(
+    "ColumnOrSqlExpr", Union["snowflake.snowpark.column.Column", str]
+)
+LiteralType = NewType("LiteralType", Union[VALID_PYTHON_TYPES_FOR_LITERAL_VALUE])
+ColumnOrLiteral = NewType(
     "ColumnOrLiteral", Union["snowflake.snowpark.column.Column", LiteralType]
 )

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -63,7 +63,9 @@ from snowflake.snowpark._internal.analyzer.unary_expression import (
 from snowflake.snowpark._internal.type_utils import (
     VALID_PYTHON_TYPES_FOR_LITERAL_VALUE,
     ColumnOrLiteral,
+    ColumnOrLiteralStr,
     ColumnOrName,
+    ColumnOrSqlExpr,
     type_string_to_type_object,
 )
 from snowflake.snowpark._internal.utils import parse_positional_args_to_list
@@ -84,7 +86,7 @@ def _to_col_if_lit(
         )
 
 
-def _to_col_if_sql_expr(col: Union["Column", str], func_name: str) -> "Column":
+def _to_col_if_sql_expr(col: ColumnOrSqlExpr, func_name: str) -> "Column":
     if isinstance(col, Column):
         return col
     elif isinstance(col, str):
@@ -499,7 +501,7 @@ class Column:
         (null values sorted after non-null values)."""
         return Column(SortOrder(self.expression, Ascending(), NullsLast()))
 
-    def like(self, pattern: Union["Column", str]) -> "Column":
+    def like(self, pattern: ColumnOrLiteralStr) -> "Column":
         """Allows case-sensitive matching of strings based on comparison with a pattern.
 
         Args:
@@ -516,7 +518,7 @@ class Column:
             )
         )
 
-    def regexp(self, pattern: Union["Column", str]) -> "Column":
+    def regexp(self, pattern: ColumnOrLiteralStr) -> "Column":
         """Returns true if this Column matches the specified regular expression.
 
         Args:
@@ -536,7 +538,7 @@ class Column:
             )
         )
 
-    def startswith(self, other: Union["Column", str]) -> "Column":
+    def startswith(self, other: ColumnOrLiteralStr) -> "Column":
         """Returns true if this Column starts with another string.
 
         Args:
@@ -546,7 +548,7 @@ class Column:
         other = snowflake.snowpark.functions.lit(other)
         return snowflake.snowpark.functions.startswith(self, other)
 
-    def endswith(self, other: Union["Column", str]) -> "Column":
+    def endswith(self, other: ColumnOrLiteralStr) -> "Column":
         """Returns true if this Column ends with another string.
 
         Args:
@@ -759,7 +761,7 @@ class CaseExpr(Column):
         self._branches = expr.branches
 
     def when(
-        self, condition: Union[Column, str], value: Union[ColumnOrLiteral]
+        self, condition: ColumnOrSqlExpr, value: Union[ColumnOrLiteral]
     ) -> "CaseExpr":
         """
         Appends one more WHEN condition to the CASE expression.

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -66,12 +66,15 @@ from snowflake.snowpark._internal.telemetry import (
     df_action_telemetry,
     df_usage_telemetry,
 )
-from snowflake.snowpark._internal.type_utils import ColumnOrName, LiteralType
+from snowflake.snowpark._internal.type_utils import (
+    ColumnOrName,
+    ColumnOrSqlExpr,
+    LiteralType,
+)
 from snowflake.snowpark._internal.utils import (
     TempObjectType,
     column_to_bool,
     create_statement_query_tag,
-    deprecate,
     generate_random_alphanumeric,
     parse_positional_args_to_list,
     random_name_for_temp_object,
@@ -747,7 +750,7 @@ class DataFrame:
         else:
             return self.select(list(keep_col_names))
 
-    def filter(self, expr: Union[Column, str]) -> "DataFrame":
+    def filter(self, expr: ColumnOrSqlExpr) -> "DataFrame":
         """Filters rows based on the specified conditional expression (similar to WHERE
         in SQL).
 
@@ -1714,7 +1717,7 @@ class DataFrame:
         pattern: Optional[str] = None,
         validation_mode: Optional[str] = None,
         target_columns: Optional[Iterable[str]] = None,
-        transformations: Optional[Iterable[Union[Column, str]]] = None,
+        transformations: Optional[Iterable[ColumnOrName]] = None,
         format_type_options: Optional[Dict[str, Any]] = None,
         **copy_options: Any,
     ) -> List[Row]:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -157,7 +157,7 @@ The return type is always ``Column``. The input types tell you the acceptable va
     -----------------------------
     <BLANKLINE>
 
-  - ``Union[Column, str]`` accepts a ``Column`` object, or a SQL expression. For instance, the first parameter in :func:``when``.
+  - ``ColumnOrSqlExpr`` accepts a ``Column`` object, or a SQL expression. For instance, the first parameter in :func:``when``.
 
     >>> df.select(when("a > 2", "Greater than 2").else_("Less than 2").alias("compare_with_2")).show()
     --------------------
@@ -185,7 +185,9 @@ from snowflake.snowpark._internal.analyzer.expression import (
 from snowflake.snowpark._internal.analyzer.window_expression import Lag, Lead
 from snowflake.snowpark._internal.type_utils import (
     ColumnOrLiteral,
+    ColumnOrLiteralStr,
     ColumnOrName,
+    ColumnOrSqlExpr,
     LiteralType,
 )
 from snowflake.snowpark._internal.utils import (
@@ -1102,7 +1104,7 @@ substr = substring
 
 def regexp_count(
     subject: ColumnOrName,
-    pattern: Union[Column, str],
+    pattern: ColumnOrLiteralStr,
     position: Union[Column, int] = lit(1),
     *parameters: ColumnOrLiteral,
 ) -> Column:
@@ -1118,8 +1120,8 @@ def regexp_count(
 
 def regexp_replace(
     subject: ColumnOrName,
-    pattern: Union[Column, str],
-    replacement: Union[Column, str] = lit(""),
+    pattern: ColumnOrLiteralStr,
+    replacement: ColumnOrLiteralStr = lit(""),
     position: Union[Column, int] = lit(1),
     occurrences: Union[Column, int] = lit(0),
     *parameters: ColumnOrLiteral,
@@ -1140,8 +1142,8 @@ def regexp_replace(
 
 def replace(
     subject: ColumnOrName,
-    pattern: Union[Column, str],
-    replacement: Union[Column, str] = lit(""),
+    pattern: ColumnOrLiteralStr,
+    replacement: ColumnOrLiteralStr = lit(""),
 ) -> Column:
     """
     Removes all occurrences of a specified subject and optionally replaces them with replacement.
@@ -1266,7 +1268,7 @@ def char(col: ColumnOrName) -> Column:
     return builtin("char")(c)
 
 
-def to_char(c: ColumnOrName, format: Optional[Union[Column, str]] = None) -> Column:
+def to_char(c: ColumnOrName, format: Optional[ColumnOrLiteralStr] = None) -> Column:
     """Converts a Unicode code point (including 7-bit ASCII) into the character that
     matches the input Unicode."""
     c = _to_col_if_str(c, "to_char")
@@ -1941,7 +1943,7 @@ def timestamp_from_parts(
     minute: Union[ColumnOrName, int],
     second: Union[ColumnOrName, int],
     nanosecond: Optional[Union[ColumnOrName, int]] = None,
-    timezone: Optional[Union[Column, str]] = None,
+    timezone: Optional[ColumnOrLiteralStr] = None,
 ) -> Column:
     ...
 
@@ -2074,7 +2076,7 @@ def timestamp_tz_from_parts(
     minute: Union[ColumnOrName, int],
     second: Union[ColumnOrName, int],
     nanoseconds: Optional[Union[ColumnOrName, int]] = None,
-    timezone: Optional[Union[Column, str]] = None,
+    timezone: Optional[ColumnOrLiteralStr] = None,
 ) -> Column:
     """
     Creates a timestamp from individual numeric components and a string timezone.
@@ -2619,7 +2621,7 @@ def get(col1: ColumnOrName, col2: ColumnOrName) -> Column:
     return builtin("get")(c1, c2)
 
 
-def when(condition: Union[Column, str], value: Union[ColumnOrLiteral]) -> CaseExpr:
+def when(condition: ColumnOrSqlExpr, value: Union[ColumnOrLiteral]) -> CaseExpr:
     """Works like a cascading if-then-else statement.
     A series of conditions are evaluated in sequence.
     When a condition evaluates to TRUE, the evaluation stops and the associated
@@ -2645,7 +2647,7 @@ def when(condition: Union[Column, str], value: Union[ColumnOrLiteral]) -> CaseEx
 
 
 def iff(
-    condition: Union[Column, str],
+    condition: ColumnOrSqlExpr,
     expr1: Union[ColumnOrLiteral],
     expr2: Union[ColumnOrLiteral],
 ) -> Column:


### PR DESCRIPTION
Now we have `ColumnOrName`, `ColumnOrSQLExpression` and `ColumnOrLiteralStr` to differentiate the three different usage of `str` in snowpark functions. 