### PR TITLE
SNOW-500400: Allow structured data to be literal value 

### DIFF
--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -177,10 +177,17 @@ PYTHON_TO_SNOW_TYPE_MAPPINGS = {
 }
 
 
-VALID_PYTHON_TYPES_FOR_LITERAL_VALUE = tuple(PYTHON_TO_SNOW_TYPE_MAPPINGS.keys())
+VALID_PYTHON_TYPES_FOR_LITERAL_VALUE = (
+    *PYTHON_TO_SNOW_TYPE_MAPPINGS.keys(),
+    list,
+    tuple,
+    dict,
+)
 VALID_SNOWPARK_TYPES_FOR_LITERAL_VALUE = (
     *PYTHON_TO_SNOW_TYPE_MAPPINGS.values(),
     _NumericType,
+    ArrayType,
+    MapType,
 )
 
 # Mapping Python array types to DataType

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -222,10 +222,11 @@ def column(col_name: str) -> Column:
 def lit(literal: LiteralType) -> Column:
     """
     Creates a :class:`~snowflake.snowpark.Column` expression for a literal value.
-    It only supports basic Python data types, such as: ``int``, ``float``, ``str``,
+    It supports basic Python data types, including ``int``, ``float``, ``str``,
     ``bool``, ``bytes``, ``bytearray``, ``datetime.time``, ``datetime.date``,
-    ``datetime.datetime``, ``decimal.Decimal``. Structured data types,
-    such as: ``list``, ``tuple``, ``dict`` are not supported.
+    ``datetime.datetime`` and ``decimal.Decimal``. Also, it supports Python structured data types,
+    including ``list``, ``tuple`` and ``dict``, whereas all elements in the container must
+    be JSON serializable.
     """
     return literal if isinstance(literal, Column) else Column(Literal(literal))
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -225,7 +225,7 @@ def lit(literal: LiteralType) -> Column:
     It supports basic Python data types, including ``int``, ``float``, ``str``,
     ``bool``, ``bytes``, ``bytearray``, ``datetime.time``, ``datetime.date``,
     ``datetime.datetime`` and ``decimal.Decimal``. Also, it supports Python structured data types,
-    including ``list``, ``tuple`` and ``dict``, whereas all elements in the container must
+    including ``list``, ``tuple`` and ``dict``, but this container must
     be JSON serializable.
     """
     return literal if isinstance(literal, Column) else Column(Literal(literal))

--- a/tests/integ/scala/test_permanent_udf_suite.py
+++ b/tests/integ/scala/test_permanent_udf_suite.py
@@ -316,6 +316,8 @@ def test_call_udf_with_literal_value(session):
         datetime.datetime.strptime("2017-02-24 12:00:05.456", "%Y-%m-%d %H:%M:%S.%f"),
         datetime.datetime.strptime("20:57:06", "%H:%M:%S").time(),
         datetime.datetime.strptime("2017-02-25", "%Y-%m-%d").date(),
+        [1, 2],
+        {"1": "2"},
     ]
     udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
@@ -329,11 +331,17 @@ def test_call_udf_with_literal_value(session):
         h: datetime.datetime,
         i: datetime.time,
         j: datetime.date,
+        k: list,
+        m: dict,
     ) -> str:
-        return f"{a} {b} {float(c)} {d} {e} {g} {h} {i} {j}"
+        return f"{a} {b} {float(c)} {d} {e} {g} {h} {i} {j} {k} {m}"
 
     session.udf.register(func, name=udf_name)
     Utils.check_answer(
         session.range(1).select(call_udf(udf_name, *values)),
-        [Row("2 1.1 1.2 str True b'a' 2017-02-24 12:00:05.456000 20:57:06 2017-02-25")],
+        [
+            Row(
+                "2 1.1 1.2 str True b'a' 2017-02-24 12:00:05.456000 20:57:06 2017-02-25 [1, 2] {'1': '2'}"
+            )
+        ],
     )

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1713,8 +1713,8 @@ def test_replace(session):
 
     df = session.create_dataframe([[[1, 2], (1, 3)]], schema=["col1", "col2"])
     Utils.check_answer(
-        df.replace((1, 3), [2, 3]),
-        [Row("[\n  1,\n  2\n]", "[\n  1,\n  3\n]")],
+        df.replace([(1, 3)], [[2, 3]]),
+        [Row("[\n  1,\n  2\n]", "[\n  2,\n  3\n]")],
     )
 
     # negative case

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1646,22 +1646,21 @@ def test_fillna(session):
         [Row(1, 1.1), Row(None, 1)],
     )
 
-    # negative case
     df = session.create_dataframe(
         [[[1, 2], (1, 3)], [None, None]], schema=["col1", "col2"]
     )
+    Utils.check_answer(
+        df.fillna([1, 3]),
+        [
+            Row("[\n  1,\n  2\n]", "[\n  1,\n  3\n]"),
+            Row("[\n  1,\n  3\n]", "[\n  1,\n  3\n]"),
+        ],
+    )
+
+    # negative case
     with pytest.raises(TypeError) as ex_info:
         df.fillna(1, subset={1: "a"})
     assert "subset should be a list or tuple of column names" in str(ex_info)
-    with pytest.raises(ValueError) as ex_info:
-        df.fillna([1, 3])
-    assert "All values in value should be in one of" in str(ex_info)
-    with pytest.raises(ValueError) as ex_info:
-        df.fillna((1, 3))
-    assert "All values in value should be in one of" in str(ex_info)
-    with pytest.raises(ValueError) as ex_info:
-        df.fillna({1: 3})
-    assert "All keys in value should be column names (str)" in str(ex_info)
 
 
 def test_replace(session):
@@ -1712,6 +1711,12 @@ def test_replace(session):
         [Row(1, None, "1.0"), Row(2, 2.0, "2.0")],
     )
 
+    df = session.create_dataframe([[[1, 2], (1, 3)]], schema=["col1", "col2"])
+    Utils.check_answer(
+        df.replace((1, 3), [2, 3]),
+        [Row("[\n  1,\n  2\n]", "[\n  1,\n  3\n]")],
+    )
+
     # negative case
     with pytest.raises(SnowparkColumnException) as ex_info:
         df.replace({1: 3}, subset=["d"])
@@ -1722,15 +1727,6 @@ def test_replace(session):
     with pytest.raises(ValueError) as ex_info:
         df.replace([1], [2, 3])
     assert "to_replace and value lists should be of the same length" in str(ex_info)
-    with pytest.raises(ValueError) as ex_info:
-        df.replace(1, [2, 3])
-    assert "All keys and values in value should be in one of" in str(ex_info)
-    with pytest.raises(ValueError) as ex_info:
-        df.replace([1, (1, 2)], [2, 3])
-    assert "All keys and values in value should be in one of" in str(ex_info)
-    with pytest.raises(ValueError) as ex_info:
-        df.replace(1, {1: 2})
-    assert "All keys and values in value should be in one of" in str(ex_info)
 
 
 def test_select_case_expr(session):

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -8,12 +8,12 @@ import decimal
 import pytest
 
 from snowflake.snowpark._internal.analyzer.expression import Literal
-from snowflake.snowpark._internal.type_utils import PYTHON_TO_SNOW_TYPE_MAPPINGS
+from snowflake.snowpark._internal.type_utils import infer_type
 from snowflake.snowpark.exceptions import SnowparkPlanException
 
 
 def test_literal():
-    basic_data = [
+    valid_data = [
         1,
         "one",
         1.0,
@@ -24,14 +24,17 @@ def test_literal():
         bytearray("a", "utf-8"),
         bytes("a", "utf-8"),
         decimal.Decimal(0.5),
+        (1, 1),
+        [2, 2],
+        {"1": 2},
     ]
 
-    structured_data = [(1, 1), [2, 2], {"1": 2}]
+    invalid_data = [pytest]
 
-    for d in basic_data:
-        assert isinstance(Literal(d).datatype, PYTHON_TO_SNOW_TYPE_MAPPINGS[type(d)])
+    for d in valid_data:
+        assert isinstance(Literal(d).datatype, infer_type(d).__class__)
 
-    for d in structured_data:
+    for d in invalid_data:
         with pytest.raises(SnowparkPlanException) as ex_info:
             Literal(d)
         assert "Cannot create a Literal" in str(ex_info)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-500400

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Make list, tuple and dict a valid literal value in snowpark
