### PR TITLE
SNOW-695533 remove redundant and error prone telemetry tracker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,10 +63,10 @@ repos:
         args:
             - --license-filepath
             - license_header.txt
--   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.9.2
+-   repo: https://github.com/pycqa/flake8.git
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear == 20.11.1
+          - flake8-bugbear
           - flake8-init-return == 1.0.0

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -11,7 +11,6 @@ import snowflake.snowpark
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark._internal.analyzer.expression import Expression, SnowflakeUDF
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
-from snowflake.snowpark._internal.telemetry import TelemetryField
 from snowflake.snowpark._internal.type_utils import ColumnOrName, convert_sp_to_sf_type
 from snowflake.snowpark._internal.udf_utils import (
     UDFColumn,
@@ -86,10 +85,6 @@ class UserDefinedFunction:
                     f"The input of UDF {self.name} must be Column, column name, or a list of them"
                 )
 
-        session = snowflake.snowpark.context.get_active_session()
-        session._conn._telemetry_client.send_function_usage_telemetry(
-            "UserDefinedFunction.__call__", TelemetryField.FUNC_CAT_USAGE.value
-        )
         return Column(self._create_udf_expression(exprs))
 
     def _create_udf_expression(self, exprs: List[Expression]) -> SnowflakeUDF:

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -383,6 +383,7 @@ def test_close_session_twice(db_parameters):
 
 
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Can't create a session in SP")
+@pytest.mark.skip(reason="Server side overrides the client parameter")
 def test_sql_simplifier_enabled_on_session(db_parameters):
     with Session.builder.configs(db_parameters).create() as new_session:
         assert new_session.sql_simplifier_enabled is False


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-695533

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Telemetry calls were added to udf/udtf/sprocs and a [potential error was identified](https://github.com/snowflakedb/snowpark-python/pull/520) where `get_active_session()` call could throw in case there were no sessions or more than one active sessions. To fix this, we made [changes](https://github.com/snowflakedb/snowpark-python/pull/539) to telemetry path but one of the `get_active_session()` was left out. This PR fixes the instance that got left out.
