### PR TITLE
SNOW-667857: Add support for creating an `AsyncJob` from a query ID

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -317,7 +317,7 @@ class ServerConnection:
         is_ddl_on_temp_object: bool = False,
         block: bool = True,
         data_type: _AsyncResultType = _AsyncResultType.ROW,
-        plan: Optional[
+        async_job_plan: Optional[
             SnowflakePlan
         ] = None,  # this argument is currently only used by AsyncJob
         **kwargs,
@@ -360,9 +360,9 @@ class ServerConnection:
             return AsyncJob(
                 results_cursor["queryId"],
                 query,
-                plan.session,
+                async_job_plan.session,
                 data_type,
-                plan.post_actions,
+                async_job_plan.post_actions,
                 **kwargs,
             )
 
@@ -488,7 +488,7 @@ $$"""
                     is_ddl_on_temp_object=plan.queries[0].is_ddl_on_temp_object,
                     block=block,
                     data_type=data_type,
-                    plan=plan,
+                    async_job_plan=plan,
                     **kwargs,
                 )
 
@@ -513,7 +513,7 @@ $$"""
                             is_ddl_on_temp_object=query.is_ddl_on_temp_object,
                             block=not is_last,
                             data_type=data_type,
-                            plan=plan,
+                            async_job_plan=plan,
                             **kwargs,
                         )
                         placeholders[query.query_id_place_holder] = (

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -42,7 +42,7 @@ from snowflake.snowpark._internal.utils import (
     result_set_to_rows,
     unwrap_stage_location_single_quote,
 )
-from snowflake.snowpark.async_job import AsyncJob, _AsyncDataType
+from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.query_history import QueryHistory, QueryRecord
 from snowflake.snowpark.row import Row
 
@@ -316,7 +316,10 @@ class ServerConnection:
         to_iter: bool = False,
         is_ddl_on_temp_object: bool = False,
         block: bool = True,
-        data_type: _AsyncDataType = _AsyncDataType.ROW,
+        data_type: _AsyncResultType = _AsyncResultType.ROW,
+        plan: Optional[
+            SnowflakePlan
+        ] = None,  # this argument is currently only used by AsyncJob
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncJob]:
         try:
@@ -357,8 +360,9 @@ class ServerConnection:
             return AsyncJob(
                 results_cursor["queryId"],
                 query,
-                self,
+                plan.session,
                 data_type,
+                plan.post_actions,
                 **kwargs,
             )
 
@@ -405,7 +409,7 @@ class ServerConnection:
         to_pandas: bool = False,
         to_iter: bool = False,
         block: bool = True,
-        data_type: _AsyncDataType = _AsyncDataType.ROW,
+        data_type: _AsyncResultType = _AsyncResultType.ROW,
         **kwargs,
     ) -> Union[
         List[Row], "pandas.DataFrame", Iterator[Row], Iterator["pandas.DataFrame"]
@@ -434,7 +438,7 @@ class ServerConnection:
         to_pandas: bool = False,
         to_iter: bool = False,
         block: bool = True,
-        data_type: _AsyncDataType = _AsyncDataType.ROW,
+        data_type: _AsyncResultType = _AsyncResultType.ROW,
         **kwargs,
     ) -> Tuple[
         Dict[
@@ -484,9 +488,9 @@ $$"""
                     is_ddl_on_temp_object=plan.queries[0].is_ddl_on_temp_object,
                     block=block,
                     data_type=data_type,
+                    plan=plan,
                     **kwargs,
                 )
-                result.query = final_query
 
                 # since we will return a AsyncJob instance, result_meta is not needed, we will create reuslt_meta in
                 # AsyncJob instance when needed
@@ -509,6 +513,7 @@ $$"""
                             is_ddl_on_temp_object=query.is_ddl_on_temp_object,
                             block=not is_last,
                             data_type=data_type,
+                            plan=plan,
                             **kwargs,
                         )
                         placeholders[query.query_id_place_holder] = (
@@ -527,9 +532,6 @@ $$"""
                         block=block,
                         **kwargs,
                     )
-
-            else:
-                result._plan = plan
 
         if result is None:
             raise SnowparkClientExceptionMessages.SQL_LAST_QUERY_RETURN_RESULTSET()

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -2,41 +2,55 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 from enum import Enum
-from typing import Iterator, List, Union
+from logging import getLogger
+from typing import Iterator, List, Literal, Optional, Union
 
 import snowflake.snowpark
 from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
+from snowflake.snowpark._internal.analyzer.snowflake_plan import Query
 from snowflake.snowpark._internal.utils import (
     check_is_pandas_dataframe_in_to_pandas,
     experimental,
     result_set_to_iter,
     result_set_to_rows,
 )
+from snowflake.snowpark.exceptions import SnowparkSQLException
+from snowflake.snowpark.functions import col
 from snowflake.snowpark.row import Row
 
+_logger = getLogger(__name__)
 
-class _AsyncDataType(Enum):
-    PANDAS = "pandas"
+
+class _AsyncResultType(Enum):
     ROW = "row"
-    ITERATOR = "iterator"
-    PANDAS_BATCH = "pandas_batch"
+    ITERATOR = "row_iterator"
+    PANDAS = "pandas"
+    PANDAS_BATCH = "pandas_batches"
     COUNT = "count"
-    NONE_TYPE = "no_type"
+    NONE_TYPE = "none"
     UPDATE = "update"
     DELETE = "delete"
     MERGE = "merge"
 
 
 class AsyncJob:
-    """Provides a way to track an asynchronous query in Snowflake. A :class:`DataFrame` object can be evaluated asynchronously and an :class:`AsyncJob` object will be returned. With this instance, you can:
-    - retrieve results;
-    - check the query status (still running or done);
-    - cancel the running query;
-    - retrieve the query ID and perform other operations on this query ID manually.
-    :class:`AsyncJob` is created by action methods in :class:`DataFrame`. All functions in :class:`DataFrame` with a suffix of ``_nowait`` execute
-    asynchronously and create an :class:`AsyncJob` instance. They are also equivalent to corresponding functions in :class:`DataFrame` that
-    set ``block=False``. Therefore, to use it, you need to create a dataframe first. Here we demonstrate how to do that:
+    """
+    Provides a way to track an asynchronous query in Snowflake. A :class:`DataFrame` object can be
+    evaluated asynchronously and an :class:`AsyncJob` object will be returned. With this instance,
+    you can:
 
+        - retrieve results;
+        - check the query status (still running or done);
+        - cancel the running query;
+        - retrieve the query ID and perform other operations on this query ID manually.
+
+    :class:`AsyncJob` can be created by :meth:`Session.create_async_job` or action methods in
+    :class:`DataFrame` and other classes. All methods in :class:`DataFrame` with a suffix of
+    ``_nowait`` execute asynchronously and create an :class:`AsyncJob` instance. They are also
+    equivalent to corresponding functions in :class:`DataFrame` and other classes that set
+    ``block=False``. Therefore, to use it, you need to create a dataframe first. Here we demonstrate
+    how to do that:
 
     First, we create a dataframe:
         >>> from snowflake.snowpark.functions import when_matched, when_not_matched
@@ -129,6 +143,23 @@ class AsyncJob:
             >>> time2 < time1
             True
 
+    Example 10
+        Creating an :class:`AsyncJob` from an existing query ID, retrieving results and converting it back to a :class:`DataFrame`:
+
+            >>> from snowflake.snowpark.functions import col
+            >>> query_id = session.sql("select 1 as A, 2 as B, 3 as C").collect_nowait().query_id
+            >>> async_job = session.create_async_job(query_id)
+            >>> async_job.query
+            'select 1 as A, 2 as B, 3 as C'
+            >>> async_job.result()
+            [Row(A=1, B=2, C=3)]
+            >>> async_job.result(result_type="pandas")
+               A  B  C
+            0  1  2  3
+            >>> df = async_job.to_df()
+            >>> df.select(col("A").as_("D"), "B").collect()
+            [Row(D=1, B=2)]
+
     Note:
         - This feature is experimental since 0.10.0. Methods in this class are subject to change in future releases.
         - If a dataframe is associated with multiple queries,
@@ -140,25 +171,65 @@ class AsyncJob:
     def __init__(
         self,
         query_id: str,
-        query: str,
-        server_connection: "snowflake.snowpark._internal.server_connection.ServerConnection",
-        data_type: _AsyncDataType = _AsyncDataType.ROW,
+        query: Optional[str],
+        session: "snowflake.snowpark.session.Session",
+        result_type: _AsyncResultType = _AsyncResultType.ROW,
+        post_actions: Optional[List[Query]] = None,
         **kwargs,
     ) -> None:
-        #: The query ID of the executed query
-        self.query_id: str = query_id
-        #: The SQL text of of the executed query
-        self.query: str = query
-        self._conn = server_connection._conn
-        self._cursor = self._conn.cursor()
-        self._data_type = data_type
+        self.query_id: str = query_id  #: The query ID of the executed query
+        self._query = query
+        self._can_query_be_retrieved = True
+        self._session = session
+        self._cursor = session._conn._conn.cursor()
+        self._result_type = result_type
+        self._post_actions = post_actions if post_actions else []
         self._parameters = kwargs
         self._result_meta = None
-        self._server_connection = server_connection
         self._inserted = False
         self._updated = False
         self._deleted = False
-        self._plan = None
+
+    @property
+    @experimental(version="0.10.0")
+    def query(self) -> Optional[str]:
+        """
+        The SQL text of of the executed query. Returns ``None`` if it cannot be retrieved from Snowflake.
+        """
+        if not self._can_query_be_retrieved:
+            return None
+        else:
+            error_message = f"query cannot be retrieved from query ID {self.query_id}"
+            if not self._query:
+                try:
+                    result = (
+                        self._session.table_function("information_schema.query_history")
+                        .where(col("query_id") == self.query_id)
+                        .select("query_text")
+                        .collect()
+                    )
+                except SnowparkSQLException as ex:
+                    _logger.debug(f"{error_message}: {ex}")
+                    self._can_query_be_retrieved = False
+                    return None
+                except Exception:
+                    raise
+                else:
+                    if len(result) == 0:
+                        _logger.debug(f"{error_message}: result is empty")
+                        self._can_query_be_retrieved = False
+                        return None
+                    else:
+                        self._query = str(result[0][0])
+
+            return self._query
+
+    @experimental(version="0.12.0")
+    def to_df(self) -> "snowflake.snowpark.dataframe.DataFrame":
+        """
+        Returns a :class:`DataFrame` built from the result of this asynchronous job.
+        """
+        return self._session.sql(result_scan_statement(self.query_id))
 
     @experimental(version="0.10.0")
     def is_done(self) -> bool:
@@ -166,9 +237,8 @@ class AsyncJob:
         Checks the status of the query associated with this instance and returns a bool value
         indicating whether the query has finished.
         """
-        status = self._conn.get_query_status(self.query_id)
-        is_running = self._conn.is_still_running(status)
-
+        status = self._session._conn._conn.get_query_status(self.query_id)
+        is_running = self._session._conn._conn.is_still_running(status)
         return not is_running
 
     @experimental(version="0.10.0")
@@ -178,17 +248,19 @@ class AsyncJob:
         self._cursor.execute(f"select SYSTEM$CANCEL_QUERY('{self.query_id}')")
 
     def _table_result(
-        self, result_data: Union[List[tuple], List[dict]]
+        self,
+        result_data: Union[List[tuple], List[dict]],
+        result_type: _AsyncResultType,
     ) -> Union[
         "snowflake.snowpark.MergeResult",
         "snowflake.snowpark.UpdateResult",
         "snowflake.snowpark.DeleteResult",
     ]:
-        if self._data_type == _AsyncDataType.UPDATE:
+        if result_type == _AsyncResultType.UPDATE:
             return snowflake.snowpark.UpdateResult(
                 int(result_data[0][0]), int(result_data[0][1])
             )
-        elif self._data_type == _AsyncDataType.DELETE:
+        elif result_type == _AsyncResultType.DELETE:
             return snowflake.snowpark.DeleteResult(int(result_data[0][0]))
         else:
             idx = 0
@@ -206,45 +278,84 @@ class AsyncJob:
             )
 
     @experimental(version="0.10.0")
-    def result(self) -> Union[List[Row], "pandas.DataFrame", Iterator[Row], int, None]:
+    def result(
+        self,
+        result_type: Optional[
+            Literal["row", "row_iterator", "pandas", "pandas_batches", "none"]
+        ] = None,
+    ) -> Union[
+        List[Row],
+        Iterator[Row],
+        "pandas.DataFrame",
+        Iterator["pandas.DataFrame"],
+        int,
+        None,
+    ]:
         """
-        Blocks and waits until the query associated with this instance finishes, then returns query results, this
-        functions acts like execute query in a synchronous way. The data type of returned results is determined by how
-        you create this :class:`AsyncJob` instance. For example, if this instance is returned by
-        :meth:`DataFrame.collect_nowait`, you will get a list of :class:`Row` s from this method.
+        Blocks and waits until the query associated with this instance finishes, then returns query
+        results, this functions acts like executing query in a synchronous way. The data type of
+        returned query results is determined by how you create this :class:`AsyncJob` instance.
+        For example, if this instance is returned by :meth:`DataFrame.collect_nowait`, you will get
+        a list of :class:`Row` s from this method.
+
+        Args:
+            result_type: Specifies the data type of returned query results. Currently it only
+                supports the following return data types:
+
+                - "row": returns a list of :class:`Row` objects, which is the same as the return
+                  type of :meth:`DataFrame.collect`.
+                - "row_iterator": returns an iterator of :class:`Row` objects, which is the same as
+                  the return type of :meth:`DataFrame.to_local_iterator`.
+                - "row": returns a ``pandas.DataFrame``, which is the same as the return type of
+                  :meth:`DataFrame.to_pandas`.
+                - "pandas_batches": returns an iterator of ``pandas.DataFrame`` s, which is the same
+                  as the return type of :meth:`DataFrame.to_pandas_batches`.
+                - "none": returns ``None``. You can use this option when you intend to execute the
+                  query but don't care about query results (the client will not fetch results
+                  either).
+
+                When you create an :class:`AsyncJob` by :meth:`Session.create_async_job` and
+                retrieve results with this method, ``result_type`` should be specified to determine
+                the result data type. Otherwise, it will return a list of :class:`Row` objects.
+                When you create an :class:`AsyncJob` by action methods in :class:`DataFrame` and
+                other classes, ``result_type`` is optional and it will return results with
+                corresponding type. If you still provide a value for it, this value will overwrite
+                the original result data type.
         """
+        result_type = (
+            _AsyncResultType(result_type) if result_type else self._result_type
+        )
         self._cursor.get_results_from_sfqid(self.query_id)
-        if self._data_type == _AsyncDataType.NONE_TYPE:
-            self._cursor.fetchall()
+        if result_type == _AsyncResultType.NONE_TYPE:
             result = None
-        elif self._data_type == _AsyncDataType.PANDAS:
-            result = self._server_connection._to_data_or_iter(
+        elif result_type == _AsyncResultType.PANDAS:
+            result = self._session._conn._to_data_or_iter(
                 self._cursor, to_pandas=True, to_iter=False
             )["data"]
             check_is_pandas_dataframe_in_to_pandas(result)
-        elif self._data_type == _AsyncDataType.PANDAS_BATCH:
-            result = self._server_connection._to_data_or_iter(
+        elif result_type == _AsyncResultType.PANDAS_BATCH:
+            result = self._session._conn._to_data_or_iter(
                 self._cursor, to_pandas=True, to_iter=True
             )["data"]
         else:
             result_data = self._cursor.fetchall()
             self._result_meta = self._cursor.description
-            if self._data_type == _AsyncDataType.ROW:
+            if result_type == _AsyncResultType.ROW:
                 result = result_set_to_rows(result_data, self._result_meta)
-            elif self._data_type == _AsyncDataType.ITERATOR:
+            elif result_type == _AsyncResultType.ITERATOR:
                 result = result_set_to_iter(result_data, self._result_meta)
-            elif self._data_type == _AsyncDataType.COUNT:
+            elif result_type == _AsyncResultType.COUNT:
                 result = result_data[0][0]
-            elif self._data_type in [
-                _AsyncDataType.UPDATE,
-                _AsyncDataType.DELETE,
-                _AsyncDataType.MERGE,
+            elif result_type in [
+                _AsyncResultType.UPDATE,
+                _AsyncResultType.DELETE,
+                _AsyncResultType.MERGE,
             ]:
-                result = self._table_result(result_data)
+                result = self._table_result(result_data, result_type)
             else:
-                raise ValueError(f"{self._data_type} is not supported")
-        for action in self._plan.post_actions:
-            self._server_connection.run_query(
+                raise ValueError(f"{result_type} is not supported")
+        for action in self._post_actions:
+            self._session._conn.run_query(
                 action.sql,
                 is_ddl_on_temp_object=action.is_ddl_on_temp_object,
                 **self._parameters,

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -163,14 +163,15 @@ class AsyncJob:
     Note:
         - This feature is experimental since 0.10.0. Methods in this class are subject to change in
           future releases.
-        - If a dataframe is associated with multiple queries,
+        - If a dataframe is associated with multiple queries:
+
             + if you use :meth:`Session.create_dataframe` to create a dataframe from a large amount
               of local data and evaluate this dataframe asynchronously, data will still be loaded
               into Snowflake synchronously, and only fetching data from Snowflake again will be
               performed asynchronously.
             + otherwise, multiple queries will be wrapped into a
-             `Snowflake Anonymous Block <https://docs.snowflake.com/en/developer-guide/snowflake-scripting/blocks.html#using-an-anonymous-block>`_
-             and executed asynchronously as one query.
+              `Snowflake Anonymous Block <https://docs.snowflake.com/en/developer-guide/snowflake-scripting/blocks.html#using-an-anonymous-block>`_
+              and executed asynchronously as one query.
         - Temporary objects (e.g., tables) might be created when evaluating dataframes and they will
           be dropped automatically after all queries finish when calling a synchronous API. When you
           evaluate dataframes asynchronously, temporary objects will only be dropped after calling

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -212,8 +212,6 @@ class AsyncJob:
                     _logger.debug(f"{error_message}: {ex}")
                     self._can_query_be_retrieved = False
                     return None
-                except Exception:
-                    raise
                 else:
                     if len(result) == 0:
                         _logger.debug(f"{error_message}: result is empty")
@@ -293,14 +291,14 @@ class AsyncJob:
     ]:
         """
         Blocks and waits until the query associated with this instance finishes, then returns query
-        results, this functions acts like executing query in a synchronous way. The data type of
-        returned query results is determined by how you create this :class:`AsyncJob` instance.
-        For example, if this instance is returned by :meth:`DataFrame.collect_nowait`, you will get
-        a list of :class:`Row` s from this method.
+        results. This acts like executing query in a synchronous way. The data type of returned
+        query results is determined by how you create this :class:`AsyncJob` instance. For example,
+        if this instance is returned by :meth:`DataFrame.collect_nowait`, you will get a list of
+        :class:`Row` s from this method.
 
         Args:
-            result_type: Specifies the data type of returned query results. Currently it only
-                supports the following return data types:
+            result_type: (Experimental) specifies the data type of returned query results. Currently
+                it only supports the following return data types:
 
                 - "row": returns a list of :class:`Row` objects, which is the same as the return
                   type of :meth:`DataFrame.collect`.

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -206,7 +206,7 @@ class AsyncJob:
                         self._session.table_function("information_schema.query_history")
                         .where(col("query_id") == self.query_id)
                         .select("query_text")
-                        .collect()
+                        ._internal_collect_with_tag_no_telemetry()
                     )
                 except SnowparkSQLException as ex:
                     _logger.debug(f"{error_message}: {ex}")

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -115,7 +115,7 @@ from snowflake.snowpark._internal.utils import (
     validate_object_name,
     warning,
 )
-from snowflake.snowpark.async_job import AsyncJob, _AsyncDataType
+from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.column import Column, _to_col_if_sql_expr, _to_col_if_str
 from snowflake.snowpark.dataframe_na_functions import DataFrameNaFunctions
 from snowflake.snowpark.dataframe_stat_functions import DataFrameStatFunctions
@@ -575,7 +575,9 @@ class DataFrame:
             :meth:`collect()`
         """
         return self._internal_collect_with_tag_no_telemetry(
-            statement_params=statement_params, block=False, data_type=_AsyncDataType.ROW
+            statement_params=statement_params,
+            block=False,
+            data_type=_AsyncResultType.ROW,
         )
 
     def _internal_collect_with_tag_no_telemetry(
@@ -583,7 +585,7 @@ class DataFrame:
         *,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        data_type: _AsyncDataType = _AsyncDataType.ROW,
+        data_type: _AsyncResultType = _AsyncResultType.ROW,
     ) -> Union[List[Row], AsyncJob]:
         # When executing a DataFrame in any method of snowpark (either public or private),
         # we should always call this method instead of collect(), to make sure the
@@ -659,7 +661,7 @@ class DataFrame:
             self._plan,
             to_iter=True,
             block=block,
-            data_type=_AsyncDataType.ITERATOR,
+            data_type=_AsyncResultType.ITERATOR,
             _statement_params=create_or_update_statement_params_with_query_tag(
                 statement_params, self._session.query_tag, SKIP_LEVELS_THREE
             ),
@@ -727,7 +729,7 @@ class DataFrame:
             self._plan,
             to_pandas=True,
             block=block,
-            data_type=_AsyncDataType.PANDAS,
+            data_type=_AsyncResultType.PANDAS,
             _statement_params=create_or_update_statement_params_with_query_tag(
                 statement_params, self._session.query_tag, SKIP_LEVELS_TWO
             ),
@@ -813,7 +815,7 @@ class DataFrame:
             to_pandas=True,
             to_iter=True,
             block=block,
-            data_type=_AsyncDataType.PANDAS_BATCH,
+            data_type=_AsyncResultType.PANDAS_BATCH,
             _statement_params=create_or_update_statement_params_with_query_tag(
                 statement_params, self._session.query_tag, SKIP_LEVELS_TWO
             ),
@@ -2530,7 +2532,7 @@ class DataFrame:
         result = df._internal_collect_with_tag(
             statement_params=statement_params,
             block=block,
-            data_type=_AsyncDataType.COUNT,
+            data_type=_AsyncResultType.COUNT,
         )
         return result[0][0] if block else result
 

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -194,7 +194,7 @@ class DataFrameWriter:
             snowflake_plan,
             _statement_params=statement_params,
             block=block,
-            data_type=_AsyncResultType.NONE_TYPE,
+            data_type=_AsyncResultType.NO_RESULT,
         )
         return result if not block else None
 

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -21,7 +21,7 @@ from snowflake.snowpark._internal.utils import (
     validate_object_name,
     warning,
 )
-from snowflake.snowpark.async_job import AsyncJob, _AsyncDataType
+from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.functions import sql_expr
 from snowflake.snowpark.row import Row
@@ -194,7 +194,7 @@ class DataFrameWriter:
             snowflake_plan,
             _statement_params=statement_params,
             block=block,
-            data_type=_AsyncDataType.NONE_TYPE,
+            data_type=_AsyncResultType.NONE_TYPE,
         )
         return result if not block else None
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1490,11 +1490,15 @@ class Session:
     @experimental(version="0.12.0")
     def create_async_job(self, query_id: str) -> AsyncJob:
         """
-        Creates an :class:`AsnycJob` from a query ID.
+        Creates an :class:`AsyncJob` from a query ID.
 
         See also:
-            :class:`AsnycJob`
+            :class:`AsyncJob`
         """
+        if is_in_stored_procedure():
+            raise NotImplementedError(
+                "Async query is not supported in stored procedure yet"
+            )
         return AsyncJob(query_id, None, self)
 
     def get_current_account(self) -> Optional[str]:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -59,6 +59,7 @@ from snowflake.snowpark._internal.utils import (
     TempObjectType,
     calculate_checksum,
     deprecated,
+    experimental,
     get_connector_version,
     get_os_name,
     get_python_version,
@@ -75,6 +76,7 @@ from snowflake.snowpark._internal.utils import (
     warning,
     zip_file_or_directory_to_stream,
 )
+from snowflake.snowpark.async_job import AsyncJob
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.context import _use_scoped_temp_objects
 from snowflake.snowpark.dataframe import DataFrame
@@ -1484,6 +1486,16 @@ class Session:
             df = DataFrame(self, range_plan)
         set_api_call_source(df, "Session.range")
         return df
+
+    @experimental(version="0.12.0")
+    def create_async_job(self, query_id: str) -> AsyncJob:
+        """
+        Creates an :class:`AsnycJob` from a query ID.
+
+        See also:
+            :class:`AsnycJob`
+        """
+        return AsyncJob(query_id, None, self)
 
     def get_current_account(self) -> Optional[str]:
         """

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -438,7 +438,7 @@ class Table(DataFrame):
         result = new_df._internal_collect_with_tag(
             statement_params=statement_params,
             block=block,
-            data_type=snowflake.snowpark.async_job._AsyncDataType.UPDATE,
+            data_type=snowflake.snowpark.async_job._AsyncResultType.UPDATE,
         )
         return _get_update_result(result) if block else result
 
@@ -538,7 +538,7 @@ class Table(DataFrame):
         result = new_df._internal_collect_with_tag(
             statement_params=statement_params,
             block=block,
-            data_type=snowflake.snowpark.async_job._AsyncDataType.DELETE,
+            data_type=snowflake.snowpark.async_job._AsyncResultType.DELETE,
         )
         return _get_delete_result(result) if block else result
 
@@ -645,7 +645,7 @@ class Table(DataFrame):
         result = new_df._internal_collect_with_tag(
             statement_params=statement_params,
             block=block,
-            data_type=snowflake.snowpark.async_job._AsyncDataType.MERGE,
+            data_type=snowflake.snowpark.async_job._AsyncResultType.MERGE,
         )
         if not block:
             result._inserted = inserted

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -398,7 +398,7 @@ def test_create_async_job(session, create_async_job_from_query_id):
     res = list(res)
     assert isinstance(res[0], pd.DataFrame)
 
-    assert async_job.result("none") is None
+    assert async_job.result("no_result") is None
 
     with pytest.raises(
         ValueError, match="'invalid_type' is not a valid _AsyncResultType"

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -398,6 +398,11 @@ def test_create_async_job(session, create_async_job_from_query_id):
 
     assert async_job.result("none") is None
 
+    with pytest.raises(
+        ValueError, match="'invalid_type' is not a valid _AsyncResultType"
+    ):
+        async_job.result("invalid_type")
+
 
 def test_create_async_job_negative(session):
     query_id = session.sql("select to_number('not_a_number')").collect_nowait().query_id

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -2,8 +2,10 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import logging
+from collections import Iterator
 from time import sleep, time
 
+import pandas as pd
 import pytest
 from pandas.util.testing import assert_frame_equal
 
@@ -14,6 +16,7 @@ from snowflake.snowpark._internal.utils import (
     random_name_for_temp_object,
     warning_dict,
 )
+from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import col, when_matched, when_not_matched
 from snowflake.snowpark.table import DeleteResult, MergeResult, UpdateResult
 from snowflake.snowpark.types import (
@@ -276,8 +279,13 @@ def test_multiple_queries(session, resources_path):
     )
     df = session.read.schema(user_schema).csv(f"@{tmp_stage_name1}/{test_file_csv}")
     assert len(df._plan.queries) > 1
-    res = df.collect_nowait()
-    Utils.check_answer(res.result(), df)
+    async_job = df.collect_nowait()
+    Utils.check_answer(async_job.result(), df)
+
+    # make sure temp object is dropped
+    temp_object = async_job._post_actions[0].sql.split(" ")[-1]
+    with pytest.raises(SnowparkSQLException, match="does not exist or not authorized"):
+        session.sql(f"drop file format {temp_object}").collect()
 
 
 def test_async_batch_insert(session):
@@ -292,6 +300,14 @@ def test_async_batch_insert(session):
         Utils.check_answer(
             async_job.result(), [Row(A=1, B=2), Row(A=4, B=4), Row(A=1, B=3)]
         )
+
+        # make sure temp object is dropped
+        temp_object = async_job._post_actions[0].sql.split(" ")[-1]
+        with pytest.raises(
+            SnowparkSQLException, match="does not exist or not authorized"
+        ):
+            session.sql(f"drop table {temp_object}").collect()
+
     finally:
         analyzer.ARRAY_BIND_THRESHOLD = original_value
 
@@ -347,3 +363,90 @@ def test_async_experimental(session, caplog):
         assert "DataFrame.collect_nowait() is experimental" in caplog.text
     finally:
         warning_dict.clear()
+
+
+@pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
+def test_create_async_job(session, create_async_job_from_query_id):
+    df = session.range(3)
+    if create_async_job_from_query_id:
+        query_id = df._execute_and_get_query_id()
+        async_job = session.create_async_job(query_id)
+    else:
+        async_job = df.collect_nowait()
+
+    res = async_job.result()
+    assert isinstance(res, list)
+    assert isinstance(res[0], Row)
+    assert res == [Row(0), Row(1), Row(2)]
+
+    res = async_job.result("row")
+    assert isinstance(res, list)
+    assert isinstance(res[0], Row)
+
+    res = async_job.result("row_iterator")
+    assert isinstance(res, Iterator)
+    res = list(res)
+    assert isinstance(res[0], Row)
+
+    res = async_job.result("pandas")
+    assert isinstance(res, pd.DataFrame)
+
+    res = async_job.result("pandas_batches")
+    assert isinstance(res, Iterator)
+    res = list(res)
+    assert isinstance(res[0], pd.DataFrame)
+
+    assert async_job.result("none") is None
+
+
+def test_create_async_job_negative(session):
+    query_id = session.sql("select to_number('not_a_number')").collect_nowait().query_id
+    async_job = session.create_async_job(query_id)
+
+    with pytest.raises(DatabaseError) as ex_info:
+        async_job.result()
+    assert "100038: Numeric value 'not_a_number' is not recognized" in str(
+        ex_info.value
+    ) or f"Status of query '{query_id}' is FAILED_WITH_ERROR, results are unavailable" in str(
+        ex_info.value
+    )
+
+    invalid_query_id = "negative_test_invalid_query_id"
+    async_job = session.create_async_job(invalid_query_id)
+    with pytest.raises(
+        ValueError, match=f"Invalid UUID: '{invalid_query_id}'"
+    ) as ex_info:
+        async_job.result()
+
+
+@pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
+def test_get_query_from_async_job(session, create_async_job_from_query_id):
+    query_text = "select 1, 2, 3"
+    df = session.sql(query_text)
+    if create_async_job_from_query_id:
+        query_id = df._execute_and_get_query_id()
+        async_job = session.create_async_job(query_id)
+    else:
+        async_job = df.collect_nowait()
+
+    assert async_job.query == query_text
+
+
+def test_get_query_from_async_job_negative(session):
+    invalid_query_id = "negative_test_invalid_query_id"
+    async_job = session.create_async_job(invalid_query_id)
+    assert async_job.query is None
+
+
+@pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
+def test_async_job_to_df(session, create_async_job_from_query_id):
+    df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
+    if create_async_job_from_query_id:
+        query_id = df._execute_and_get_query_id()
+        async_job = session.create_async_job(query_id)
+    else:
+        async_job = df.collect_nowait()
+
+    new_df = async_job.to_df()
+    assert "result_scan" in new_df.queries["queries"][0].lower()
+    Utils.check_answer(df, new_df)

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -236,6 +236,8 @@ def test_async_save_as_table(session):
     )
     table_name = random_name_for_temp_object(TempObjectType.TABLE)
     async_job = df.write.save_as_table(table_name, create_temp_table=True, block=False)
+    while not async_job.is_done():
+        sleep(1)
     assert async_job.result() is None
     table_df = session.table(table_name)
     Utils.check_answer(table_df, df)

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -432,10 +432,13 @@ def test_get_query_from_async_job(session, create_async_job_from_query_id):
     assert async_job.query == query_text
 
 
-def test_get_query_from_async_job_negative(session):
+def test_get_query_from_async_job_negative(session, caplog):
     invalid_query_id = "negative_test_invalid_query_id"
     async_job = session.create_async_job(invalid_query_id)
-    assert async_job.query is None
+
+    with caplog.at_level(logging.DEBUG):
+        assert async_job.query is None
+        assert "result is empty" in caplog.text
 
 
 @pytest.mark.parametrize("create_async_job_from_query_id", [True, False])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR adds support for creating an `AsyncJob` from a query ID.
   - Add `Session.create_async_job` to allow creating an `AsyncJob` from a query ID.
   - Add (reimplement) `AsyncJob.query` property so we can get the query text (lazily) from a query ID.
   - Add `AsyncJob.to_df()` method to convert an async job to a dataframe using result scan. 
   - Add an argument `result_type` in `AsyncJob.result()` to allow converting the result to the desired type.
