### PR TITLE
Pin sphinx==5.0.2 instead of latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
             "pytest",
             "pytest-cov",
             "coverage",
-            "sphinx",
+            "sphinx==5.0.2",
             "cachetools",  # used in UDF doctest
         ],
     },


### PR DESCRIPTION
Some new versions of Sphinx may introduce break changes. For instance, 5.1.0 reports `Extension error (sphinx.ext.napoleon)`
