### PR TITLE
Add code block buttons for copy and toggle prompt

### DIFF
--- a/docs/source/_themes/snowflake_rtd_theme/static/css/style.css
+++ b/docs/source/_themes/snowflake_rtd_theme/static/css/style.css
@@ -4117,3 +4117,15 @@ a.sflogo:after {
         text-align: left !important;
         text-indent: 1.5em;
     }
+
+button.copybtn {
+    position: absolute;
+    top: 0px;
+    right: 40px;
+    background: transparent;
+    padding: unset;
+}
+
+svg.icon-tabler-copy, svg.icon-tabler-check {
+    transform: scale(0.7);
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx.ext.coverage",
+    "sphinx_toggleprompt",
+    "sphinx_copybutton",
 ]
 
 # -- Options for autodoc --------------------------------------------------
@@ -89,3 +91,4 @@ html_show_sourcelink = False  # Hide "view page source" link
 
 # Disable footer message "Built with Sphinx using a theme provided by Read the Docs."
 html_show_sphinx = False
+

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ setup(
             "pytest-cov",
             "coverage",
             "sphinx==5.0.2",
+            "jinja2",
+            "sphinx-copybutton",
+            "sphinx-toggleprompt",
             "cachetools",  # used in UDF doctest
         ],
     },


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
<img width="1226" alt="Screen Shot 2022-11-03 at 4 22 19 PM" src="https://user-images.githubusercontent.com/77285980/199826287-5180cd86-ba76-4862-b056-f06b4552de62.png">

Add the copy and toggle button.

Note: this installs new sphinx extension packages, please run `pip install ".[development]"`  under `snowpark-python/` before `make html`

