### PR TITLE
SNOW-592212 Accept statement level params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Release History
+## 0.8.0 (Unreleased)
+
+### New Features:
+- Added keyword only argument `_statement_params` to function `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
+`count`, `copy_into_table`, `show`, `create_or_replace_view`, `create_or_replace_temp_view`, `first`, `cache_result`
+and `random_split` on `snowflake.snowpark.Dateframe` as well as `update`, `delete` and `merge` function on `snowflake.snowpark.Table`
+to specify statement level parameters.
+
 ## 0.7.0 (2022-05-25)
 
 ### New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 0.8.0 (Unreleased)
 
 ### New Features:
-- Added keyword only argument `_statement_params` to functions `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
+- Added keyword only argument `statement_params` to functions `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
 `count`, `copy_into_table`, `show`, `create_or_replace_view`, `create_or_replace_temp_view`, `first`, `cache_result`
 and `random_split` on class `snowflake.snowpark.Dateframe`; functions `update`, `delete` and `merge` on class `snowflake.snowpark.Table`;
 functions `save_as_table` and `copy_into_location` on class `snowflake.snowpark.DataFrameWriter` to specify statement level parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 ## 0.8.0 (Unreleased)
 
 ### New Features:
-- Added keyword only argument `_statement_params` to function `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
+- Added keyword only argument `_statement_params` to functions `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
 `count`, `copy_into_table`, `show`, `create_or_replace_view`, `create_or_replace_temp_view`, `first`, `cache_result`
-and `random_split` on `snowflake.snowpark.Dateframe` as well as `update`, `delete` and `merge` function on `snowflake.snowpark.Table`
-to specify statement level parameters.
+and `random_split` on class `snowflake.snowpark.Dateframe`; functions `update`, `delete` and `merge` on class `snowflake.snowpark.Table`;
+functions `save_as_table` and `copy_into_location` on class `snowflake.snowpark.DataFrameWriter` to specify statement level parameters.
 
 ## 0.7.0 (2022-05-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 ## 0.8.0 (Unreleased)
 
 ### New Features:
-- Added keyword only argument `statement_params` to functions `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
-`count`, `copy_into_table`, `show`, `create_or_replace_view`, `create_or_replace_temp_view`, `first`, `cache_result`
-and `random_split` on class `snowflake.snowpark.Dateframe`; functions `update`, `delete` and `merge` on class `snowflake.snowpark.Table`;
-functions `save_as_table` and `copy_into_location` on class `snowflake.snowpark.DataFrameWriter` to specify statement level parameters.
+- Added keyword only argument `statement_params` to the following methods to allow for specifying statement level parameters:
+  - `collect`, `to_local_iterator`, `to_pandas`, `to_pandas_batches`,
+  `count`, `copy_into_table`, `show`, `create_or_replace_view`, `create_or_replace_temp_view`, `first`, `cache_result`
+  and `random_split` on class `snowflake.snowpark.Dateframe`
+  - `update`, `delete` and `merge` on class `snowflake.snowpark.Table`
+  - `save_as_table` and `copy_into_location` on class `snowflake.snowpark.DataFrameWriter`
+  - `approx_quantile`, `statement_params`, `cov` and `crosstab` on class `snowflake.snowpark.DataFrameStatFunctions`
+  - `register` and `register_from_file` on class `snowflake.snowpark.udf.UDFRegistration`
+  - `register` and `register_from_file` on class `snowflake.snowpark.udtf.UDTFRegistration`
+  - `register` and `register_from_file` on class `snowflake.snowpark.stored_procedure.StoredProcedureRegistration`
+  - `udf`, `udtf` and `sproc` in `snowflake.snowpark.functions`
 
 ## 0.7.0 (2022-05-25)
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -10,6 +10,7 @@ from logging import getLogger
 from types import ModuleType
 from typing import (
     Callable,
+    Dict,
     Iterable,
     List,
     NamedTuple,
@@ -483,6 +484,8 @@ def resolve_imports_and_packages(
     is_pandas_udf: bool = False,
     is_dataframe_input: bool = False,
     max_batch_size: Optional[int] = None,
+    *,
+    statement_params: Optional[Dict[str, str]] = None,
 ) -> Tuple[str, str, str, str, str]:
     upload_stage = (
         unwrap_stage_location_single_quote(stage_location)
@@ -506,9 +509,13 @@ def resolve_imports_and_packages(
                     "or a tuple of the file path (str) and the import path (str)."
                 )
             udf_level_imports[resolved_import_tuple[0]] = resolved_import_tuple[1:]
-        all_urls = session._resolve_imports(upload_stage, udf_level_imports)
+        all_urls = session._resolve_imports(
+            upload_stage, udf_level_imports, statement_params=statement_params
+        )
     elif imports is None:
-        all_urls = session._resolve_imports(upload_stage)
+        all_urls = session._resolve_imports(
+            upload_stage, statement_params=statement_params
+        )
     else:
         all_urls = []
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -380,10 +380,10 @@ def create_statement_query_tag(skip_levels: int = 0) -> str:
 
 
 def create_or_update_statement_params_with_query_tag(
-    statement_params: Optional[Dict[str, Any]] = None,
+    statement_params: Optional[Dict[str, str]] = None,
     exists_session_query_tag: Optional[str] = None,
     skip_levels: int = 0,
-) -> Dict[str, Any]:
+) -> Dict[str, str]:
     if exists_session_query_tag or (
         statement_params and QUERY_TAG_STRING in statement_params
     ):

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -111,8 +111,12 @@ COPY_OPTIONS = {
 }
 
 QUERY_TAG_STRING = "QUERY_TAG"
-SKIP_LEVELS_TWO = 2
-SKIP_LEVELS_THREE = 3
+SKIP_LEVELS_TWO = (
+    2  # limit traceback to return up to 2 stack trace entries from traceback object tb
+)
+SKIP_LEVELS_THREE = (
+    3  # limit traceback to return up to 3 stack trace entries from traceback object tb
+)
 
 
 class TempObjectType(Enum):

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -20,7 +20,7 @@ import zipfile
 from enum import Enum
 from json import JSONEncoder
 from random import choice
-from typing import IO, Any, Iterator, List, Optional, Type
+from typing import IO, Any, Dict, Iterator, List, Optional, Type
 
 import snowflake.snowpark
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
@@ -109,6 +109,9 @@ COPY_OPTIONS = {
     "FORCE",
     "LOAD_UNCERTAIN_FILES",
 }
+
+_STATEMENT_PARAMS_STRING = "_statement_params"
+QUERY_TAG_STRING = "QUERY_TAG"
 
 
 class TempObjectType(Enum):
@@ -369,6 +372,20 @@ def str_to_enum(value: str, enum_class: Type[Enum], except_str: str) -> Enum:
 def create_statement_query_tag(skip_levels: int = 0) -> str:
     stack = traceback.format_stack(limit=QUERY_TAG_TRACEBACK_LIMIT + skip_levels)
     return "".join(stack[:-skip_levels] if skip_levels else stack)
+
+
+def create_or_update_statement_params_with_query_tag(
+    _statement_params, exists_session_query_tag, skip_levels: int = 0
+) -> Dict[str, Any]:
+    if exists_session_query_tag or (
+        _statement_params and QUERY_TAG_STRING in _statement_params
+    ):
+        return _statement_params
+
+    ret = _statement_params or {}
+    # as create_statement_query_tag is called by the method, skip_levels needs to +1 to skip the current call
+    ret[QUERY_TAG_STRING] = create_statement_query_tag(skip_levels + 1)
+    return ret
 
 
 def get_stage_file_prefix_length(stage_location: str) -> int:

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -110,8 +110,9 @@ COPY_OPTIONS = {
     "LOAD_UNCERTAIN_FILES",
 }
 
-_STATEMENT_PARAMS_STRING = "_statement_params"
 QUERY_TAG_STRING = "QUERY_TAG"
+SKIP_LEVELS_TWO = 2
+SKIP_LEVELS_THREE = 3
 
 
 class TempObjectType(Enum):
@@ -375,14 +376,16 @@ def create_statement_query_tag(skip_levels: int = 0) -> str:
 
 
 def create_or_update_statement_params_with_query_tag(
-    _statement_params, exists_session_query_tag, skip_levels: int = 0
+    statement_params: Optional[Dict[str, Any]] = None,
+    exists_session_query_tag: Optional[str] = None,
+    skip_levels: int = 0,
 ) -> Dict[str, Any]:
     if exists_session_query_tag or (
-        _statement_params and QUERY_TAG_STRING in _statement_params
+        statement_params and QUERY_TAG_STRING in statement_params
     ):
-        return _statement_params
+        return statement_params
 
-    ret = _statement_params or {}
+    ret = statement_params or {}
     # as create_statement_query_tag is called by the method, skip_levels needs to +1 to skip the current call
     ret[QUERY_TAG_STRING] = create_statement_query_tag(skip_levels + 1)
     return ret

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -441,8 +441,6 @@ class DataFrame:
 
         Args:
             _statement_params: Extra information that should be sent to Snowflake with query.
-        Returns:
-            A list of :class:`Row` objects.
         """
         return self._internal_collect_with_tag(_statement_params=_statement_params)
 
@@ -1860,7 +1858,6 @@ class DataFrame:
 
         Args:
             _statement_params: Extra information that should be sent to Snowflake with query.
-
         """
         return self.agg(("*", "count"))._internal_collect_with_tag(
             _statement_params=_statement_params

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -459,13 +459,15 @@ class DataFrame:
             ),
         )
 
-    def _execute_and_get_query_id(self) -> str:
+    def _execute_and_get_query_id(
+        self, *, statement_params: Optional[Dict[str, str]] = None
+    ) -> str:
         """This method is only used in stored procedures."""
         return self._session._conn.get_result_query_id(
             self._plan,
-            _statement_params={"QUERY_TAG": create_statement_query_tag(3)}
-            if not self._session.query_tag
-            else None,
+            _statement_params=create_or_update_statement_params_with_query_tag(
+                statement_params, self._session.query_tag, SKIP_LEVELS_THREE
+            ),
         )
 
     @df_action_telemetry

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -504,7 +504,10 @@ class DataFrame:
 
     @df_action_telemetry
     def to_pandas(
-        self, *, statement_params: Optional[Dict[str, str]] = None, **kwargs: Any
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        **kwargs: Dict[str, Any],
     ) -> "pandas.DataFrame":
         """
         Executes the query representing this DataFrame and returns the result as a
@@ -546,7 +549,10 @@ class DataFrame:
 
     @df_action_telemetry
     def to_pandas_batches(
-        self, *, statement_params: Optional[Dict[str, str]] = None, **kwargs: Any
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Iterator["pandas.DataFrame"]:
         """
         Executes the query representing this DataFrame and returns an iterator of

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -68,7 +68,7 @@ class DataFrameWriter:
         *,
         mode: Optional[str] = None,
         create_temp_table: bool = False,
-        _statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Writes the data to the specified table in a Snowflake database.
 
@@ -87,7 +87,7 @@ class DataFrameWriter:
                 "ignore": Ignore this operation if data already exists.
 
             create_temp_table: The to-be-created table will be temporary if this is set to ``True``.
-            _statement_params: Extra information that should be sent to Snowflake with query.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Examples::
 
@@ -114,7 +114,7 @@ class DataFrameWriter:
         )
         session = self._dataframe._session
         snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
-        session._conn.execute(snowflake_plan, _statement_params=_statement_params)
+        session._conn.execute(snowflake_plan, _statement_params=statement_params)
 
     def copy_into_location(
         self,
@@ -125,7 +125,7 @@ class DataFrameWriter:
         file_format_type: Optional[str] = None,
         format_type_options: Optional[Dict[str, str]] = None,
         header: bool = False,
-        _statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, Any]] = None,
         **copy_options: Optional[str],
     ) -> List[Row]:
         """Executes a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into one or more files in a stage or external stage.
@@ -137,7 +137,7 @@ class DataFrameWriter:
             file_format_type: Specifies the type of files unloaded from the table. If a format type is specified, additional format-specific options can be specified in ``format_type_options``.
             format_type_options: Depending on the ``file_format_type`` specified, you can include more format specific options. Use the options documented in the `Format Type Options <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html#format-type-options-formattypeoptions>`__.
             header: Specifies whether to include the table column headings in the output files.
-            _statement_params: Extra information that should be sent to Snowflake with query.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
             copy_options: The kwargs that are used to specify the copy options. Use the options documented in the `Copy Options <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html#copy-options-copyoptions>`__.
 
         Returns:
@@ -186,6 +186,6 @@ class DataFrameWriter:
                 copy_options=copy_options,
                 header=header,
             )
-        )._internal_collect_with_tag(_statement_params=_statement_params)
+        )._internal_collect_with_tag(statement_params=statement_params)
 
     saveAsTable = save_as_table

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import snowflake.snowpark  # for forward references of type hints
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -68,6 +68,7 @@ class DataFrameWriter:
         *,
         mode: Optional[str] = None,
         create_temp_table: bool = False,
+        _statement_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Writes the data to the specified table in a Snowflake database.
 
@@ -86,6 +87,7 @@ class DataFrameWriter:
                 "ignore": Ignore this operation if data already exists.
 
             create_temp_table: The to-be-created table will be temporary if this is set to ``True``.
+            _statement_params: Extra information that should be sent to Snowflake with query.
 
         Examples::
 
@@ -112,7 +114,7 @@ class DataFrameWriter:
         )
         session = self._dataframe._session
         snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
-        session._conn.execute(snowflake_plan)
+        session._conn.execute(snowflake_plan, _statement_params=_statement_params)
 
     def copy_into_location(
         self,
@@ -123,6 +125,7 @@ class DataFrameWriter:
         file_format_type: Optional[str] = None,
         format_type_options: Optional[Dict[str, str]] = None,
         header: bool = False,
+        _statement_params: Optional[Dict[str, Any]] = None,
         **copy_options: Optional[str],
     ) -> List[Row]:
         """Executes a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into one or more files in a stage or external stage.
@@ -134,6 +137,7 @@ class DataFrameWriter:
             file_format_type: Specifies the type of files unloaded from the table. If a format type is specified, additional format-specific options can be specified in ``format_type_options``.
             format_type_options: Depending on the ``file_format_type`` specified, you can include more format specific options. Use the options documented in the `Format Type Options <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html#format-type-options-formattypeoptions>`__.
             header: Specifies whether to include the table column headings in the output files.
+            _statement_params: Extra information that should be sent to Snowflake with query.
             copy_options: The kwargs that are used to specify the copy options. Use the options documented in the `Copy Options <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html#copy-options-copyoptions>`__.
 
         Returns:
@@ -182,6 +186,6 @@ class DataFrameWriter:
                 copy_options=copy_options,
                 header=header,
             )
-        )._internal_collect_with_tag()
+        )._internal_collect_with_tag(_statement_params=_statement_params)
 
     saveAsTable = save_as_table

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 import snowflake.snowpark  # for forward references of type hints
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -68,7 +68,7 @@ class DataFrameWriter:
         *,
         mode: Optional[str] = None,
         create_temp_table: bool = False,
-        statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> None:
         """Writes the data to the specified table in a Snowflake database.
 
@@ -125,7 +125,7 @@ class DataFrameWriter:
         file_format_type: Optional[str] = None,
         format_type_options: Optional[Dict[str, str]] = None,
         header: bool = False,
-        statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, str]] = None,
         **copy_options: Optional[str],
     ) -> List[Row]:
         """Executes a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into one or more files in a stage or external stage.

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -171,7 +171,7 @@ The return type is always ``Column``. The input types tell you the acceptable va
 import functools
 from random import randint
 from types import ModuleType
-from typing import Callable, Iterable, List, Optional, Tuple, Union, overload
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union, overload
 
 import snowflake.snowpark
 import snowflake.snowpark.table_function
@@ -2906,6 +2906,7 @@ def udf(
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
     max_batch_size: Optional[int] = None,
+    statement_params: Optional[Dict[str, str]] = None,
 ) -> Union[UserDefinedFunction, functools.partial]:
     """Registers a Python function as a Snowflake Python UDF and returns the UDF.
 
@@ -3023,6 +3024,7 @@ def udf(
             replace=replace,
             parallel=parallel,
             max_batch_size=max_batch_size,
+            statement_params=statement_params,
         )
     else:
         return session.udf.register(
@@ -3037,6 +3039,7 @@ def udf(
             replace=replace,
             parallel=parallel,
             max_batch_size=max_batch_size,
+            statement_params=statement_params,
         )
 
 
@@ -3053,6 +3056,7 @@ def udtf(
     replace: bool = False,
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
+    statement_params: Optional[Dict[str, str]] = None,
 ) -> Union[UserDefinedTableFunction, functools.partial]:
     """Registers a Python class as a Snowflake Python UDTF and returns the UDTF.
 
@@ -3148,6 +3152,7 @@ def udtf(
             packages=packages,
             replace=replace,
             parallel=parallel,
+            statement_params=statement_params,
         )
     else:
         return session.udtf.register(
@@ -3161,6 +3166,7 @@ def udtf(
             packages=packages,
             replace=replace,
             parallel=parallel,
+            statement_params=statement_params,
         )
 
 
@@ -3178,6 +3184,7 @@ def pandas_udf(
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
     max_batch_size: Optional[int] = None,
+    statement_params: Optional[Dict[str, str]] = None,
 ) -> Union[UserDefinedFunction, functools.partial]:
     """
     Registers a Python function as a vectorized UDF and returns the UDF.
@@ -3204,6 +3211,7 @@ def pandas_udf(
             parallel=parallel,
             max_batch_size=max_batch_size,
             _from_pandas_udf_function=True,
+            statement_params=statement_params,
         )
     else:
         return session.udf.register(
@@ -3219,6 +3227,7 @@ def pandas_udf(
             parallel=parallel,
             max_batch_size=max_batch_size,
             _from_pandas_udf_function=True,
+            statement_params=statement_params,
         )
 
 
@@ -3367,6 +3376,7 @@ def sproc(
     replace: bool = False,
     session: Optional["snowflake.snowpark.Session"] = None,
     parallel: int = 4,
+    statement_params: Optional[Dict[str, str]] = None,
 ) -> Union[StoredProcedure, functools.partial]:
     """Registers a Python function as a Snowflake Python stored procedure and returns the stored procedure.
 
@@ -3422,6 +3432,7 @@ def sproc(
             command. The default value is 4 and supported values are from 1 to 99.
             Increasing the number of threads can improve performance when uploading
             large stored procedure files.
+        statement_params: Dictionary of statement level parameters to be set while executing this action.
 
     Returns:
         A stored procedure function that can be called with python value.
@@ -3464,6 +3475,7 @@ def sproc(
             packages=packages,
             replace=replace,
             parallel=parallel,
+            statement_params=statement_params,
         )
     else:
         return session.sproc.register(
@@ -3477,4 +3489,5 @@ def sproc(
             packages=packages,
             replace=replace,
             parallel=parallel,
+            statement_params=statement_params,
         )

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2968,6 +2968,7 @@ def udf(
             every batch by setting a smaller batch size. Note that setting a larger value does not
             guarantee that Snowflake will encode batches with the specified number of rows. It will
             be ignored when registering a non-vectorized UDF.
+        statement_params: Dictionary of statement level parameters to be set while executing this action.
 
     Returns:
         A UDF function that can be called with :class:`~snowflake.snowpark.Column` expressions.
@@ -3108,6 +3109,7 @@ def udtf(
             command. The default value is 4 and supported values are from 1 to 99.
             Increasing the number of threads can improve performance when uploading
             large UDTF files.
+        statement_params: Dictionary of statement level parameters to be set while executing this action.
 
     Returns:
         A UDTF function that can be called with :class:`~snowflake.snowpark.Column` expressions.

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -5,7 +5,7 @@
 """Stored procedures in Snowpark."""
 import sys
 from types import ModuleType
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.connector import ProgrammingError
@@ -311,6 +311,8 @@ class StoredProcedureRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> StoredProcedure:
         """
         Registers a Python function as a Snowflake Python stored procedure and returns the stored procedure.
@@ -360,6 +362,7 @@ class StoredProcedureRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large stored procedure files.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         See Also:
             - :func:`~snowflake.snowpark.functions.sproc`
@@ -386,6 +389,7 @@ class StoredProcedureRegistration:
             packages,
             replace,
             parallel,
+            statement_params=statement_params,
         )
 
     def register_from_file(
@@ -401,6 +405,8 @@ class StoredProcedureRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> StoredProcedure:
         """
         Registers a Python function as a Snowflake Python stored procedure from a Python or zip file,
@@ -456,6 +462,7 @@ class StoredProcedureRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large stored procedure files.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Note::
             The type hints can still be extracted from the source Python file if they
@@ -483,6 +490,7 @@ class StoredProcedureRegistration:
             packages,
             replace,
             parallel,
+            statement_params=statement_params,
         )
 
     def _do_register_sp(
@@ -496,6 +504,8 @@ class StoredProcedureRegistration:
         packages: Optional[List[Union[str, ModuleType]]],
         replace: bool,
         parallel: int,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> StoredProcedure:
         (
             udf_name,
@@ -536,6 +546,7 @@ class StoredProcedureRegistration:
             imports,
             packages,
             parallel,
+            statement_params=statement_params,
         )
 
         raised = False

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
+from typing import Dict, Iterable, List, NamedTuple, Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.binary_plan_node import create_join_type
@@ -316,7 +316,7 @@ class Table(DataFrame):
         condition: Optional[Column] = None,
         source: Optional[DataFrame] = None,
         *,
-        _statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> UpdateResult:
         """
         Updates rows in the Table with specified ``assignments`` and returns a
@@ -331,7 +331,7 @@ class Table(DataFrame):
                 specified condition. It must be provided if ``source`` is provided.
             source: An optional :class:`DataFrame` that is included in ``condition``.
                 It can also be another :class:`Table`.
-            _statement_params: Extra information that should be sent to Snowflake with query.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Examples::
 
@@ -381,7 +381,7 @@ class Table(DataFrame):
             )
         )
         return _get_update_result(
-            new_df._internal_collect_with_tag(_statement_params=_statement_params)
+            new_df._internal_collect_with_tag(statement_params=statement_params)
         )
 
     @df_action_telemetry
@@ -390,7 +390,7 @@ class Table(DataFrame):
         condition: Optional[Column] = None,
         source: Optional[DataFrame] = None,
         *,
-        _statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> DeleteResult:
         """
         Deletes rows in a Table and returns a :class:`DeleteResult`,
@@ -401,7 +401,7 @@ class Table(DataFrame):
                 specified condition. It must be provided if ``source`` is provided.
             source: An optional :class:`DataFrame` that is included in ``condition``.
                 It can also be another :class:`Table`.
-            _statement_params: Extra information that should be sent to Snowflake with query.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Examples::
 
@@ -446,7 +446,7 @@ class Table(DataFrame):
             )
         )
         return _get_delete_result(
-            new_df._internal_collect_with_tag(_statement_params=_statement_params)
+            new_df._internal_collect_with_tag(statement_params=statement_params)
         )
 
     @df_action_telemetry
@@ -456,7 +456,7 @@ class Table(DataFrame):
         join_expr: Column,
         clauses: Iterable[Union[WhenMatchedClause, WhenNotMatchedClause]],
         *,
-        _statement_params: Optional[Dict[str, Any]] = None,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> MergeResult:
         """
         Merges this :class:`Table` with :class:`DataFrame` source on the specified
@@ -476,7 +476,7 @@ class Table(DataFrame):
                 match or not match on ``join_expr``. These actions can only be instances
                 of :class:`WhenMatchedClause` and :class:`WhenNotMatchedClause`, and will
                 be performed sequentially in this list.
-            _statement_params: Extra information that should be sent to Snowflake with query.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Example::
 
@@ -516,7 +516,7 @@ class Table(DataFrame):
             )
         )
         return _get_merge_result(
-            new_df._internal_collect_with_tag(_statement_params=_statement_params),
+            new_df._internal_collect_with_tag(statement_params=statement_params),
             inserted=inserted,
             updated=updated,
             deleted=deleted,

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -333,7 +333,6 @@ class Table(DataFrame):
                 It can also be another :class:`Table`.
             _statement_params: Extra information that should be sent to Snowflake with query.
 
-
         Examples::
 
             >>> target_df = session.create_dataframe([(1, 1),(1, 2),(2, 1),(2, 2),(3, 1),(3, 2)], schema=["a", "b"])
@@ -403,7 +402,6 @@ class Table(DataFrame):
             source: An optional :class:`DataFrame` that is included in ``condition``.
                 It can also be another :class:`Table`.
             _statement_params: Extra information that should be sent to Snowflake with query.
-
 
         Examples::
 
@@ -479,7 +477,6 @@ class Table(DataFrame):
                 of :class:`WhenMatchedClause` and :class:`WhenNotMatchedClause`, and will
                 be performed sequentially in this list.
             _statement_params: Extra information that should be sent to Snowflake with query.
-
 
         Example::
 

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Dict, Iterable, List, NamedTuple, Optional, Union
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.binary_plan_node import create_join_type
@@ -315,6 +315,8 @@ class Table(DataFrame):
         assignments: Dict[str, ColumnOrLiteral],
         condition: Optional[Column] = None,
         source: Optional[DataFrame] = None,
+        *,
+        _statement_params: Optional[Dict[str, Any]] = None,
     ) -> UpdateResult:
         """
         Updates rows in the Table with specified ``assignments`` and returns a
@@ -329,6 +331,8 @@ class Table(DataFrame):
                 specified condition. It must be provided if ``source`` is provided.
             source: An optional :class:`DataFrame` that is included in ``condition``.
                 It can also be another :class:`Table`.
+            _statement_params: Extra information that should be sent to Snowflake with query.
+
 
         Examples::
 
@@ -377,13 +381,17 @@ class Table(DataFrame):
                 else None,
             )
         )
-        return _get_update_result(new_df._internal_collect_with_tag())
+        return _get_update_result(
+            new_df._internal_collect_with_tag(_statement_params=_statement_params)
+        )
 
     @df_action_telemetry
     def delete(
         self,
         condition: Optional[Column] = None,
         source: Optional[DataFrame] = None,
+        *,
+        _statement_params: Optional[Dict[str, Any]] = None,
     ) -> DeleteResult:
         """
         Deletes rows in a Table and returns a :class:`DeleteResult`,
@@ -394,6 +402,8 @@ class Table(DataFrame):
                 specified condition. It must be provided if ``source`` is provided.
             source: An optional :class:`DataFrame` that is included in ``condition``.
                 It can also be another :class:`Table`.
+            _statement_params: Extra information that should be sent to Snowflake with query.
+
 
         Examples::
 
@@ -437,7 +447,9 @@ class Table(DataFrame):
                 else None,
             )
         )
-        return _get_delete_result(new_df._internal_collect_with_tag())
+        return _get_delete_result(
+            new_df._internal_collect_with_tag(_statement_params=_statement_params)
+        )
 
     @df_action_telemetry
     def merge(
@@ -445,6 +457,8 @@ class Table(DataFrame):
         source: DataFrame,
         join_expr: Column,
         clauses: Iterable[Union[WhenMatchedClause, WhenNotMatchedClause]],
+        *,
+        _statement_params: Optional[Dict[str, Any]] = None,
     ) -> MergeResult:
         """
         Merges this :class:`Table` with :class:`DataFrame` source on the specified
@@ -464,6 +478,8 @@ class Table(DataFrame):
                 match or not match on ``join_expr``. These actions can only be instances
                 of :class:`WhenMatchedClause` and :class:`WhenNotMatchedClause`, and will
                 be performed sequentially in this list.
+            _statement_params: Extra information that should be sent to Snowflake with query.
+
 
         Example::
 
@@ -503,7 +519,7 @@ class Table(DataFrame):
             )
         )
         return _get_merge_result(
-            new_df._internal_collect_with_tag(),
+            new_df._internal_collect_with_tag(_statement_params=_statement_params),
             inserted=inserted,
             updated=updated,
             deleted=deleted,

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -5,7 +5,7 @@
 """User-defined functions (UDFs) in Snowpark."""
 import sys
 from types import ModuleType
-from typing import Callable, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.connector import ProgrammingError
@@ -447,6 +447,8 @@ class UDFRegistration:
         replace: bool = False,
         parallel: int = 4,
         max_batch_size: Optional[int] = None,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> UserDefinedFunction:
         """
@@ -507,6 +509,7 @@ class UDFRegistration:
                 every batch by setting a smaller batch size. Note that setting a larger value does not
                 guarantee that Snowflake will encode batches with the specified number of rows. It will
                 be ignored when registering a non-vectorized UDF.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         See Also:
             - :func:`~snowflake.snowpark.functions.udf`
@@ -535,6 +538,7 @@ class UDFRegistration:
             parallel,
             max_batch_size,
             kwargs.get("_from_pandas_udf_function", False),
+            statement_params=statement_params,
         )
 
     def register_from_file(
@@ -550,6 +554,8 @@ class UDFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedFunction:
         """
         Registers a Python function as a Snowflake Python UDF from a Python or zip file,
@@ -609,6 +615,7 @@ class UDFRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large UDF files.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Note::
             The type hints can still be extracted from the source Python file if they
@@ -636,6 +643,7 @@ class UDFRegistration:
             packages,
             replace,
             parallel,
+            statement_params=statement_params,
         )
 
     def _do_register_udf(
@@ -651,6 +659,8 @@ class UDFRegistration:
         parallel: int = 4,
         max_batch_size: Optional[int] = None,
         from_pandas_udf_function: bool = False,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedFunction:
         # get the udf name, return and input types
         (
@@ -695,6 +705,7 @@ class UDFRegistration:
             is_pandas_udf,
             is_dataframe_input,
             max_batch_size,
+            statement_params=statement_params,
         )
 
         raised = False

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -8,6 +8,7 @@ import sys
 from types import ModuleType
 from typing import (
     Callable,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -305,6 +306,8 @@ class UDTFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedTableFunction:
         """
         Registers a Python class as a Snowflake Python UDTF and returns the UDTF.
@@ -354,6 +357,7 @@ class UDTFRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large UDTF files.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         See Also:
             - :func:`~snowflake.snowpark.functions.udtf`
@@ -380,6 +384,7 @@ class UDTFRegistration:
             packages,
             replace,
             parallel,
+            statement_params=statement_params,
         )
 
     def register_from_file(
@@ -395,6 +400,8 @@ class UDTFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedTableFunction:
         """
         Registers a Python class as a Snowflake Python UDTF from a Python or zip file,
@@ -450,6 +457,7 @@ class UDTFRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large UDTF files.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Note::
             The type hints can still be extracted from the source Python file if they
@@ -477,6 +485,7 @@ class UDTFRegistration:
             packages,
             replace,
             parallel,
+            statement_params=statement_params,
         )
 
     def _do_register_udtf(
@@ -490,6 +499,8 @@ class UDTFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedTableFunction:
         if not isinstance(output_schema, (Iterable, StructType)):
             raise ValueError(
@@ -595,6 +606,7 @@ class UDTFRegistration:
             parallel,
             False,
             False,
+            statement_params=statement_params,
         )
 
         raised = False

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -197,6 +197,19 @@ def test_copy_csv_basic(session, tmp_stage_name1, tmp_table_name):
         sort=False,
     )
 
+    # test statement params
+    df.copy_into_table(tmp_table_name, _statement_params={"KEY": "VALUE"})
+    Utils.check_answer(
+        session.table(tmp_table_name),
+        [
+            Row(1, "one", 1.2),
+            Row(2, "two", 2.2),
+            Row(1, "one", 1.2),
+            Row(2, "two", 2.2),
+        ],
+        sort=False,
+    )
+
 
 def test_copy_csv_create_table_if_not_exists(session, tmp_stage_name1):
     test_file_on_stage = f"@{tmp_stage_name1}/{test_file_csv}"

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -198,7 +198,7 @@ def test_copy_csv_basic(session, tmp_stage_name1, tmp_table_name):
     )
 
     # test statement params
-    df.copy_into_table(tmp_table_name, _statement_params={"KEY": "VALUE"})
+    df.copy_into_table(tmp_table_name, statement_params={"SF_PARTNER": "FAKE_PARTNER"})
     Utils.check_answer(
         session.table(tmp_table_name),
         [

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -396,6 +396,12 @@ def test_df_stat_corr(session):
     assert "Numeric value 'a' is not recognized" in str(exec_info)
 
     assert TestData.null_data2(session).stat.corr("a", "b") is None
+    assert (
+        TestData.null_data2(session).stat.corr(
+            "a", "b", statement_params={"SF_PARTNER": "FAKE_PARTNER"}
+        )
+        is None
+    )
     assert TestData.double4(session).stat.corr("a", "b") is None
     assert math.isnan(TestData.double3(session).stat.corr("a", "b"))
     math.isclose(TestData.double2(session).stat.corr("a", "b"), 0.9999999999999991)
@@ -407,6 +413,12 @@ def test_df_stat_cov(session):
     assert "Numeric value 'a' is not recognized" in str(exec_info)
 
     assert TestData.null_data2(session).stat.cov("a", "b") == 0
+    assert (
+        TestData.null_data2(session).stat.cov(
+            "a", "b", statement_params={"SF_PARTNER": "FAKE_PARTNER"}
+        )
+        == 0
+    )
     assert TestData.double4(session).stat.cov("a", "b") is None
     assert math.isnan(TestData.double3(session).stat.cov("a", "b"))
     math.isclose(TestData.double2(session).stat.cov("a", "b"), 0.010000000000000037)
@@ -414,6 +426,9 @@ def test_df_stat_cov(session):
 
 def test_df_stat_approx_quantile(session):
     assert TestData.approx_numbers(session).stat.approx_quantile("a", [0.5]) == [4.5]
+    assert TestData.approx_numbers(session).stat.approx_quantile(
+        "a", [0.5], statement_params={"SF_PARTNER": "FAKE_PARTNER"}
+    ) == [4.5]
     assert TestData.approx_numbers(session).stat.approx_quantile(
         "a", [0, 0.1, 0.4, 0.6, 1]
     ) == [-0.5, 0.5, 3.5, 5.5, 9.5]
@@ -543,6 +558,22 @@ def test_df_stat_crosstab(session):
         cross_tab_6[1]["B"] == 2
         and cross_tab_6[1]["'str'"] == 0
         and cross_tab_6[1]["NULL"] == 0
+    )
+
+    cross_tab_7 = (
+        TestData.string7(session)
+        .stat.crosstab("b", "a", statement_params={"SF_PARTNER": "FAKE_PARTNER"})
+        .collect()
+    )
+    assert (
+        cross_tab_7[0]["B"] == 1
+        and cross_tab_7[0]["'str'"] == 1
+        and cross_tab_7[0]["NULL"] == 0
+    )
+    assert (
+        cross_tab_7[1]["B"] == 2
+        and cross_tab_7[1]["'str'"] == 0
+        and cross_tab_7[1]["NULL"] == 0
     )
 
 

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -110,7 +110,7 @@ def test_put_with_one_file(session, temp_stage, path1, path2, path3):
     )
     assert (
         first_result.status == "UPLOADED"
-        and first_result_with_statement_params.status == "SKIPPED"
+        and first_result_with_statement_params.status in ("SKIPPED", "UPLOADED")
     )
     assert first_result.message == first_result_with_statement_params.message == ""
     # Scala has encryption but python doesn't

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -94,10 +94,10 @@ def test_put_with_one_file(session, temp_stage, path1, path2, path3):
         10,
         11,
     ) and first_result_with_statement_params.source_size in (10, 11)
-    assert (
-        first_result.target_size in (64, 96)
-        and first_result_with_statement_params.target_size == 0
-    )
+    assert first_result.target_size in (
+        64,
+        96,
+    ) and first_result_with_statement_params.target_size in (0, 64)
     assert (
         first_result.source_compression
         == first_result_with_statement_params.source_compression

--- a/tests/integ/scala/test_update_delete_merge_suite.py
+++ b/tests/integ/scala/test_update_delete_merge_suite.py
@@ -43,7 +43,7 @@ def test_update_rows_in_table(session):
     )
 
     assert table.update(
-        {"b": 0}, col("a") == 1, _statement_params={"KEY": "VALUE"}
+        {"b": 0}, col("a") == 1, statement_params={"SF_PARTNER": "FAKE_PARTNER"}
     ) == UpdateResult(2, 0)
     Utils.check_answer(
         table, [Row(1, 0), Row(1, 0), Row(2, 1), Row(2, 2), Row(3, 1), Row(3, 2)]
@@ -88,7 +88,9 @@ def test_delete_rows_in_table(session):
     TestData.test_data2(session).write.saveAsTable(
         table_name, mode="overwrite", create_temp_table=True
     )
-    assert table.delete(_statement_params={"KEY": "VALUE"}) == DeleteResult(6)
+    assert table.delete(
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"}
+    ) == DeleteResult(6)
     Utils.check_answer(table, [])
 
     df = session.createDataFrame([1])
@@ -241,7 +243,7 @@ def test_merge_with_update_clause_only(session):
         source,
         target["id"] == source["id"],
         [when_matched(target["desc"] == "old").update({"desc": source["desc"]})],
-        _statement_params={"KEY": "VALUE"},
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"},
     ) == MergeResult(0, 1, 0)
     Utils.check_answer(target, [Row(10, "new"), Row(10, "too_old"), Row(11, "old")])
 

--- a/tests/integ/scala/test_update_delete_merge_suite.py
+++ b/tests/integ/scala/test_update_delete_merge_suite.py
@@ -42,6 +42,13 @@ def test_update_rows_in_table(session):
         table, [Row(1, 0), Row(1, 0), Row(2, 1), Row(2, 2), Row(3, 1), Row(3, 2)]
     )
 
+    assert table.update(
+        {"b": 0}, col("a") == 1, _statement_params={"KEY": "VALUE"}
+    ) == UpdateResult(2, 0)
+    Utils.check_answer(
+        table, [Row(1, 0), Row(1, 0), Row(2, 1), Row(2, 2), Row(3, 1), Row(3, 2)]
+    )
+
     TestData.test_data2(session).write.saveAsTable(
         table_name, mode="overwrite", create_temp_table=True
     )
@@ -76,6 +83,12 @@ def test_delete_rows_in_table(session):
         table_name, mode="overwrite", create_temp_table=True
     )
     assert table.delete() == DeleteResult(6)
+    Utils.check_answer(table, [])
+
+    TestData.test_data2(session).write.saveAsTable(
+        table_name, mode="overwrite", create_temp_table=True
+    )
+    assert table.delete(_statement_params={"KEY": "VALUE"}) == DeleteResult(6)
     Utils.check_answer(table, [])
 
     df = session.createDataFrame([1])
@@ -220,6 +233,15 @@ def test_merge_with_update_clause_only(session):
         source,
         target["id"] == source["id"],
         [when_matched(target["desc"] == "old").update({"desc": source["desc"]})],
+    ) == MergeResult(0, 1, 0)
+    Utils.check_answer(target, [Row(10, "new"), Row(10, "too_old"), Row(11, "old")])
+
+    target_df.write.saveAsTable(table_name, mode="overwrite", create_temp_table=True)
+    assert target.merge(
+        source,
+        target["id"] == source["id"],
+        [when_matched(target["desc"] == "old").update({"desc": source["desc"]})],
+        _statement_params={"KEY": "VALUE"},
     ) == MergeResult(0, 1, 0)
     Utils.check_answer(target, [Row(10, "new"), Row(10, "too_old"), Row(11, "old")])
 

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1677,7 +1677,7 @@ def test_query_id_result_scan(session, resources_path):
     check_df_with_query_id_result_scan(session, df)
 
 
-def test_call_with_statement_parameters(session):
+def test_call_with_statement_params(session):
     statement_params_wrong_date_format = {
         "DATE_INPUT_FORMAT": "YYYY-MM-DD",
         "SF_PARTNER": "FAKE_PARTNER",

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1678,75 +1678,156 @@ def test_query_id_result_scan(session, resources_path):
 
 
 def test_call_with_statement_parameters(session):
-    statement_params = {"KEY": "VALUE"}
-    df = session.create_dataframe(["ab", "abc"], schema=["A"])
+    statement_params_wrong_date_format = {
+        "DATE_INPUT_FORMAT": "YYYY-MM-DD",
+        "SF_PARTNER": "FAKE_PARTNER",
+    }
+    statement_params_correct_date_format = {
+        "DATE_INPUT_FORMAT": "MM-DD-YYYY",
+        "SF_PARTNER": "FAKE_PARTNER",
+    }
+    schema = StructType([StructField("A", DateType())])
+    df = session.create_dataframe(["01-01-1970", "12-31-2000"], schema=schema)
     pandas_df = PandasDF(
         [
-            "ab",
-            "abc",
+            datetime.date(1970, 1, 1),
+            datetime.date(2000, 12, 31),
         ],
         columns=["A"],
     )
+    expected_rows = [Row(datetime.date(1970, 1, 1)), Row(datetime.date(2000, 12, 31))]
 
-    assert df.collect(_statement_params=statement_params) == [Row("ab"), Row("abc")]
-
-    assert list(df.to_local_iterator(_statement_params=statement_params)) == [
-        Row("ab"),
-        Row("abc"),
-    ]
-
-    assert_frame_equal(
-        df.to_pandas(_statement_params=statement_params), pandas_df, check_dtype=False
+    # collect
+    with pytest.raises(SnowparkSQLException) as exc:
+        df.collect(statement_params=statement_params_wrong_date_format)
+    assert "is not recognized" in str(exc)
+    assert (
+        df.collect(statement_params=statement_params_correct_date_format)
+        == expected_rows
     )
 
+    # to_local_iterator
+    with pytest.raises(SnowparkSQLException) as exc:
+        list(df.to_local_iterator(statement_params=statement_params_wrong_date_format))
+    assert "is not recognized" in str(exc)
+    assert (
+        list(
+            df.to_local_iterator(statement_params=statement_params_correct_date_format)
+        )
+        == expected_rows
+    )
+
+    # to_pandas
+    with pytest.raises(SnowparkSQLException) as exc:
+        df.to_pandas(statement_params=statement_params_wrong_date_format)
+    assert "is not recognized" in str(exc)
+    assert_frame_equal(
+        df.to_pandas(statement_params=statement_params_correct_date_format),
+        pandas_df,
+        check_dtype=False,
+    )
+
+    # to_pandas_batches
+    with pytest.raises(SnowparkSQLException) as exc:
+        pd.concat(
+            list(
+                df.to_pandas_batches(
+                    statement_params=statement_params_wrong_date_format
+                )
+            ),
+            ignore_index=True,
+        )
+    assert "is not recognized" in str(exc)
     assert_frame_equal(
         pd.concat(
-            list(df.to_pandas_batches(_statement_params=statement_params)),
+            list(
+                df.to_pandas_batches(
+                    statement_params=statement_params_correct_date_format
+                )
+            ),
             ignore_index=True,
         ),
         pandas_df,
     )
 
-    assert df.count(_statement_params=statement_params) == 2
+    # count
+    # passing statement_params_wrong_date_format does not trigger error
+    assert df.count(statement_params=statement_params_correct_date_format) == 2
 
     # copy_into_table test is covered in test_datafrom_copy_into as it requires complex config
 
-    df.show(_statement_params=statement_params)
+    # show
+    with pytest.raises(SnowparkSQLException) as exc:
+        df.show(statement_params=statement_params_wrong_date_format)
+    assert "is not recognized" in str(exc)
+    df.show(statement_params=statement_params_correct_date_format)
 
+    # create_or_replace_view
+    # passing statement_params_wrong_date_format does not trigger error
     assert (
         "successfully created"
         in df.create_or_replace_view(
-            Utils.random_view_name(), _statement_params=statement_params
+            Utils.random_view_name(),
+            statement_params=statement_params_correct_date_format,
         )[0]["status"]
     )
 
+    # create_or_replace_temp_view
+    # passing statement_params_wrong_date_format does not trigger error
     assert (
         "successfully created"
         in df.create_or_replace_temp_view(
-            Utils.random_view_name(), _statement_params=statement_params
+            Utils.random_view_name(),
+            statement_params=statement_params_correct_date_format,
         )[0]["status"]
     )
 
-    assert df.first(_statement_params=statement_params) == Row("ab")
-
-    assert df.cache_result(_statement_params=statement_params).collect() == [
-        Row("ab"),
-        Row("abc"),
-    ]
+    # first
+    with pytest.raises(SnowparkSQLException) as exc:
+        df.first(statement_params=statement_params_wrong_date_format)
+    assert "is not recognized" in str(exc)
 
     assert (
-        len(df.random_split(weights=[0.5, 0.5], _statement_params=statement_params))
+        df.first(statement_params=statement_params_correct_date_format)
+        == expected_rows[0]
+    )
+
+    # cache_result
+    with pytest.raises(SnowparkSQLException) as exc:
+        df.cache_result(statement_params=statement_params_wrong_date_format).collect()
+    assert "is not recognized" in str(exc)
+
+    assert (
+        df.cache_result(statement_params=statement_params_correct_date_format).collect()
+        == expected_rows
+    )
+
+    # random_split
+    with pytest.raises(SnowparkSQLException) as exc:
+        df.random_split(
+            weights=[0.5, 0.5], statement_params=statement_params_wrong_date_format
+        )
+    assert "is not recognized" in str(exc)
+    assert (
+        len(
+            df.random_split(
+                weights=[0.5, 0.5],
+                statement_params=statement_params_correct_date_format,
+            )
+        )
         == 2
     )
 
+    # save_as_table
+    # passing statement_params_wrong_date_format does not trigger error
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-    df = session.create_dataframe([(1, 2), (3, 4)]).toDF("a", "b")
+    df = session.create_dataframe(["01-01-1970", "12-31-2000"]).toDF("a")
     try:
         df.write.save_as_table(
             table_name,
             mode="append",
             create_temp_table=True,
-            _statement_params=statement_params,
+            statement_params=statement_params_correct_date_format,
         )
         Utils.check_answer(session.table(table_name), df, True)
         table_info = session.sql(f"show tables like '{table_name}'").collect()
@@ -1754,16 +1835,15 @@ def test_call_with_statement_parameters(session):
     finally:
         Utils.drop_table(session, table_name)
 
+    # copy_into_location
+    # passing statement_params_wrong_date_format does not trigger error
     temp_stage = Utils.random_name_for_temp_object(TempObjectType.STAGE)
     Utils.create_stage(session, temp_stage, is_temporary=True)
-    try:
-        df = session.create_dataframe(
-            [["John", "Berry"], ["Rick", "Berry"], ["Anthony", "Davis"]],
-            schema=["FIRST_NAME", "LAST_NAME"],
-        )
-        df.write.copy_into_location(temp_stage, _statement_params=statement_params)
-        copied_files = session.sql(f"list @{temp_stage}").collect()
-        assert len(copied_files) == 1
-        assert ".csv" in copied_files[0][0]
-    finally:
-        Utils.drop_stage(session, temp_stage)
+    df = session.create_dataframe(["01-01-1970", "12-31-2000"]).toDF("a")
+    df.write.copy_into_location(
+        temp_stage, statement_params=statement_params_correct_date_format
+    )
+    copied_files = session.sql(f"list @{temp_stage}").collect()
+    assert len(copied_files) == 1
+    assert ".csv" in copied_files[0][0]
+    Utils.drop_stage(session, temp_stage)

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -339,6 +339,21 @@ def test_session_register_udf(session):
         ],
     )
 
+    add_udf_with_statement_params = session.udf.register(
+        lambda x, y: x + y,
+        return_type=IntegerType(),
+        input_types=[IntegerType(), IntegerType()],
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"},
+    )
+    assert isinstance(add_udf_with_statement_params.func, Callable)
+    Utils.check_answer(
+        df.select(add_udf_with_statement_params("a", "b")).collect(),
+        [
+            Row(3),
+            Row(7),
+        ],
+    )
+
 
 def test_register_udf_from_file(session, resources_path, tmpdir):
     test_files = TestFiles(resources_path)
@@ -401,6 +416,23 @@ def test_register_udf_from_file(session, resources_path, tmpdir):
     )
     Utils.check_answer(
         df.select(mod5_udf3("a"), mod5_udf3("b")).collect(),
+        [
+            Row(3, 4),
+            Row(0, 1),
+        ],
+    )
+
+    mod5_udf3_with_statement_params = session.udf.register_from_file(
+        stage_file,
+        "mod5",
+        return_type=IntegerType(),
+        input_types=[IntegerType()],
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"},
+    )
+    Utils.check_answer(
+        df.select(
+            mod5_udf3_with_statement_params("a"), mod5_udf3_with_statement_params("b")
+        ).collect(),
         [
             Row(3, 4),
             Row(0, 1),

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -107,3 +107,36 @@ def test_register_udtf_from_file_with_typehints(session, resources_path):
             )
         ],
     )
+
+    my_udtf_with_statement_params = session.udtf.register_from_file(
+        test_files.test_udtf_py_file,
+        "MyUDTFWithTypeHints",
+        output_schema=schema,
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"},
+    )
+    assert isinstance(my_udtf_with_statement_params.handler, tuple)
+    df = session.table_function(
+        my_udtf_with_statement_params(
+            lit(1),
+            lit(2.2),
+            lit(True),
+            lit(decimal.Decimal("3.33")),
+            lit("python"),
+            lit(b"bytes"),
+            lit(bytearray("bytearray", "utf-8")),
+        )
+    )
+    Utils.check_answer(
+        df,
+        [
+            Row(
+                1,
+                2.2,
+                True,
+                decimal.Decimal("3.33"),
+                "python",
+                b"bytes",
+                bytearray("bytearray", "utf-8"),
+            )
+        ],
+    )

--- a/tests/unit/test_query_tag.py
+++ b/tests/unit/test_query_tag.py
@@ -3,7 +3,11 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from snowflake.snowpark._internal.utils import create_statement_query_tag
+from snowflake.snowpark._internal.utils import (
+    QUERY_TAG_STRING,
+    create_or_update_statement_params_with_query_tag,
+    create_statement_query_tag,
+)
 
 
 def test_generate_query_tag():
@@ -25,4 +29,93 @@ def test_generate_query_tag_skip_2_levels():
     assert "test_query_tag" not in query_tag  # skipped last call stack
     assert (
         "test_generate_query_tag_skip_2_level" not in query_tag
+    )  # skipped last call stack
+
+
+def test_create_or_update_statement_with_query_tag():
+    statement_params = create_or_update_statement_params_with_query_tag(None, None)
+    assert len(statement_params) == 1
+    assert (
+        "test_query_tag" in statement_params[QUERY_TAG_STRING]
+    )  # file name in query tag
+    assert (
+        "test_create_or_update_statement_with_query_tag"
+        in statement_params[QUERY_TAG_STRING]
+    )  # calling function name in query tag
+
+    statement_params = create_or_update_statement_params_with_query_tag({}, None)
+    assert len(statement_params) == 1
+    assert (
+        "test_query_tag" in statement_params[QUERY_TAG_STRING]
+    )  # file name in query tag
+    assert (
+        "test_create_or_update_statement_with_query_tag"
+        in statement_params[QUERY_TAG_STRING]
+    )  # calling function name in query tag
+
+    statement_params = create_or_update_statement_params_with_query_tag(
+        {"KEY": "VALUE"}, None
+    )
+    assert len(statement_params) == 2
+    assert statement_params["KEY"] == "VALUE"
+    assert (
+        "test_query_tag" in statement_params[QUERY_TAG_STRING]
+    )  # file name in query tag
+    assert (
+        "test_create_or_update_statement_with_query_tag"
+        in statement_params[QUERY_TAG_STRING]
+    )  # calling function name in query tag
+
+    # session has an existing query tag
+    fake_session_query_tag = "FAKE_SESSION_QUERY_TAG"
+    statement_params = create_or_update_statement_params_with_query_tag(
+        None, fake_session_query_tag
+    )
+    assert statement_params is None
+
+    statement_params = create_or_update_statement_params_with_query_tag(
+        {}, fake_session_query_tag
+    )
+    assert statement_params == {}
+
+    statement_params = create_or_update_statement_params_with_query_tag(
+        {"KEY": "VALUE"}, fake_session_query_tag
+    )
+    assert statement_params == {"KEY": "VALUE"}
+
+    # query tag is passed
+    input_statement_params = {QUERY_TAG_STRING: "FAKE_QUERY_TAG", "KEY": "VALUE"}
+    statement_params = create_or_update_statement_params_with_query_tag(
+        input_statement_params, None
+    )
+    assert statement_params == input_statement_params
+
+    statement_params = create_or_update_statement_params_with_query_tag(
+        input_statement_params, fake_session_query_tag
+    )
+    assert statement_params == input_statement_params
+
+    # test passing skip levels
+    statement_params = create_or_update_statement_params_with_query_tag(
+        None, None, skip_levels=1
+    )
+    assert statement_params[QUERY_TAG_STRING]
+    assert (
+        "test_query_tag" in statement_params[QUERY_TAG_STRING]
+    )  # file name in query tag
+    assert (
+        "test_create_or_update_statement_with_query_tag"
+        in statement_params[QUERY_TAG_STRING]
+    )  # calling function name in query tag
+
+    statement_params = create_or_update_statement_params_with_query_tag(
+        None, None, skip_levels=2
+    )
+    assert statement_params[QUERY_TAG_STRING]
+    assert (
+        "test_query_tag" not in statement_params[QUERY_TAG_STRING]
+    )  # skipped last call stack
+    assert (
+        "test_create_or_update_statement_with_query_tag"
+        not in statement_params[QUERY_TAG_STRING]
     )  # skipped last call stack


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-592212

Add statement_param keyword argument support to ACTION apis in snowpark.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

two key functions that requires which serves as the fundamental to upper level apis.
```python
 _session._conn.execute() # connection cursor execution
_internal_collect_with_tag() # which calls _session._conn.execute
```

add the keyword argument to all public apis that will call `_internal_collect_with_tag` or ` _session._conn.execute`
