### PR TITLE
Check _session_parameters is not None

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -261,6 +261,7 @@ class Session:
         self._last_canceled_id = 0
         self._use_scoped_temp_objects = (
             _use_scoped_temp_objects
+            and conn._conn._session_parameters
             and conn._conn._session_parameters.get(
                 _PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS_STRING, True
             )


### PR DESCRIPTION
Description

Connector's _session_parameters can be None so we should also check before using the field

Testing

Existing test + stored proc regression test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   N/A

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It's possible that the connector's `_session_parameter` is `None`, so we should do a check before using it.
