### PR TITLE
SNOW-619431: Support save_as_table with column name sequence

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -552,7 +552,7 @@ class Analyzer:
         if isinstance(logical_plan, SnowflakeCreateTable):
             return self.plan_builder.save_as_table(
                 logical_plan.table_name,
-                logical_plan.column_list,
+                logical_plan.column_names,
                 logical_plan.mode,
                 logical_plan.table_type,
                 resolved_children[logical_plan.children[0]],

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -552,6 +552,7 @@ class Analyzer:
         if isinstance(logical_plan, SnowflakeCreateTable):
             return self.plan_builder.save_as_table(
                 logical_plan.table_name,
+                logical_plan.column_list,
                 logical_plan.mode,
                 logical_plan.table_type,
                 resolved_children[logical_plan.children[0]],

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -586,7 +586,7 @@ def create_table_statement(
 
 
 def insert_into_statement(
-    table_name: str, column_names: Optional[Iterable[str]], child: str
+    table_name: str, child: str, column_names: Optional[Iterable[str]] = None
 ) -> str:
     table_columns = f"({COMMA.join(column_names)})" if column_names else EMPTY_STRING
     return f"{INSERT}{INTO}{table_name}{table_columns}{project_statement([], child)}"

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     JoinType,
@@ -585,8 +585,11 @@ def create_table_statement(
     )
 
 
-def insert_into_statement(table_name: str, child: str) -> str:
-    return f"{INSERT}{INTO}{table_name} {project_statement([], child)}"
+def insert_into_statement(
+    table_name: str, column_list: Optional[Iterable[str]], child: str
+) -> str:
+    table_columns = f"({COMMA.join(column_list)})" if column_list else EMPTY_STRING
+    return f"{INSERT}{INTO}{table_name}{table_columns}{project_statement([], child)}"
 
 
 def batch_insert_into_statement(table_name: str, column_names: List[str]) -> str:

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -586,9 +586,9 @@ def create_table_statement(
 
 
 def insert_into_statement(
-    table_name: str, column_list: Optional[Iterable[str]], child: str
+    table_name: str, column_names: Optional[Iterable[str]], child: str
 ) -> str:
-    table_columns = f"({COMMA.join(column_list)})" if column_list else EMPTY_STRING
+    table_columns = f"({COMMA.join(column_names)})" if column_names else EMPTY_STRING
     return f"{INSERT}{INTO}{table_name}{table_columns}{project_statement([], child)}"
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -512,7 +512,9 @@ class SnowflakePlanBuilder:
                     Query(create_table),
                     Query(
                         insert_into_statement(
-                            table_name, column_names, child.queries[-1].sql
+                            table_name=table_name,
+                            child=child.queries[-1].sql,
+                            column_names=column_names,
                         )
                     ),
                 ],

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -625,7 +625,10 @@ class SnowflakePlanBuilder:
             table_type="temporary",
         )
 
-        return [create_table, insert_into_statement(name, None, query)]
+        return [
+            create_table,
+            insert_into_statement(table_name=name, column_names=None, child=query),
+        ]
 
     def read_file(
         self,

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -493,7 +493,7 @@ class SnowflakePlanBuilder:
     def save_as_table(
         self,
         table_name: str,
-        column_list: Optional[Iterable[str]],
+        column_names: Optional[Iterable[str]],
         mode: SaveMode,
         table_type: str,
         child: SnowflakePlan,
@@ -512,7 +512,7 @@ class SnowflakePlanBuilder:
                     Query(create_table),
                     Query(
                         insert_into_statement(
-                            table_name, column_list, child.queries[-1].sql
+                            table_name, column_names, child.queries[-1].sql
                         )
                     ),
                 ],

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -6,7 +6,7 @@ import re
 import sys
 import uuid
 from functools import cached_property, reduce
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import snowflake.connector
 import snowflake.snowpark
@@ -493,6 +493,7 @@ class SnowflakePlanBuilder:
     def save_as_table(
         self,
         table_name: str,
+        column_list: Optional[Iterable[str]],
         mode: SaveMode,
         table_type: str,
         child: SnowflakePlan,
@@ -504,11 +505,16 @@ class SnowflakePlanBuilder:
                 error=False,
                 table_type=table_type,
             )
+
             return SnowflakePlan(
                 [
                     *child.queries[0:-1],
                     Query(create_table),
-                    Query(insert_into_statement(table_name, child.queries[-1].sql)),
+                    Query(
+                        insert_into_statement(
+                            table_name, column_list, child.queries[-1].sql
+                        )
+                    ),
                 ],
                 create_table,
                 child.post_actions,
@@ -619,7 +625,7 @@ class SnowflakePlanBuilder:
             table_type="temporary",
         )
 
-        return [create_table, insert_into_statement(name, query)]
+        return [create_table, insert_into_statement(name, None, query)]
 
     def read_file(
         self,

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.expression import Attribute, Expression
@@ -55,12 +55,14 @@ class SnowflakeCreateTable(LogicalPlan):
     def __init__(
         self,
         table_name: str,
+        column_list: Optional[Iterable[str]],
         mode: SaveMode,
         query: Optional[LogicalPlan],
         table_type: str = "",
     ) -> None:
         super().__init__()
         self.table_name = table_name
+        self.column_list = column_list
         self.mode = mode
         self.query = query
         self.table_type = table_type

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -55,14 +55,14 @@ class SnowflakeCreateTable(LogicalPlan):
     def __init__(
         self,
         table_name: str,
-        column_list: Optional[Iterable[str]],
+        column_names: Optional[Iterable[str]],
         mode: SaveMode,
         query: Optional[LogicalPlan],
         table_type: str = "",
     ) -> None:
         super().__init__()
         self.table_name = table_name
-        self.column_list = column_list
+        self.column_names = column_names
         self.mode = mode
         self.query = query
         self.table_type = table_type

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -452,10 +452,11 @@ class ServerConnection:
         # with qmark, Python data type will be dynamically mapped to Snowflake data type
         # https://docs.snowflake.com/en/user-guide/python-connector-api.html#data-type-mappings-for-qmark-and-numeric-bindings
         params = [list(row) for row in rows]
+        statement_params = kwargs.get("_statement_params")
         query_tag = (
-            kwargs["_statement_params"]["QUERY_TAG"]
-            if "_statement_params" in kwargs
-            and "QUERY_TAG" in kwargs["_statement_params"]
+            statement_params["QUERY_TAG"]
+            if statement_params is not None
+            and "QUERY_TAG" in statement_params
             and not is_in_stored_procedure()
             else None
         )

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -91,10 +91,10 @@ class DataFrameWriter:
 
                 "ignore": Ignore this operation if data already exists.
 
-            column_order: When ``mode`` is "append", data will be inserted to the target table by matching column sequence or column name. Default is "index".
+            column_order: When ``mode`` is "append", data will be inserted into the target table by matching column sequence or column name. Default is "index".
 
-                "index": Data will be inserted to the target table by column sequence.
-                "name": Data will be inserted to the target table by matching column names. If the target table has more columns than the source DataFrame, use this one.
+                "index": Data will be inserted into the target table by column sequence.
+                "name": Data will be inserted into the target table by matching column names. If the target table has more columns than the source DataFrame, use this one.
 
             create_temp_table: (Deprecated) The to-be-created table will be temporary if this is set to ``True``.
             table_type: The table type of table to be created. The supported values are: ``temp``, ``temporary``,
@@ -140,16 +140,16 @@ class DataFrameWriter:
         if column_order:
             column_order_lower = column_order.lower()
             if column_order_lower == "name":
-                column_list = self._dataframe.columns
+                column_names = self._dataframe.columns
             elif column_order_lower == "index":
-                column_list = None
+                column_names = None
             else:
                 raise ValueError("'column_order' must be either 'name' or 'index'")
         else:
-            column_list = None  # column_order default is index.
+            column_names = None  # column_order default is index.
         create_table_logic_plan = SnowflakeCreateTable(
             full_table_name,
-            column_list,
+            column_names,
             save_mode,
             self._dataframe._plan,
             table_type,

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -91,7 +91,7 @@ class DataFrameWriter:
 
                 "ignore": Ignore this operation if data already exists.
 
-            column_order: When ``mode`` is "append", data will be inserted into the target table by matching column sequence or column name. Default is "index".
+            column_order: When ``mode`` is "append", data will be inserted into the target table by matching column sequence or column name. Default is "index". When ``mode`` is not "append", the ``column_order`` makes no difference.
 
                 "index": Data will be inserted into the target table by column sequence.
                 "name": Data will be inserted into the target table by matching column names. If the target table has more columns than the source DataFrame, use this one.
@@ -122,6 +122,12 @@ class DataFrameWriter:
             table_name if isinstance(table_name, str) else ".".join(table_name)
         )
         validate_object_name(full_table_name)
+        if column_order is None or column_order.lower() not in ("name", "index"):
+            raise ValueError("'column_order' must be either 'name' or 'index'")
+        column_names = (
+            self._dataframe.columns if column_order.lower() == "name" else None
+        )
+
         if create_temp_table:
             warnings.warn(
                 "create_temp_table is deprecated. We still respect this parameter when it is True but "
@@ -137,16 +143,6 @@ class DataFrameWriter:
                 "Unsupported table type. Expected table types: temp/temporary, transient"
             )
 
-        if column_order:
-            column_order_lower = column_order.lower()
-            if column_order_lower == "name":
-                column_names = self._dataframe.columns
-            elif column_order_lower == "index":
-                column_names = None
-            else:
-                raise ValueError("'column_order' must be either 'name' or 'index'")
-        else:
-            column_names = None  # column_order default is index.
         create_table_logic_plan = SnowflakeCreateTable(
             full_table_name,
             column_names,

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -92,12 +92,16 @@ def test_negative_write_with_target_column_name_order(session):
                 table_name, mode="append", column_order="name", table_type="temp"
             )
 
-        with pytest.raises(
-            ValueError, match="'column_order' must be either 'name' or 'index'"
-        ):
-            df1.write.save_as_table(
-                table_name, mode="append", column_order="any_value", table_type="temp"
-            )
+        for column_order in ("any_value", "", None):
+            with pytest.raises(
+                ValueError, match="'column_order' must be either 'name' or 'index'"
+            ):
+                df1.write.save_as_table(
+                    table_name,
+                    mode="append",
+                    column_order=column_order,
+                    table_type="temp",
+                )
     finally:
         Utils.drop_table(session, table_name)
 

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -66,7 +66,7 @@ def test_write_with_target_column_name_order(session):
 
 def test_write_with_target_table_autoincrement(
     session,
-):  # Scala doesn't suppor this yet.
+):  # Scala doesn't support this yet.
     table_name = Utils.random_table_name()
     Utils.create_table(
         session, table_name, "a int, b int, c int autoincrement", is_temporary=True
@@ -90,6 +90,13 @@ def test_negative_write_with_target_column_name_order(session):
         with pytest.raises(SnowparkSQLException, match="invalid identifier 'C'"):
             df1.write.save_as_table(
                 table_name, mode="append", column_order="name", table_type="temp"
+            )
+
+        with pytest.raises(
+            ValueError, match="'column_order' must be either 'name' or 'index'"
+        ):
+            df1.write.save_as_table(
+                table_name, mode="append", column_order="any_value", table_type="temp"
             )
     finally:
         Utils.drop_table(session, table_name)

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -1,0 +1,196 @@
+#
+# Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
+#
+
+import copy
+
+import pytest
+
+from snowflake.snowpark import Row
+from snowflake.snowpark.exceptions import SnowparkSQLException
+from snowflake.snowpark.types import (
+    DoubleType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
+from tests.utils import TestFiles, Utils
+
+
+def test_write_with_target_column_name_order(session):
+    table_name = Utils.random_table_name()
+    Utils.create_table(session, table_name, "a int, b int", is_temporary=True)
+    try:
+        df1 = session.create_dataframe([[1, 2]], schema=["b", "a"])
+
+        # By default, it is by index
+        df1.write.save_as_table(table_name, mode="append", table_type="temp")
+        Utils.check_answer(session.table(table_name), [Row(1, 2)])
+
+        # Explicitly use "index"
+        session._conn.run_query(f"truncate table {table_name}")
+        df1.write.save_as_table(
+            table_name, mode="append", column_order="index", table_type="temp"
+        )
+        Utils.check_answer(session.table(table_name), [Row(1, 2)])
+
+        # use order by "name"
+        session._conn.run_query(f"truncate table {table_name}")
+        df1.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(session.table(table_name), [Row(2, 1)])
+
+        # If target table doesn't exists, "order by name" is not actually used.
+        Utils.drop_table(session, table_name)
+        df1.write.saveAsTable(table_name, mode="append", column_order="name")
+        Utils.check_answer(session.table(table_name), [Row(1, 2)])
+    finally:
+        Utils.drop_table(session, table_name)
+
+    # column name and table name with special characters
+    special_table_name = '"test table name"'
+    Utils.create_table(
+        session, special_table_name, '"a a" int, "b b" int', is_temporary=True
+    )
+    try:
+        df2 = session.create_dataframe([(1, 2)]).to_df("b b", "a a")
+        df2.write.save_as_table(
+            special_table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(session.table(special_table_name), [Row(2, 1)])
+    finally:
+        Utils.drop_table(session, special_table_name)
+
+
+def test_write_with_target_table_autoincrement(
+    session,
+):  # Scala doesn't suppor this yet.
+    table_name = Utils.random_table_name()
+    Utils.create_table(
+        session, table_name, "a int, b int, c int autoincrement", is_temporary=True
+    )
+    try:
+        df1 = session.create_dataframe([[1, 2]], schema=["b", "a"])
+        df1.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(session.table(table_name), [Row(2, 1, 1)])
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_negative_write_with_target_column_name_order(session):
+    table_name = Utils.random_table_name()
+    Utils.create_table(session, table_name, "a int, b int", is_temporary=True)
+    try:
+        df1 = session.create_dataframe([[1, 2]], schema=["a", "c"])
+        # The "columnOrder = name" needs the DataFrame has the same column name set
+        with pytest.raises(SnowparkSQLException, match="invalid identifier 'C'"):
+            df1.write.save_as_table(
+                table_name, mode="append", column_order="name", table_type="temp"
+            )
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_write_with_target_column_name_order_all_kinds_of_dataframes(
+    session, resources_path
+):
+    table_name = Utils.random_table_name()
+    Utils.create_table(session, table_name, "a int, b int", is_temporary=True)
+    try:
+        df1 = session.create_dataframe([[1, 2]], schema=["b", "a"])
+        # DataFrame.cache_result()
+        df_cached = df1.cache_result()
+        df_cached.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(session.table(table_name), [Row(2, 1)])
+
+        # copy DataFrame
+        session._conn.run_query(f"truncate table {table_name}")
+        df_cloned = copy.copy(df1)
+        df_cloned.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(session.table(table_name), [Row(2, 1)])
+
+        # large local relation
+        session._conn.run_query(f"truncate table {table_name}")
+        large_df = session.create_dataframe([[1, 2]] * 1024, schema=["b", "a"])
+        large_df.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        rows = session.table(table_name).collect()
+        assert len(rows) == 1024
+        for row in rows:
+            assert row["B"] == 1 and row["A"] == 2
+    finally:
+        Utils.drop_table(session, table_name)
+
+    # show tables
+    # Create a DataFrame from SQL `show tables` and then filter on it not supported yet. Enable the following test after it's supported.
+    # try:
+    #     show_table_fields = session.sql("show tables").schema.fields
+    #     columns = ", ".join(f"{analyzer_utils.quote_name(f.name)} {type_utils.convert_sp_to_sf_type(f.datatype)}" for f in show_table_fields)
+    #     # exchange column orders: "name"(1) <-> "kind"(4)
+    #     schema_string = columns \
+    #         .replace("\"kind\"", "test_place_holder") \
+    #         .replace("\"name\"", "\"kind\"") \
+    #         .replace("test_place_holder", "\"name\"")
+    #     Utils.create_table(session, table_name, schema_string, is_temporary=True)
+    #     session.sql("show tables").write.save_as_table(table_name, mode="append", column_order="name", table_type="temp")
+    #     # In "show tables" result, "name" is 2nd column.
+    #     # In the target table, "name" is the 4th column.
+    #     assert(session.table(table_name).collect()[0][4].contains(table_name))
+    # finally:
+    #     Utils.drop_table(session, table_name)
+
+    # Read file, table columns are in reverse order
+    source_stage_name = Utils.random_stage_name()
+    target_stage_name = Utils.random_stage_name()
+    Utils.create_stage(session, source_stage_name)
+    Utils.create_stage(session, target_stage_name)
+    Utils.create_table(
+        session, table_name, "c double, b string, a int", is_temporary=True
+    )
+    try:
+        test_files = TestFiles(resources_path)
+        test_file_on_stage = f"@{source_stage_name}/testCSV.csv"
+        Utils.upload_to_stage(
+            session, source_stage_name, test_files.test_file_csv, compress=False
+        )
+        user_schema = StructType(
+            [
+                StructField("a", IntegerType()),
+                StructField("b", StringType()),
+                StructField("c", DoubleType()),
+            ]
+        )
+        df_readfile = session.read.schema(user_schema).csv(test_file_on_stage)
+        Utils.check_answer(df_readfile, [Row(1, "one", 1.2), Row(2, "two", 2.2)])
+        df_readfile.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(
+            session.table(table_name), [Row(1.2, "one", 1), Row(2.2, "two", 2)]
+        )
+        # read with copy options
+        df_readcopy = (
+            session.read.schema(user_schema)
+            .option("PURGE", False)
+            .csv(test_file_on_stage)
+        )
+        session._conn.run_query(f"truncate table {table_name}", session)
+        df_readcopy.write.save_as_table(
+            table_name, mode="append", column_order="name", table_type="temp"
+        )
+        Utils.check_answer(
+            session.table(table_name), [Row(1.2, "one", 1), Row(2.2, "two", 2)]
+        )
+    finally:
+        Utils.drop_table(session, table_name)
+        Utils.drop_stage(session, source_stage_name)
+        Utils.drop_stage(session, target_stage_name)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   `df.write.save_as_table` needs to match column names when appending new data to an existing table.
It currently insert data by column sequence.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When appending data to a table, change the SQL from `insert into t values(val1, val2, ...)` to `insert into t(col1, col2, ...) values (val1, val2, ...)`. A new parameter is added to `save_as_table` for users to choose what they want.