### PR TITLE
SNOW-670988 Support strict UD(T)F/SP

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -673,9 +673,7 @@ $$
         else ""
     )
 
-    strict_as_sql = "\nSTRICT" if strict_as_sql else ""
-    if strict:
-        strict_as_sql = "\nSTRICT"
+    strict_as_sql = "\nSTRICT" if strict else ""
 
     create_query = f"""
 CREATE{" OR REPLACE " if replace else ""}

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -673,7 +673,7 @@ $$
         else ""
     )
 
-    strict_as_sql = ""
+    strict_as_sql = "\nSTRICT" if strict_as_sql else ""
     if strict:
         strict_as_sql = "\nSTRICT"
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -641,6 +641,7 @@ def create_python_udf_or_sp(
     inline_python_code: Optional[str] = None,
     execute_as: Optional[typing.Literal["caller", "owner"]] = None,
     api_call_source: Optional[str] = None,
+    strict: bool = False,
 ) -> None:
     if isinstance(return_type, StructType):
         return_sql = f'RETURNS TABLE ({",".join(f"{field.name} {convert_sp_to_sf_type(field.datatype)}" for field in return_type.fields)})'
@@ -672,11 +673,15 @@ $$
         else ""
     )
 
+    strict_as_sql = ""
+    if strict:
+        strict_as_sql = "\nSTRICT"
+
     create_query = f"""
 CREATE{" OR REPLACE " if replace else ""}
 {"TEMPORARY" if is_temporary else ""} {object_type.value} {object_name}({sql_func_args})
 {return_sql}
-LANGUAGE PYTHON
+LANGUAGE PYTHON {strict_as_sql}
 RUNTIME_VERSION=3.8
 {imports_in_sql}
 {packages_in_sql}

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -184,7 +184,12 @@ from snowflake.snowpark._internal.analyzer.expression import (
     MultipleExpression,
     Star,
 )
-from snowflake.snowpark._internal.analyzer.window_expression import FirstValue, Lag, LastValue, Lead
+from snowflake.snowpark._internal.analyzer.window_expression import (
+    FirstValue,
+    Lag,
+    LastValue,
+    Lead,
+)
 from snowflake.snowpark._internal.type_utils import (
     ColumnOrLiteral,
     ColumnOrLiteralStr,
@@ -2820,9 +2825,7 @@ def last_value(
     Returns the last value within an ordered group of values.
     """
     c = _to_col_if_str(e, "last_value")
-    return Column(
-        LastValue(c._expression, None, None, ignore_nulls)
-    )
+    return Column(LastValue(c._expression, None, None, ignore_nulls))
 
 
 def first_value(
@@ -2833,9 +2836,7 @@ def first_value(
     Returns the first value within an ordered group of values.
     """
     c = _to_col_if_str(e, "last_value")
-    return Column(
-        FirstValue(c._expression, None, None, ignore_nulls)
-    )
+    return Column(FirstValue(c._expression, None, None, ignore_nulls))
 
 
 def ntile(e: Union[int, ColumnOrName]) -> Column:
@@ -2947,6 +2948,7 @@ def udf(
     max_batch_size: Optional[int] = None,
     statement_params: Optional[Dict[str, str]] = None,
     source_code_display: bool = True,
+    strict: bool = False,
 ) -> Union[UserDefinedFunction, functools.partial]:
     """Registers a Python function as a Snowflake Python UDF and returns the UDF.
 
@@ -3013,6 +3015,9 @@ def udf(
             The source code is dynamically generated therefore it may not be identical to how the
             `func` is originally defined. The default is ``True``.
             If it is ``False``, source code will not be generated or displayed.
+        strict: Whether the created UDF is strict. A strict UDF will not invoke the UDF if any input is
+            null. Instead, a null value will always be returned for that row. Note that the UDF might
+            still return null for non-null inputs.
 
     Returns:
         A UDF function that can be called with :class:`~snowflake.snowpark.Column` expressions.
@@ -3071,6 +3076,7 @@ def udf(
             max_batch_size=max_batch_size,
             statement_params=statement_params,
             source_code_display=source_code_display,
+            strict=strict,
         )
     else:
         return session.udf.register(
@@ -3087,6 +3093,7 @@ def udf(
             max_batch_size=max_batch_size,
             statement_params=statement_params,
             source_code_display=source_code_display,
+            strict=strict,
         )
 
 
@@ -3104,6 +3111,7 @@ def udtf(
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
     statement_params: Optional[Dict[str, str]] = None,
+    strict: bool = False,
 ) -> Union[UserDefinedTableFunction, functools.partial]:
     """Registers a Python class as a Snowflake Python UDTF and returns the UDTF.
 
@@ -3156,6 +3164,9 @@ def udtf(
             Increasing the number of threads can improve performance when uploading
             large UDTF files.
         statement_params: Dictionary of statement level parameters to be set while executing this action.
+        strict: Whether the created UDTF is strict. A strict UDTF will not invoke the UDTF if any input is
+            null. Instead, a null value will always be returned for that row. Note that the UDTF might
+            still return null for non-null inputs.
 
     Returns:
         A UDTF function that can be called with :class:`~snowflake.snowpark.Column` expressions.
@@ -3201,6 +3212,7 @@ def udtf(
             replace=replace,
             parallel=parallel,
             statement_params=statement_params,
+            strict=strict,
         )
     else:
         return session.udtf.register(
@@ -3215,6 +3227,7 @@ def udtf(
             replace=replace,
             parallel=parallel,
             statement_params=statement_params,
+            strict=strict,
         )
 
 
@@ -3440,6 +3453,7 @@ def sproc(
     parallel: int = 4,
     statement_params: Optional[Dict[str, str]] = None,
     execute_as: typing.Literal["caller", "owner"] = "owner",
+    strict: bool = False,
 ) -> Union[StoredProcedure, functools.partial]:
     """Registers a Python function as a Snowflake Python stored procedure and returns the stored procedure.
 
@@ -3499,6 +3513,9 @@ def sproc(
             supports caller, or owner for now. See `owner and caller rights <https://docs.snowflake.com/en/sql-reference/stored-procedures-rights.html>`_
             for more information.
         statement_params: Dictionary of statement level parameters to be set while executing this action.
+        strict: Whether the created stored procedure is strict. A strict stored procedure will not invoke
+            the stored procedure if any input is null. Instead, a null value will always be returned. Note
+            that the stored procedure might still return null for non-null inputs.
 
     Returns:
         A stored procedure function that can be called with python value.
@@ -3543,6 +3560,7 @@ def sproc(
             parallel=parallel,
             statement_params=statement_params,
             execute_as=execute_as,
+            strict=strict,
         )
     else:
         return session.sproc.register(
@@ -3558,4 +3576,5 @@ def sproc(
             parallel=parallel,
             statement_params=statement_params,
             execute_as=execute_as,
+            strict=strict,
         )

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -332,6 +332,7 @@ class StoredProcedureRegistration:
         replace: bool = False,
         parallel: int = 4,
         execute_as: typing.Literal["caller", "owner"] = "owner",
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
     ) -> StoredProcedure:
@@ -385,6 +386,9 @@ class StoredProcedureRegistration:
                 large stored procedure files.
             execute_as: What permissions should the procedure have while executing. This
                 supports caller, or owner for now.
+            strict: Whether the created stored procedure is strict. A strict stored procedure will not invoke
+                the stored procedure if any input is null. Instead, a null value will always be returned. Note
+                that the stored procedure might still return null for non-null inputs.
             statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         See Also:
@@ -420,6 +424,7 @@ class StoredProcedureRegistration:
             packages,
             replace,
             parallel,
+            strict,
             statement_params=statement_params,
             execute_as=execute_as,
             api_call_source="StoredProcedureRegistration.register",
@@ -438,6 +443,7 @@ class StoredProcedureRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
     ) -> StoredProcedure:
@@ -495,6 +501,9 @@ class StoredProcedureRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large stored procedure files.
+            strict: Whether the created stored procedure is strict. A strict stored procedure will not invoke
+                the stored procedure if any input is null. Instead, a null value will always be returned. Note
+                that the stored procedure might still return null for non-null inputs.
             statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Note::
@@ -523,6 +532,7 @@ class StoredProcedureRegistration:
             packages,
             replace,
             parallel,
+            strict,
             statement_params=statement_params,
             api_call_source="StoredProcedureRegistration.register_from_file",
         )
@@ -538,6 +548,7 @@ class StoredProcedureRegistration:
         packages: Optional[List[Union[str, ModuleType]]],
         replace: bool,
         parallel: int,
+        strict: bool,
         *,
         statement_params: Optional[Dict[str, str]] = None,
         execute_as: typing.Literal["caller", "owner"] = "owner",
@@ -601,6 +612,7 @@ class StoredProcedureRegistration:
                 inline_python_code=code,
                 execute_as=execute_as,
                 api_call_source=api_call_source,
+                strict=strict,
             )
         # an exception might happen during registering a stored procedure
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -461,6 +461,7 @@ class UDFRegistration:
         replace: bool = False,
         parallel: int = 4,
         max_batch_size: Optional[int] = None,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
@@ -524,6 +525,9 @@ class UDFRegistration:
                 every batch by setting a smaller batch size. Note that setting a larger value does not
                 guarantee that Snowflake will encode batches with the specified number of rows. It will
                 be ignored when registering a non-vectorized UDF.
+            strict: Whether the created UDF is strict. A strict UDF will not invoke the UDF if any input is
+                null. Instead, a null value will always be returned for that row. Note that the UDF might
+                still return null for non-null inputs.
             statement_params: Dictionary of statement level parameters to be set while executing this action.
             source_code_display: Display the source code of the UDF `func` as comments in the generated script.
                 The source code is dynamically generated therefore it may not be identical to how the
@@ -559,6 +563,7 @@ class UDFRegistration:
             parallel,
             max_batch_size,
             _from_pandas,
+            strict,
             statement_params=statement_params,
             source_code_display=source_code_display,
             api_call_source="UDFRegistration.register"
@@ -578,6 +583,7 @@ class UDFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
@@ -640,6 +646,9 @@ class UDFRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large UDF files.
+            strict: Whether the created UDF is strict. A strict UDF will not invoke the UDF if any input is
+                null. Instead, a null value will always be returned for that row. Note that the UDF might
+                still return null for non-null inputs.
             statement_params: Dictionary of statement level parameters to be set while executing this action.
             source_code_display: Display the source code of the UDF `func` as comments in the generated script.
                 The source code is dynamically generated therefore it may not be identical to how the
@@ -672,6 +681,7 @@ class UDFRegistration:
             packages,
             replace,
             parallel,
+            strict,
             statement_params=statement_params,
             source_code_display=source_code_display,
             api_call_source="UDFRegistration.register_from_file",
@@ -690,6 +700,7 @@ class UDFRegistration:
         parallel: int = 4,
         max_batch_size: Optional[int] = None,
         from_pandas_udf_function: bool = False,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
@@ -757,6 +768,7 @@ class UDFRegistration:
                 replace=replace,
                 inline_python_code=code,
                 api_call_source=api_call_source,
+                strict=strict,
             )
         # an exception might happen during registering a udf
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -24,7 +24,6 @@ import snowflake.snowpark
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark._internal import type_utils
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
-from snowflake.snowpark._internal.telemetry import TelemetryField
 from snowflake.snowpark._internal.type_utils import (
     ColumnOrName,
     python_type_str_to_object,
@@ -324,6 +323,7 @@ class UDTFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedTableFunction:
@@ -375,6 +375,9 @@ class UDTFRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large UDTF files.
+            strict: Whether the created UDTF is strict. A strict UDTF will not invoke the UDTF if any input is
+                null. Instead, a null value will always be returned for that row. Note that the UDTF might
+                still return null for non-null inputs.
             statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         See Also:
@@ -402,6 +405,7 @@ class UDTFRegistration:
             packages,
             replace,
             parallel,
+            strict,
             statement_params=statement_params,
             api_call_source="UDTFRegistration.register",
         )
@@ -419,6 +423,7 @@ class UDTFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
     ) -> UserDefinedTableFunction:
@@ -476,6 +481,9 @@ class UDTFRegistration:
                 command. The default value is 4 and supported values are from 1 to 99.
                 Increasing the number of threads can improve performance when uploading
                 large UDTF files.
+            strict: Whether the created UDTF is strict. A strict UDTF will not invoke the UDTF if any input is
+                null. Instead, a null value will always be returned for that row. Note that the UDTF might
+                still return null for non-null inputs.
             statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Note::
@@ -504,6 +512,7 @@ class UDTFRegistration:
             packages,
             replace,
             parallel,
+            strict,
             statement_params=statement_params,
             api_call_source="UDTFRegistration.register_from_file",
         )
@@ -519,6 +528,7 @@ class UDTFRegistration:
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
         parallel: int = 4,
+        strict: bool = False,
         *,
         statement_params: Optional[Dict[str, str]] = None,
         api_call_source: str,
@@ -645,6 +655,7 @@ class UDTFRegistration:
                 replace=replace,
                 inline_python_code=code,
                 api_call_source=api_call_source,
+                strict=strict,
             )
         # an exception might happen during registering a udtf
         # (e.g., a dependency might not be found on the stage),

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -895,3 +895,13 @@ def test_call_sproc_with_session_as_first_argument(session):
     with pytest.raises(ValueError) as ex_info:
         plus1(session, 1, session=session)
     assert "Two sessions specified in arguments" in str(ex_info)
+
+
+def test_strict_stored_procedure(session):
+    @sproc(strict=True)
+    def echo(_: Session, num: int) -> int:
+        if num is None:
+            raise ValueError("num should not be None")
+        return num
+
+    assert echo(None) is None

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1942,3 +1942,16 @@ def test_deprecate_call_udf_with_list(session, caplog):
         )
     finally:
         warning_dict.clear()
+
+
+def test_strict_udf(session):
+    @udf(strict=True)
+    def echo(num: int) -> int:
+        if num is None:
+            raise ValueError("num should not be None")
+        return num
+
+    Utils.check_answer(
+        TestData.all_nulls(session).to_df(["a"]).select(echo("a")),
+        [Row(None), Row(None), Row(None), Row(None)],
+    )


### PR DESCRIPTION
Description

Supporting strict will allow skip invoking the python function if input contains NULL.

Testing

integ

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-670988

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Supporting strict will allow skip invoking the python function if input contains NULL.
