### PR TITLE
SNOW-641129 Skip stored-proc file-not-found test

### DIFF
--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from snowflake.connector import ProgrammingError
+from snowflake.connector import OperationalError, ProgrammingError
 from snowflake.snowpark.exceptions import (
     SnowparkColumnException,
     SnowparkCreateViewException,
@@ -270,6 +270,12 @@ class SnowparkClientExceptionMessages:
         pe: ProgrammingError,
     ) -> SnowparkSQLException:
         return SnowparkSQLException(pe.msg, "1304", pe.sfqid)
+
+    @staticmethod
+    def SQL_EXCEPTION_FROM_OPERATIONAL_ERROR(
+        oe: OperationalError,
+    ) -> SnowparkSQLException:
+        return SnowparkSQLException(oe.msg, "1305", oe.sfqid)
 
     # Server Error Messages 04XX
 

--- a/src/snowflake/snowpark/file_operation.py
+++ b/src/snowflake/snowpark/file_operation.py
@@ -320,7 +320,7 @@ class FileOperation:
             >>> fd.close()
 
         Returns:
-            An `BytesIO` object which points to the downloaded file.
+            An ``BytesIO`` object which points to the downloaded file.
         """
         # check stage location has a file name
         stage_location = _validate_stage_location(stage_location)

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -9,7 +9,6 @@ import string
 
 import pytest
 
-from snowflake.connector.errors import OperationalError
 from snowflake.snowpark._internal.utils import is_in_stored_procedure
 from snowflake.snowpark.exceptions import (
     SnowparkSQLException,
@@ -520,7 +519,7 @@ def test_get_stream_negative(session, temp_stage):
         session.file.get_stream(stage_with_prefix)
     assert "stage_location should end with target file name"
 
-    with pytest.raises(OperationalError) as ex_info:
+    with pytest.raises(SnowparkSQLException) as ex_info:
         session.file.get_stream(f"{stage_with_prefix}non_existing_file")
     assert "the file does not exist" in str(ex_info)
 

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -519,6 +519,8 @@ def test_get_stream_negative(session, temp_stage):
         session.file.get_stream(stage_with_prefix)
     assert "stage_location should end with target file name"
 
+    if is_in_stored_procedure():
+        pytest.skip("Skip in stored-proc to prevent XP failing whole test")
     with pytest.raises(SnowparkSQLException) as ex_info:
         session.file.get_stream(f"{stage_with_prefix}non_existing_file")
     assert "the file does not exist" in str(ex_info)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-641129

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Regtests started failing for stored proc because XP fails entire tests when we do the file-not-found test with the following message:
```
! FAILURE: Remote file 'https://sfc-dev1-regression.s3.us-west-2.amazonaws.com/jenkins/jenkins-RT-PC-TestWorker-453403/pc-jenkins/reg-RT-PC-TestWorker-453403/s3testaccount/stage/prefix_6RIzo/non_existing_file' was not found. There are several potential causes. The file might not exist. The required credentials may be missing or invalid. If you are running a copy command, please make sure files are not deleted when they are being loaded or files are not being loaded into two different tables concurrently with auto purge option.
! -- failed command:
! call snowpark_scala_test_file_operation_suite();
```
