### PR TITLE
SNOW-614533: Fix `create_dataframe` that mistakenly converts 0 and False to None when the input data is only a list

### DIFF
--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -42,7 +42,7 @@ class DataFrameStatFunctions:
 
             >>> df = session.create_dataframe([1, 2, 3, 4, 5, 6, 7, 8, 9, 0], schema=["a"])
             >>> df.stat.approx_quantile("a", [0, 0.1, 0.4, 0.6, 1])
-            [0.5, 1.5, 4.5, 6.5, 9.5]
+            [-0.5, 0.5, 3.5, 5.5, 9.5]
 
             >>> df2 = session.create_dataframe([[0.1, 0.5], [0.2, 0.6], [0.3, 0.7]], schema=["a", "b"])
             >>> df2.stat.approx_quantile(["a", "b"], [0, 0.1, 0.6])

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1137,7 +1137,7 @@ class Session:
             row: Union[Dict, List, Tuple], names: List[str]
         ) -> List:
             row_dict = None
-            if not row:
+            if row is None:
                 row = [None]
             elif isinstance(row, (tuple, list)):
                 if getattr(row, "_fields", None):  # Row or namedtuple

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1140,7 +1140,9 @@ class Session:
             if row is None:
                 row = [None]
             elif isinstance(row, (tuple, list)):
-                if getattr(row, "_fields", None):  # Row or namedtuple
+                if not row:
+                    row = [None]
+                elif getattr(row, "_fields", None):  # Row or namedtuple
                     row_dict = row.asDict() if isinstance(row, Row) else row._asdict()
             elif isinstance(row, dict):
                 row_dict = row.copy()

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1134,7 +1134,7 @@ class Session:
             )
 
         def convert_row_to_list(
-            row: Union[Dict, List, Tuple], names: List[str]
+            row: Union[Iterable[Any], Any], names: List[str]
         ) -> List:
             row_dict = None
             if row is None:

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -284,9 +284,9 @@ class UDFRegistration:
             >>> @udf(packages=["numpy"])
             ... def sin_udf(x: float) -> float:
             ...     return np.sin(x)
-            >>> df = session.create_dataframe([0.25 * math.pi, 0.5 * math.pi], schema=["d"])
+            >>> df = session.create_dataframe([0.0, 0.5 * math.pi], schema=["d"])
             >>> df.select(sin_udf("d")).to_df("col1").collect()
-            [Row(COL1=0.7071067811865475), Row(COL1=1.0)]
+            [Row(COL1=0.0), Row(COL1=1.0)]
 
     Example 6
         Creating a UDF from a local Python file::

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -412,7 +412,7 @@ def test_df_stat_cov(session):
     math.isclose(TestData.double2(session).stat.cov("a", "b"), 0.010000000000000037)
 
 
-def test_df_stat_approxQuantile(session):
+def test_df_stat_approx_quantile(session):
     assert TestData.approx_numbers(session).stat.approx_quantile("a", [0.5]) == [4.5]
     assert TestData.approx_numbers(session).stat.approx_quantile(
         "a", [0, 0.1, 0.4, 0.6, 1]

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -959,14 +959,13 @@ def test_create_dataframe_with_variant(session):
     ]
 
 
-def test_create_dataframe_with_single_value(session):
-    data = [1, 2, 3]
+@pytest.mark.parametrize("data", [[0, 1, 2, 3], [False], [None]])
+def test_create_dataframe_with_single_value(session, data):
     expected_names = ["_1"]
     expected_rows = [Row(d) for d in data]
     df = session.create_dataframe(data)
     assert [field.name for field in df.schema.fields] == expected_names
-    assert df.collect() == expected_rows
-    assert df.select(expected_names).collect() == expected_rows
+    Utils.check_answer(df, expected_rows)
 
 
 def test_create_dataframe_empty(session):

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -959,7 +959,7 @@ def test_create_dataframe_with_variant(session):
     ]
 
 
-@pytest.mark.parametrize("data", [[0, 1, 2, 3], [False], [None]])
+@pytest.mark.parametrize("data", [[0, 1, 2, 3], ["", "a"], [False, True], [None]])
 def test_create_dataframe_with_single_value(session, data):
     expected_names = ["_1"]
     expected_rows = [Row(d) for d in data]


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-614533. 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
