### PR TITLE
SNOW-607224: "Create or replace" temp table for `create_dataframe` with large local data and reading files from a stage

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -578,7 +578,7 @@ def create_table_statement(
     temp: bool = False,
 ) -> str:
     return (
-        f"{CREATE}{(OR + REPLACE) if replace else EMPTY_STRING} "
+        f"{CREATE}{(OR + REPLACE) if replace else EMPTY_STRING}"
         f"{TEMPORARY if temp else EMPTY_STRING}"
         f"{TABLE}{table_name}{(IF + NOT + EXISTS) if not replace and not error else EMPTY_STRING}"
         f"{LEFT_PARENTHESIS}{schema}{RIGHT_PARENTHESIS}"
@@ -1106,18 +1106,6 @@ def merge_statement(
         + ON
         + join_expr
         + EMPTY_STRING.join(clauses)
-    )
-
-
-def create_temp_table_statement(table_name: str, schema: str) -> str:
-    return (
-        CREATE
-        + TEMPORARY
-        + TABLE
-        + table_name
-        + LEFT_PARENTHESIS
-        + schema
-        + RIGHT_PARENTHESIS
     )
 
 

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -92,7 +92,9 @@ def test_limit_on_order_by(session, is_sample_data_available):
 
 def test_create_dataframe_for_large_values_check_plan(session):
     def check_plan(df, data):
-        assert df._plan.queries[0].sql.strip().startswith("CREATE  TEMPORARY  TABLE")
+        assert (
+            df._plan.queries[0].sql.strip().startswith("CREATE  OR  REPLACE  TEMPORARY")
+        )
         assert df._plan.queries[1].sql.strip().startswith("INSERT  INTO")
         assert df._plan.queries[2].sql.strip().startswith("SELECT")
         assert len(df._plan.post_actions) == 1

--- a/tests/integ/test_query_history.py
+++ b/tests/integ/test_query_history.py
@@ -80,7 +80,7 @@ def test_query_history_executemany(session):
 
     queries = query_listener.queries
     assert all(query.query_id is not None for query in queries)
-    assert "CREATE  TEMPORARY" in queries[0].sql_text
+    assert "CREATE  OR  REPLACE  TEMPORARY" in queries[0].sql_text
     assert "alter session set query_tag" in queries[1].sql_text
     assert "INSERT  INTO" in queries[2].sql_text and "VALUES (?)" in queries[2].sql_text
     assert "alter session unset query_tag" in queries[3].sql_text


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-607224 by replacing the created temp table. We should avoid using `if not exist` when creating a temp table in case the underlying table is changed, though both should be fine as our dataframe is immutable. Actually not only `create_dataframe`, this PR also fixes this issue when reading files from a stage. 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
