### PR TITLE
SNOW-623550: Fix the bug that packages with underscores cannot be added

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -710,17 +710,23 @@ class Session:
         )
         for package in packages:
             if isinstance(package, ModuleType):
-                package_name = MODULE_NAME_TO_PACKAGE_NAME_MAP.get(
+                package = MODULE_NAME_TO_PACKAGE_NAME_MAP.get(
                     package.__name__, package.__name__
                 )
-                package = f"{package_name}=={pkg_resources.get_distribution(package_name).version}"
+                package = (
+                    f"{package}=={pkg_resources.get_distribution(package).version}"
+                )
                 use_local_version = True
             else:
                 package = package.strip().lower()
                 use_local_version = False
             package_req = pkg_resources.Requirement.parse(package)
-            # get the standard package name
-            package_name = package_req.key
+            # get the standard package name if there is no underscore
+            # underscores are discouraged in package names, but are still used in Anaconda channel
+            # pkg_resources.Requirement.parse will convert all underscores to dashes
+            package_name = (
+                package if not use_local_version and "_" in package else package_req.key
+            )
             if validate_package:
                 if package_name not in valid_packages:
                     is_anaconda_terms_acknowledged = self._run_query(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #395 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `pkg_resources.Requirement.parse` will convert all underscores to dashes, whereas some packages in Anaconda are still using underscores. The fix is that if a package is added as a string which contains an underscore, we just pass this raw string to the server without parsing it. 
