### PR TITLE
Revert changes in _table_exists

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1623,16 +1623,10 @@ class Session:
         self._conn.add_query_listener(query_listener)
         return query_listener
 
-    def _table_exists(self, table_name: str) -> bool:
-        try:
-            # DESC is used here because SHOW does not work for qualified table name. We use `cursor#describe` so that
-            # the failed query does not show up in query history to avoid confusion.
-            self._conn._cursor.describe(f"DESC TABLE {table_name}")
-            return True
-        except ProgrammingError:
-            # Assuming table does not exist is the current behavior. Ideally we can check whether "does not exist or
-            # not authorized" is in error message before returning False, but it can be fragile.
-            return False
+    def _table_exists(self, table_name: str):
+        # TODO: Support qualified table names
+        tables = self._run_query(f"show tables like '{table_name}'")
+        return tables is not None and len(tables) > 0
 
     def _explain_query(self, query: str) -> Optional[str]:
         try:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1580,8 +1580,9 @@ def test_append_existing_table(session):
         with session.query_history() as history:
             df.write.save_as_table(table_name, mode="append")
         Utils.check_answer(session.table(table_name), df, True)
-        assert len(history.queries) == 1  # INSERT only
-        assert history.queries[0].sql_text.startswith("INSERT")
+        assert len(history.queries) == 2  # SHOW + INSERT
+        assert history.queries[0].sql_text.startswith("show")
+        assert history.queries[1].sql_text.startswith("INSERT")
     finally:
         Utils.drop_table(session, table_name)
 


### PR DESCRIPTION
The workaround of using `DESC TABLE` in `describe_only` mode risks failure because it depends on  `ENABLE_COMBINED_DESCRIBE` being `false`. Currently this param is false in prod but is true in test deployment, so we should avoid using `DESC TABLE` in `describe_only` mode.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
