### PR TITLE
SNOW-664210: Fix create_dataframe when schema has special characters

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -452,10 +452,8 @@ def values_statement(output: List[Attribute], data: List[Row]) -> str:
         SELECT
         + COMMA.join([f"{DOLLAR}{i+1}{AS}{c}" for i, c in enumerate(names)])
         + FROM
-        + LEFT_PARENTHESIS
         + VALUES
         + COMMA.join(rows)
-        + RIGHT_PARENTHESIS
     )
     return query
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -438,7 +438,6 @@ def range_statement(start: int, end: int, step: int, column_name: str) -> str:
 
 
 def values_statement(output: List[Attribute], data: List[Row]) -> str:
-    table_name = random_name_for_temp_object(TempObjectType.TABLE)
     data_types = [attr.datatype for attr in output]
     names = [quote_name(attr.name) for attr in output]
     rows = []
@@ -448,16 +447,17 @@ def values_statement(output: List[Attribute], data: List[Row]) -> str:
             for value, data_type in zip(row, data_types)
         ]
         rows.append(LEFT_PARENTHESIS + COMMA.join(cells) + RIGHT_PARENTHESIS)
-    query_source = (
-        VALUES
-        + COMMA.join(rows)
-        + AS
-        + table_name
+
+    query = (
+        SELECT
+        + COMMA.join([f"{DOLLAR}{i+1}{AS}{c}" for i, c in enumerate(names)])
+        + FROM
         + LEFT_PARENTHESIS
-        + COMMA.join(names)
+        + VALUES
+        + COMMA.join(rows)
         + RIGHT_PARENTHESIS
     )
-    return project_statement([], query_source)
+    return query
 
 
 def empty_values_statement(output: List[Attribute]) -> str:

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -97,9 +97,9 @@ def test_create_dataframe_namedtuple(session):
 
 
 def test_create_dataframe_special_char_column_name(session):
-    df = session.create_dataframe([1], schema=["a b"])
-    assert df.columns == ['"a b"']
-    Utils.check_answer(df, Row(1))
+    df = session.create_dataframe([[1, 2], [1, 2]], schema=["a b", "c"])
+    assert df.columns == ['"a b"', "C"]
+    Utils.check_answer(df, [Row(1, 2), Row(1, 2)])
 
 
 # this test requires the parameters used for connection has `public role`,

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -96,6 +96,12 @@ def test_create_dataframe_namedtuple(session):
     assert [field.name for field in df.schema.fields] == ["A", "B", "C"]
 
 
+def test_create_dataframe_special_char_column_name(session):
+    df = session.create_dataframe([1], schema=["a b"])
+    assert df.columns == ['"a b"']
+    Utils.check_answer(df, Row(1))
+
+
 # this test requires the parameters used for connection has `public role`,
 # and the public role has the privilege to access the current database and
 # schema of the current role

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -96,12 +96,6 @@ def test_create_dataframe_namedtuple(session):
     assert [field.name for field in df.schema.fields] == ["A", "B", "C"]
 
 
-def test_create_dataframe_special_char_column_name(session):
-    df = session.create_dataframe([[1, 2], [1, 2]], schema=["a b", "c"])
-    assert df.columns == ['"a b"', "C"]
-    Utils.check_answer(df, [Row(1, 2), Row(1, 2)])
-
-
 # this test requires the parameters used for connection has `public role`,
 # and the public role has the privilege to access the current database and
 # schema of the current role

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2312,3 +2312,16 @@ def test_df_join_how_on_overwrite(session):
 
     df = df1.natural_join(df2, how="left", join_type="right")
     Utils.check_answer(df, [Row(1, 1, "1"), Row(2, 3, "5")])
+
+
+def test_create_dataframe_special_char_column_name(session):
+    df1 = session.create_dataframe(
+        [[1, 2, 3], [1, 2, 3]], schema=["a b", '"abc"', "@%!^@&#"]
+    )
+    expected_columns = ['"a b"', '"abc"', '"@%!^@&#"']
+    assert df1.columns == expected_columns
+    Utils.check_answer(df1, [Row(1, 2, 3), Row(1, 2, 3)])
+
+    df2 = session.create_dataframe([[1, 2, 3], [1, 2, 3]], schema=expected_columns)
+    assert df2.columns == expected_columns
+    Utils.check_answer(df2, [Row(1, 2, 3), Row(1, 2, 3)])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-664210

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use `SELECT $1 AS "a b" FROM ( VALUES (1 :: INT))` instead of `SELECT  *  FROM ( VALUES (1 :: INT) AS SNOWPARK_TEMP_TABLE_EVQQHTZLRR("a b"))`. The latter has column `"""a b"""` instead of `"a b"`. The former has column `"a b"`.
