### PR TITLE
SNOW-650679: Add alias support to TableFunctionCall

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/table_function.py
+++ b/src/snowflake/snowpark/_internal/analyzer/table_function.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import Expression
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import LogicalPlan
@@ -27,10 +27,12 @@ class TableFunctionExpression(Expression):
         self,
         func_name: str,
         partition_spec: Optional[TableFunctionPartitionSpecDefinition] = None,
+        aliases: Optional[Iterable[str]] = None,
     ) -> None:
         super().__init__()
         self.func_name = func_name
         self.partition_spec = partition_spec
+        self.aliases = aliases
 
 
 class FlattenFunction(TableFunctionExpression):

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1989,7 +1989,7 @@ class DataFrame:
                 "The same column name is used multiple times in the col_names parameter."
             )
 
-        new_cols = [col.alias(name) for name, col in zip(qualified_names, values)]
+        new_cols = [col.as_(name) for name, col in zip(qualified_names, values)]
 
         # Get a list of existing column names that are not being replaced
         old_cols = [

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1927,12 +1927,12 @@ class DataFrame:
             ...     def process(self, a: int, b: int) -> Iterable[Tuple[int]]:
             ...         yield (a + b, )
             >>> df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
-            >>> df.with_column("total", sum_udtf(df.a, df.b)).show()
+            >>> df.with_column("total", sum_udtf(df.a, df.b)).sort(df.a).show()
             -----------------------
             |"A"  |"B"  |"TOTAL"  |
             -----------------------
-            |3    |4    |7        |
             |1    |2    |3        |
+            |3    |4    |7        |
             -----------------------
             <BLANKLINE>
 
@@ -1961,12 +1961,12 @@ class DataFrame:
             ...     def process(self, a: int, b: int) -> Iterable[Tuple[int]]:
             ...         yield (a + b, )
             >>> df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
-            >>> df.with_columns(["mean", "total"], [(df["a"] + df["b"]) / 2, sum_udtf(df.a, df.b)]).show()
+            >>> df.with_columns(["mean", "total"], [(df["a"] + df["b"]) / 2, sum_udtf(df.a, df.b)]).sort(df.a).show()
             ----------------------------------
             |"A"  |"B"  |"MEAN"    |"TOTAL"  |
             ----------------------------------
-            |3    |4    |3.500000  |7        |
             |1    |2    |1.500000  |3        |
+            |3    |4    |3.500000  |7        |
             ----------------------------------
             <BLANKLINE>
 

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -108,6 +108,17 @@ class TableFunctionCall:
             new_table_function._order_by = order_spec
         return new_table_function
 
+    def as_(self, *aliases: str) -> "TableFunctionCall":
+        """Alias the output columns from the output of this table function call.
+
+        Args:
+            aliases: An iterable of unique column names that do not collide with columns names after join with the main table.
+
+        Raises:
+            ValueError: Raises error when the aliases are not unique after being canonicalized.
+        """
+        return self.alias(*aliases)
+
     def alias(self, *aliases: str) -> "TableFunctionCall":
         """Alias the output columns from the output of this table function call.
 

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -108,17 +108,6 @@ class TableFunctionCall:
             new_table_function._order_by = order_spec
         return new_table_function
 
-    def as_(self, *aliases: str) -> "TableFunctionCall":
-        """Alias the output columns from the output of this table function call.
-
-        Args:
-            aliases: An iterable of unique column names that do not collide with column names after join with the main table.
-
-        Raises:
-            ValueError: Raises error when the aliases are not unique after being canonicalized.
-        """
-        return self.alias(*aliases)
-
     def alias(self, *aliases: str) -> "TableFunctionCall":
         """Alias the output columns from the output of this table function call.
 
@@ -134,6 +123,8 @@ class TableFunctionCall:
 
         self._aliases = canon_aliases
         return self
+
+    as_ = alias
 
 
 def _create_order_by_expression(e: Union[str, Column]) -> SortOrder:

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -112,7 +112,7 @@ class TableFunctionCall:
         """Alias the output columns from the output of this table function call.
 
         Args:
-            aliases: An iterable of unique column names that do not collide with columns names after join with the main table.
+            aliases: An iterable of unique column names that do not collide with column names after join with the main table.
 
         Raises:
             ValueError: Raises error when the aliases are not unique after being canonicalized.
@@ -123,7 +123,7 @@ class TableFunctionCall:
         """Alias the output columns from the output of this table function call.
 
         Args:
-            aliases: An iterable of unique column names that do not collide with columns names after join with the main table.
+            aliases: An iterable of unique column names that do not collide with column names after join with the main table.
 
         Raises:
             ValueError: Raises error when the aliases are not unique after being canonicalized.

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -5,6 +5,7 @@
 """Contains table function related classes."""
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
+from snowflake.snowpark._internal.analyzer.analyzer_utils import quote_name
 from snowflake.snowpark._internal.analyzer.sort_expression import Ascending, SortOrder
 from snowflake.snowpark._internal.analyzer.table_function import (
     NamedArgumentsTableFunction,
@@ -47,6 +48,7 @@ class TableFunctionCall:
         self._over = False
         self._partition_by = None
         self._order_by = None
+        self._aliases: Optional[Iterable[str]] = None
 
     def over(
         self,
@@ -106,6 +108,22 @@ class TableFunctionCall:
             new_table_function._order_by = order_spec
         return new_table_function
 
+    def alias(self, *aliases: str) -> "TableFunctionCall":
+        """Alias the output columns from the output of this table function call.
+
+        Args:
+            aliases: An iterable of unique column names that do not collide with columns names after join with the main table.
+
+        Raises:
+            ValueError: Raises error when the aliases are not unique after being canonicalized.
+        """
+        canon_aliases = [quote_name(col) for col in aliases]
+        if len(set(canon_aliases)) != len(aliases):
+            raise ValueError("All output column names after aliasing must be unique.")
+
+        self._aliases = canon_aliases
+        return self
+
 
 def _create_order_by_expression(e: Union[str, Column]) -> SortOrder:
     if isinstance(e, str):
@@ -129,6 +147,7 @@ def _create_table_function_expression(
     over = None
     partition_by = None
     order_by = None
+    aliases = None
     if args and named_args:
         raise ValueError("A table function shouldn't have both args and named args.")
     if isinstance(func, str):
@@ -148,6 +167,7 @@ def _create_table_function_expression(
         over = func._over
         partition_by = func._partition_by
         order_by = func._order_by
+        aliases = func._aliases
     else:
         raise TypeError(
             "'func' should be a function name in str, a list of strs that have all or a part of the fully qualified name, or a TableFunctionCall instance."
@@ -170,6 +190,7 @@ def _create_table_function_expression(
         if over
         else None
     )
+    table_function_expression.aliases = aliases
     return table_function_expression
 
 
@@ -184,10 +205,22 @@ def _get_cols_after_join_table(
     # we ensure that all columns coming after the join should be unique
     cols_before_join = get_column_names_from_plan(current_plan)
     cols_after_join = get_column_names_from_plan(join_plan)
+    aliases = func_expr.aliases
 
-    new_cols = [
-        Column(col)._named() for col in cols_after_join if col not in cols_before_join
-    ]
+    new_cols = [col for col in cols_after_join if col not in cols_before_join]
     old_cols = [Column(col)._named() for col in cols_before_join]
+
+    if aliases:
+        if len(new_cols) != len(aliases):
+            raise ValueError(
+                f"The number of aliases should be same as the number of cols added by table function. "
+                f"Columns added by table function are {new_cols} and aliases given are {aliases}"
+            )
+        new_cols = [
+            Column(col).alias(alias_col)._named()
+            for col, alias_col in zip(new_cols, aliases)
+        ]
+    else:
+        new_cols = [Column(col)._named() for col in new_cols]
 
     return old_cols, new_cols


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-650679

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add support to alias the columns names that come from the output of table function joins. The support can be seen for functions `select`, `join_table_function`, `with_column` and `with_columns`
