### PR TITLE
SNOW-683056 Add exception tests for server_connection.py

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -18,7 +18,6 @@ from snowflake.connector.network import ReauthenticationRequest
 from snowflake.connector.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     escape_quotes,
-    quote_name,
     quote_name_without_upper_casing,
 )
 from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql
@@ -174,20 +173,6 @@ class ServerConnection:
     @_Decorator.wrap_exception
     def get_session_id(self) -> int:
         return self._conn.session_id
-
-    def get_default_database(self) -> Optional[str]:
-        return (
-            quote_name(self._lower_case_parameters["database"])
-            if "database" in self._lower_case_parameters
-            else None
-        )
-
-    def get_default_schema(self) -> Optional[str]:
-        return (
-            quote_name(self._lower_case_parameters["schema"])
-            if "schema" in self._lower_case_parameters
-            else None
-        )
 
     @_Decorator.wrap_exception
     def _get_current_parameter(self, param: str, quoted: bool = True) -> Optional[str]:
@@ -492,7 +477,7 @@ $$"""
                     **kwargs,
                 )
 
-                # since we will return a AsyncJob instance, result_meta is not needed, we will create reuslt_meta in
+                # since we will return a AsyncJob instance, result_meta is not needed, we will create result_meta in
                 # AsyncJob instance when needed
                 result_meta = None
                 if action_id < plan.session._last_canceled_id:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
+#
+
+from unittest import mock
+
+import pytest
+
+from snowflake.connector import SnowflakeConnection
+from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.snowpark._internal.server_connection import ServerConnection
+
+
+@pytest.fixture
+def mock_server_connection() -> ServerConnection:
+    fake_snowflake_connection = mock.create_autospec(SnowflakeConnection)
+    fake_snowflake_connection._telemetry = None
+    fake_snowflake_connection._session_parameters = {}
+    fake_snowflake_connection.cursor.return_value = mock.create_autospec(
+        SnowflakeCursor
+    )
+    fake_snowflake_connection.is_closed.return_value = False
+    return ServerConnection({}, fake_snowflake_connection)

--- a/tests/unit/test_pandas_to_df.py
+++ b/tests/unit/test_pandas_to_df.py
@@ -6,19 +6,12 @@ from unittest import mock
 import pandas
 import pytest
 
-from snowflake.connector import SnowflakeConnection
 from snowflake.snowpark import Session
-from snowflake.snowpark._internal.server_connection import ServerConnection
 from snowflake.snowpark.exceptions import SnowparkPandasException
 
 
-def test_df_pandas_general_exception():
-    fake_snowflake_connection = mock.create_autospec(SnowflakeConnection)
-    fake_snowflake_connection._telemetry = None
-    fake_snowflake_connection._session_parameters = {}
-    fake_snowflake_connection.is_closed.return_value = False
-    fake_server_connection = ServerConnection({}, fake_snowflake_connection)
-    fake_session = Session(fake_server_connection)
+def test_df_pandas_general_exception(mock_server_connection):
+    fake_session = Session(mock_server_connection)
     with mock.patch("snowflake.snowpark.session.write_pandas") as mock_write_pandas:
         mock_write_pandas.return_value = (False, 0, 0, [])
         with pytest.raises(SnowparkPandasException):

--- a/tests/unit/test_server_connection.py
+++ b/tests/unit/test_server_connection.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
+#
+import io
+import logging
+from unittest import mock
+
+import pytest
+
+from snowflake.connector.network import ReauthenticationRequest
+from snowflake.snowpark import Session
+from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
+from snowflake.snowpark.exceptions import (
+    SnowparkFetchDataException,
+    SnowparkQueryCancelledException,
+    SnowparkSessionException,
+    SnowparkSQLException,
+    SnowparkUploadFileException,
+    SnowparkUploadUdfFileException,
+)
+
+
+def test_wrap_exception(mock_server_connection):
+    with mock.patch.object(
+        mock_server_connection._cursor,
+        "execute",
+        side_effect=ReauthenticationRequest("fake exception"),
+    ):
+        with pytest.raises(
+            SnowparkSessionException, match="Your Snowpark session has expired"
+        ):
+            mock_server_connection.run_query("fake query")
+
+    with mock.patch.object(
+        mock_server_connection._cursor,
+        "execute",
+        side_effect=Exception("fake exception"),
+    ):
+        with pytest.raises(Exception, match="fake exception"):
+            mock_server_connection.run_query("fake query")
+
+    with mock.patch.object(
+        mock_server_connection._conn, "is_closed", return_value=True
+    ):
+        with pytest.raises(
+            SnowparkSessionException, match="the session has been closed"
+        ):
+            mock_server_connection.get_session_id()
+
+
+def test_upload_stream_exceptions(mock_server_connection):
+    with mock.patch.object(
+        mock_server_connection._cursor,
+        "execute",
+        side_effect=ValueError("fake exception"),
+    ):
+        input_stream = io.BytesIO(b"fake stream")
+        with pytest.raises(ValueError, match="fake exception"):
+            mock_server_connection.upload_stream(
+                input_stream, "fake_state", "fake_file_name"
+            )
+
+        input_stream.close()
+        with pytest.raises(
+            SnowparkUploadUdfFileException,
+            match="A file stream was closed when uploading UDF files",
+        ):
+            mock_server_connection.upload_stream(
+                input_stream, "fake_state", "fake_file_name", is_in_udf=True
+            )
+
+        with pytest.raises(
+            SnowparkUploadFileException,
+            match="A file stream was closed when uploading files to the server",
+        ):
+            mock_server_connection.upload_stream(
+                input_stream, "fake_state", "fake_file_name"
+            )
+
+
+def test_run_query_exceptions(mock_server_connection, caplog):
+    with mock.patch.object(
+        mock_server_connection._cursor,
+        "execute",
+        side_effect=Exception("fake exception"),
+    ):
+        with pytest.raises(Exception, match="fake exception"):
+            with caplog.at_level(logging.ERROR):
+                mock_server_connection.run_query("fake query")
+        assert "Failed to execute query" in caplog.text
+
+    mock_server_connection._cursor.execute.return_value = mock_server_connection._cursor
+    mock_server_connection._cursor.sfqid = "fake id"
+    mock_server_connection._cursor.query = "fake query"
+    with mock.patch.object(
+        mock_server_connection._cursor,
+        "fetch_pandas_all",
+        side_effect=KeyboardInterrupt("fake exception"),
+    ):
+        with pytest.raises(KeyboardInterrupt, match="fake exception"):
+            mock_server_connection.run_query("fake query", to_pandas=True)
+
+    with mock.patch.object(
+        mock_server_connection._cursor,
+        "fetch_pandas_all",
+        side_effect=BaseException("fake exception"),
+    ):
+        with pytest.raises(
+            SnowparkFetchDataException, match="Failed to fetch a Pandas Dataframe"
+        ):
+            mock_server_connection.run_query("fake query", to_pandas=True)
+
+
+def test_get_result_set_exception(mock_server_connection):
+    fake_plan = SnowflakePlan(
+        queries=[Query("fake query 1"), Query("fake query 2")],
+        schema_query="fake schema query",
+    )
+    fake_session = mock.create_autospec(Session)
+    fake_session._generate_new_action_id.return_value = 1
+    fake_session._last_canceled_id = 100
+    fake_session._conn = mock_server_connection
+    fake_plan.session = fake_session
+    with pytest.raises(
+        SnowparkQueryCancelledException,
+        match="The query has been cancelled by the user",
+    ):
+        mock_server_connection.get_result_set(fake_plan)
+
+    with pytest.raises(
+        SnowparkQueryCancelledException,
+        match="The query has been cancelled by the user",
+    ):
+        mock_server_connection.get_result_set(fake_plan, block=False)
+
+    fake_session._last_canceled_id = 0
+    with mock.patch.object(mock_server_connection, "run_query", return_value=None):
+        with pytest.raises(SnowparkSQLException, match="doesn't return a ResultSet"):
+            mock_server_connection.get_result_set(fake_plan, block=False)


### PR DESCRIPTION
Description

This adds coverage to code paths not covered by existing tests. The remaining ones are all with `is_stored_procedure()` being True.

Testing

unit test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-683056

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This makes all non-stored-proc code path covered
