### PR TITLE
SNOW-679724 Fix test flakiness in test_udf_suite

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,6 +171,28 @@ class Utils:
                     ), f"Expected {expected_value}. Actual {actual_value}"
 
     @staticmethod
+    def get_sorted_rows(rows: List[Row]) -> List[Row]:
+        def compare_rows(row1, row2):
+            assert len(row1) == len(
+                row2
+            ), "rows1 and row2 have different length so they're not comparable."
+            for value1, value2 in zip(row1, row2):
+                if value1 == value2:
+                    continue
+                if value1 is None:
+                    return -1
+                elif value2 is None:
+                    return 1
+                elif value1 > value2:
+                    return 1
+                elif value1 < value2:
+                    return -1
+            return 0
+
+        sort_key = functools.cmp_to_key(compare_rows)
+        return sorted(rows, key=sort_key)
+
+    @staticmethod
     def check_answer(
         actual: Union[Row, List[Row], DataFrame],
         expected: Union[Row, List[Row], DataFrame],
@@ -192,27 +214,8 @@ class Utils:
         actual_rows = get_rows(actual)
         expected_rows = get_rows(expected)
         if sort:
-
-            def compare_rows(row1, row2):
-                assert len(row1) == len(
-                    row2
-                ), "rows1 and row2 have different length so they're not comparable."
-                for value1, value2 in zip(row1, row2):
-                    if value1 == value2:
-                        continue
-                    if value1 is None:
-                        return -1
-                    elif value2 is None:
-                        return 1
-                    elif value1 > value2:
-                        return 1
-                    elif value1 < value2:
-                        return -1
-                return 0
-
-            sort_key = functools.cmp_to_key(compare_rows)
-            sorted_expected_rows = sorted(expected_rows, key=sort_key)
-            sorted_actual_rows = sorted(actual_rows, key=sort_key)
+            sorted_expected_rows = Utils.get_sorted_rows(expected_rows)
+            sorted_actual_rows = Utils.get_sorted_rows(actual_rows)
             Utils.assert_rows(sorted_actual_rows, sorted_expected_rows)
         else:
             Utils.assert_rows(actual_rows, expected_rows)


### PR DESCRIPTION
Description

Use Utils.check_answer and Utils.get_sorted_rows when applicable for all tests in test_udf_suite. Note that some one-row result check theoretically does not need this but are still changed for consistency

Testing

existing tests

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-679724

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Returned rows by snowflake is inherently a set, so asserting on the sequence of the result is not stable. We use
existing util functions to help sort the result before actually comparing with expected result.
