### PR TITLE
SNOW-621596: flatten union by name

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -279,13 +279,12 @@ class DataFrame:
 
     Broadly, the operations on DataFrame can be divided into two types:
 
-    - **Transformations** produce a new DataFrame from one or more existing DataFrames. Note that tranformations are lazy and don't cause the DataFrame to be evaluated. If the API does not provide a method to express the SQL that you want to use, you can use :func:`functions.sqlExpr` as a workaround.
+    - **Transformations** produce a new DataFrame from one or more existing DataFrames. Note that transformations are lazy and don't cause the DataFrame to be evaluated. If the API does not provide a method to express the SQL that you want to use, you can use :func:`functions.sqlExpr` as a workaround.
     - **Actions** cause the DataFrame to be evaluated. When you call a method that performs an action, Snowpark sends the SQL query for the DataFrame to the server for evaluation.
 
     **Transforming a DataFrame**
 
-    The following exam
-    ples demonstrate how you can transform a DataFrame.
+    The following examples demonstrate how you can transform a DataFrame.
 
     Example 5
         Using the :func:`select()` method to select the columns that should be in the
@@ -1519,11 +1518,27 @@ class DataFrame:
             rattr for rattr in right_output_attrs if rattr not in right_project_list
         ]
 
-        right_child = self._with_plan(
-            Project(right_project_list + not_found_attrs, other._plan)
-        )
+        from snowflake.snowpark import context
 
-        return self._with_plan(UnionPlan(self._plan, right_child._plan, is_all))
+        names = right_project_list + not_found_attrs
+        if context._use_sql_simplifier and other._select_statement:
+            right_child = self._with_plan(other._select_statement.select(names))
+        else:
+            right_child = self._with_plan(Project(names, other._plan))
+
+        union_plan = UnionPlan(self._plan, right_child._plan, is_all)
+        if context._use_sql_simplifier:
+            df = self._with_plan(
+                SelectStatement(
+                    from_=SelectSnowflakePlan(
+                        snowflake_plan=union_plan, analyzer=self._session._analyzer
+                    ),
+                    analyzer=self._session._analyzer,
+                )
+            )
+        else:
+            df = self._with_plan(union_plan)
+        return df
 
     @df_api_usage
     def intersect(self, other: "DataFrame") -> "DataFrame":


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-621596

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR addresses `dataframe.union_by_name` as a larger effort to simplify the sql query generated on the client side and reduce the amount of nesting.
