### PR TITLE
SNOW-588067 Wrap ProgrammingErrors from stored procs

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -215,9 +215,9 @@ class ServerConnection:
         overwrite: bool = False,
     ) -> Optional[Dict[str, Any]]:
         if is_in_stored_procedure():
+            file_name = os.path.basename(path)
+            target_path = _build_target_path(stage_location, dest_prefix)
             try:
-                file_name = os.path.basename(path)
-                target_path = _build_target_path(stage_location, dest_prefix)
                 # upload_stream directly consume stage path, so we don't need to normalize it
                 self._cursor.upload_stream(
                     open(path, "rb"), f"{target_path}/{file_name}"
@@ -255,9 +255,9 @@ class ServerConnection:
         uri = normalize_local_file(f"/tmp/placeholder/{dest_filename}")
         try:
             if is_in_stored_procedure():
+                input_stream.seek(0)
+                target_path = _build_target_path(stage_location, dest_prefix)
                 try:
-                    input_stream.seek(0)
-                    target_path = _build_target_path(stage_location, dest_prefix)
                     # upload_stream directly consume stage path, so we don't need to normalize it
                     self._cursor.upload_stream(
                         input_stream, f"{target_path}/{dest_filename}"

--- a/src/snowflake/snowpark/file_operation.py
+++ b/src/snowflake/snowpark/file_operation.py
@@ -96,11 +96,16 @@ class FileOperation:
             "overwrite": overwrite,
         }
         if is_in_stored_procedure():
-            cursor = self._session._conn._cursor
-            cursor._upload(local_file_name, stage_location, options)
-            result_meta = cursor.description
-            result_data = cursor.fetchall()
-            put_result = result_set_to_rows(result_data, result_meta)
+            try:
+                cursor = self._session._conn._cursor
+                cursor._upload(local_file_name, stage_location, options)
+                result_meta = cursor.description
+                result_data = cursor.fetchall()
+                put_result = result_set_to_rows(result_data, result_meta)
+            except ProgrammingError as pe:
+                raise SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
+                    pe
+                ) from pe
         else:
             plan = self._session._plan_builder.file_operation_plan(
                 "put",


### PR DESCRIPTION
Description
Missed some cases where a ProgrammingError gets thrown when running as a stored proc since it doesn't go through our normal query path in Snowpark

Testing
Running tests locally for this (won't show up in GH actions)