### PR TITLE
SNOW-689204: Add missing sequence generator funcs to docs

### DIFF
--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -354,6 +354,10 @@ The return type is always ``Column``. The input types tell you the acceptable va
         rpad
         rtrim
         second
+        seq1
+        seq2
+        seq4
+        seq8
         sha1
         sha2
         sin


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-689204

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [x] I am adding missing documentation

3. Please describe how your code solves the related issue.

   SNOW-677088 added new functions seq1, seq2, seq4, seq8 and associated docstrings into v1.0.0 but due to
   a parallel change in the documentation build it missed adding it to the functions index that appears required
   to generate their docstrings into HTML.
   
   This change adds the missing sequence functions into the functions index so they can be generated
   during subsequent docs builds.
   
   Testing: (Manual) Ran `make html` under the `docs/` directory and compared before/after the index.html
   and each individual seq1, seq2, seq4, and seq8 function's pages.