### PR TITLE
SNOW-654839: Additional regression test for save_as_table

### DIFF
--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -109,6 +109,29 @@ def test_project_null_values(session):
     assert df2.collect() == [Row(None), Row(None)]
 
 
+def test_bulk_insert_from_collected_result(session):
+    """Tests columnless bulk insert into a new table from a collected result of 'SELECT *'"""
+    table_name_source = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    table_name_copied = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    source_df = session.create_dataframe(
+        [
+            [Utils.random_alphanumeric_str(230), Utils.random_alphanumeric_str(230)]
+            for _ in range(1000)
+        ],
+        schema=["a", "b"],
+    )
+    try:
+        source_df.write.save_as_table(table_name_source)
+        results = session.sql(f"select * from {table_name_source}").collect()
+        new_df = session.create_dataframe(results)
+        new_df.write.save_as_table(table_name_copied)
+        Utils.check_answer(session.table(table_name_source), source_df, True)
+        Utils.check_answer(session.table(table_name_copied), source_df, True)
+    finally:
+        Utils.drop_table(session, table_name_source)
+        Utils.drop_table(session, table_name_copied)
+
+
 def test_write_null_data_to_table(session):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     df = session.create_dataframe([(1, None), (2, None), (3, None)]).to_df("a", "b")


### PR DESCRIPTION
Attempting to save a new dataframe created out of a `SELECT *` result failed in 0.8.0 but was fixed by SNOW-619431 inadvertently.

This change adds an additional test covering a scenario where a bulk insert is made from data collected through a SELECT * query (no columns specified).

This is a test-only change. It makes no changes to any library or API files.

Testing:

  - Ran all of the test suites via pytest
  - Newly added unit test passes on main
  - Verified manually that the unit test:
    - Passes on tag 0.7.0
    - Fails  on tag 0.8.0 - Passes on tag 0.9.0

Failure in tag 0.8.0 matches the reported issue:

```
FAILED tests/integ/scala/test_dataframe_suite.py::test_write_from_collected_dataframe - TypeError: argument of type 'NoneType' is not iterable
```

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
