### PR TITLE
SNOW-697912: Fix SQL simplifier for renaming column names

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
+import copy
 import uuid
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
 
@@ -8,8 +9,6 @@ if TYPE_CHECKING:
     from snowflake.snowpark._internal.analyzer.snowflake_plan import (
         SnowflakePlan,
     )  # pragma: no cover
-
-from functools import cached_property
 
 import snowflake.snowpark._internal.analyzer.analyzer_utils as analyzer_utils
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
@@ -82,10 +81,18 @@ class Expression:
 
 class NamedExpression:
     name: str = None
+    _expr_id: str = None
 
-    @cached_property
+    @property
     def expr_id(self) -> uuid.UUID:
-        return uuid.uuid4()
+        if not self._expr_id:
+            self._expr_id = uuid.uuid4()
+        return self._expr_id
+
+    def __copy__(self):
+        new = copy.copy(super())
+        new._expr_id = None
+        return new
 
 
 class ScalarSubquery(Expression):

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -740,6 +740,11 @@ class DeriveColumnDependencyError(Exception):
 def parse_column_name(column: Expression, analyzer: "Analyzer") -> Optional[str]:
     if isinstance(column, Expression):
         if isinstance(column, Attribute):
+            # Use analyze for the case of
+            #     df1 = session.create_dataframe([[1]], schema=["a"])
+            #     df2 = df1.select(df1["a"].alias("b"))
+            #     df3 = df2.select(df1["a"])  # df1["a"] converted to column name "b" instead of "a"
+            #     df3.show()
             return analyzer.analyze(column)
         if isinstance(column, UnresolvedAttribute):
             if not column.is_sql_text:

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -508,7 +508,7 @@ class SelectStatement(Selectable):
                     )
                     if not can_be_flattened:
                         break
-                    final_projection.append(state.expression)
+                    final_projection.append(copy(state.expression))
                 elif state.change_state == ColumnChangeState.UNCHANGED_EXP:
                     # query may change sequence of columns. If subquery has same-level reference, flattened sql may not work.
                     if (
@@ -518,7 +518,7 @@ class SelectStatement(Selectable):
                         can_be_flattened = False
                         break
                     final_projection.append(
-                        subquery_column_states[col].expression
+                        copy(subquery_column_states[col].expression)
                     )  # add subquery's expression for this column name
                 elif state.change_state == ColumnChangeState.DROPPED:
                     if (
@@ -740,7 +740,7 @@ class DeriveColumnDependencyError(Exception):
 def parse_column_name(column: Expression, analyzer: "Analyzer") -> Optional[str]:
     if isinstance(column, Expression):
         if isinstance(column, Attribute):
-            return column.name
+            return analyzer.analyze(column)
         if isinstance(column, UnresolvedAttribute):
             if not column.is_sql_text:
                 return column.name
@@ -867,9 +867,9 @@ def derive_column_states_from_subquery(
         if isinstance(c, UnresolvedAlias) and isinstance(c.child, Star):
             if c.child.expressions:
                 # df.select(df["*"]) will have child expressions. df.select("*") doesn't.
-                columns_from_star = c.child.expressions
+                columns_from_star = [copy(e) for e in c.child.expressions]
             else:
-                columns_from_star = from_.column_states.projection
+                columns_from_star = [copy(e) for e in from_.column_states.projection]
             column_states.update(initiate_column_states(columns_from_star, analyzer))
             column_states.projection.extend(columns_from_star)
             continue

--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -1123,7 +1123,8 @@ def test_join_diamond_shape_error(session):
     df2 = session.create_dataframe([[1]], schema=["a"])
     df3 = df1.join(df2, df1["a"] == df2["a"])
     df4 = df3.select(df1["a"].as_("a"))
-    # df1["a"] and df4["a"] has the same expr id in map expr_to_alias. So df1["a"]
+    # df1["a"] and df4["a"] has the same expr_id in map expr_to_alias. When they join, only one will be in df5's alias
+    # map. It leaves the other one resolved to "a" instead of the alias.
     df5 = df1.join(df4, df1["a"] == df4["a"])
     with pytest.raises(
         SnowparkSQLAmbiguousJoinException,

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -963,3 +963,13 @@ def test_natural_join(session, simplifier_table):
     df = df.select("a").select("a").select("a")
     df.collect()
     assert df.queries["queries"][0].count('SELECT "A"') == 1
+
+
+def test_rename_to_existing_column(session):
+    session.sql_simplifier_enabled = True
+    df1 = session.create_dataframe([[1, 2, 3]], schema=["a", "b", "c"])
+    df2 = df1.drop("a").drop("b")
+    df3 = df2.withColumn("a", df2["c"])
+    df4 = df3.withColumn("b", sql_expr("1"))
+    assert df4.columns == ["C", "A", "B"]
+    Utils.check_answer(df4, [Row(3, 3, 1)])

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -965,11 +965,21 @@ def test_natural_join(session, simplifier_table):
     assert df.queries["queries"][0].count('SELECT "A"') == 1
 
 
-def test_rename_to_existing_column(session):
+def test_rename_to_dropped_column_name(session):
     session.sql_simplifier_enabled = True
     df1 = session.create_dataframe([[1, 2, 3]], schema=["a", "b", "c"])
     df2 = df1.drop("a").drop("b")
     df3 = df2.withColumn("a", df2["c"])
+    df4 = df3.withColumn("b", sql_expr("1"))
+    assert df4.columns == ["C", "A", "B"]
+    Utils.check_answer(df4, [Row(3, 3, 1)])
+
+
+def test_rename_to_existing_column_column(session):
+    session.sql_simplifier_enabled = True
+    df1 = session.create_dataframe([[1, 2, 3]], schema=["a", "b", "c"])
+    # df2 = df1.drop("a").drop("b")
+    df3 = df1.withColumn("a", df1["c"])
     df4 = df3.withColumn("b", sql_expr("1"))
     assert df4.columns == ["C", "A", "B"]
     Utils.check_answer(df4, [Row(3, 3, 1)])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-697912

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
When sql simplifier is enabled, a DataFrame's and its previous level DataFrame (the subquery) share the same `Attribute` instances. This generates a wrong SQL in a specific case. The fix is to copy those `Attribute` instances.