### PR TITLE
SNOW-700720 Change python SnowflakeFile.open API that requires scoped URL

### DIFF
--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -28,12 +28,15 @@ class SnowflakeFile(RawIOBase):
         self,
         file_location: str,
         mode: str = "r",
+        allow_owner_file_access: bool = False,
     ) -> None:
         super().__init__()
         # The URL/URI of the file to be opened by the SnowflakeFile object
         self._file_location: str = file_location
         # The mode of file stream
         self._mode: str = mode
+        # If False, user is allowed to get access to files by stage url/uri. True by default(only scope url is allowed.
+        self._allow_owner_file_access = allow_owner_file_access
 
         # The attributes supported as part of IOBase
         self.buffer = None
@@ -46,6 +49,7 @@ class SnowflakeFile(RawIOBase):
         cls,
         file_location: str,
         mode: str = "r",
+        allow_owner_file_access: bool = False,
     ) -> SnowflakeFile:
         """
         Returns a :class:`~snowflake.snowpark.file.SnowflakeFile`.
@@ -54,8 +58,9 @@ class SnowflakeFile(RawIOBase):
         Args:
             file_location: A string of file location. It can be a remote URL/URI.
             mode: A string used to mark the type of an IO stream.
+            allow_owner_file_access: A boolean value to control access to files without scope url(with stage url/uri)
         """
-        return cls(file_location, mode)
+        return cls(file_location, mode, allow_owner_file_access)
 
     def close(self) -> None:
         """

--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -28,15 +28,15 @@ class SnowflakeFile(RawIOBase):
         self,
         file_location: str,
         mode: str = "r",
-        allow_owner_file_access: bool = False,
+        is_owner_file: bool = False,
     ) -> None:
         super().__init__()
         # The URL/URI of the file to be opened by the SnowflakeFile object
         self._file_location: str = file_location
         # The mode of file stream
         self._mode: str = mode
-        # If False, user is allowed to get access to files by stage url/uri. True by default(only scope url is allowed.
-        self._allow_owner_file_access = allow_owner_file_access
+        # Whether it is intended to access owner's files
+        self._is_owner_file = is_owner_file 
 
         # The attributes supported as part of IOBase
         self.buffer = None
@@ -49,18 +49,20 @@ class SnowflakeFile(RawIOBase):
         cls,
         file_location: str,
         mode: str = "r",
-        allow_owner_file_access: bool = False,
+        is_owner_file: bool = False,
     ) -> SnowflakeFile:
         """
         Returns a :class:`~snowflake.snowpark.file.SnowflakeFile`.
         In UDF and Stored Procedures, the object works like a Python IOBase object and as a wrapper for an IO stream of remote files. The IO Stream is to support the file operations defined in this class.
 
+	All files are accessed in the context of the UDF owner and therefore when accessing call files user should prefer setting is_owner_file to default false value as it only allows scoped URLs and therefore a caller cannot inadvertently or maliciously access the owner's files.
+
         Args:
             file_location: A string of file location. It can be a remote URL/URI.
             mode: A string used to mark the type of an IO stream.
-            allow_owner_file_access: A boolean value to control access to files without scope url(with stage url/uri)
+            is_owner_file: A boolean value, if True, the API is intended to access owner's files and all url/uri are allowed. If False, the API is intended to access files passed into the function by the caller and only scope url is allowed.
         """
-        return cls(file_location, mode, allow_owner_file_access)
+        return cls(file_location, mode, is_owner_file)
 
     def close(self) -> None:
         """


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-700720](https://snowflakecomputing.atlassian.net/browse/SNOW-700720)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
    For safety reason, we want to warn the users when using stage url/uri for file access. We add an arg "require_scope_url" to SnowflakeFile.open func, so that by default when using stage url/uri, the users will be declined and received an error msg to require the arg as False, which will be implemented in XP


[SNOW-700720]: https://snowflakecomputing.atlassian.net/browse/SNOW-700720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ