### PR TITLE
[SNOW-647398] show details when printing a snowpark session

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -265,8 +265,8 @@ class Session:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def __repr__(self):
-        return f"<{self.__class__.__module__}.{self.__class__.__name__}: account={repr(self._conn._conn.account)}, role={repr(self._conn._conn.role)}, database={repr(self._conn._conn.database)}, schema={repr(self._conn._conn.schema)}, warehouse={repr(self._conn._conn.warehouse)}>"
+    def __str__(self):
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}: account={self.get_current_account()}, role={self.get_current_role()}, database={self.get_current_database()}, schema={self.get_current_schema()}, warehouse={self.get_current_warehouse()}>"
 
     def _generate_new_action_id(self) -> int:
         self._last_action_id += 1
@@ -1420,6 +1420,13 @@ class Session:
         df = DataFrame(self, range_plan)
         set_api_call_source(df, "Session.range")
         return df
+
+    def get_current_account(self) -> Optional[str]:
+        """
+        Returns the name of the current account for the Python connector session attached
+        to this session.
+        """
+        return self._conn._get_current_parameter("account")
 
     def get_current_database(self) -> Optional[str]:
         """

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -266,7 +266,7 @@ class Session:
         self.close()
 
     def __repr__(self):
-        return f"<{self.__class__.__module__}.{self.__class__.__name__}: role={repr(self._conn._conn.role)}, database={repr(self._conn._conn.database)}, schema={repr(self._conn._conn.schema)}, warehouse={repr(self._conn._conn.warehouse)}>"
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}: account={repr(self._conn._conn.account)}, role={repr(self._conn._conn.role)}, database={repr(self._conn._conn.database)}, schema={repr(self._conn._conn.schema)}, warehouse={repr(self._conn._conn.warehouse)}>"
 
     def _generate_new_action_id(self) -> int:
         self._last_action_id += 1

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -265,6 +265,9 @@ class Session:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def __repr__(self):
+        return f"<{self.__class__.__module__}.{self.__class__.__name__}: role={repr(self._conn._conn.role)}, database={repr(self._conn._conn.database)}, schema={repr(self._conn._conn.schema)}, warehouse={repr(self._conn._conn.warehouse)}>"
+
     def _generate_new_action_id(self) -> int:
         self._last_action_id += 1
         return self._last_action_id

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -266,7 +266,11 @@ class Session:
         self.close()
 
     def __str__(self):
-        return f"<{self.__class__.__module__}.{self.__class__.__name__}: account={self.get_current_account()}, role={self.get_current_role()}, database={self.get_current_database()}, schema={self.get_current_schema()}, warehouse={self.get_current_warehouse()}>"
+        return (
+            f"<{self.__class__.__module__}.{self.__class__.__name__}: account={self.get_current_account()}, "
+            f"role={self.get_current_role()}, database={self.get_current_database()}, "
+            f"schema={self.get_current_schema()}, warehouse={self.get_current_warehouse()}>"
+        )
 
     def _generate_new_action_id(self) -> int:
         self._last_action_id += 1

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -15,12 +15,17 @@ def test_aliases():
 
 def test_repr():
     mock_sf_connection = mock.create_autospec(
-        SnowflakeConnection, role="ROLE", database="DB", schema="SCHEMA", warehouse="WH"
+        SnowflakeConnection,
+        account="ACCOUNT",
+        role="ROLE",
+        database="DB",
+        schema="SCHEMA",
+        warehouse="WH",
     )
     mock_server_connection = mock.create_autospec(
         ServerConnection, _conn=mock_sf_connection
     )
     assert (
         repr(Session(mock_server_connection))
-        == "<snowflake.snowpark.session.Session: role='ROLE', database='DB', schema='SCHEMA', warehouse='WH'>"
+        == "<snowflake.snowpark.session.Session: account='ACCOUNT', role='ROLE', database='DB', schema='SCHEMA', warehouse='WH'>"
     )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2,8 +2,25 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
+from unittest import mock
+
+from snowflake.connector import SnowflakeConnection
 from snowflake.snowpark import Session
+from snowflake.snowpark._internal.server_connection import ServerConnection
 
 
 def test_aliases():
     assert Session.createDataFrame == Session.create_dataframe
+
+
+def test_repr():
+    mock_sf_connection = mock.create_autospec(
+        SnowflakeConnection, role="ROLE", database="DB", schema="SCHEMA", warehouse="WH"
+    )
+    mock_server_connection = mock.create_autospec(
+        ServerConnection, _conn=mock_sf_connection
+    )
+    assert (
+        repr(Session(mock_server_connection))
+        == "<snowflake.snowpark.session.Session: role='ROLE', database='DB', schema='SCHEMA', warehouse='WH'>"
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-647398](https://snowflakecomputing.atlassian.net/browse/SNOW-647398)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

It implements a `__repr__` method for Snowpark.Session so `print(session)` will display some helpful information about the session.
Before: `<snowflake.snowpark.session.Session object at 0x11c681700>`
After: `<snowflake.snowpark.session.Session: role='ROLE', database='DB', schema='SCHEMA', warehouse='WH'>`
