### PR TITLE
SNOW-609875 Change skip message for tests involving alter session

### DIFF
--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -14,7 +14,8 @@ from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 
 @pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="SNOW-533647: Support statement level parameter"
+    IS_IN_STORED_PROC,
+    reason="alter session is not supported in owner's right stored proc",
 )
 def test_non_select_queries(session):
     try:

--- a/tests/integ/test_query_history.py
+++ b/tests/integ/test_query_history.py
@@ -66,7 +66,8 @@ def test_query_history_no_actions(session):
 
 
 @pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="SNOW-533647: Support statement level parameters"
+    IS_IN_STORED_PROC,
+    reason="alter session is not supported in owner's right stored proc",
 )
 @pytest.mark.parametrize("use_scoped_temp_objects", [True, False])
 def test_query_history_executemany(session, use_scoped_temp_objects):


### PR DESCRIPTION
Description

alter session is not allowed in owner's right stored procedure, so this skip message is not accurate

Testing

N/A

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
