### PR TITLE
SNOW-544808 Use existing connector in test_create_session_in_sp

### DIFF
--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -65,17 +65,14 @@ def test_no_default_session():
         _active_sessions.update(sessions_backup)
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="SNOW-544808: Use same connection to create session"
-)
-def test_create_session_in_sp(session, db_parameters):
+def test_create_session_in_sp(session):
     import snowflake.snowpark._internal.utils as internal_utils
 
     original_platform = internal_utils.PLATFORM
     internal_utils.PLATFORM = "XP"
     try:
         with pytest.raises(SnowparkSessionException) as exec_info:
-            Session.builder.configs(db_parameters).create()
+            Session(session._conn)
         assert exec_info.value.error_code == "1410"
     finally:
         internal_utils.PLATFORM = original_platform
@@ -347,7 +344,8 @@ def test_get_current_schema(session):
 
 
 @pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="use secondary role is not allowed in stored proc (owner mode)"
+    IS_IN_STORED_PROC,
+    reason="use secondary role is not allowed in stored proc (owner mode)",
 )
 def test_use_secondary_roles(session):
     session.use_secondary_roles("all")


### PR DESCRIPTION
Description

Currently we try to create a new session directly from db_parameters, which does not work in sp because creating a new connection is not allowed in sp connector. To make sure we could test not allowing new session being created, we should reuse existing connection.

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-544808

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fix to enable test_create_session_in_sp in sp test
