### PR TITLE
SNOW-616929: Update API docs to remove old ProgrammingError mention

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2953,7 +2953,7 @@ def udf(
             session-level packages.
         replace: Whether to replace a UDF that already was registered. The default is ``False``.
             If it is ``False``, attempting to register a UDF with a name that already exists
-            results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+            results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing UDF with the same name is overwritten.
         session: Use this session to register the UDF. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
@@ -3100,7 +3100,7 @@ def udtf(
             :meth:`~snowflake.snowpark.Session.add_requirements`.
         replace: Whether to replace a UDTF that already was registered. The default is ``False``.
             If it is ``False``, attempting to register a UDTF with a name that already exists
-            results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+            results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing UDTF with the same name is overwritten.
         session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
@@ -3425,7 +3425,7 @@ def sproc(
             :meth:`~snowflake.snowpark.Session.add_requirements`.
         replace: Whether to replace a stored procedure that already was registered. The default is ``False``.
             If it is ``False``, attempting to register a stored procedure with a name that already exists
-            results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+            results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing stored procedure with the same name is overwritten.
         session: Use this session to register the stored procedure. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -355,7 +355,7 @@ class StoredProcedureRegistration:
                 :meth:`~snowflake.snowpark.Session.add_requirements`.
             replace: Whether to replace a stored procedure that already was registered. The default is ``False``.
                 If it is ``False``, attempting to register a stored procedure with a name that already exists
-                results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+                results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing stored procedure with the same name is overwritten.
             parallel: The number of threads to use for uploading stored procedure files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
@@ -455,7 +455,7 @@ class StoredProcedureRegistration:
                 :meth:`~snowflake.snowpark.Session.add_requirements`.
             replace: Whether to replace a stored procedure that already was registered. The default is ``False``.
                 If it is ``False``, attempting to register a stored procedure with a name that already exists
-                results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+                results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing stored procedure with the same name is overwritten.
             parallel: The number of threads to use for uploading stored procedure files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -496,7 +496,7 @@ class UDFRegistration:
                 session-level packages.
             replace: Whether to replace a UDF that already was registered. The default is ``False``.
                 If it is ``False``, attempting to register a UDF with a name that already exists
-                results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+                results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDF with the same name is overwritten.
             parallel: The number of threads to use for uploading UDF files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
@@ -608,7 +608,7 @@ class UDFRegistration:
                 session-level packages.
             replace: Whether to replace a UDF that already was registered. The default is ``False``.
                 If it is ``False``, attempting to register a UDF with a name that already exists
-                results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+                results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDF with the same name is overwritten.
             parallel: The number of threads to use for uploading UDF files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -348,7 +348,7 @@ class UDTFRegistration:
                 :meth:`~snowflake.snowpark.Session.add_requirements`.
             replace: Whether to replace a UDTF that already was registered. The default is ``False``.
                 If it is ``False``, attempting to register a UDTF with a name that already exists
-                results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+                results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDTF with the same name is overwritten.
             session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
                 You need to specify this parameter if you have created multiple sessions before calling this method.
@@ -448,7 +448,7 @@ class UDTFRegistration:
                 :meth:`~snowflake.snowpark.Session.add_requirements`.
             replace: Whether to replace a UDTF that already was registered. The default is ``False``.
                 If it is ``False``, attempting to register a UDTF with a name that already exists
-                results in a ``ProgrammingError`` exception being thrown. If it is ``True``,
+                results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDTF with the same name is overwritten.
             session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
                 You need to specify this parameter if you have created multiple sessions before calling this method.


### PR DESCRIPTION
1. Fixes SNOW-616929

2. Fill out the following pre-review checklist:

Not applicable

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 In 0.7.0, we added a Snowpark-specific exception class for SQL errors. This replaces the previous ProgrammingError from the Python connector. This PR updates the documentation to reflect that change.
