### PR TITLE
SNOW-620212: Execute and get the result query id of a dataframe

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -450,6 +450,14 @@ class DataFrame:
             else None,
         )
 
+    def _execute_and_get_query_id(self) -> str:
+        return self._session._conn.get_result_query_id(
+            self._plan,
+            _statement_params={"QUERY_TAG": create_statement_query_tag(3)}
+            if not self._session.query_tag
+            else None,
+        )
+
     @df_action_telemetry
     def to_local_iterator(self) -> Iterator[Row]:
         """Executes the query representing this DataFrame and returns an iterator

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -451,6 +451,7 @@ class DataFrame:
         )
 
     def _execute_and_get_query_id(self) -> str:
+        """This method is only used in stored procedures."""
         return self._session._conn.get_result_query_id(
             self._plan,
             _statement_params={"QUERY_TAG": create_statement_query_tag(3)}


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   This internal method is needed for table stored proc that executes the dataframe and get the result query ID, which will be returned back to GS and used for getting the result back with result scan. 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
