### PR TITLE
SNOW-624867: flatten session.table_function

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -610,9 +610,9 @@ class SelectTableFunction(Selectable):
     def __init__(
         self,
         func_expr: TableFunctionExpression,
-        analyzer: "Analyzer",
         *,
         other_plan: Optional[LogicalPlan] = None,
+        analyzer: "Analyzer",
     ) -> None:
         super().__init__(analyzer)
         self.func_expr = func_expr

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -8,6 +8,12 @@ from copy import copy
 from enum import Enum
 from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Union
 
+from snowflake.snowpark._internal.analyzer.table_function import (
+    TableFunctionExpression,
+    TableFunctionJoin,
+    TableFunctionRelation,
+)
+
 if TYPE_CHECKING:
     from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 
@@ -596,6 +602,38 @@ class SelectStatement(Selectable):
         new.offset = (self.offset + offset) if self.offset else offset
         new._column_states = self._column_states
         return new
+
+
+class SelectTableFunction(Selectable):
+    """Wrap table function related plan to a subclass of Selectable."""
+
+    def __init__(
+        self,
+        func_expr: TableFunctionExpression,
+        analyzer: "Analyzer",
+        *,
+        other_plan: Optional[LogicalPlan] = None,
+    ) -> None:
+        super().__init__(analyzer)
+        self.func_expr = func_expr
+        if other_plan:
+            self._snowflake_plan = analyzer.resolve(
+                TableFunctionJoin(func_expr, other_plan)
+            )
+        else:
+            self._snowflake_plan = analyzer.resolve(TableFunctionRelation(func_expr))
+
+    @property
+    def snowflake_plan(self):
+        return self._snowflake_plan
+
+    @property
+    def sql_query(self) -> str:
+        return self._snowflake_plan.queries[-1].sql
+
+    @property
+    def schema_query(self) -> str:
+        return self._snowflake_plan.schema_query
 
 
 class SetOperand:

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -618,7 +618,7 @@ class SelectTableFunction(Selectable):
         self.func_expr = func_expr
         if other_plan:
             self._snowflake_plan = analyzer.resolve(
-                TableFunctionJoin(func_expr, other_plan)
+                TableFunctionJoin(other_plan, func_expr)
             )
         else:
             self._snowflake_plan = analyzer.resolve(TableFunctionRelation(func_expr))

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -32,6 +32,7 @@ from snowflake.snowpark._internal.analyzer.select_statement import (
     SelectSnowflakePlan,
     SelectSQL,
     SelectStatement,
+    SelectTableFunction,
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlanBuilder
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -924,10 +925,7 @@ class Session:
             d = DataFrame(
                 self,
                 SelectStatement(
-                    from_=SelectSnowflakePlan(
-                        snowflake_plan=TableFunctionRelation(func_expr),
-                        analyzer=self._analyzer,
-                    ),
+                    from_=SelectTableFunction(func_expr, analyzer=self._analyzer),
                     analyzer=self._analyzer,
                 ),
             )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-624867

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Convert `TableFunctionRelation` to a `Selectable` so that we can leverage the sql simplifier and flatten select queries
