### PR TITLE
SNOW-608590: Update Python Snowpark API docs to fix typos and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please refer to [CONTRIBUTING.md][contributing].
 
 [add other sample code repo links]: # (Developer advocacy is open-sourcing a repo that has excellent sample code. The link will be added here.)
 
-[developer guide]: https://docs.snowflake.com/en/LIMITEDACCESS/snowpark-python.html
+[developer guide]: https://docs.snowflake.com/en/developer-guide/snowpark/python/index.html
 [api references]: https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/index.html
 [snowpark]: https://www.snowflake.com/snowpark
 [sign up trial]: https://signup.snowflake.com
@@ -82,7 +82,7 @@ Please refer to [CONTRIBUTING.md][contributing].
 [virtualenv]: https://docs.python.org/3/tutorial/venv.html
 [config pycharm interpreter]: https://www.jetbrains.com/help/pycharm/configuring-python-interpreter.html
 [python connector]: https://pypi.org/project/snowflake-connector-python/
-[use snowflake channel]: https://docs.snowflake.com/en/LIMITEDACCESS/udf-python-packages.html#local-development-and-testing
+[use snowflake channel]: https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-packages.html#local-development-and-testing
 [snowflake lab sample code]: https://github.com/Snowflake-Labs/snowpark-python-demos
 [samples]: https://github.com/snowflakedb/snowpark-python/blob/main/README.md#samples
 [contributing]: https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md

--- a/docs/source/_themes/snowflake_rtd_theme/layout.html
+++ b/docs/source/_themes/snowflake_rtd_theme/layout.html
@@ -260,7 +260,7 @@
                   {% endif %}
                 {% endblock %}
 
-                <p><a style="color: white" href="https://docs.snowflake.com/en/LIMITEDACCESS/snowpark-python.html">Snowpark Developer Guide for Python</a></p>
+                <p><a style="color: white" href="https://docs.snowflake.com/en/developer-guide/snowpark/python/index.html">Snowpark Developer Guide for Python</a></p>
 
               </div>
               </div>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,14 +1,14 @@
 Snowpark API Reference (Python)
 ===========================================================
 
-.. sidebar:: Preview Feature --- Private
+.. sidebar:: Preview Feature --- Open
 
    Support for this feature is currently not in production and is available only to selected accounts.
 
 Snowpark is a new developer experience that provides an intuitive API for querying and handling data.
 Snowpark simplifies the process of building complex data pipelines and allows you to interact with
 Snowflake directly without moving data to the system where your application code runs. For more
-information, see the `Snowpark Developer Guide for Python <https://docs.snowflake.com/en/LIMITEDACCESS/snowpark-python.html>`_.
+information, see the `Snowpark Developer Guide for Python <https://docs.snowflake.com/en/developer-guide/snowpark/python/index.html>`_.
 
 .. rubric:: Modules
 

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -538,7 +538,7 @@ class Column:
         For details, see the Snowflake documentation on
         `regular expressions <https://docs.snowflake.com/en/sql-reference/functions-regexp.html#label-regexp-general-usage-notes>`_.
 
-        :meth:`rlike` is an alias of :meth`regexp`.
+        :meth:`rlike` is an alias of :meth:`regexp`.
 
         """
         return Column(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -540,7 +540,7 @@ class Session:
         Use this method to add packages for UDFs as installing packages using
         `conda <https://docs.conda.io/en/latest/>`_. You can also find examples in
         :class:`~snowflake.snowpark.udf.UDFRegistration`. See details of
-        `third-party Python packages in Snowflake <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python-packages.html>`_.
+        `third-party Python packages in Snowflake <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-packages.html>`_.
 
         Args:
             packages: A `requirement specifier <https://packaging.python.org/en/latest/glossary/#term-Requirement-Specifier>`_,
@@ -586,7 +586,7 @@ class Session:
             ``packages`` argument in :func:`functions.udf` or
             :meth:`session.udf.register() <snowflake.snowpark.udf.UDFRegistration.register>`.
 
-            2. We recommend you to `setup the local environment with Anaconda <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python-packages.html#local-development-and-testing>`_,
+            2. We recommend you to `setup the local environment with Anaconda <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-packages.html#local-development-and-testing>`_,
             to ensure the consistent experience of a UDF between your local environment
             and the Snowflake server.
         """
@@ -662,7 +662,7 @@ class Session:
             ``packages`` argument in :func:`functions.udf` or
             :meth:`session.udf.register() <snowflake.snowpark.udf.UDFRegistration.register>`.
 
-            2. We recommend you to `setup the local environment with Anaconda <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python-packages.html#local-development-and-testing>`_,
+            2. We recommend you to `setup the local environment with Anaconda <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-packages.html#local-development-and-testing>`_,
             to ensure the consistent experience of a UDF between your local environment
             and the Snowflake server.
         """

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -70,7 +70,7 @@ class StoredProcedure:
 class StoredProcedureRegistration:
     """
     Provides methods to register lambdas and functions as stored procedures in the Snowflake database.
-    For more information about Snowflake Python stored procedures, see `Python stored procedures <https://docs.snowflake.com/en/LIMITEDACCESS/stored-procedures-python.html>`__.
+    For more information about Snowflake Python stored procedures, see `Python stored procedures <https://docs.snowflake.com/en/sql-reference/stored-procedures-python.html>`__.
 
     :attr:`session.sproc <snowflake.snowpark.Session.sproc>` returns an object of this class.
     You can use this object to register stored procedures that you plan to use in the current session or

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -60,7 +60,7 @@ class TableFunctionCall:
           - Partitioning allows Snowflake to divide up the workload to improve parallelization and thus performance.
           - Partitioning allows Snowflake to process all rows with a common characteristic as a group. You can return results that are based on all rows in the group, not just on individual rows.
 
-        Refer to `table functions and partitions <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python-tabular-functions.html#processing-partitions>`__ for more information.
+        Refer to `table functions and partitions <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-tabular-functions.html#processing-partitions>`__ for more information.
 
         Args:
             partition_by: Specify the partitioning column(s). It tells the table function to partition by these columns.

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -96,7 +96,7 @@ class UserDefinedFunction:
 class UDFRegistration:
     """
     Provides methods to register lambdas and functions as UDFs in the Snowflake database.
-    For more information about Snowflake Python UDFs, see `Python UDFs <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python.html>`__.
+    For more information about Snowflake Python UDFs, see `Python UDFs <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python.html>`__.
 
     :attr:`session.udf <snowflake.snowpark.Session.udf>` returns an object of this class.
     You can use this object to register UDFs that you plan to use in the current session or
@@ -179,7 +179,7 @@ class UDFRegistration:
     :func:`~snowflake.snowpark.functions.pandas_udf` to create a vectorized UDF by providing
     appropriate return and input types. If you would like to use :meth:`register_from_file` to
     create a vectorized UDF, you should follow the guide of
-    `Python UDF Batch API <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python-batch.html>`_ in
+    `Python UDF Batch API <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-batch.html>`_ in
     your Python source files. See Example 9, 10 and 11 here for registering a vectorized UDF.
 
     Snowflake supports the following data types for the parameters for a UDF:

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -85,7 +85,7 @@ class UserDefinedTableFunction:
 class UDTFRegistration:
     """
     Provides methods to register classes as UDTFs in the Snowflake database.
-    For more information about Snowflake Python UDTFs, see `Python UDTFs <https://docs.snowflake.com/en/LIMITEDACCESS/udf-python.html>`__.
+    For more information about Snowflake Python UDTFs, see `Python UDTFs <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python.html>`__.
 
     :attr:`session.udtf <snowflake.snowpark.Session.udtf>` returns an object of this class.
     You can use this object to register UDTFs that you plan to use in the current session or


### PR DESCRIPTION
1. Fixes SNOW-608590

2. Fill out the following pre-review checklist:

Not applicable
   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Changed old private preview "LIMITEDACCESS" URLs to use the new URLs.
   Fixed some typos.
   谢谢你！