### PR TITLE
feat: add first_value and last_value

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -312,7 +312,7 @@ class Analyzer:
                 expr.sql,
                 self.analyze(expr.expr),
                 expr.offset,
-                self.analyze(expr.default),
+                self.analyze(expr.default) if expr.default else None,
                 expr.ignore_nulls,
             )
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -802,10 +802,8 @@ def rank_related_function_expression(
         func_name
         + LEFT_PARENTHESIS
         + expr
-        + COMMA
-        + str(offset)
-        + COMMA
-        + default
+        + (COMMA + str(offset) if offset else EMPTY_STRING)
+        + (COMMA + default if default else EMPTY_STRING)
         + RIGHT_PARENTHESIS
         + (IGNORE_NULLS if ignore_nulls else EMPTY_STRING)
     )

--- a/src/snowflake/snowpark/_internal/analyzer/window_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/window_expression.py
@@ -115,3 +115,11 @@ class Lag(RankRelatedFunctionExpression):
 
 class Lead(RankRelatedFunctionExpression):
     sql = "LEAD"
+
+
+class LastValue(RankRelatedFunctionExpression):
+    sql = "LAST_VALUE"
+
+
+class FirstValue(RankRelatedFunctionExpression):
+    sql = "FIRST_VALUE"

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -184,7 +184,7 @@ from snowflake.snowpark._internal.analyzer.expression import (
     MultipleExpression,
     Star,
 )
-from snowflake.snowpark._internal.analyzer.window_expression import Lag, Lead
+from snowflake.snowpark._internal.analyzer.window_expression import FirstValue, Lag, LastValue, Lead
 from snowflake.snowpark._internal.type_utils import (
     ColumnOrLiteral,
     ColumnOrLiteralStr,
@@ -2811,6 +2811,32 @@ def lead(
     c = _to_col_if_str(e, "lead")
     return Column(
         Lead(c._expression, offset, Column._to_expr(default_value), ignore_nulls)
+    )
+
+
+def last_value(
+    e: ColumnOrName,
+    ignore_nulls: bool = False,
+) -> Column:
+    """
+    Returns the last value within an ordered group of values.
+    """
+    c = _to_col_if_str(e, "last_value")
+    return Column(
+        LastValue(c._expression, None, None, ignore_nulls)
+    )
+
+
+def first_value(
+    e: ColumnOrName,
+    ignore_nulls: bool = False,
+) -> Column:
+    """
+    Returns the first value within an ordered group of values.
+    """
+    c = _to_col_if_str(e, "last_value")
+    return Column(
+        FirstValue(c._expression, None, None, ignore_nulls)
     )
 
 

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -81,6 +81,7 @@ from snowflake.snowpark.functions import (
     equal_nan,
     exp,
     factorial,
+    first_value,
     floor,
     get,
     get_ignore_case,
@@ -109,6 +110,7 @@ from snowflake.snowpark.functions import (
     json_extract_path_text,
     kurtosis,
     lag,
+    last_value,
     lead,
     left,
     length,
@@ -2729,6 +2731,28 @@ def test_lead(session, col_z):
             lead(col_z).over(Window.partition_by(col("X")).order_by(col("X")))
         ),
         [Row(1), Row(3), Row(None), Row(3), Row(None)],
+        sort=False,
+    )
+
+
+@pytest.mark.parametrize("col_z", ["Z", col("Z")])
+def test_last_value(session, col_z):
+    Utils.check_answer(
+        TestData.xyz(session).select(
+            last_value(col_z).over(Window.partition_by(col("X")).order_by(col("Z")))
+        ),
+        [Row(3), Row(3), Row(10), Row(10), Row(10)],
+        sort=False,
+    )
+
+
+@pytest.mark.parametrize("col_z", ["Z", col("Z")])
+def test_first_value(session, col_z):
+    Utils.check_answer(
+        TestData.xyz(session).select(
+            first_value(col_z).over(Window.partition_by(col("X")).order_by(col("Z")))
+        ),
+        [Row(1), Row(1), Row(1), Row(1), Row(1)],
         sort=False,
     )
 

--- a/tests/integ/scala/test_window_frame_suite.py
+++ b/tests/integ/scala/test_window_frame_suite.py
@@ -13,7 +13,9 @@ from snowflake.snowpark.functions import (
     avg,
     col,
     count,
+    first_value,
     lag,
+    last_value,
     lead,
     min as min_,
     sum as sum_,
@@ -111,6 +113,32 @@ def test_lead_lag_with_ignore_or_respect_nulls(session):
             Row(5, None, 2, 6, 2),
             Row(6, 6, None, 6, 2),
             Row(7, None, None, None, 2),
+        ],
+    )
+
+
+def test_first_last_value_with_ignore_or_respect_nulls(session):
+    df = session.create_dataframe(
+        [(1, None), (2, 4), (3, None), (4, 2), (5, None), (6, 6), (7, None)],
+        schema=["key", "value"],
+    )
+    window = Window.order_by("key")
+    Utils.check_answer(
+        df.select(
+            "key",
+            first_value("value").over(window),
+            last_value("value").over(window),
+            first_value("value", ignore_nulls=True).over(window),
+            last_value("value", ignore_nulls=True).over(window),
+        ).sort("key"),
+        [
+            Row(1, None, None, 4, 6),
+            Row(2, None, None, 4, 6),
+            Row(3, None, None, 4, 6),
+            Row(4, None, None, 4, 6),
+            Row(5, None, None, 4, 6),
+            Row(6, None, None, 4, 6),
+            Row(7, None, None, 4, 6),
         ],
     )
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #540 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This adds two new functions (i.e. `last_value` and `first_value`) that are subclasses of `RankRelatedFunctionExpression`. 

    Since `RankRelatedFunctionExpression` was implemented with a requirement for `offset` and `default` arguments, some modifications were needed in the `analyzer` to allow for null values since `first/last_value` do not support `offset` and `default`, contrary to the already-implemented `lag` and `lead` functions.
