### PR TITLE
Constrait libffi to <3.4.2 in conda recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python
     - typing-extensions >=4.1.0
+    # need to pin libffi to <3.4.2 because of problems in cryptography
+    - libffi <3.4.2
 
 test:
   imports:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   libffi 3.4.2 is not compatible with the latest cryptography library in conda channel. As a result we want to pin libffi version to unblock stored proc regression test
