### PR TITLE
SNOW-606808: Move blocklist of SP regression test to snowpark 

### DIFF
--- a/tests/integ/scala/test_complex_dataframe_suite.py
+++ b/tests/integ/scala/test_complex_dataframe_suite.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
+import pytest
 
 from snowflake.snowpark import Row
 from snowflake.snowpark._internal.utils import TempObjectType
@@ -12,7 +13,7 @@ from snowflake.snowpark.types import (
     StructField,
     StructType,
 )
-from tests.utils import TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 
 def test_combination_of_multiple_operators(session):
@@ -86,6 +87,7 @@ def test_join_on_top_of_unions(session):
     assert res == [Row(i, f"test{i}") for i in range(1, 11)]
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="need resources")
 def test_combination_of_multiple_data_sources(session, resources_path):
     test_files = TestFiles(resources_path)
     test_file_csv = "testCSV.csv"

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -22,7 +22,7 @@ from snowflake.snowpark.types import (
     StructField,
     StructType,
 )
-from tests.utils import TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 test_file_csv = "testCSV.csv"
 test_file2_csv = "test2CSV.csv"
@@ -756,6 +756,10 @@ def test_copy_non_csv_transformation(
         Utils.drop_table(session, table_name)
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="SNOW-595068 the column order from infer_schema is not preserved",
+)
 @pytest.mark.parametrize(
     "file_format, file_name, assert_data",
     [

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -27,7 +27,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
 )
-from tests.utils import TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 test_file_csv = "testCSV.csv"
 test_file2_csv = "test2CSV.csv"
@@ -521,6 +521,10 @@ def test_read_parquet_with_no_schema(session, mode):
     ]
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="SNOW-595068 the column order from infer_schema is not preserved",
+)
 @pytest.mark.parametrize("mode", ["select", "copy"])
 def test_read_parquet_all_data_types_with_no_schema(session, mode):
     path = f"@{tmp_stage_name1}/{test_file_all_data_types_parquet}"
@@ -593,6 +597,10 @@ def test_read_parquet_all_data_types_with_no_schema(session, mode):
     ]
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="SNOW-595068 the column order from infer_schema is not preserved",
+)
 @pytest.mark.parametrize("mode", ["select", "copy"])
 def test_read_parquet_with_special_characters_in_column_names(session, mode):
     path = f"@{tmp_stage_name1}/{test_file_with_special_characters_parquet}"

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -54,7 +54,13 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
-from tests.utils import TestData, TestFiles, Utils
+from tests.utils import (
+    IS_IN_STORED_PROC,
+    IS_IN_STORED_PROC_LOCALFS,
+    TestData,
+    TestFiles,
+    Utils,
+)
 
 SAMPLING_DEVIATION = 0.4
 
@@ -113,7 +119,7 @@ def test_write_null_data_to_table(session):
         Utils.drop_table(session, table_name)
 
 
-def test_createOrReplaceView_with_null_data(session):
+def test_create_or_replace_view_with_null_data(session):
     df = session.create_dataframe([[1, None], [2, "NotNull"], [3, None]]).to_df(
         ["a", "b"]
     )
@@ -593,6 +599,7 @@ def test_df_stat_sampleBy(session):
     assert len(sample_by_3.collect()) == 0
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_df_stat_crosstab_max_column_test(session):
     df1 = session.create_dataframe(
         [
@@ -654,6 +661,7 @@ def test_first(session):
     assert sorted(res, key=lambda x: x[0]) == [Row(1), Row(2), Row(3)]
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_sample_with_row_count(session):
     """Tests sample using n (row count)"""
     row_count = 10000
@@ -669,6 +677,7 @@ def test_sample_with_row_count(session):
     assert len(df.sample(n=row_count + 10).collect()) == row_count
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_sample_with_frac(session):
     """Tests sample using frac"""
     row_count = 10000
@@ -1437,6 +1446,7 @@ def test_createDataFrame_with_given_schema_time(session):
     assert df.collect() == data
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="need to support PUT/GET command")
 def test_show_collect_with_misc_commands(session, resources_path, tmpdir):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
@@ -1528,6 +1538,10 @@ def test_escaped_character(session):
     assert res == [Row("'"), Row("\\"), Row("\n")]
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="creating new sessions within stored proc is not supported",
+)
 def test_create_or_replace_temporary_view(session, db_parameters):
     view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
     view_name1 = f'"{view_name}%^11"'

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -11,7 +11,7 @@ import pytest
 
 from snowflake.snowpark._internal.utils import is_in_stored_procedure
 from snowflake.snowpark.exceptions import SnowparkSQLException
-from tests.utils import TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 
 def random_alphanumeric_name():
@@ -132,6 +132,9 @@ def test_put_with_one_file_twice(session, temp_stage, path1):
     # assert "File with same destination name and checksum already exists" in second_result.message
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="cannot write file to root directory in sandbox"
+)
 def test_put_with_one_relative_path_file(session, temp_stage, path1):
     stage_prefix = f"prefix_{random_alphanumeric_name()}"
     stage_with_prefix = f"@{temp_stage}/{stage_prefix}/"
@@ -237,6 +240,9 @@ def test_get_multiple_files(
         os.remove(f"{temp_target_directory}/{os.path.basename(path3)}")
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="SNOW-570941: get with pattern is not supported"
+)
 def test_get_with_pattern_and_relative_target_directory(
     session, temp_stage, temp_target_directory, path1, path2, path3
 ):

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -30,8 +30,10 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
+from tests.utils import IS_IN_STORED_PROC
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="flaky test in SP")
 def test_to_local_iterator_should_not_load_all_data_at_once(session):
     df = (
         session.range(1000000)

--- a/tests/integ/scala/test_result_attributes_suite.py
+++ b/tests/integ/scala/test_result_attributes_suite.py
@@ -4,6 +4,8 @@
 #
 from typing import List
 
+import pytest
+
 from snowflake.snowpark import Session
 from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.utils import TempObjectType
@@ -20,7 +22,7 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
-from tests.utils import Utils as utils
+from tests.utils import IS_IN_STORED_PROC, Utils
 
 
 def get_table_attributes(session: Session, name: str) -> List[Attribute]:
@@ -32,16 +34,16 @@ def get_attributes_with_types(
 ) -> List[Attribute]:
     try:
         schema = ",".join([f"col_{idx} {tp}" for idx, tp in enumerate(types)])
-        utils.create_table(session, name, schema)
+        Utils.create_table(session, name, schema)
         attributes = get_table_attributes(session, name)
     finally:
-        utils.drop_table(session, name)
+        Utils.drop_table(session, name)
     return attributes
 
 
 def test_integer_type(session):
     integers = ["number", "decimal", "numeric", "bigint", "int", "integer", "smallint"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, integers)
     for attribute in attributes:
         assert type(attribute.datatype) == LongType
@@ -49,7 +51,7 @@ def test_integer_type(session):
 
 def test_float_type(session):
     floats = ["float", "float4", "double", "real"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, floats)
     for attribute in attributes:
         assert type(attribute.datatype) == DoubleType
@@ -57,7 +59,7 @@ def test_float_type(session):
 
 def test_string_type(session):
     strings = ["varchar", "char", "character", "string", "text"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, strings)
     for attribute in attributes:
         assert type(attribute.datatype) == StringType
@@ -65,7 +67,7 @@ def test_string_type(session):
 
 def test_binary_type(session):
     binarys = ["binary", "varbinary"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, binarys)
     for attribute in attributes:
         assert type(attribute.datatype) == BinaryType
@@ -73,7 +75,7 @@ def test_binary_type(session):
 
 def test_logical_type(session):
     logicals = ["boolean"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, logicals)
     for attribute in attributes:
         assert type(attribute.datatype) == BooleanType
@@ -89,7 +91,7 @@ def test_date_and_time_type(session):
         "timestamp_ntz": TimestampType,
         "timestamp_tz": TimestampType,
     }
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, list(dates.keys()))
     for attribute, expected_type in zip(attributes, dates.values()):
         assert type(attribute.datatype) == expected_type
@@ -97,7 +99,7 @@ def test_date_and_time_type(session):
 
 def test_semi_structured_type(session):
     semi_structures = ["variant", "object"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, semi_structures)
     assert type(attributes[0].datatype) == VariantType
     assert type(attributes[1].datatype) == MapType
@@ -105,11 +107,14 @@ def test_semi_structured_type(session):
 
 def test_array_type(session):
     semi_structures = ["array"]
-    table_name = utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     attributes = get_attributes_with_types(session, table_name, semi_structures)
     assert type(attributes[0].datatype) == ArrayType
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="SNOW-507565: fix local_aws reg test environment"
+)
 def test_describe_schema_matches_execute_schema_for_show_queries(session):
     objs = [
         "tables",

--- a/tests/integ/scala/test_result_schema_suite.py
+++ b/tests/integ/scala/test_result_schema_suite.py
@@ -7,7 +7,13 @@ import pytest
 
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import col
-from tests.utils import TYPE_MAP, TempObjectType, TestFiles, Utils
+from tests.utils import (
+    IS_IN_STORED_PROC_LOCALFS,
+    TYPE_MAP,
+    TempObjectType,
+    TestFiles,
+    Utils,
+)
 
 tmp_stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
 tmp_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -38,6 +44,7 @@ def setup(session):
     )
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_show_database_objects(session):
     sqls = [
         "show schemas",
@@ -66,6 +73,7 @@ def test_show_database_objects(session):
         Utils.verify_schema(sql, session.sql(sql).schema, session)
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_show_account_objects(session):
     sqls = ["show functions", "show network policies", "show roles", "show databases"]
     for sql in sqls:
@@ -107,6 +115,7 @@ def test_alter(session):
     Utils.verify_schema(sql, session.sql(sql).schema, session)
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="need resources")
 def test_list_remove_file(session, resources_path):
     test_files = TestFiles(resources_path)
 

--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -10,9 +10,12 @@ from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import col
 from snowflake.snowpark.types import LongType, StructField, StructType
-from tests.utils import TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="SNOW-533647: Support statement level parameter"
+)
 def test_non_select_queries(session):
     try:
         stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
@@ -39,6 +42,7 @@ def test_non_select_queries(session):
         Utils.drop_table(session, table_name1)
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="need to support PUT/GET command")
 def test_put_get_should_not_be_performed_when_preparing(
     session, resources_path, tmpdir
 ):

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -34,9 +34,10 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
-from tests.utils import TestData, TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC_LOCALFS, TestData, TestFiles, Utils
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="need resources")
 def test_read_stage_file_show(session, resources_path):
     tmp_stage_name = Utils.random_stage_name()
     test_files = TestFiles(resources_path)
@@ -1023,6 +1024,7 @@ def test_create_dataframe_empty(session):
     assert df.with_column("c", lit(2)).columns == ["A", "B", "C"]
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_create_dataframe_from_none_data(session):
     assert session.create_dataframe([None, None]).collect() == [
         Row(None),

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -6,16 +6,14 @@ from typing import Iterator
 
 import pandas as pd
 import pytest
-from packaging import version
 from pandas import DataFrame as PandasDF, Series as PandasSeries
 from pandas.util.testing import assert_frame_equal
 
-import snowflake.connector
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkFetchDataException
 from snowflake.snowpark.functions import col, to_timestamp
 from snowflake.snowpark.types import DecimalType, IntegerType
-from tests.utils import Utils
+from tests.utils import IS_IN_STORED_PROC, Utils
 
 
 def test_to_pandas_new_df_from_range(session):
@@ -117,8 +115,7 @@ def test_to_pandas_non_select(session):
 
 
 @pytest.mark.skipif(
-    version.parse(snowflake.connector.__version__) < version.parse("2.7.5"),
-    reason="Python connector >= v2.7.5 ignores the index for the dataframe from fetch_pandas_all()",
+    IS_IN_STORED_PROC, reason="SNOW-507565: Need localaws for large result"
 )
 def test_to_pandas_batches(session):
     df = session.range(100000).cache_result()

--- a/tests/integ/test_query_history.py
+++ b/tests/integ/test_query_history.py
@@ -1,8 +1,10 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
+import pytest
 
 from snowflake.snowpark._internal.analyzer.analyzer import ARRAY_BIND_THRESHOLD
+from tests.utils import IS_IN_STORED_PROC
 
 
 def test_query_history(session):
@@ -63,6 +65,9 @@ def test_query_history_no_actions(session):
     assert len(query_listener.queries) == 0
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="SNOW-533647: Support statement level parameters"
+)
 def test_query_history_executemany(session):
     """Large local data frame uses ServerConnection.run_batch_insert instead of ServerConnection.run_query.
     run_batch_insert create a temp table and use parameter binding to insert values, then select from the temp table.

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -18,7 +18,7 @@ from snowflake.snowpark.exceptions import (
 )
 from snowflake.snowpark.functions import sproc
 from snowflake.snowpark.types import DoubleType, IntegerType, PandasSeries, StringType
-from tests.utils import TempObjectType, TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TempObjectType, TestFiles, Utils
 
 try:
     import numpy  # noqa: F401
@@ -78,6 +78,10 @@ def test_basic_stored_procedure(session):
     assert pow_sp(2, 10, session=session) == 1024
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Named temporary procedure is not supported in stored proc",
+)
 def test_call_named_stored_procedure(session, temp_schema, db_parameters):
     sproc_name = f"test_mul_{Utils.random_alphanumeric_str(3)}"
     session._run_query("drop function if exists sproc_name(int, int)")
@@ -462,6 +466,7 @@ def return_datetime(_: Session) -> datetime.datetime:
     assert return_datetime_sp() == dt
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot create session in SP")
 def test_permanent_sp(session, db_parameters):
     stage_name = Utils.random_stage_name()
     sp_name = Utils.random_name_for_temp_object(TempObjectType.PROCEDURE)
@@ -653,6 +658,10 @@ def test_add_import_negative(session, resources_path):
     )
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Named temporary procedure is not supported in stored proc",
+)
 def test_sp_replace(session):
     # Register named sp and expect that it works.
     add_sp = session.sproc.register(

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -56,7 +56,7 @@ from snowflake.snowpark.types import (
     Variant,
     VariantType,
 )
-from tests.utils import TempObjectType, TestData, TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TempObjectType, TestData, TestFiles, Utils
 
 pytestmark = pytest.mark.udf
 
@@ -117,6 +117,9 @@ def test_basic_udf(session):
     )
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
+)
 def test_call_named_udf(session, temp_schema, db_parameters):
     session._run_query("drop function if exists test_mul(int, int)")
     udf(
@@ -545,6 +548,9 @@ def test_add_import_package(session):
     session.clear_imports()
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="SNOW-609328: support caplog in SP regression test"
+)
 def test_add_import_duplicate(session, resources_path, caplog):
     test_files = TestFiles(resources_path)
     abs_path = test_files.test_udf_directory
@@ -733,6 +739,7 @@ def return_dict(v: dict) -> Dict[str, str]:
     )
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="need to support permanent udf")
 def test_permanent_udf(session, db_parameters):
     stage_name = Utils.random_stage_name()
     udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
@@ -1022,6 +1029,9 @@ def test_udf_geography_type(session):
     )
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
+)
 def test_udf_replace(session):
     df = session.create_dataframe([[1, 2], [3, 4]]).to_df("a", "b")
 
@@ -1123,7 +1133,8 @@ def test_udf_parallel(session):
 
 
 @pytest.mark.skipif(
-    not is_pandas_and_numpy_available, reason="numpy and pandas are required"
+    not is_pandas_and_numpy_available and IS_IN_STORED_PROC,
+    reason="numpy and pandas are required",
 )
 def test_add_packages(session):
     session.add_packages(["numpy==1.20.1", "pandas==1.3.5", "pandas==1.3.5"])
@@ -1184,6 +1195,9 @@ def test_add_packages(session):
     session.clear_packages()
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="Need certain version of datautil/pandas/numpy"
+)
 def test_add_packages_negative(session, caplog):
     with pytest.raises(ValueError) as ex_info:
         session.add_packages("python-dateutil****")
@@ -1209,7 +1223,8 @@ def test_add_packages_negative(session, caplog):
 
 
 @pytest.mark.skipif(
-    not is_pandas_and_numpy_available, reason="numpy and pandas are required"
+    not is_pandas_and_numpy_available and IS_IN_STORED_PROC,
+    reason="numpy and pandas are required",
 )
 def test_add_requirements(session, resources_path):
     test_files = TestFiles(resources_path)
@@ -1233,7 +1248,8 @@ def test_add_requirements(session, resources_path):
 
 
 @pytest.mark.skipif(
-    not is_pandas_and_numpy_available, reason="numpy and pandas are required"
+    not is_pandas_and_numpy_available and IS_IN_STORED_PROC,
+    reason="numpy and pandas are required",
 )
 def test_udf_describe(session):
     def get_numpy_pandas_version(s: str) -> str:

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1133,7 +1133,7 @@ def test_udf_parallel(session):
 
 
 @pytest.mark.skipif(
-    not is_pandas_and_numpy_available and IS_IN_STORED_PROC,
+    (not is_pandas_and_numpy_available) or IS_IN_STORED_PROC,
     reason="numpy and pandas are required",
 )
 def test_add_packages(session):
@@ -1223,7 +1223,7 @@ def test_add_packages_negative(session, caplog):
 
 
 @pytest.mark.skipif(
-    not is_pandas_and_numpy_available and IS_IN_STORED_PROC,
+    (not is_pandas_and_numpy_available) or IS_IN_STORED_PROC,
     reason="numpy and pandas are required",
 )
 def test_add_requirements(session, resources_path):
@@ -1248,7 +1248,7 @@ def test_add_requirements(session, resources_path):
 
 
 @pytest.mark.skipif(
-    not is_pandas_and_numpy_available and IS_IN_STORED_PROC,
+    (not is_pandas_and_numpy_available) or IS_IN_STORED_PROC,
     reason="numpy and pandas are required",
 )
 def test_udf_describe(session):

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -739,7 +739,7 @@ def return_dict(v: dict) -> Dict[str, str]:
     )
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC, reason="need to support permanent udf")
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot create session in SP")
 def test_permanent_udf(session, db_parameters):
     stage_name = Utils.random_stage_name()
     udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
 )
 from snowflake.snowpark._internal.type_utils import convert_sf_to_sp_type
-from snowflake.snowpark._internal.utils import TempObjectType
+from snowflake.snowpark._internal.utils import TempObjectType, is_in_stored_procedure
 from snowflake.snowpark.types import (
     ArrayType,
     BinaryType,
@@ -42,6 +42,10 @@ IS_WINDOWS = platform.system() == "Windows"
 IS_MACOS = platform.system() == "Darwin"
 IS_LINUX = platform.system() == "Linux"
 IS_UNIX = IS_LINUX or IS_MACOS
+IS_IN_STORED_PROC = is_in_stored_procedure()
+IS_IN_STORED_PROC_LOCALFS = (
+    IS_IN_STORED_PROC and os.getenv("SF_ACCOUNT") == "testaccount"
+)
 
 
 class Utils:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,9 +43,8 @@ IS_MACOS = platform.system() == "Darwin"
 IS_LINUX = platform.system() == "Linux"
 IS_UNIX = IS_LINUX or IS_MACOS
 IS_IN_STORED_PROC = is_in_stored_procedure()
-IS_IN_STORED_PROC_LOCALFS = (
-    IS_IN_STORED_PROC and os.getenv("SF_ACCOUNT") == "testaccount"
-)
+# this env variable is set in regression test
+IS_IN_STORED_PROC_LOCALFS = IS_IN_STORED_PROC and os.getenv("IS_LOCAL_FS")
 
 
 class Utils:


### PR DESCRIPTION
In this way, we can easily fix/disable the test without committing to snowflake repo. Also, I enabled several test which is working in SP regression test now:
- test_add_import_stage_file (SNOW-539576 is done)
- test_limit_on_order_by (fixture is added, but this test will be skipped since sample data is not available)
- test_add_import_package (this doesn't not require the specific package on the server)

Please also review other disabled tests (which probably can be enabled)!

Regression test:
https://buwa.c1.us-west-2.aws-dev.app.snowflake.com/builds/precommit/ci73.int.snowflakecomputing.com/8080 (the only failed test is caused by the new commit https://github.com/snowflakedb/snowpark-python/commit/1604b6573da36445489c05dac2bbf10bf0c5b4b4)