### PR TITLE
SNOW-743672 Fix how=cross in df.join

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -2245,10 +2245,12 @@ class DataFrame:
                 lsuffix=lsuffix,
                 rsuffix=rsuffix,
             )
+            if not isinstance(join_type, Cross):
+                join_type = UsingJoin(join_type, using_columns)
             join_logical_plan = Join(
                 lhs._plan,
                 rhs._plan,
-                UsingJoin(join_type, using_columns),
+                join_type,
                 None,
             )
             if self._select_statement:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -2245,7 +2245,9 @@ class DataFrame:
                 lsuffix=lsuffix,
                 rsuffix=rsuffix,
             )
-            if not isinstance(join_type, Cross):
+            if not isinstance(
+                join_type, Cross
+            ):  # cross joins does not allow specifying columns
                 join_type = UsingJoin(join_type, using_columns)
             join_logical_plan = Join(
                 lhs._plan,

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -904,7 +904,7 @@ def test_drop(session):
 def test_alias(session):
     """Test for dropping columns from a dataframe."""
     # Selecting non-existing column (already renamed) should fail
-    with pytest.raises(Exception):
+    with pytest.raises(SnowparkSQLException):
         session.range(3, 8).select(col("id").alias("id_prime")).select(
             col("id").alias("id_prime")
         ).collect()
@@ -1078,9 +1078,12 @@ def test_join_cross(session):
 
     df1 = session.range(3, 8)
     df2 = session.range(5, 10)
-    res = df1.cross_join(df2).collect()
+
+    res1 = df1.cross_join(df2).collect()
     expected = [Row(x, y) for x, y in product(range(3, 8), range(5, 10))]
-    assert sorted(res, key=lambda r: (r[0], r[1])) == expected
+    assert sorted(res1, key=lambda r: (r[0], r[1])) == expected
+    res2 = df1.join(df2, how="cross").collect()
+    assert sorted(res2, key=lambda r: (r[0], r[1])) == expected
 
     # Join on same-name column, other columns have same name
     df1 = session.range(3, 8).select([col("id"), col("id").alias("id_prime")])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-743672

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fixed a bug where `df.join(..., how="cross")` fails with `snowflake.snowpark.exceptions.SnowparkJoinException: (1112): Unsupported using join type 'Cross'`
