### PR TITLE
SNOW-734704 Remove usage of create_temp_table

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1390,7 +1390,7 @@ class Session:
                 schema=sf_schema,
                 quote_identifiers=True,
                 auto_create_table=True,
-                create_temp_table=True,
+                table_type="temporary",
             )
             set_api_call_source(t, "Session.create_dataframe[pandas]")
             return t


### PR DESCRIPTION
Description

Now that table_type was released on connector's write_pandas, we should stop using create_temp_table to avoid warning messages.

Testing

Existing tests

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-734704

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Now that table_type was released on connector's write_pandas, we should stop using create_temp_table to avoid warning messages.
