### PR TITLE
SNOW-659103: Fix support for df.select(df['*'])

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -817,6 +817,7 @@ def derive_column_states_from_subquery(
     for c in cols:
         if isinstance(c, UnresolvedAlias) and isinstance(c.child, Star):
             if c.child.expressions:
+                # df.select(df["*"]) will have child expressions. df.select("*") doesn't.
                 columns_from_star = map(analyzer.analyze, c.child.expressions)
             else:
                 columns_from_star = from_.column_states.projection

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -274,6 +274,7 @@ class SelectSnowflakePlan(Selectable):
             if isinstance(snowflake_plan, SnowflakePlan)
             else analyzer.resolve(snowflake_plan)
         )
+        self.expr_to_alias.update(self._snowflake_plan.expr_to_alias)
         self.pre_actions = self._snowflake_plan.queries[:-1]
         self.post_actions = self._snowflake_plan.post_actions
 
@@ -436,6 +437,9 @@ class SelectStatement(Selectable):
             len(cols) == 1
             and isinstance(cols[0], UnresolvedAlias)
             and isinstance(cols[0].child, Star)
+            and not cols[0].child.expressions
+            # df.select("*") doesn't have the child.expressions
+            # df.select(df["*"]) has the child.expressions
         ):
             return self
         final_projection = []
@@ -448,6 +452,7 @@ class SelectStatement(Selectable):
             # There must be duplicate columns in the projection.
             # We don't flatten when there are duplicate columns.
             can_be_flattened = False
+            disable_next_level_flatten = True
         elif self.flatten_disabled or self.has_clause_using_columns:
             can_be_flattened = False
         else:
@@ -775,6 +780,7 @@ def initiate_column_states(column_names: List[str]) -> ColumnStateDict:
             referenced_by_same_level_columns=COLUMN_DEPENDENCY_EMPTY,
             state_dict=column_states,
         )
+    column_states.projection = column_names
     return column_states
 
 
@@ -810,14 +816,14 @@ def derive_column_states_from_subquery(
     column_states = ColumnStateDict()
     for c in cols:
         if isinstance(c, UnresolvedAlias) and isinstance(c.child, Star):
-            column_states.projection.extend(from_.column_states.projection)
+            if c.child.expressions:
+                columns_from_star = map(analyzer.analyze, c.child.expressions)
+            else:
+                columns_from_star = from_.column_states.projection
             column_states.update(
-                initiate_column_states(
-                    c_state
-                    for c_state in column_states
-                    if c_state.change_state != ColumnChangeState.DROPPED
-                )
-            )  # use column_states instead of column_states.active_columns, which is a set, not ordered. column_states is a dict so it's ordered.
+                initiate_column_states(c_state for c_state in columns_from_star)
+            )
+            column_states.projection.extend(columns_from_star)
             continue
         c_name = parse_column_name(c, analyzer)
         if c_name is None:

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -770,6 +770,12 @@ def test_select_star(session, simplifier_table):
         == f'SELECT "B" FROM ( SELECT *, "A" FROM ( SELECT  *  FROM {simplifier_table}))'
     )
 
+    df6 = df4.select("b")
+    assert (
+        df6.queries["queries"][0]
+        == f'SELECT "B" FROM ( SELECT "A","B", "A" FROM ( SELECT  *  FROM {simplifier_table}))'
+    )
+
     with pytest.raises(SnowparkSQLException, match="ambiguous column name 'A'"):
         df3.select("a").collect()
 

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -739,3 +739,39 @@ def test_unpivot(session, simplifier_table):
         .select((col("sales") + 1).as_("sales"))
     )
     assert df2.queries["queries"][-1].count("SELECT") == 6
+
+
+def test_select_star(session, simplifier_table):
+    df = session.table(simplifier_table)
+    df1 = df.select("*")
+    assert df1.queries["queries"][0] == f"SELECT  *  FROM {simplifier_table}"
+
+    df2 = df.select(df["*"])  # no flatten
+    assert (
+        df2.queries["queries"][0]
+        == f'SELECT "A","B" FROM ( SELECT  *  FROM {simplifier_table})'
+    )
+
+    df3 = df.select("*", "a")
+    assert (
+        df3.queries["queries"][0]
+        == f'SELECT *, "A" FROM ( SELECT  *  FROM {simplifier_table})'
+    )
+
+    df4 = df.select(df["*"], "a")
+    assert (
+        df4.queries["queries"][0]
+        == f'SELECT "A","B", "A" FROM ( SELECT  *  FROM {simplifier_table})'
+    )
+
+    df5 = df3.select("b")
+    assert (
+        df5.queries["queries"][0]
+        == f'SELECT "B" FROM ( SELECT *, "A" FROM ( SELECT  *  FROM {simplifier_table}))'
+    )
+
+    with pytest.raises(SnowparkSQLException, match="ambiguous column name 'A'"):
+        df3.select("a").collect()
+
+    with pytest.raises(SnowparkSQLException, match="ambiguous column name 'A'"):
+        df4.select("a").collect()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-659103

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Get the full list of attributes when `df["*"]` is used.
