### PR TITLE
SNOW-707132 Support creating UDFs that reference non-local-scoped functions

### DIFF
--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -399,5 +399,5 @@ class SnowparkClientExceptionMessages:
         func: object, exc: Exception
     ) -> SnowparkSourceCodeExtractionException:
         return SnowparkSourceCodeExtractionException(
-            f"Failed to extract source code for function: {func} due to {exc}"
+            f"Failed to extract source code for function: {func} due to {exc}", "1600"
         )

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -16,6 +16,7 @@ from snowflake.snowpark.exceptions import (
     SnowparkPlanException,
     SnowparkQueryCancelledException,
     SnowparkSessionException,
+    SnowparkSourceCodeExtractionException,
     SnowparkSQLAmbiguousJoinException,
     SnowparkSQLException,
     SnowparkSQLInvalidIdException,
@@ -389,4 +390,14 @@ class SnowparkClientExceptionMessages:
     ) -> SnowparkInvalidObjectNameException:
         return SnowparkInvalidObjectNameException(
             f"The object name '{type_name}' is invalid.", "1500"
+        )
+
+    # Source Code Extraction Error codes 16XX
+
+    @staticmethod
+    def SOURCE_CODE_EXTRACTION_ERROR(
+        func: object, exc: Exception
+    ) -> SnowparkSourceCodeExtractionException:
+        return SnowparkSourceCodeExtractionException(
+            f"Failed to extract source code for function: {func} due to {exc}"
         )

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -573,7 +573,12 @@ def resolve_imports_and_packages(
         )
 
         if pickled_by_reference:
-            source_code = code_generation.generate_source_code(func, False)
+            try:
+                source_code = code_generation.generate_source_code(func, False)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Could not register udf, source code extraction failed for function pickled by reference: {e}"
+                )
             with tempfile.TemporaryDirectory() as tempdir:
                 abs_path = tempdir + f"/{func.__module__.replace('.', '/')}.py"
                 os.makedirs(os.path.dirname(abs_path), exist_ok=True)

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -582,7 +582,9 @@ def resolve_imports_and_packages(
             try:
                 source_code = code_generation.generate_source_code(func, False)
                 with tempfile.TemporaryDirectory() as tempdir:
-                    abs_path = tempdir + f"/{func.__module__.replace('.', '/')}.py"
+                    abs_path = os.path.join(
+                        tempdir, f"{func.__module__.replace('.', '/')}.py"
+                    )
                     os.makedirs(os.path.dirname(abs_path), exist_ok=True)
                     with open(abs_path, "w") as fp:
                         fp.write(source_code)

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -601,6 +601,12 @@ def resolve_imports_and_packages(
                         additional_imports,
                         statement_params=statement_params,
                     )
+            except TypeError as exc:
+                if (
+                    str(exc)
+                    != "module, class, method, function, traceback, frame, or code object was expected, got builtin_function_or_method"
+                ):
+                    raise
             except Exception as e:
                 raise SnowparkClientException(
                     f"Could not register udf, source code inspection/upload failed for function pickled by reference: {e}"

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -590,7 +590,7 @@ def resolve_imports_and_packages(
                 )
             with tempfile.TemporaryDirectory() as tempdir:
                 abs_path = os.path.join(
-                    tempdir, f"{func.__module__.replace('.', '/')}.py"
+                    tempdir, f"{func.__module__.replace('.', os.sep)}.py"
                 )
                 os.makedirs(os.path.dirname(abs_path), exist_ok=True)
                 with open(abs_path, "w") as fp:

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -380,7 +380,7 @@ def generate_python_code(
     else:
         pickled_func = pickle_function(func)
 
-    pickled_by_reference = b"cloudpickle" not in pickled_func
+    pickled_by_reference = b"cloudpickle_submodules" not in pickled_func
     args = ",".join(arg_names)
 
     try:

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-
+import inspect
 import io
 import os
 import pickle
@@ -43,6 +43,7 @@ from snowflake.snowpark._internal.utils import (
     unwrap_stage_location_single_quote,
     validate_object_name,
 )
+from snowflake.snowpark.exceptions import SnowparkClientException
 from snowflake.snowpark.types import (
     DataType,
     PandasDataFrameType,
@@ -580,7 +581,7 @@ def resolve_imports_and_packages(
 
         if pickled_by_reference:
             try:
-                source_code = code_generation.generate_source_code(func, False)
+                source_code = inspect.getsource(func)
                 with tempfile.TemporaryDirectory() as tempdir:
                     abs_path = os.path.join(
                         tempdir, f"{func.__module__.replace('.', '/')}.py"
@@ -601,8 +602,8 @@ def resolve_imports_and_packages(
                         statement_params=statement_params,
                     )
             except Exception as e:
-                raise RuntimeError(
-                    f"Could not register udf, source code extraction/upload failed for function pickled by reference: {e}"
+                raise SnowparkClientException(
+                    f"Could not register udf, source code inspection/upload failed for function pickled by reference: {e}"
                 )
 
         if len(code) > _MAX_INLINE_CLOSURE_SIZE_BYTES:

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -5,6 +5,7 @@
 import io
 import os
 import pickle
+import tempfile
 import typing
 import zipfile
 from logging import getLogger
@@ -355,7 +356,7 @@ def generate_python_code(
     is_dataframe_input: bool,
     max_batch_size: Optional[int] = None,
     source_code_display: bool = False,
-) -> str:
+) -> Tuple[str, bool]:
     # if func is a method object, we need to extract the target function first to check
     # annotations. However, we still serialize the original method because the extracted
     # function will have an extra argument `cls` or `self` from the class.
@@ -378,6 +379,8 @@ def generate_python_code(
             target_func.__annotations__ = annotations
     else:
         pickled_func = pickle_function(func)
+
+    pickled_by_reference = b"cloudpickle" not in pickled_func
     args = ",".join(arg_names)
 
     try:
@@ -484,10 +487,13 @@ def {_DEFAULT_HANDLER_NAME}({args}):
     return lock_function_once(func, invoked)({args})
 """.rstrip()
 
-    return f"""
+    return (
+        f"""
 {deserialization_code}
 {func_code}
-""".strip()
+""".strip(),
+        pickled_by_reference,
+    )
 
 
 def resolve_imports_and_packages(
@@ -497,8 +503,8 @@ def resolve_imports_and_packages(
     arg_names: List[str],
     udf_name: str,
     stage_location: Optional[str],
-    imports: Optional[List[Union[str, Tuple[str, str]]]],
-    packages: Optional[List[Union[str, ModuleType]]],
+    imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
+    packages: Optional[List[Union[str, ModuleType]]] = None,
     parallel: int = 4,
     is_pandas_udf: bool = False,
     is_dataframe_input: bool = False,
@@ -556,7 +562,7 @@ def resolve_imports_and_packages(
         # and we compress it first then upload it
         udf_file_name_base = f"udf_py_{random_number()}"
         udf_file_name = f"{udf_file_name_base}.zip"
-        code = generate_python_code(
+        code, pickled_by_reference = generate_python_code(
             func,
             arg_names,
             object_type,
@@ -565,6 +571,23 @@ def resolve_imports_and_packages(
             max_batch_size,
             source_code_display=source_code_display,
         )
+
+        if pickled_by_reference:
+            source_code = code_generation.generate_source_code(func, False)
+            with tempfile.TemporaryDirectory() as tempdir:
+                abs_path = tempdir + f"/{func.__module__.replace('.', '/')}.py"
+                os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+                with open(abs_path, "w") as fp:
+                    fp.write(source_code)
+                additional_imports = {}
+                resolved_import_tuple = session._resolve_import_path(
+                    abs_path, func.__module__
+                )
+                additional_imports[resolved_import_tuple[0]] = resolved_import_tuple[1:]
+                all_urls += session._resolve_imports(
+                    upload_stage, additional_imports, statement_params=statement_params
+                )
+
         if len(code) > _MAX_INLINE_CLOSURE_SIZE_BYTES:
             dest_prefix = get_udf_upload_prefix(udf_name)
             upload_file_stage_location = normalize_remote_file_or_dir(

--- a/src/snowflake/snowpark/exceptions.py
+++ b/src/snowflake/snowpark/exceptions.py
@@ -255,3 +255,12 @@ class SnowparkInvalidObjectNameException(SnowparkGeneralException):
     """
 
     pass
+
+
+class SnowparkSourceCodeExtractionException(SnowparkClientException):
+    """Exception for when we fail to extract source code for a given function/method in UDF registration. Checked locally.
+
+    his exception is specifically raised for error codes 1600.
+    """
+
+    pass

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -84,6 +84,17 @@ def setup(session, resources_path):
     )
 
 
+def return1():
+    return "1"
+
+
+def test_basic_non_local_udf(session):
+    return1_udf = udf(return1, return_type=StringType())
+
+    df = session.create_dataframe([[1, 2], [3, 4]]).to_df("a", "b")
+    Utils.check_answer(df.select(return1_udf()).collect(), [Row("1"), Row("1")])
+
+
 def test_basic_udf(session):
     def return1():
         return "1"

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -88,6 +88,9 @@ def return1():
     return "1"
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="Source code extraction fails in stored proc"
+)
 def test_basic_non_local_udf(session):
     return1_udf = udf(return1, return_type=StringType())
 

--- a/tests/unit/test_udf_utils.py
+++ b/tests/unit/test_udf_utils.py
@@ -56,7 +56,7 @@ def test_generate_python_code_exception():
         "snowflake.snowpark._internal.code_generation.generate_source_code",
         side_effect=Exception("fake error"),
     ):
-        generated_code = generate_python_code(
+        generated_code, _ = generate_python_code(
             func=lambda: None,
             arg_names=[],
             object_type=TempObjectType.FUNCTION,

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands = flake8 {posargs}
 [testenv:fix_lint]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
 basepython = python3.8
-allowlist_externals = /bin/bash
+allowlist_externals = bash
 passenv =
     PROGRAMDATA
 deps =


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #[SNOW-707132](https://snowflakecomputing.atlassian.net/browse/SNOW-707132)
2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The error is caused by `cloudpickle` de-pickling a function that has reference to the module in where it's defined in the newly created UDF, i.e. pickle by reference then depickle in a different environment. This is the issue `cloudpickle` tries to tackle by introducing [pickle by value](https://github.com/cloudpipe/cloudpickle#overriding-pickles-serialization-mechanism-for-importable-constructs). For local functions, `cloudpickle` automatically pickles by value. An ideal fix in this case is to register the function to be always pickled by value using `cloudpickle.register_pickle_by_value(func.__module__)`, but doing this causes [recursion errors](https://github.com/cloudpipe/cloudpickle/blob/40aa8465b519d2d56a371a1e1bd08afc7da4e7d2/cloudpickle/cloudpickle_fast.py#L634) in our tests. So as a workaround, this fix detects when a function is being pickled by reference, then exposes the extracted source code as a udf level import under the name of the referenced module.

Note that, this fix is for **outside stored procedures**, referencing functions outside the local scope still fails in stored procedures due to source code extraction currently not working in stored procedures. 

