### PR TITLE
SNOW-620677 Using Builtin sum Function Causes Hanging

### DIFF
--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -304,7 +304,14 @@ class Column:
         )
 
     def __iter__(self) -> None:
-        raise TypeError("Column is not iterable")
+        raise TypeError(
+            "Column is not iterable. This error can occur when you use the Python built-ins for sum, min and max. Please make sure you use the corresponding function from snowflake.snowpark.functions."
+        )
+
+    def __round__(self, n=None):
+        raise TypeError(
+            "Column cannot be rounded. This error can occur when you use the Python built-in round. Please make sure you use the snowflake.snowpark.functions.round function intead."
+        )
 
     def in_(
         self,

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -303,6 +303,9 @@ class Column:
             "'~' for 'not' if you're building DataFrame filter expressions. For example, use df.filter((col1 > 1) & (col2 > 2)) instead of df.filter(col1 > 1 and col2 > 2)."
         )
 
+    def __iter__(self) -> None:
+        raise TypeError("Column is not iterable")
+
     def in_(
         self,
         *vals: Union[

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -151,3 +151,36 @@ def test_when_accept_sql_expr(session):
     assert TestData.null_data1(session).select(
         when("a is NULL", 5).when("a = 1", 6).as_("a")
     ).collect() == [Row(5), Row(None), Row(6), Row(None), Row(5)]
+
+
+def test_column_with_builtins_that_shadow_functions(session):
+    with pytest.raises(TypeError) as ex_info:
+        TestData.double1(session).select(max(col("a"), 25)).collect()
+    assert "Cannot convert a Column object into bool" in str(ex_info)
+
+    with pytest.raises(TypeError) as ex_info:
+        TestData.double1(session).select(max(col("a"))).collect()
+    assert "Column is not iterable" in str(ex_info)
+
+    with pytest.raises(TypeError) as ex_info:
+        TestData.double1(session).select(min(col("a"), 25)).collect()
+    assert "Cannot convert a Column object into bool" in str(ex_info)
+
+    with pytest.raises(TypeError) as ex_info:
+        TestData.double1(session).select(min(col("a"))).collect()
+    assert "Column is not iterable" in str(ex_info)
+
+    # This works because we explicitly implement the __pow__ and __rpow__ methods
+    assert TestData.double1(session).select(pow(col("a"), 2)).collect() == [
+        Row(1.234321),
+        Row(4.937284),
+        Row(11.108889000000001),
+    ]
+
+    with pytest.raises(TypeError) as ex_info:
+        TestData.double1(session).select(round(col("a"))).collect()
+    assert "Column doesn't define __round__ method" in str(ex_info)
+
+    with pytest.raises(TypeError) as ex_info:
+        TestData.double1(session).select(sum(col("a"))).collect()
+    assert "Column is not iterable" in str(ex_info)

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -154,21 +154,25 @@ def test_when_accept_sql_expr(session):
 
 
 def test_column_with_builtins_that_shadow_functions(session):
+    conversion_error_msg_text = "Cannot convert a Column object into bool"
+    iter_error_msg_text = "Column is not iterable. This error can occur when you use the Python built-ins for sum, min and max. Please make sure you use the corresponding function from snowflake.snowpark.functions."
+    round_error_msg_text = "Column cannot be rounded. This error can occur when you use the Python built-in round. Please make sure you use the snowflake.snowpark.functions.round function intead."
+
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(max(col("a"), 25)).collect()
-    assert "Cannot convert a Column object into bool" in str(ex_info)
+    assert conversion_error_msg_text in str(ex_info)
 
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(max(col("a"))).collect()
-    assert "Column is not iterable" in str(ex_info)
+    assert iter_error_msg_text in str(ex_info)
 
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(min(col("a"), 25)).collect()
-    assert "Cannot convert a Column object into bool" in str(ex_info)
+    assert conversion_error_msg_text in str(ex_info)
 
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(min(col("a"))).collect()
-    assert "Column is not iterable" in str(ex_info)
+    assert iter_error_msg_text in str(ex_info)
 
     # This works because we explicitly implement the __pow__ and __rpow__ methods
     assert TestData.double1(session).select(pow(col("a"), 2)).collect() == [
@@ -179,8 +183,8 @@ def test_column_with_builtins_that_shadow_functions(session):
 
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(round(col("a"))).collect()
-    assert "Column doesn't define __round__ method" in str(ex_info)
+    assert round_error_msg_text in str(ex_info)
 
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(sum(col("a"))).collect()
-    assert "Column is not iterable" in str(ex_info)
+    assert iter_error_msg_text in str(ex_info)


### PR DESCRIPTION
Description
When we use the builtin sum function instead of the Snowpark defined sum function, then the library hangs and uses up a lot of memory. This PR addresses that and tests for other builtin functions that shadow Snowpark function names

Testing
Tested builtin sum function as well as other builtin functions

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
