### PR TITLE
SNOW-630799 Support table_type in session#write_pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Release History
+## 0.10.0 (Unreleased)
+
+### New Features:
+- Added support for `table_type` in `session.write_pandas()`. You can now choose from these `table_type` options: `"temporary"`, `"temp"`, and `"transient"`.
+
+### Deprecations:
+- Keyword Argument `create_temp_table` in `session.write_pandas()`.
+
+### Dependency updates
+- Updated ``snowflake-connector-python`` to 2.7.12.
+
 ## 0.9.0 (2022-08-30)
 
 ### New Features:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
-CONNECTOR_DEPENDENCY_VERSION = "2.7.11"
+CONNECTOR_DEPENDENCY_VERSION = "2.7.12"
 
 # read the version
 VERSION = ()

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import warnings
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Literal, Optional, Union
 
 import snowflake.snowpark  # for forward references of type hints
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -72,7 +72,7 @@ class DataFrameWriter:
         mode: Optional[str] = None,
         column_order: str = "index",
         create_temp_table: bool = False,
-        table_type: str = "",
+        table_type: Literal["", "temp", "temporary", "transient"] = "",
         statement_params: Optional[Dict[str, str]] = None,
     ) -> None:
         """Writes the data to the specified table in a Snowflake database.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -7,12 +7,13 @@ import decimal
 import json
 import logging
 import os
+import warnings
 from array import array
 from functools import reduce
 from logging import getLogger
 from threading import RLock
 from types import ModuleType
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 
 import cloudpickle
 import pkg_resources
@@ -988,6 +989,7 @@ class Session:
         auto_create_table: bool = False,
         create_temp_table: bool = False,
         overwrite: bool = False,
+        table_type: Literal["", "temp", "temporary", "transient"] = "",
     ) -> Table:
         """Writes a pandas DataFrame to a table in Snowflake and returns a
         Snowpark :class:`DataFrame` object referring to the table where the
@@ -1018,12 +1020,14 @@ class Session:
                 then it drops the table. If set to ``True`` and if auto_create_table is set to ``False``,
                 then it trunctates the table. Note that in both cases (when overwrite is set to ``True``) it will replace the existing
                 contents of the table with that of the passed in Pandas DataFrame.
+            table_type: The table type of to-be-created table. The supported table types include ``temp``/``temporary``
+                and ``transient``. Empty means permanent table as per SQL convention.
 
         Example::
 
             >>> import pandas as pd
             >>> pandas_df = pd.DataFrame([(1, "Steve"), (2, "Bob")], columns=["id", "name"])
-            >>> snowpark_df = session.write_pandas(pandas_df, "write_pandas_table", auto_create_table=True, create_temp_table=True)
+            >>> snowpark_df = session.write_pandas(pandas_df, "write_pandas_table", auto_create_table=True, table_type="temp")
             >>> snowpark_df.to_pandas()
                id   name
             0   1  Steve
@@ -1043,12 +1047,33 @@ class Session:
                id  name
             0   1  Jane
 
+            >>> pandas_df4 = pd.DataFrame([(1, "Jane")], columns=["id", "name"])
+            >>> snowpark_df4 = session.write_pandas(pandas_df4, "write_pandas_transient_table", auto_create_table=True, table_type="transient")
+            >>> snowpark_df4.to_pandas()
+               id  name
+            0   1  Jane
+
         Note:
             Unless ``auto_create_table`` is ``True``, you must first create a table in
             Snowflake that the passed in pandas DataFrame can be written to. If
             your pandas DataFrame cannot be written to the specified table, an
             exception will be raised.
         """
+        if create_temp_table:
+            warnings.warn(
+                "create_temp_table is deprecated. We still respect this parameter when it is True but "
+                'please consider using `table_type="temporary"` instead.',
+                DeprecationWarning,
+                # warnings.warn -> write_pandas
+                stacklevel=2,
+            )
+            table_type = "temporary"
+
+        if table_type and table_type.lower() not in ["temp", "temporary", "transient"]:
+            raise ValueError(
+                "Unsupported table type. Expected table types: temp/temporary, transient"
+            )
+
         success = None  # forward declaration
         try:
             if quote_identifiers:
@@ -1075,8 +1100,8 @@ class Session:
                 parallel=parallel,
                 quote_identifiers=quote_identifiers,
                 auto_create_table=auto_create_table,
-                create_temp_table=create_temp_table,
                 overwrite=overwrite,
+                table_type=table_type,
             )
         except ProgrammingError as pe:
             if pe.msg.endswith("does not exist"):

--- a/tests/integ/test_pandas_to_df.py
+++ b/tests/integ/test_pandas_to_df.py
@@ -198,6 +198,67 @@ def test_write_pandas(session, tmp_table_basic):
     session._run_query('drop table if exists "tmp_table_complex"')
 
 
+@pytest.mark.parametrize("table_type", ["", "temp", "temporary", "transient"])
+def test_write_pandas_with_table_type(session, table_type):
+    pd = PandasDF(
+        [
+            (1, 4.5, "t1"),
+            (2, 7.5, "t2"),
+            (3, 10.5, "t3"),
+        ],
+        columns=["id".upper(), "foot_size".upper(), "shoe_model".upper()],
+    )
+
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    try:
+        df = session.write_pandas(
+            pd,
+            table_name,
+            table_type=table_type,
+            auto_create_table=True,
+        )
+        results = df.to_pandas()
+        assert_frame_equal(results, pd, check_dtype=False)
+        table_info = session.sql(f"show tables like '{table_name}'").collect()
+        if not table_type:
+            expected_table_kind = "TABLE"
+        elif table_type == "temp":
+            expected_table_kind = "TEMPORARY"
+        else:
+            expected_table_kind = table_type.upper()
+        assert table_info[0]["kind"] == expected_table_kind
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_write_temp_table_no_breaking_change(session):
+    pd = PandasDF(
+        [
+            (1, 4.5, "t1"),
+            (2, 7.5, "t2"),
+            (3, 10.5, "t3"),
+        ],
+        columns=["id".upper(), "foot_size".upper(), "shoe_model".upper()],
+    )
+
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    try:
+        with pytest.deprecated_call(match="create_temp_table is deprecated"):
+            df = session.write_pandas(
+                pd,
+                table_name,
+                create_temp_table=True,
+                auto_create_table=True,
+            )
+
+        results = df.to_pandas()
+        assert_frame_equal(results, pd, check_dtype=False)
+        table_info = session.sql(f"show tables like '{table_name}'").collect()
+        assert table_info[0]["kind"] == "TEMPORARY"
+    finally:
+        Utils.drop_table(session, table_name)
+
+
 def test_create_dataframe_from_pandas(session):
     pd = PandasDF(
         [
@@ -248,9 +309,7 @@ def test_write_pandas_temp_table_and_irregular_column_names(session):
     )
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
-        session.write_pandas(
-            pd, table_name, auto_create_table=True, create_temp_table=True
-        )
+        session.write_pandas(pd, table_name, auto_create_table=True, table_type="temp")
         table_info = session.sql(f"show tables like '{table_name}'").collect()
         assert table_info[0]["kind"] == "TEMPORARY"
     finally:
@@ -270,9 +329,7 @@ def test_write_pandas_with_timestamps(session):
     )
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
-        session.write_pandas(
-            pd, table_name, auto_create_table=True, create_temp_table=True
-        )
+        session.write_pandas(pd, table_name, auto_create_table=True, table_type="temp")
         data = session.sql(f'select * from "{table_name}"').collect()
         assert data[0]["tm_tz"] is not None
         assert data[0]["tm_ntz"] is not None


### PR DESCRIPTION
Description

Now that connector's latest change has been released, we could
use this from the connector

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-630799

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This change adds table_type in write_pandas, which make uses of `write_pandas` from connector.
