### PR TITLE
SNOW-703369 Support DataFrame.dtypes

### DIFF
--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -458,39 +458,41 @@ def python_type_to_snow_type(tp: Union[str, Type]) -> Tuple[DataType, bool]:
     raise TypeError(f"invalid type {tp}")
 
 
-def data_type_to_python_type(dtype: DataType) -> Type:
-    if isinstance(dtype, ArrayType):
-        return list
-    elif isinstance(dtype, BinaryType):
-        return bytes
-    elif isinstance(dtype, BooleanType):
-        return bool
-    elif isinstance(dtype, DateType):
-        return datetime.date
-    elif isinstance(dtype, DecimalType):
-        return int if dtype.scale == 0 else decimal.Decimal
-    elif isinstance(dtype, FloatType):
-        return float
-    elif isinstance(dtype, DoubleType):
-        return float
-    elif isinstance(dtype, GeographyType):
-        return dict
-    elif isinstance(dtype, LongType):
-        return int
-    elif isinstance(dtype, MapType):
-        return dict
-    elif isinstance(dtype, StringType):
-        return str
-    elif isinstance(dtype, StructType):
-        return dict
-    elif isinstance(dtype, TimestampType):
-        return datetime.datetime
-    elif isinstance(dtype, TimeType):
-        return datetime.time
-    elif isinstance(dtype, VariantType):
-        return dict
+def snow_type_to_dtype_str(snow_type: DataType) -> str:
+    if isinstance(
+        snow_type,
+        (
+            BinaryType,
+            BooleanType,
+            FloatType,
+            DoubleType,
+            StringType,
+            DateType,
+            TimestampType,
+            TimeType,
+            GeographyType,
+            VariantType,
+        ),
+    ):
+        return snow_type.__class__.__name__[:-4].lower()
+    if isinstance(snow_type, ByteType):
+        return "tinyint"
+    if isinstance(snow_type, ShortType):
+        return "smallint"
+    if isinstance(snow_type, IntegerType):
+        return "int"
+    if isinstance(snow_type, LongType):
+        return "bigint"
+    if isinstance(snow_type, ArrayType):
+        return f"array<{snow_type_to_dtype_str(snow_type.element_type)}>"
+    if isinstance(snow_type, DecimalType):
+        return f"decimal({snow_type.precision},{snow_type.scale})"
+    if isinstance(snow_type, MapType):
+        return f"map<{snow_type_to_dtype_str(snow_type.key_type)},{snow_type_to_dtype_str(snow_type.value_type)}>"
+    if isinstance(snow_type, StructType):
+        return f"struct<{','.join([snow_type_to_dtype_str(field.datatype) for field in snow_type.fields])}>"
 
-    raise TypeError(f"invalid DataType {dtype}")
+    raise TypeError(f"invalid DataType {snow_type}")
 
 
 def retrieve_func_type_hints_from_source(

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -458,6 +458,41 @@ def python_type_to_snow_type(tp: Union[str, Type]) -> Tuple[DataType, bool]:
     raise TypeError(f"invalid type {tp}")
 
 
+def data_type_to_python_type(dtype: DataType) -> Type:
+    if isinstance(dtype, ArrayType):
+        return list
+    elif isinstance(dtype, BinaryType):
+        return bytes
+    elif isinstance(dtype, BooleanType):
+        return bool
+    elif isinstance(dtype, DateType):
+        return datetime.date
+    elif isinstance(dtype, DecimalType):
+        return int if dtype.scale == 0 else decimal.Decimal
+    elif isinstance(dtype, FloatType):
+        return float
+    elif isinstance(dtype, DoubleType):
+        return float
+    elif isinstance(dtype, GeographyType):
+        return dict
+    elif isinstance(dtype, LongType):
+        return int
+    elif isinstance(dtype, MapType):
+        return dict
+    elif isinstance(dtype, StringType):
+        return str
+    elif isinstance(dtype, StructType):
+        return dict
+    elif isinstance(dtype, TimestampType):
+        return datetime.datetime
+    elif isinstance(dtype, TimeType):
+        return datetime.time
+    elif isinstance(dtype, VariantType):
+        return dict
+
+    raise TypeError(f"invalid DataType {dtype}")
+
+
 def retrieve_func_type_hints_from_source(
     file_path: str,
     func_name: str,

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -95,6 +95,7 @@ from snowflake.snowpark._internal.type_utils import (
     ColumnOrName,
     ColumnOrSqlExpr,
     LiteralType,
+    data_type_to_python_type,
 )
 from snowflake.snowpark._internal.utils import (
     SKIP_LEVELS_THREE,
@@ -3400,6 +3401,15 @@ Query List:
         the DataFrame).
         """
         return StructType._from_attributes(self._plan.attributes)
+
+    @cached_property
+    def dtypes(self) -> "pandas.Series":
+        from snowflake.connector.options import pandas
+
+        python_types = [
+            data_type_to_python_type(field.datatype) for field in self.schema.fields
+        ]
+        return pandas.Series(python_types, index=self.schema.names)
 
     def _with_plan(self, plan):
         return DataFrame(self._session, plan)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -95,7 +95,7 @@ from snowflake.snowpark._internal.type_utils import (
     ColumnOrName,
     ColumnOrSqlExpr,
     LiteralType,
-    data_type_to_python_type,
+    snow_type_to_dtype_str,
 )
 from snowflake.snowpark._internal.utils import (
     SKIP_LEVELS_THREE,
@@ -3403,13 +3403,12 @@ Query List:
         return StructType._from_attributes(self._plan.attributes)
 
     @cached_property
-    def dtypes(self) -> "pandas.Series":
-        from snowflake.connector.options import pandas
-
-        python_types = [
-            data_type_to_python_type(field.datatype) for field in self.schema.fields
+    def dtypes(self) -> List[Tuple[str, str]]:
+        dtypes = [
+            (name, snow_type_to_dtype_str(field.datatype))
+            for name, field in zip(self.schema.names, self.schema.fields)
         ]
-        return pandas.Series(python_types, index=self.schema.names)
+        return dtypes
 
     def _with_plan(self, plan):
         return DataFrame(self._session, plan)

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -3,12 +3,7 @@
 #
 
 # Many of the tests have been moved to unit/scala/test_datattype_suite.py
-import datetime
-import decimal
 from decimal import Decimal
-
-import pandas
-from pandas.testing import assert_series_equal
 
 from snowflake.snowpark import Row
 from snowflake.snowpark.functions import lit
@@ -102,49 +97,6 @@ def test_verify_datatypes_reference(session):
         "StructField('ARRAY', ArrayType(StringType()), nullable=True), "
         "StructField('MAP', MapType(StringType(), StringType()), nullable=True)]"
     )
-    assert_series_equal(
-        df.dtypes,
-        pandas.Series(
-            [
-                dict,
-                dict,
-                datetime.date,
-                datetime.time,
-                datetime.datetime,
-                str,
-                bool,
-                bytes,
-                int,
-                int,
-                int,
-                int,
-                float,
-                float,
-                decimal.Decimal,
-                list,
-                dict,
-            ],
-            index=[
-                "VAR",
-                "GEO",
-                "DATE",
-                "TIME",
-                "TIMESTAMP",
-                "STRING",
-                "BOOLEAN",
-                "BINARY",
-                "BYTE",
-                "SHORT",
-                "INT",
-                "LONG",
-                "FLOAT",
-                "DOUBLE",
-                "DECIMAL",
-                "ARRAY",
-                "MAP",
-            ],
-        ),
-    )
 
 
 def test_verify_datatypes_reference2(session):
@@ -163,3 +115,72 @@ def test_verify_datatypes_reference2(session):
         == "[StructField('A', DecimalType(5, 2), nullable=False), "
         "StructField('B', DecimalType(7, 2), nullable=False)]"
     )
+
+
+def test_dtypes(session):
+    schema = StructType(
+        [
+            StructField("var", VariantType()),
+            StructField("geo", GeographyType()),
+            StructField("date", DateType()),
+            StructField("time", TimeType()),
+            StructField("timestamp", TimestampType()),
+            StructField("string", StringType()),
+            StructField("boolean", BooleanType()),
+            StructField("binary", BinaryType()),
+            StructField("byte", ByteType()),
+            StructField("short", ShortType()),
+            StructField("int", IntegerType()),
+            StructField("long", LongType()),
+            StructField("float", FloatType()),
+            StructField("double", DoubleType()),
+            StructField("decimal", DecimalType(10, 2)),
+            StructField("array", ArrayType(IntegerType())),
+            StructField("map", MapType(ByteType(), TimeType())),
+        ]
+    )
+
+    df = session.create_dataframe(
+        [
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                "a",
+                True,
+                None,
+                1,
+                2,
+                3,
+                4,
+                5.0,
+                6.0,
+                Decimal(123),
+                None,
+                None,
+            ]
+        ],
+        schema,
+    )
+
+    assert df.dtypes == [
+        ("VAR", "variant"),
+        ("GEO", "geography"),
+        ("DATE", "date"),
+        ("TIME", "time"),
+        ("TIMESTAMP", "timestamp"),
+        ("STRING", "string"),
+        ("BOOLEAN", "boolean"),
+        ("BINARY", "binary"),
+        ("BYTE", "bigint"),
+        ("SHORT", "bigint"),
+        ("INT", "bigint"),
+        ("LONG", "bigint"),
+        ("FLOAT", "double"),
+        ("DOUBLE", "double"),
+        ("DECIMAL", "decimal(10,2)"),
+        ("ARRAY", "array<string>"),
+        ("MAP", "map<string,string>"),
+    ]

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -3,7 +3,12 @@
 #
 
 # Many of the tests have been moved to unit/scala/test_datattype_suite.py
+import datetime
+import decimal
 from decimal import Decimal
+
+import pandas
+from pandas.testing import assert_series_equal
 
 from snowflake.snowpark import Row
 from snowflake.snowpark.functions import lit
@@ -96,6 +101,49 @@ def test_verify_datatypes_reference(session):
         "StructField('DECIMAL', DecimalType(10, 2), nullable=False), "
         "StructField('ARRAY', ArrayType(StringType()), nullable=True), "
         "StructField('MAP', MapType(StringType(), StringType()), nullable=True)]"
+    )
+    assert_series_equal(
+        df.dtypes,
+        pandas.Series(
+            [
+                dict,
+                dict,
+                datetime.date,
+                datetime.time,
+                datetime.datetime,
+                str,
+                bool,
+                bytes,
+                int,
+                int,
+                int,
+                int,
+                float,
+                float,
+                decimal.Decimal,
+                list,
+                dict,
+            ],
+            index=[
+                "VAR",
+                "GEO",
+                "DATE",
+                "TIME",
+                "TIMESTAMP",
+                "STRING",
+                "BOOLEAN",
+                "BINARY",
+                "BYTE",
+                "SHORT",
+                "INT",
+                "LONG",
+                "FLOAT",
+                "DOUBLE",
+                "DECIMAL",
+                "ARRAY",
+                "MAP",
+            ],
+        ),
     )
 
 


### PR DESCRIPTION
Description

Add dtypes as a property of DataFrame, which returns datatype with names in pandas Series.

This change referenced mobilize's implementation in https://github.com/MobilizeNet/snowpark-extensions-py/blob/main/tests/test_dataframe_extensions.py with modifications.

Testing

Integration test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-703369

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add dtypes as a property of DataFrame, which returns datatype with names in pandas Series.

   Note that the implementation is not exactly the same as mobilize, for example, this change does not use numpy array.
