### PR TITLE
SNOW-654033 add a randomized sleep to handle rmtree error

### DIFF
--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -6,7 +6,6 @@ import os
 import random
 import shutil
 import string
-from time import sleep
 
 import pytest
 
@@ -25,24 +24,12 @@ def random_alphanumeric_name():
     )
 
 
-def onerror(func, path, exc_info):
-    retries = 3
-    for retry in range(retries):
-        try:
-            sleep(1)
-            func(path)
-            return
-        except Exception as ex:
-            if retry == retries - 1:
-                raise ex
-
-
 @pytest.fixture(scope="module")
 def temp_source_directory(tmpdir_factory):
     directory = tmpdir_factory.mktemp("snowpark_test_source")
     yield directory
     if not is_in_stored_procedure():
-        shutil.rmtree(str(directory), onerror=onerror)
+        shutil.rmtree(str(directory))
 
 
 @pytest.fixture(scope="module")
@@ -50,7 +37,7 @@ def temp_target_directory(tmpdir_factory):
     directory = tmpdir_factory.mktemp("snowpark_test_target")
     yield directory
     if not is_in_stored_procedure():
-        shutil.rmtree(str(directory), onerror=onerror)
+        shutil.rmtree(str(directory))
 
 
 @pytest.fixture(scope="module")
@@ -299,6 +286,7 @@ def test_put_stream_with_one_file_twice(session, temp_stage, path1):
     second_result = session.file.put_stream(
         fd, f"{stage_with_prefix}/{file_name}", overwrite=False
     )
+    fd.close()
     assert second_result.source == os.path.basename(path1)
     assert second_result.target == os.path.basename(path1) + ".gz"
     assert second_result.source_size in (10, 11)

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -3,9 +3,9 @@
 #
 
 import os
+import random
 import shutil
 import string
-from random import random
 from time import sleep
 
 import pytest

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -3,9 +3,10 @@
 #
 
 import os
-import random
 import shutil
 import string
+from random import random
+from time import sleep
 
 import pytest
 
@@ -24,12 +25,17 @@ def random_alphanumeric_name():
     )
 
 
+def onerror(func, path, exc_info):
+    sleep(1 + random.random() * 4)
+    func(path)
+
+
 @pytest.fixture(scope="module")
 def temp_source_directory(tmpdir_factory):
     directory = tmpdir_factory.mktemp("snowpark_test_source")
     yield directory
     if not is_in_stored_procedure():
-        shutil.rmtree(str(directory))
+        shutil.rmtree(str(directory), onerror=onerror)
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +43,7 @@ def temp_target_directory(tmpdir_factory):
     directory = tmpdir_factory.mktemp("snowpark_test_target")
     yield directory
     if not is_in_stored_procedure():
-        shutil.rmtree(str(directory))
+        shutil.rmtree(str(directory), onerror=onerror)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -26,8 +26,15 @@ def random_alphanumeric_name():
 
 
 def onerror(func, path, exc_info):
-    sleep(1 + random.random() * 4)
-    func(path)
+    retries = 3
+    for retry in range(retries):
+        try:
+            sleep(1)
+            func(path)
+            return
+        except Exception as ex:
+            if retry == retries - 1:
+                raise ex
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-654033

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fix flaky test for windows environment caused by `rmtree`
