### PR TITLE
SNOW-719900 Remove random alias for subqeury in joins

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -574,6 +574,7 @@ class Analyzer:
                 logical_plan.join_type,
                 self.analyze(logical_plan.condition) if logical_plan.condition else "",
                 logical_plan,
+                self.session.use_constant_subquery_alias,
             )
 
         if isinstance(logical_plan, Sort):

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -23,10 +23,8 @@ from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.type_utils import convert_sp_to_sf_type
 from snowflake.snowpark._internal.utils import (
-    TempObjectType,
     get_temp_type_for_object,
     is_single_quoted,
-    random_name_for_temp_object,
 )
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import DataType
@@ -479,8 +477,8 @@ def set_operator_statement(left: str, right: str, operator: str) -> str:
 def left_semi_or_anti_join_statement(
     left: str, right: str, join_type: JoinType, condition: str
 ) -> str:
-    left_alias = random_name_for_temp_object(TempObjectType.TABLE)
-    right_alias = random_name_for_temp_object(TempObjectType.TABLE)
+    left_alias = "SNOWPARK_TEMP_LEFT_RESULT"
+    right_alias = "SNOWPARK_TEMP_RIGHT_RESULT"
 
     if isinstance(join_type, LeftSemi):
         where_condition = WHERE + EXISTS
@@ -517,8 +515,8 @@ def left_semi_or_anti_join_statement(
 def snowflake_supported_join_statement(
     left: str, right: str, join_type: JoinType, condition: str
 ) -> str:
-    left_alias = random_name_for_temp_object(TempObjectType.TABLE)
-    right_alias = random_name_for_temp_object(TempObjectType.TABLE)
+    left_alias = "SNOWPARK_TEMP_LEFT_RESULT"
+    right_alias = "SNOWPARK_TEMP_RIGHT_RESULT"
 
     if isinstance(join_type, UsingJoin):
         join_sql = join_type.tpe.sql

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -485,9 +485,12 @@ class SnowflakePlanBuilder:
         join_type: JoinType,
         condition: str,
         source_plan: Optional[LogicalPlan],
+        use_constant_subquery_alias: bool,
     ):
         return self.build_binary(
-            lambda x, y: join_statement(x, y, join_type, condition),
+            lambda x, y: join_statement(
+                x, y, join_type, condition, use_constant_subquery_alias
+            ),
             left,
             right,
             source_plan,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -235,7 +235,10 @@ class Session:
             self, conn: Optional[SnowflakeConnection] = None
         ) -> "Session":
             new_session = Session(
-                ServerConnection({}, conn) if conn else ServerConnection(self._options)
+                ServerConnection({}, conn) if conn else ServerConnection(self._options),
+                use_constant_subquery_alias=self._options.get(
+                    "use_constant_subquery_alias", True
+                ),
             )
             if "password" in self._options:
                 self._options["password"] = None
@@ -249,7 +252,9 @@ class Session:
     #: and create a :class:`Session` object.
     builder: SessionBuilder = SessionBuilder()
 
-    def __init__(self, conn: ServerConnection) -> None:
+    def __init__(
+        self, conn: ServerConnection, use_constant_subquery_alias: bool = True
+    ) -> None:
         if len(_active_sessions) >= 1 and is_in_stored_procedure():
             raise SnowparkClientExceptionMessages.DONT_CREATE_SESSION_IN_SP()
         self._conn = conn
@@ -285,6 +290,8 @@ class Session:
         self._sql_simplifier_enabled: bool = self._get_client_side_session_parameter(
             _PYTHON_SNOWPARK_USE_SQL_SIMPLIFIER_STRING, True
         )
+        self._use_constant_subquery_alias: bool = use_constant_subquery_alias
+
         _logger.info("Snowpark Session information: %s", self._session_info)
 
     def __enter__(self):
@@ -325,6 +332,14 @@ class Session:
                 _logger.info("Closed session: %s", self._session_id)
             finally:
                 _remove_session(self)
+
+    @property
+    def use_constant_subquery_alias(self) -> bool:
+        return self._use_constant_subquery_alias
+
+    @use_constant_subquery_alias.setter
+    def use_constant_subquery_alias(self, value: bool) -> None:
+        self._use_constant_subquery_alias = value
 
     @property
     def sql_simplifier_enabled(self) -> bool:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2585,3 +2585,34 @@ def test_create_or_replace_view_with_multiple_queries(session):
         match="Your dataframe may include DDL or DML operations",
     ):
         df.create_or_replace_view("temp")
+
+
+def test_nested_joins(session):
+    df1 = session.create_dataframe([[1, 2], [4, 5]], schema=["a", "b"])
+    df2 = session.create_dataframe([[1, 3], [4, 6]], schema=["c", "d"])
+    df3 = session.create_dataframe([[1, 4], [4, 7]], schema=["e", "f"])
+    res1 = sorted(
+        df1.join(df2)
+        .join(df3)
+        .sort("a", "b", "c", "d", "e", "f")
+        .select("a", "b", "c", "d", "e", "f")
+        .collect(),
+        key=lambda r: r[0],
+    )
+    res2 = sorted(
+        df2.join(df3)
+        .join(df1)
+        .sort("a", "b", "c", "d", "e", "f")
+        .select("a", "b", "c", "d", "e", "f")
+        .collect(),
+        key=lambda r: r[0],
+    )
+    res3 = sorted(
+        df3.join(df1)
+        .join(df2)
+        .sort("a", "b", "c", "d", "e", "f")
+        .select("a", "b", "c", "d", "e", "f")
+        .collect(),
+        key=lambda r: r[0],
+    )
+    assert res1 == res2 == res3

--- a/tests/unit/test_analyzer_util_suite.py
+++ b/tests/unit/test_analyzer_util_suite.py
@@ -173,10 +173,10 @@ def test_join_statement_negative():
     with pytest.raises(
         ValueError, match=f"Unexpected using clause in {join_type.tpe} join"
     ):
-        join_statement("", "", join_type, "")
+        join_statement("", "", join_type, "", False)
 
     join_type = UsingJoin(Inner(), ["cond1"])
     with pytest.raises(
         ValueError, match="A join should either have using clause or a join condition"
     ):
-        join_statement("", "", join_type, "cond2")
+        join_statement("", "", join_type, "cond2", False)

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -180,3 +180,22 @@ def test_create_or_replace_temp_view_bad_input():
         "The input of create_or_replace_temp_view() can only a str or list of strs."
         in str(exc_info)
     )
+
+
+def test_same_joins_should_generate_same_queries():
+    mock_connection = mock.create_autospec(ServerConnection)
+    mock_connection._conn = mock.MagicMock()
+    session = snowflake.snowpark.session.Session(mock_connection)
+    session._conn._telemetry_client = mock.MagicMock()
+    df1 = session.create_dataframe([[1, 1, "1"], [2, 2, "3"]]).to_df(["a", "b", "str"])
+    df2 = session.create_dataframe([[2, 2, "2"], [3, 3, "4"]]).to_df(["a", "b", "str"])
+
+    q1 = df1.join(df2, how="left", lsuffix="_L", rsuffix="_R").queries
+    q2 = df1.join(df2, how="left", lsuffix="_L", rsuffix="_R").queries
+
+    assert q1 == q2
+
+    q3 = df2.join(df1, how="semi", lsuffix="_L", rsuffix="_R").queries
+    q4 = df2.join(df1, how="semi", lsuffix="_L", rsuffix="_R").queries
+
+    assert q3 == q4


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-719900

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Previously, dataframe/table joins will use random aliases for the left and right subquery results at query generation, which means users cannot take advantage of query [result cache](https://community.snowflake.com/s/article/Caching-in-Snowflake-Data-Warehouse). This PR removes that and adds a unit test.
