### PR TITLE
SNOW-588269 Support session as the first argument when calling sp

### DIFF
--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -64,7 +64,18 @@ class StoredProcedure:
         *args: Any,
         session: Optional["snowflake.snowpark.session.Session"] = None,
     ) -> any:
-        session = session or snowflake.snowpark.session._get_active_session()
+        if session and args and isinstance(args[0], snowflake.snowpark.session.Session):
+            raise ValueError(
+                "Two sessions specified in arguments. Session should either be the first argument or as "
+                "a named argument at the end, but not both"
+            )
+
+        if args and isinstance(args[0], snowflake.snowpark.session.Session):
+            session = args[0]
+            args = args[1:]
+        else:
+            session = session or snowflake.snowpark.session._get_active_session()
+
         if len(self._input_types) != len(args):
             raise ValueError(
                 f"Incorrect number of arguments passed to the stored procedure. Expected: {len(self._input_types)}, Found: {len(args)}"

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -64,13 +64,12 @@ class StoredProcedure:
         *args: Any,
         session: Optional["snowflake.snowpark.session.Session"] = None,
     ) -> any:
-        if session and args and isinstance(args[0], snowflake.snowpark.session.Session):
-            raise ValueError(
-                "Two sessions specified in arguments. Session should either be the first argument or as "
-                "a named argument at the end, but not both"
-            )
-
         if args and isinstance(args[0], snowflake.snowpark.session.Session):
+            if session:
+                raise ValueError(
+                    "Two sessions specified in arguments. Session should either be the first argument or as "
+                    "a named argument at the end, but not both"
+                )
             session = args[0]
             args = args[1:]
         else:

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -874,3 +874,24 @@ def test_execute_as_options(session, execute_as):
 
     return1_sp = sproc(return1, **sproc_kwargs)
     assert return1_sp() == 1
+
+
+def test_call_sproc_with_session_as_first_argument(session):
+    @sproc
+    def return1(_: Session) -> int:
+        return 1
+
+    @sproc
+    def plus1(_: Session, x: int) -> int:
+        return x + 1
+
+    assert return1(session) == 1
+    assert plus1(session, 1) == 2
+
+    with pytest.raises(ValueError) as ex_info:
+        return1(session, session=session)
+    assert "Two sessions specified in arguments" in str(ex_info)
+
+    with pytest.raises(ValueError) as ex_info:
+        plus1(session, 1, session=session)
+    assert "Two sessions specified in arguments" in str(ex_info)


### PR DESCRIPTION
Description

This is more natural given the sp function is defined as my_proc(session, a, b)

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-588269

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This is more natural given the sp function is defined as `my_proc(session, a, b)`
