### PR TITLE
SNOW-689204: Add missing sequence generator funcs to docs

### DIFF
--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -354,6 +354,10 @@ The return type is always ``Column``. The input types tell you the acceptable va
         rpad
         rtrim
         second
+        seq1
+        seq2
+        seq4
+        seq8
         sha1
         sha2
         sin


### PR DESCRIPTION
SNOW-677088 added new functions seq1, seq2, seq4, seq8 and associated docstrings but due to a change in the documentation generation it missed adding it to the index required to generate their docstrings into HTML.

This change adds the missing sequence functions into the functions index so they can be generated during docs builds.

Testing:

- Manual: Ran `make html` under the docs/ directory and compared the index and sequence function pages before and after the change.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
