### PR TITLE
SNOW-607796: Escape query tag in SQL when it has special characters

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -21,6 +21,7 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name,
     quote_name_without_upper_casing,
 )
+from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql
 from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.analyzer.schema_utils import (
     convert_result_meta_to_attribute,
@@ -449,7 +450,7 @@ class ServerConnection:
         )
         if query_tag:
             set_query_tag_cursor = self._cursor.execute(
-                f"alter session set query_tag='{query_tag}'"
+                f"alter session set query_tag = {str_to_sql(query_tag)}"
             )
             self.notify_query_listeners(
                 QueryRecord(set_query_tag_cursor.sfqid, set_query_tag_cursor.query)

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -25,7 +25,7 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     escape_quotes,
     quote_name,
 )
-from snowflake.snowpark._internal.analyzer.datatype_mapper import to_sql
+from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql, to_sql
 from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlanBuilder
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -792,7 +792,7 @@ class Session:
     @query_tag.setter
     def query_tag(self, tag: str) -> None:
         if tag:
-            self._conn.run_query(f"alter session set query_tag = '{tag}'")
+            self._conn.run_query(f"alter session set query_tag = {str_to_sql(tag)}")
         else:
             self._conn.run_query("alter session unset query_tag")
         self._query_tag = tag

--- a/tests/integ/scala/test_query_tag_suite.py
+++ b/tests/integ/scala/test_query_tag_suite.py
@@ -22,6 +22,8 @@ from tests.utils import Utils
         "te\\st_tag",
         "te\nst_tag",
         r"\utest_tag",
+        "test tag",
+        'test"tag',
     ],
 )
 def test_set_query_tag(session, query_tag):
@@ -94,7 +96,7 @@ def test_query_tags_from_trackback(session, code):
     assert len(query_history) == 1
 
 
-@pytest.mark.parametrize("data", ["a", "'a'", "\\a", "a\n", r"\ua"])
+@pytest.mark.parametrize("data", ["a", "'a'", "\\a", "a\n", r"\ua", " a", '"a'])
 def test_large_local_relation_query_tag_from_traceback(session, data):
     session.create_dataframe(
         [[data] * (ARRAY_BIND_THRESHOLD + 1)]

--- a/tests/integ/scala/test_query_tag_suite.py
+++ b/tests/integ/scala/test_query_tag_suite.py
@@ -14,9 +14,18 @@ from snowflake.snowpark._internal.utils import TempObjectType
 from tests.utils import Utils
 
 
-def test_set_query_tag(session):
+@pytest.mark.parametrize(
+    "query_tag",
+    [
+        Utils.random_name_for_temp_object(TempObjectType.QUERY_TAG),
+        "'test_tag'",
+        "te\\st_tag",
+        "te\nst_tag",
+        r"\utest_tag",
+    ],
+)
+def test_set_query_tag(session, query_tag):
     """Test set query_tag properties on session"""
-    query_tag = Utils.random_name_for_temp_object(TempObjectType.QUERY_TAG)
     try:
         session.query_tag = query_tag
         assert session.query_tag == query_tag
@@ -85,9 +94,10 @@ def test_query_tags_from_trackback(session, code):
     assert len(query_history) == 1
 
 
-def test_large_local_relation_query_tag_from_traceback(session):
+@pytest.mark.parametrize("data", ["a", "'a'", "\\a", "a\n", r"\ua"])
+def test_large_local_relation_query_tag_from_traceback(session, data):
     session.create_dataframe(
-        [["a"] * (ARRAY_BIND_THRESHOLD + 1)]
+        [[data] * (ARRAY_BIND_THRESHOLD + 1)]
     ).count()  # trigger large local relation query
     query_history = get_query_history_for_tags(
         session, "test_large_local_relation_query_tag_from_traceback"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-607796. See another fix for `use <object>` in #380. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
