### PR TITLE
SNOW-588226: Improve the error message and add examples in API doc for joining ambiguous columns

### DIFF
--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -260,9 +260,9 @@ class SnowparkClientExceptionMessages:
             f"present in both DataFrames used in the join. To identify the "
             f"DataFrame that you want to use in the reference, use the syntax "
             f'<df>["{c2}"] in join conditions and in select() calls on the '
-            f"result of the join. Or you can rename the column in either DataFrame "
-            f"for disambiguation. See the API doc of DataFrame.join() method for "
-            f"more details.",
+            f"result of the join. Alternatively, you can rename the column in "
+            f"either DataFrame for disambiguation. See the API documentation of "
+            f"the DataFrame.join() method for more details.",
             "1303",
         )
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1471,6 +1471,15 @@ class DataFrame:
             |3    |4    |8    |
             -------------------
             <BLANKLINE>
+            >>> # refer a single column "a"
+            >>> df1.join(df2, "a").select(df1.a.alias("a"), df1.b, df2.c).show()
+            -------------------
+            |"A"  |"B"  |"C"  |
+            -------------------
+            |1    |2    |7    |
+            |3    |4    |8    |
+            -------------------
+            <BLANKLINE>
             >>> # rename the ambiguous columns
             >>> df3 = df1.to_df("df1_a", "b")
             >>> df4 = df2.to_df("df2_a", "c")
@@ -1490,8 +1499,8 @@ class DataFrame:
             join_type: The type of join ("inner", "full", "left", "right").
 
         Note:
-            When performing chained operations, this method might not work due to ambiguous
-            column names. For example,
+            When performing chained operations, this method will not work if there are
+            ambiguous column names. For example,
 
             >>> df1.filter(df1.a == 1).join(df2, df1.a == df2.a).select(df1.a.alias("a"), df1.b, df2.c) # doctest: +SKIP
 

--- a/tests/unit/scala/test_error_message.py
+++ b/tests/unit/scala/test_error_message.py
@@ -297,9 +297,9 @@ def test_sql_report_join_ambiguous():
         f"present in both DataFrames used in the join. To identify the "
         f"DataFrame that you want to use in the reference, use the syntax "
         f'<df>["{c2}"] in join conditions and in select() calls on the '
-        f"result of the join. Or you can rename the column in either DataFrame "
-        f"for disambiguation. See the API doc of DataFrame.join() method for "
-        f"more details."
+        f"result of the join. Alternatively, you can rename the column in "
+        f"either DataFrame for disambiguation. See the API documentation of "
+        f"the DataFrame.join() method for more details."
     )
 
 


### PR DESCRIPTION
After discussing with Bing, the root cause of this problem can't be easily address unless we re-architect our sql translator. Therefore, we decide to improve the error message and refer to API doc, so the user can pick up the correct behavior when joining dataframes with ambiguous columns. 