### PR TITLE
SNOW-676378: Add private preview decorator

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -579,7 +579,7 @@ def warning(name: str, text: str, warning_times: int = 1) -> None:
 
 
 def func_decorator(
-    decorator_type: Literal["deprecated", "experimental"],
+    decorator_type: Literal["deprecated", "experimental", "in private preview"],
     *,
     version: str,
     extra_warning_text: str,

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -588,7 +588,7 @@ def func_decorator(
     def wrapper(func):
         warning_text = (
             f"{func.__qualname__}() is {decorator_type} since {version}. "
-            f"{'Do not use it in production. ' if decorator_type == 'experimental' else ''}"
+            f"{'Do not use it in production. ' if decorator_type in ('experimental', 'in private preview') else ''}"
             f"{extra_warning_text}"
         )
         doc_string_text = f"This function or method is {decorator_type} since {version}. {extra_doc_string} \n\n"
@@ -620,6 +620,17 @@ def experimental(
 ) -> Callable:
     return func_decorator(
         "experimental",
+        version=version,
+        extra_warning_text=extra_warning_text,
+        extra_doc_string=extra_doc_string,
+    )
+
+
+def private_preview(
+    *, version: str, extra_warning_text: str = "", extra_doc_string: str = ""
+) -> Callable:
+    return func_decorator(
+        "in private preview",
         version=version,
         extra_warning_text=extra_warning_text,
         extra_doc_string=extra_doc_string,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-676378

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Like the experimental decorator, use `private_preview` decorator to mark APIs as "in private preview".
