### PR TITLE
SNOW-593684: Remove spark mentions in code

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -516,7 +516,6 @@ class Analyzer:
             )
 
         if isinstance(logical_plan, Range):
-            # The column name id lower-case is hard-coded by Spark as the output
             # schema of Range. Since this corresponds to the Snowflake column "id"
             # (quoted lower-case) it's a little hard for users. So we switch it to
             # the column name "ID" == id == Id

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -378,7 +378,7 @@ def sample_statement(
 def aggregate_statement(
     grouping_exprs: List[str], aggregate_exprs: List[str], child: str
 ) -> str:
-    # add limit 1 because Spark may aggregate on non-aggregate function in a scalar aggregation
+    # add limit 1 because aggregate may be on non-aggregate function in a scalar aggregation
     # for example, df.agg(lit(1))
     return project_statement(aggregate_exprs, child) + (
         limit_expression(1)

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -46,7 +46,7 @@ def str_to_sql(value: str) -> str:
 
 
 def to_sql(value: Any, datatype: DataType) -> str:
-    """Convert a value with SparkSQL DataType to a snowflake compatible sql"""
+    """Convert a value with DataType to a snowflake compatible sql"""
 
     # Handle null values
     if isinstance(

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -1,11 +1,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-# Code in this file may constitute partial or total reimplementation, or modification of
-# existing code originally distributed by the Apache Software Foundation as part of the
-# Apache Spark project, under the Apache License, Version 2.0.
-#
-#  File containing the Expression definitions for ASTs (Spark).
 import uuid
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -160,12 +160,7 @@ def convert_sp_to_sf_type(datatype: DataType) -> str:
     raise TypeError(f"Unsupported data type: {datatype.__class__.__name__}")
 
 
-# #####################################################################################
-# Converting python types to types
-# Taken as is or modified from:
-# https://spark.apache.org/docs/3.1.1/api/python/_modules/pyspark/sql/types.html
-
-# Mapping Python types to Spark SQL DataType
+# Mapping Python types to DataType
 NoneType = type(None)
 PYTHON_TO_SNOW_TYPE_MAPPINGS = {
     NoneType: NullType,
@@ -188,7 +183,7 @@ VALID_SNOWPARK_TYPES_FOR_LITERAL_VALUE = (
     _NumericType,
 )
 
-# Mapping Python array types to Spark SQL DataType
+# Mapping Python array types to DataType
 ARRAY_SIGNED_INT_TYPECODE_CTYPE_MAPPINGS = {
     "b": ctypes.c_byte,
     "h": ctypes.c_short,

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -2345,7 +2345,6 @@ class DataFrame:
             if isinstance(field.datatype, (StringType, _NumericType))
         }
 
-        # These are five stats that pyspark's describe() outputs
         stat_func_dict = {
             "count": count,
             "mean": mean,

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -218,7 +218,7 @@ class DataFrameReader:
         self._file_type = None
 
     def table(self, name: Union[str, Iterable[str]]) -> Table:
-        """Returns a DataFrame that points to the specified table.
+        """Returns a Table that points to the specified table.
 
         This method is an alias of :meth:`~snowflake.snowpark.session.Session.table`.
 

--- a/src/snowflake/snowpark/row.py
+++ b/src/snowflake/snowpark/row.py
@@ -2,9 +2,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-# Code in this file may constitute partial or total reimplementation, or modification of
-# existing code originally distributed by the Apache Software Foundation as part of the
-# Apache Spark project, under the Apache License, Version 2.0.
 from typing import Any, Dict, Iterable, Union
 
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -799,7 +799,7 @@ class Session:
 
     def table(self, name: Union[str, Iterable[str]]) -> Table:
         """
-        Returns a DataFrame that points the specified table.
+        Returns a Table that points the specified table.
 
         Args:
             name: A string or list of strings that specify the table name or
@@ -1169,7 +1169,7 @@ class Session:
             names = [f.name for f in new_schema.fields]
         rows = [convert_row_to_list(row, names) for row in data]
 
-        # get spark attributes and data types
+        # get attributes and data types
         attrs, data_types = [], []
         for field in new_schema.fields:
             sf_type = (

--- a/tests/integ/scala/test_dataframe_aggregate_suite.py
+++ b/tests/integ/scala/test_dataframe_aggregate_suite.py
@@ -531,8 +531,8 @@ def test_stddev(session):
 
 def test_sn_moments(session):
     test_data2 = TestData.test_data2(session)
-    spark_variance = test_data2.agg(variance(col("a")))
-    Utils.check_answer(spark_variance, [Row(Decimal("0.8"))])
+    var = test_data2.agg(variance(col("a")))
+    Utils.check_answer(var, [Row(Decimal("0.8"))])
 
     Utils.check_answer(
         test_data2.group_by(col("a")).agg(variance(col("b"))),
@@ -543,22 +543,22 @@ def test_sn_moments(session):
         "select variance(a) from values(1,1),(1,2),(2,1),(2,2),(3,1),(3,2) as T(a,b);"
     ).collect()
 
-    Utils.check_answer(spark_variance, variance_result[0])
+    Utils.check_answer(var, variance_result[0])
 
-    spark_variance_pop = test_data2.agg(var_pop(col("a")))
-    Utils.check_answer(spark_variance_pop, [Row(Decimal("0.666667"))])
+    variance_pop = test_data2.agg(var_pop(col("a")))
+    Utils.check_answer(variance_pop, [Row(Decimal("0.666667"))])
 
-    spark_variance_samp = test_data2.agg(var_samp(col("a")))
-    Utils.check_answer(spark_variance_samp, [Row(Decimal("0.8"))])
+    variance_samp = test_data2.agg(var_samp(col("a")))
+    Utils.check_answer(variance_samp, [Row(Decimal("0.8"))])
 
-    spark_kurtosis = test_data2.agg(kurtosis(col("a")))
-    Utils.check_answer(spark_kurtosis, [Row(Decimal("-1.8750"))])
+    kurtosis_ = test_data2.agg(kurtosis(col("a")))
+    Utils.check_answer(kurtosis_, [Row(Decimal("-1.8750"))])
 
     # add SQL test
     agg_kurtosis_result = session.sql(
         "select kurtosis(a) from values(1,1),(1,2),(2,1),(2,2),(3,1),(3,2) as T(a,b);"
     ).collect()
-    Utils.check_answer(spark_kurtosis, agg_kurtosis_result[0])
+    Utils.check_answer(kurtosis_, agg_kurtosis_result[0])
 
 
 def test_sn_zero_moments(session):
@@ -626,7 +626,7 @@ def test_sn_null_moments(session):
     )
 
 
-def test_spark14664_decimal_sum_over_window_should_work(session):
+def test_decimal_sum_over_window_should_work(session):
     assert session.sql(
         "select sum(a) over () from values (1.0), (2.0), (3.0) T(a)"
     ).collect() == [Row(6.0), Row(6.0), Row(6.0)]
@@ -641,7 +641,7 @@ def test_aggregate_function_in_groupby(session):
     assert "is not a valid group by expression" in str(ex_info)
 
 
-def test_spark21580_ints_in_agg_exprs_are_taken_as_groupby_ordinal(session):
+def test_ints_in_agg_exprs_are_taken_as_groupby_ordinal(session):
     assert TestData.test_data2(session).group_by(lit(3), lit(4)).agg(
         [lit(6), lit(7), sum(col("b"))]
     ).collect() == [Row(3, 4, 6, 7, 9)]

--- a/tests/integ/scala/test_dataframe_set_operations_suite.py
+++ b/tests/integ/scala/test_dataframe_set_operations_suite.py
@@ -279,7 +279,7 @@ def test_intersect_nullability(session):
     assert all(not i.nullable for i in df4.schema.fields)
 
 
-def test_spark_17123_performing_set_ops_on_non_native_types(session):
+def test_performing_set_ops_on_non_native_types(session):
     dates = session.create_dataframe(
         [
             [date(1, 1, 1), Decimal(1), datetime(1, 1, 1, microsecond=2000)],

--- a/tests/integ/scala/test_table_suite.py
+++ b/tests/integ/scala/test_table_suite.py
@@ -137,7 +137,7 @@ def test_save_as_snowflake_table(session, table_name_1):
 def test_save_as_snowflake_table_string_argument(table_name_4):
     """
     Scala's `DataFrameWriter.mode()` accepts both enum values of SaveMode and str.
-    It's conventional that python uses str and pyspark does use str only. So the above test method
+    It's conventional that python uses str.
     `test_save_as_snowflake_table` already tests the string argument. This test will be the same as
     `test_save_as_snowflake_table` if ported from Scala so it's omitted.
     """

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1129,8 +1129,7 @@ def test_attribute_reference_to_sql(session):
 
 def test_dataframe_duplicated_column_names(session):
     df = session.sql("select 1 as a, 2 as a")
-    # collect() works and return a row with duplicated keys,
-    # which aligns with Pyspark
+    # collect() works and return a row with duplicated keys
     res = df.collect()
     assert len(res[0]) == 2
     assert res[0].A == 1


### PR DESCRIPTION
In this PR https://github.com/snowflakedb/snowpark-python/pull/45 we added legal disclaimer for spark reference. 
Now we have updated expressions to be the same as scala. It doesn't use spark expressions any more. We only keep the disclaimer for `type_utils.py`.
Scala has removed all disclaimers about spark.

This PR also removes text "spark" in the src and test code.