### PR TITLE
SNOW-664934 Support schema for pandas DF in create_dataframe()

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1290,20 +1290,27 @@ class Session:
                     f"create or replace temporary table {table_name} ({attribute_to_schema_string(schema._to_attributes())})"
                 )
 
-            try:
+                try:
+                    t = self.write_pandas(
+                        data,
+                        table_name,
+                        database=sf_database,
+                        schema=sf_schema,
+                        quote_identifiers=True,
+                    )
+                except Exception as e:
+                    self._run_query(f"drop table if exists {table_name}")
+                    raise e
+            else:
                 t = self.write_pandas(
                     data,
                     table_name,
                     database=sf_database,
                     schema=sf_schema,
                     quote_identifiers=True,
-                    auto_create_table=schema is None,
-                    # auto_create_table=True,
+                    auto_create_table=True,
                     table_type="temporary",
                 )
-            except Exception as e:
-                self._run_query(f"drop table if exists {table_name}")
-                raise e
 
             set_api_call_source(t, "Session.create_dataframe[pandas]")
             return t

--- a/tests/integ/test_pandas_to_df.py
+++ b/tests/integ/test_pandas_to_df.py
@@ -14,6 +14,7 @@ from snowflake.snowpark._internal.utils import TempObjectType, warning_dict
 from snowflake.snowpark.exceptions import SnowparkPandasException
 from snowflake.snowpark.types import (
     BooleanType,
+    DecimalType,
     FloatType,
     IntegerType,
     StringType,
@@ -309,15 +310,16 @@ def test_create_dataframe_from_pandas_with_schema(session):
     # TODO(SNOW-677100): Add complex type test
     pd = PandasDF(
         [
-            (1, 4.5, "t1", True),
-            (2, 7.5, "t2", False),
-            (3, 10.5, "t3", True),
+            (1, 4.5, "t1", True, 200),
+            (2, 7.5, "t2", False, 250),
+            (3, 10.5, "t3", True, 1000),
         ],
         columns=[
             "id".upper(),
             "foot_size".upper(),
             "shoe_model".upper(),
             "received".upper(),
+            "ship_distance".upper(),
         ],
     )
 
@@ -327,6 +329,7 @@ def test_create_dataframe_from_pandas_with_schema(session):
             StructField("FOOT_SIZE", FloatType()),
             StructField("SHOE_MODEL", StringType()),
             StructField("RECEIVED", BooleanType()),
+            StructField("SHIP_DISTANCE", DecimalType()),
         ]
     )
     df = session.create_dataframe(pd, schema)

--- a/tests/integ/test_pandas_to_df.py
+++ b/tests/integ/test_pandas_to_df.py
@@ -283,6 +283,7 @@ def test_create_dataframe_from_pandas(session):
     results = df.to_pandas()
     assert_frame_equal(results, pd, check_dtype=False)
 
+    # TODO(SNOW-677098): Uncomment this test
     # pd = PandasDF(
     #     [
     #         (1, 4.5, "t1", True, datetime.now()),
@@ -304,6 +305,8 @@ def test_create_dataframe_from_pandas(session):
 
 
 def test_create_dataframe_from_pandas_with_schema(session):
+    # TODO(SNOW-677098): Add timestamp test
+    # TODO(SNOW-677100): Add complex type test
     pd = PandasDF(
         [
             (1, 4.5, "t1", True),


### PR DESCRIPTION
Description

Prior to this change, schema is ignored if the input data is a pandas DF in create_dataframe(). This can be confusing as user would expect schema to take effect.

Note that this is a behavior change.

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #504 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Prior to this change, schema is ignored if the input data is a pandas DF in create_dataframe(). This can be confusing as user would expect schema to take effect.
