### PR TITLE
feat: Allow any Python minor release >= 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "Issues": "https://github.com/snowflakedb/snowpark-python/issues",
         "Changelog": "https://github.com/snowflakedb/snowpark-python/blob/main/CHANGELOG.md",
     },
-    python_requires="==3.8.*",
+    python_requires=">=3.8",
     install_requires=[
         "setuptools>=40.6.0",
         "wheel",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #377

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We should not require the Python minor version to match exactly `3.8`. Instead, we could state in the docs that the connector is tested on `3.8` only and that it is not guaranteed to work on other versions?

I have tested that the package installs and works just fine on Python `3.10.4` locally.
