### PR TITLE
SNOW-586919: Added support to use inferred schema in DataFrame.copy_into_table()

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -629,6 +629,9 @@ class Analyzer:
                     if logical_plan.transformations
                     else None,
                     user_schema=logical_plan.user_schema,
+                    create_table_from_infer_schema=logical_plan.cur_options.get(
+                        "CREATE_TABLE_FROM_INFER_SCHEMA", False
+                    ),
                 )
             elif logical_plan.file_format and logical_plan.file_format.upper() == "CSV":
                 if not logical_plan.user_schema:
@@ -642,12 +645,17 @@ class Analyzer:
                         logical_plan.user_schema._to_attributes(),
                     )
             else:
+                schema = (
+                    logical_plan.user_schema._to_attributes()
+                    if logical_plan.user_schema
+                    else [Attribute('"$1"', VariantType())]
+                )
                 return self.plan_builder.read_file(
                     logical_plan.files,
                     logical_plan.file_format,
                     logical_plan.cur_options,
                     self.session.get_fully_qualified_current_schema(),
-                    [Attribute('"$1"', VariantType())],
+                    schema,
                 )
 
         if isinstance(logical_plan, CopyIntoLocationNode):

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -629,9 +629,7 @@ class Analyzer:
                     if logical_plan.transformations
                     else None,
                     user_schema=logical_plan.user_schema,
-                    create_table_from_infer_schema=logical_plan.cur_options.get(
-                        "CREATE_TABLE_FROM_INFER_SCHEMA", False
-                    ),
+                    create_table_from_infer_schema=logical_plan.create_table_from_infer_schema,
                 )
             elif logical_plan.file_format and logical_plan.file_format.upper() == "CSV":
                 if not logical_plan.user_schema:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -744,6 +744,7 @@ class SnowflakePlanBuilder:
         column_names: Optional[List[str]] = None,
         transformations: Optional[List[str]] = None,
         user_schema: Optional[StructType] = None,
+        create_table_from_infer_schema: bool = False,
     ) -> SnowflakePlan:
         # tracking usage of pattern, will refactor this function in future
         if pattern:
@@ -763,7 +764,13 @@ class SnowflakePlanBuilder:
         )
         if self.session._table_exists(table_name):
             queries = [Query(copy_command)]
-        elif user_schema and not transformations:
+        elif user_schema and (
+            (file_format.upper() == "CSV" and not transformations)
+            or (
+                create_table_from_infer_schema
+                and file_format.upper() in INFER_SCHEMA_FORMAT_TYPES
+            )
+        ):
             attributes = user_schema._to_attributes()
             queries = [
                 Query(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -91,6 +91,7 @@ class CopyIntoTableNode(LeafNode):
         validation_mode: Optional[str] = None,
         user_schema: Optional[StructType] = None,
         cur_options: Optional[Dict[str, Any]] = None,  # the options of DataFrameReader
+        create_table_from_infer_schema: bool = False,
     ):
         super().__init__()
         self.table_name = table_name
@@ -105,6 +106,7 @@ class CopyIntoTableNode(LeafNode):
         self.validation_mode = validation_mode
         self.user_schema = user_schema
         self.cur_options = cur_options
+        self.create_table_from_infer_schema = create_table_from_infer_schema
 
 
 class CopyIntoLocationNode(LogicalPlan):

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1939,7 +1939,7 @@ class DataFrame:
         # We only want to set this if the user does not have any target columns or transformations set
         # Otherwise we operate in the mode where we don't know the schema
         create_table_from_infer_schema = False
-        if self._reader._inferred_schema and not (transformations or target_columns):
+        if self._reader._infer_schema and not (transformations or target_columns):
             transformations = self._reader._infer_schema_transformations
             target_columns = self._reader._infer_schema_target_columns
             create_table_from_infer_schema = True

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1938,16 +1938,11 @@ class DataFrame:
         )
         # We only want to set this if the user does not have any target columns or transformations set
         # Otherwise we operate in the mode where we don't know the schema
-        if self._reader._cur_options.get("INFER_SCHEMA") and not (
-            transformations or target_columns
-        ):
-            transformations = self._reader._cur_options.get(
-                "INFER_SCHEMA_TRANSFORMATIONS"
-            )
-            target_columns = self._reader._cur_options.get(
-                "INFER_SCHEMA_TARGET_COLUMNS"
-            )
-            self._reader._cur_options["CREATE_TABLE_FROM_INFER_SCHEMA"] = True
+        create_table_from_infer_schema = False
+        if self._reader._infer_schema and not (transformations or target_columns):
+            transformations = self._reader._infer_schema_transformations
+            target_columns = self._reader._infer_schema_target_columns
+            create_table_from_infer_schema = True
 
         transformations = (
             [_to_col_if_str(column, "copy_into_table") for column in transformations]
@@ -1986,6 +1981,7 @@ class DataFrame:
                 validation_mode=validation_mode,
                 user_schema=self._reader._user_schema,
                 cur_options=self._reader._cur_options,
+                create_table_from_infer_schema=create_table_from_infer_schema,
             ),
         )._internal_collect_with_tag()
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1939,7 +1939,7 @@ class DataFrame:
         # We only want to set this if the user does not have any target columns or transformations set
         # Otherwise we operate in the mode where we don't know the schema
         create_table_from_infer_schema = False
-        if self._reader._infer_schema and not (transformations or target_columns):
+        if self._reader._inferred_schema and not (transformations or target_columns):
             transformations = self._reader._infer_schema_transformations
             target_columns = self._reader._infer_schema_target_columns
             create_table_from_infer_schema = True

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1926,24 +1926,37 @@ class DataFrame:
             table_name if isinstance(table_name, str) else ".".join(table_name)
         )
         validate_object_name(full_table_name)
-        pattern = pattern or self._reader._cur_options.get("pattern")
+        pattern = pattern or self._reader._cur_options.get("PATTERN")
         format_type_options = format_type_options or self._reader._cur_options.get(
-            "format_type_options"
+            "FORMAT_TYPE_OPTIONS"
         )
         target_columns = target_columns or self._reader._cur_options.get(
-            "target_columns"
+            "TARGET_COLUMNS"
         )
         transformations = transformations or self._reader._cur_options.get(
-            "transformations"
+            "TRANSFORMATIONS"
         )
+        # We only want to set this if the user does not have any target columns or transformations set
+        # Otherwise we operate in the mode where we don't know the schema
+        if self._reader._cur_options.get("INFER_SCHEMA") and not (
+            transformations or target_columns
+        ):
+            transformations = self._reader._cur_options.get(
+                "INFER_SCHEMA_TRANSFORMATIONS"
+            )
+            target_columns = self._reader._cur_options.get(
+                "INFER_SCHEMA_TARGET_COLUMNS"
+            )
+            self._reader._cur_options["CREATE_TABLE_FROM_INFER_SCHEMA"] = True
+
         transformations = (
             [_to_col_if_str(column, "copy_into_table") for column in transformations]
             if transformations
             else None
         )
-        copy_options = copy_options or self._reader._cur_options.get("copy_options")
+        copy_options = copy_options or self._reader._cur_options.get("COPY_OPTIONS")
         validation_mode = validation_mode or self._reader._cur_options.get(
-            "validation_mode"
+            "VALIDATION_MODE"
         )
         normalized_column_names = (
             [quote_name(col_name) for col_name in target_columns]

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -422,6 +422,7 @@ class DataFrameReader:
                     schema_to_cast.append((identifier, r[0]))
                     transformations.append(identifier)
                 schema = new_schema
+                self._user_schema = StructType._from_attributes(schema)
             finally:
                 # Clean up the file format we created
                 self._session._conn.run_query(

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -218,7 +218,7 @@ class DataFrameReader:
         self._file_path = None
         self._file_type = None
         # Infer schema information
-        self._inferred_schema = False
+        self._infer_schema = False
         self._infer_schema_transformations = None
         self._infer_schema_target_columns = None
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -377,8 +377,6 @@ class DataFrameReader:
         read_file_transformations = None
         schema_to_cast = None
         if self._infer_schema:
-            # Set INFER_SCHEMA if it doesn't already exist so we can see
-            # that the schema was inferred upstream of here
             temp_file_format_name = (
                 self._session.get_fully_qualified_current_schema()
                 + "."

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from snowflake.snowpark import Row
+from snowflake.snowpark import Row, Session
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import (
     SnowparkDataframeException,
@@ -45,7 +45,9 @@ user_fields = [
 user_schema = StructType(user_fields)
 
 
-def create_df_for_file_format(session, file_format, file_location, infer_schema=False):
+def create_df_for_file_format(
+    session: Session, file_format: str, file_location: str, infer_schema: bool = False
+):
     df_reader = session.read
     if not infer_schema and file_format not in ("json", "xml"):
         df_reader.option("INFER_SCHEMA", False)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-586919

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Updated DataFrame.copy_into_table() to be able to use the inferred schema of a parquet or avro or orc file
