### PR TITLE
SNOW-608059 Change local recipe to build arch specific package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,21 +11,19 @@ source:
 
 build:
   number: {{ os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_BUILD_NUMBER', 0) }}
-  noarch: python
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps -vvv
+  skip: True  # [py<38 or py>=39 or win32 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:
-  build:
-    - wheel
   host:
-    - python 3.8
+    - python
     - pip
+    - setuptools >=40.6.0
+    - wheel
   run:
-    - python 3.8
+    - python
     - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python
-    - setuptools >34.0.0
     - typing-extensions >=4.1.0
   run_constrained:
     - pandas >1,<1.4


### PR DESCRIPTION
Given Anaconda builds packages in arch specific way, we need to
change our local recipe to adapt.

We still need local recipe for snapshot testing. The one in feedstock
is used as the latest released recipe.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
