### PR TITLE
SNOW 619461 casting decimal like python numbers to float type

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -203,7 +203,7 @@ from snowflake.snowpark.column import (
     _to_col_if_str_or_int,
 )
 from snowflake.snowpark.stored_procedure import StoredProcedure
-from snowflake.snowpark.types import DataType, StructType
+from snowflake.snowpark.types import DataType, FloatType, StructType
 from snowflake.snowpark.udf import UserDefinedFunction
 from snowflake.snowpark.udtf import UserDefinedTableFunction
 
@@ -755,12 +755,16 @@ def uniform(
         >>> df.select(uniform(1, 100, col("a")).alias("UNIFORM")).collect()
         [Row(UNIFORM=62)]
     """
-    min_col = (
-        lit(min_) if isinstance(min_, (int, float)) else _to_col_if_str(min_, "uniform")
-    )
-    max_col = (
-        lit(max_) if isinstance(max_, (int, float)) else _to_col_if_str(max_, "uniform")
-    )
+
+    def convert_limit_to_col(limit):
+        if isinstance(limit, int):
+            return lit(limit)
+        elif isinstance(limit, float):
+            return lit(limit).cast(FloatType())
+        return _to_col_if_str(limit, "uniform")
+
+    min_col = convert_limit_to_col(min_)
+    max_col = convert_limit_to_col(max_)
     gen_col = (
         lit(gen) if isinstance(gen, (int, float)) else _to_col_if_str(gen, "uniform")
     )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-619461

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The function `uniform` accepts `min` and `max` to generate random numbers. Based on the input of `min` and `max`, which can be either `int` or `float`, we generate a random number.
   When parsing the limits for `min` and `max`, we infer the type and cast the limits into `IntegerType` or `FloatType`. These values are then forwarded to built-in function `uniform`.

