### PR TITLE
SNOW-633678: Fix typo in API docs callout

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ Snowpark API Reference (Python)
 
 .. sidebar:: Preview Feature --- Open
 
-   Support for this feature is currently not in production and is available only to selected accounts.
+   Available to all accounts.
 
 Snowpark is a new developer experience that provides an intuitive API for querying and handling data.
 Snowpark simplifies the process of building complex data pipelines and allows you to interact with


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

SNOW-633678

2. Fill out the following pre-review checklist:

Not applicable
   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Some text in a callout in the api docs was out of date. 
   I already fixed this in the docs that will be getting published for 0.8.0. Just updating it in the source for next time. 
