### PR TITLE
SNOW-658388: Check session parameter is None

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -259,10 +259,14 @@ class Session:
         self._plan_builder = SnowflakePlanBuilder(self)
         self._last_action_id = 0
         self._last_canceled_id = 0
-        self._use_scoped_temp_objects = (
+        self._use_scoped_temp_objects = bool(
             _use_scoped_temp_objects
-            and conn._conn._session_parameters.get(
-                _PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS_STRING, True
+            and (
+                conn._conn._session_parameters.get(
+                    _PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS_STRING, True
+                )
+                if conn._conn._session_parameters
+                else True
             )
         )
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -259,6 +259,7 @@ class Session:
         self._plan_builder = SnowflakePlanBuilder(self)
         self._last_action_id = 0
         self._last_canceled_id = 0
+        # consider making _session_parameters check a helpful function
         self._use_scoped_temp_objects = bool(
             _use_scoped_temp_objects
             and (

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -48,6 +48,8 @@ def test_used_scoped_temp_object():
     fake_connection._conn = mock.Mock()
 
     # by default module level config is on
+    fake_connection._conn._session_parameters = None
+    assert Session(fake_connection)._use_scoped_temp_objects is True
 
     fake_connection._conn._session_parameters = {}
     assert Session(fake_connection)._use_scoped_temp_objects is True


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-658388

`_session_parameter` could be `None` is stored proc, we should check and default to `True` if it's None.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
