### PR TITLE
SNOW-637532: Use quoted names for `create_dataframe` with dicts and a given schema 

### DIFF
--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -852,6 +852,68 @@ def test_create_dataframe_with_dict(session):
     )
 
 
+def test_create_dataframe_with_dict_given_schema(session):
+    schema = StructType(
+        [
+            StructField("A", LongType(), nullable=True),
+            StructField("B", LongType(), nullable=True),
+        ]
+    )
+    df = session.createDataFrame([{"a": 1, "b": 1}, {"a": 2, "b": 2}], schema)
+    assert [field.name for field in df.schema.fields] == ["A", "B"]
+    Utils.check_answer(df, [Row(1, 1), Row(2, 2)])
+
+    schema = StructType(
+        [
+            StructField("a", LongType(), nullable=True),
+            StructField("b", LongType(), nullable=True),
+        ]
+    )
+    df = session.createDataFrame([{"A": 1, "B": 1}, {"A": 2, "B": 2}], schema)
+    assert [field.name for field in df.schema.fields] == ["A", "B"]
+    Utils.check_answer(df, [Row(1, 1), Row(2, 2)])
+
+    schema = StructType(
+        [
+            StructField("A", LongType(), nullable=True),
+            StructField("B", LongType(), nullable=True),
+        ]
+    )
+    df = session.createDataFrame([{'"a"': 1, '"b"': 1}, {'"a"': 2, '"b"': 2}], schema)
+    assert [field.name for field in df.schema.fields] == ["A", "B"]
+    Utils.check_answer(df, [Row(None, None), Row(None, None)])
+
+    schema = StructType(
+        [
+            StructField('"A"', LongType(), nullable=True),
+            StructField('"B"', LongType(), nullable=True),
+        ]
+    )
+    df = session.createDataFrame([{'"A"': 1, '"B"': 1}, {'"A"': 2, '"B"': 2}], schema)
+    assert [field.name for field in df.schema.fields] == ["A", "B"]
+    Utils.check_answer(df, [Row(1, 1), Row(2, 2)])
+
+    schema = StructType(
+        [
+            StructField('"A"', LongType(), nullable=True),
+            StructField('"B"', LongType(), nullable=True),
+        ]
+    )
+    df = session.createDataFrame([{"A": 1, "B": 1}, {"A": 2, "B": 2}], schema)
+    assert [field.name for field in df.schema.fields] == ["A", "B"]
+    Utils.check_answer(df, [Row(1, 1), Row(2, 2)])
+
+    schema = StructType(
+        [
+            StructField('"A"', LongType(), nullable=True),
+            StructField('"B"', LongType(), nullable=True),
+        ]
+    )
+    df = session.createDataFrame([{'"a"': 1, '"b"': 1}, {'"a"': 2, '"b"': 2}], schema)
+    assert [field.name for field in df.schema.fields] == ["A", "B"]
+    Utils.check_answer(df, [Row(None, None), Row(None, None)])
+
+
 def test_create_dataframe_with_namedtuple(session):
     Data = namedtuple("Data", [f"snow_{idx + 1}" for idx in range(5)])
     data = Data(*[idx**3 for idx in range(5)])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowpark-python/issues/414. 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The unquoted identifier name in Snowflake is not case sensitive, so we already quote the column name from schema when building the query. However, previously we didn't quote the keys in dicts to make sure they are consistent. This PR fixes this issue. See details of Snowflake identifier [here](https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html).  
