### PR TITLE
SNOW-665754: Avoid describing the dataframe for `df.with_column` and several other methods when using SQL simplifier

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -114,17 +114,10 @@ class InExpression(Expression):
         return derive_dependent_columns(self.columns, *self.values)
 
 
-class Star(Expression):
-    def __init__(self, expressions: List[NamedExpression]) -> None:
-        super().__init__()
-        self.expressions = expressions
-
-    def dependent_column_names(self) -> Optional[Set[str]]:
-        return derive_dependent_columns(*self.expressions)
-
-
 class Attribute(Expression, NamedExpression):
-    def __init__(self, name: str, datatype: DataType, nullable: bool = True) -> None:
+    def __init__(
+        self, name: str, datatype: Optional[DataType] = None, nullable: bool = True
+    ) -> None:
         super().__init__()
         self.name = name
         self.datatype = datatype
@@ -149,6 +142,15 @@ class Attribute(Expression, NamedExpression):
 
     def dependent_column_names(self) -> Optional[Set[str]]:
         return {self.name}
+
+
+class Star(Expression):
+    def __init__(self, expressions: List[Attribute]) -> None:
+        super().__init__()
+        self.expressions = expressions
+
+    def dependent_column_names(self) -> Optional[Set[str]]:
+        return derive_dependent_columns(*self.expressions)
 
 
 class UnresolvedAttribute(Expression, NamedExpression):

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -780,7 +780,7 @@ class DataFrame:
     def col(self, col_name: str) -> Column:
         """Returns a reference to a column in the DataFrame."""
         if col_name == "*":
-            return Column(Star(self._plan.output))
+            return Column(Star(self._output))
         else:
             return Column(self._resolve(col_name))
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3184,7 +3184,11 @@ Query List:
 
     @cached_property
     def _output(self) -> List[Attribute]:
-        return self._plan.output
+        return (
+            self._select_statement.column_states.projection
+            if self._select_statement
+            else self._plan.output
+        )
 
     @cached_property
     def schema(self) -> StructType:

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -818,9 +818,11 @@ def test_join_dataframes(session, simplifier_table):
     Utils.check_answer(df3, [Row(1, 2, 3, 4, 1, 4)])
 
     # the following can't be flattened
-    # df4 = df_right.to_df("e", "f")
-    # df5 = df_left.join(df4)
-    # df6 = df5.with_column("x", df_right.c).with_column("y", df4.f)
+    df4 = df_right.to_df("e", "f")
+    df5 = df_left.join(df4)
+    df6 = df5.with_column("x", df_right.c).with_column("y", df4.f)
+    assert df6.queries["queries"][0].count("SELECT") == 10
+    Utils.check_answer(df6, [Row(1, 2, 3, 4, 3, 4)])
 
 
 def test_sample(session, simplifier_table):
@@ -870,11 +872,8 @@ def test_select_star(session, simplifier_table):
     df1 = df.select("*")
     assert df1.queries["queries"][0] == f"SELECT  *  FROM {simplifier_table}"
 
-    df2 = df.select(df["*"])  # no flatten
-    assert (
-        df2.queries["queries"][0]
-        == f'SELECT "A","B" FROM ( SELECT  *  FROM {simplifier_table})'
-    )
+    df2 = df.select(df["*"])
+    assert df2.queries["queries"][0] == f'SELECT "A", "B" FROM {simplifier_table}'
 
     df3 = df.select("*", "a")
     assert (


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-665754

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously every `df.with_column` will have a describe query sent to snowflake to get the metadata, but it's unnecessary when sql simplifier is used (column names are saved). 
