### PR TITLE
SNOW-641398 Skip create table if exists in append mode

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -63,6 +63,7 @@ from snowflake.snowpark._internal.utils import (
     generate_random_alphanumeric,
     random_name_for_temp_object,
 )
+from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import StructType
 
@@ -490,6 +491,16 @@ class SnowflakePlanBuilder:
             source_plan,
         )
 
+    def _table_exists(self, table_name):
+        try:
+            # DESC is used here because SHOW does not work for qualified table name
+            self.session.sql(f"DESC TABLE {table_name}").collect()
+            return True
+        except SnowparkSQLException:
+            # We could verify if this is a compile error and throw otherwise, but directly return False gives no
+            # behavior change as the old behavior assumes table does not exist
+            return False
+
     def save_as_table(
         self,
         table_name: str,
@@ -499,32 +510,43 @@ class SnowflakePlanBuilder:
         child: SnowflakePlan,
     ) -> SnowflakePlan:
         if mode == SaveMode.APPEND:
-            create_table = create_table_statement(
-                table_name,
-                attribute_to_schema_string(child.attributes),
-                error=False,
-                table_type=table_type,
-            )
-
-            return SnowflakePlan(
-                [
-                    *child.queries[0:-1],
-                    Query(create_table),
-                    Query(
-                        insert_into_statement(
-                            table_name=table_name,
-                            child=child.queries[-1].sql,
-                            column_names=column_names,
-                        )
+            if self._table_exists(table_name):
+                return self.build(
+                    lambda x: insert_into_statement(
+                        table_name=table_name,
+                        child=x,
+                        column_names=column_names,
                     ),
-                ],
-                create_table,
-                child.post_actions,
-                {},
-                self.session,
-                None,
-                api_calls=child.api_calls,
-            )
+                    child,
+                    None,
+                )
+            else:
+                create_table = create_table_statement(
+                    table_name,
+                    attribute_to_schema_string(child.attributes),
+                    error=False,
+                    table_type=table_type,
+                )
+
+                return SnowflakePlan(
+                    [
+                        *child.queries[0:-1],
+                        Query(create_table),
+                        Query(
+                            insert_into_statement(
+                                table_name=table_name,
+                                child=child.queries[-1].sql,
+                                column_names=column_names,
+                            )
+                        ),
+                    ],
+                    create_table,
+                    child.post_actions,
+                    {},
+                    self.session,
+                    None,
+                    api_calls=child.api_calls,
+                )
         elif mode == SaveMode.OVERWRITE:
             return self.build(
                 lambda x: create_table_as_select_statement(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1623,8 +1623,14 @@ class Session:
         return query_listener
 
     def _table_exists(self, table_name: str):
-        tables = self._run_query(f"show tables like '{table_name}'")
-        return tables is not None and len(tables) > 0
+        try:
+            # DESC is used here because SHOW does not work for qualified table name
+            self._conn._cursor.describe(f"DESC TABLE {table_name}")
+            return True
+        except ProgrammingError:
+            # We could verify if this is a compile error and throw otherwise, but directly return False gives no
+            # behavior change as the old behavior assumes table does not exist
+            return False
 
     def _explain_query(self, query: str) -> Optional[str]:
         try:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1622,14 +1622,15 @@ class Session:
         self._conn.add_query_listener(query_listener)
         return query_listener
 
-    def _table_exists(self, table_name: str):
+    def _table_exists(self, table_name: str) -> bool:
         try:
-            # DESC is used here because SHOW does not work for qualified table name
+            # DESC is used here because SHOW does not work for qualified table name. We use `cursor#describe` so that
+            # the failed query does not show up in query history to avoid confusion.
             self._conn._cursor.describe(f"DESC TABLE {table_name}")
             return True
         except ProgrammingError:
-            # We could verify if this is a compile error and throw otherwise, but directly return False gives no
-            # behavior change as the old behavior assumes table does not exist
+            # Assuming table does not exist is the current behavior. Ideally we can check whether "does not exist or
+            # not authorized" is in error message before returning False, but it can be fragile.
             return False
 
     def _explain_query(self, query: str) -> Optional[str]:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1581,7 +1581,7 @@ def test_append_existing_table(session):
             df.write.save_as_table(table_name, mode="append")
         Utils.check_answer(session.table(table_name), df, True)
         assert len(history.queries) == 1  # INSERT only
-        assert history.queries[1].sql_text.startswith("INSERT")
+        assert history.queries[0].sql_text.startswith("INSERT")
     finally:
         Utils.drop_table(session, table_name)
 

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1572,6 +1572,21 @@ def test_write_invalid_table_type(session):
         df.write.save_as_table(table_name, table_type="invalid")
 
 
+def test_append_existing_table(session):
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    session.sql(f"create table {table_name} (a int, b int)").collect()
+    df = session.create_dataframe([(1, 2), (3, 4)]).toDF("a", "b")
+    try:
+        with session.query_history() as history:
+            df.write.save_as_table(table_name, mode="append")
+        Utils.check_answer(session.table(table_name), df, True)
+        assert len(history.queries) == 2  # DESC + INSERT
+        assert history.queries[0].sql_text.startswith("DESC TABLE")
+        assert history.queries[1].sql_text.startswith("INSERT")
+    finally:
+        Utils.drop_table(session, table_name)
+
+
 def test_write_copy_into_location_basic(session):
     temp_stage = Utils.random_name_for_temp_object(TempObjectType.STAGE)
     Utils.create_stage(session, temp_stage, is_temporary=True)


### PR DESCRIPTION
Description

Create table requires a different privilege from insert, and
appending to an existing table should be allowed for user without
create privilege. To achieve that, we skip creating table if
it already exists.

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
