### PR TITLE
SNOW-641129 skip stored-proc file not found test

### DIFF
--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -519,6 +519,8 @@ def test_get_stream_negative(session, temp_stage):
         session.file.get_stream(stage_with_prefix)
     assert "stage_location should end with target file name"
 
+    if is_in_stored_procedure():
+        pytest.skip("Skip in stored-proc to prevent XP failing whole test")
     with pytest.raises(SnowparkSQLException) as ex_info:
         session.file.get_stream(f"{stage_with_prefix}non_existing_file")
     assert "the file does not exist" in str(ex_info)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Regression tests for stored procedure are failing due to a file-not-found test which causes XP to fail the whole test instead of returning the error message to python file.
```
  call snowpark_scala_test_file_operation_suite();
! FAILURE: Remote file 'https:/xxxx/non_existing_file' was not found. There are several potential causes. The file might not exist. The required credentials may be missing or invalid. If you are running a copy command, please make sure files are not deleted when they are being loaded or files are not being loaded into two different tables concurrently with auto purge option.
! -- failed command:
! call snowpark_scala_test_file_operation_suite();
```