### PR TITLE
SNOW-560612 use is_sql_select_statement for sql check

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -615,7 +615,7 @@ class SnowflakePlanBuilder:
         if len(child.queries) != 1:
             raise SnowparkClientExceptionMessages.PLAN_CREATE_VIEW_FROM_DDL_DML_OPERATIONS()
 
-        if not child.queries[0].sql.lower().strip().startswith("select"):
+        if not is_sql_select_statement(child.queries[0].sql.lower().strip()):
             raise SnowparkClientExceptionMessages.PLAN_CREATE_VIEWS_FROM_SELECT_ONLY()
 
         return self.build(

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -103,6 +103,7 @@ from snowflake.snowpark._internal.utils import (
     deprecated,
     experimental,
     generate_random_alphanumeric,
+    is_sql_select_statement,
     parse_positional_args_to_list,
     random_name_for_temp_object,
     validate_object_name,
@@ -2694,7 +2695,7 @@ class DataFrame:
     def _show_string(self, n: int = 10, max_width: int = 50, **kwargs) -> str:
         query = self._plan.queries[-1].sql.strip().lower()
 
-        if query.startswith("select"):
+        if is_sql_select_statement(query):
             result, meta = self._session._conn.get_result_and_metadata(
                 self.limit(n)._plan, **kwargs
             )

--- a/tests/integ/scala/test_view_suite.py
+++ b/tests/integ/scala/test_view_suite.py
@@ -49,6 +49,19 @@ def test_view_name_with_special_character(session):
         Utils.drop_view(session, view_name)
 
 
+def test_view_with_with_sql_statement(session):
+    view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
+    try:
+        TestData.sql_using_with_select_statement(session).create_or_replace_view(
+            view_name
+        )
+
+        res = session.sql(f"select * from {quote_name(view_name)}").collect()
+        assert res == [Row(1, 2)]
+    finally:
+        Utils.drop_view(session, view_name)
+
+
 def test_only_works_on_select(session):
     view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
     with pytest.raises(SnowparkCreateViewException):

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -101,6 +101,34 @@ def test_read_stage_file_show(session, resources_path):
         Utils.drop_stage(session, tmp_stage_name)
 
 
+def test_show_using_with_select_statement(session):
+    df = session.sql(
+        "with t1 as (select 1 as a union all select 2 union all select 3 "
+        "   union all select 4 union all select 5 union all select 6 "
+        "   union all select 7 union all select 8 union all select 9 "
+        "   union all select 10 union all select 11 union all select 12) "
+        "select * from t1"
+    )
+    assert (
+        df._show_string()
+        == """
+-------
+|"A"  |
+-------
+|1    |
+|2    |
+|3    |
+|4    |
+|5    |
+|6    |
+|7    |
+|8    |
+|9    |
+|10   |
+-------\n""".lstrip()
+    )
+
+
 def test_distinct(session):
     """Tests df.distinct()."""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -726,6 +726,12 @@ class TestData:
         return session.create_dataframe([[1, 2], [3, 4]]).to_df(['"col %"', '"col *"'])
 
     @classmethod
+    def sql_using_with_select_statement(cls, session: "Session") -> DataFrame:
+        return session.sql(
+            "with t1 as (select 1 as a), t2 as (select 2 as b) select a, b from t1, t2"
+        )
+
+    @classmethod
     def nurse(cls, session: "Session") -> DataFrame:
         return session.create_dataframe(
             [


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-560612

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use `is_sql_select_statement` regex match instead of simple `startswith("select:)` to detect sql statement.
