### PR TITLE
SNOW-706842 add a parameter if_not_exists

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -646,6 +646,8 @@ def create_python_udf_or_sp(
     strict: bool = False,
     secure: bool = False,
 ) -> None:
+    if replace and if_not_exists:
+        raise ValueError("options replace and if_not_exists are incompatible")
     if isinstance(return_type, StructType):
         return_sql = f'RETURNS TABLE ({",".join(f"{field.name} {convert_sp_to_sf_type(field.datatype)}" for field in return_type.fields)})'
     else:

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -639,6 +639,7 @@ def create_python_udf_or_sp(
     all_packages: str,
     is_temporary: bool,
     replace: bool,
+    if_not_exists: bool,
     inline_python_code: Optional[str] = None,
     execute_as: Optional[typing.Literal["caller", "owner"]] = None,
     api_call_source: Optional[str] = None,
@@ -679,7 +680,7 @@ $$
 
     create_query = f"""
 CREATE{" OR REPLACE " if replace else ""}
-{"TEMPORARY" if is_temporary else ""} {"SECURE" if secure else ""} {object_type.value} {object_name}({sql_func_args})
+{"TEMPORARY" if is_temporary else ""} {"SECURE" if secure else ""} {object_type.value} {"IF NOT EXISTS" if if_not_exists else ""} {object_name}({sql_func_args})
 {return_sql}
 LANGUAGE PYTHON {strict_as_sql}
 RUNTIME_VERSION={sys.version_info[0]}.{sys.version_info[1]}

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3138,8 +3138,8 @@ def udf(
             results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing UDF with the same name is overwritten.
         if_not_exists: Whether to skip creation of a UDF when one with the same signature already exists.
-            The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
-            and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDF with
+            The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive
+            and a ``ValueError`` is raised when both are set. If it is ``True`` and a UDF with
             the same signature exists, the UDF creation is skipped.
         session: Use this session to register the UDF. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
@@ -3309,8 +3309,8 @@ def udtf(
             results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing UDTF with the same name is overwritten.
         if_not_exists: Whether to skip creation of a UDTF when one with the same signature already exists.
-            The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
-            and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDTF with
+            The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive
+            and a ``ValueError`` is raised when both are set. If it is ``True`` and a UDTF with
             the same signature exists, the UDTF creation is skipped.
         session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
@@ -3666,7 +3666,7 @@ def sproc(
             results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing stored procedure with the same name is overwritten.
         if_not_exists: Whether to skip creation of a stored procedure the same procedure is already registered.
-            The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive and a ``SnowparkSQLException``
+            The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive and a ``ValueError``
             is raised when both are set. If it is ``True`` and a stored procedure is already registered, the registration is skipped.
         session: Use this session to register the stored procedure. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3081,6 +3081,7 @@ def udf(
     imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
     packages: Optional[List[Union[str, ModuleType]]] = None,
     replace: bool = False,
+    if_not_exists: bool = False,
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
     max_batch_size: Optional[int] = None,
@@ -3136,6 +3137,10 @@ def udf(
             If it is ``False``, attempting to register a UDF with a name that already exists
             results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing UDF with the same name is overwritten.
+        if_not_exists: Whether to skip creation of a UDF when one with the same signature already exists.
+            The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
+            and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDF with
+            the same signature exists, the UDF creation is skipped.
         session: Use this session to register the UDF. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
         parallel: The number of threads to use for uploading UDF files with the
@@ -3213,6 +3218,7 @@ def udf(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             max_batch_size=max_batch_size,
             statement_params=statement_params,
@@ -3231,6 +3237,7 @@ def udf(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             max_batch_size=max_batch_size,
             statement_params=statement_params,
@@ -3251,6 +3258,7 @@ def udtf(
     imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
     packages: Optional[List[Union[str, ModuleType]]] = None,
     replace: bool = False,
+    if_not_exists: bool = False,
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
     statement_params: Optional[Dict[str, str]] = None,
@@ -3300,6 +3308,10 @@ def udtf(
             If it is ``False``, attempting to register a UDTF with a name that already exists
             results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing UDTF with the same name is overwritten.
+        if_not_exists: Whether to skip creation of a UDTF when one with the same signature already exists.
+            The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
+            and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDTF with
+            the same signature exists, the UDTF creation is skipped.
         session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
         parallel: The number of threads to use for uploading UDTF files with the
@@ -3356,6 +3368,7 @@ def udtf(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             statement_params=statement_params,
             strict=strict,
@@ -3372,6 +3385,7 @@ def udtf(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             statement_params=statement_params,
             strict=strict,
@@ -3390,6 +3404,7 @@ def pandas_udf(
     imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
     packages: Optional[List[Union[str, ModuleType]]] = None,
     replace: bool = False,
+    if_not_exists: bool = False,
     session: Optional["snowflake.snowpark.session.Session"] = None,
     parallel: int = 4,
     max_batch_size: Optional[int] = None,
@@ -3418,6 +3433,7 @@ def pandas_udf(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             max_batch_size=max_batch_size,
             _from_pandas_udf_function=True,
@@ -3435,6 +3451,7 @@ def pandas_udf(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             max_batch_size=max_batch_size,
             _from_pandas_udf_function=True,
@@ -3593,6 +3610,7 @@ def sproc(
     imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
     packages: Optional[List[Union[str, ModuleType]]] = None,
     replace: bool = False,
+    if_not_exists: bool = False,
     session: Optional["snowflake.snowpark.Session"] = None,
     parallel: int = 4,
     statement_params: Optional[Dict[str, str]] = None,
@@ -3647,6 +3665,9 @@ def sproc(
             If it is ``False``, attempting to register a stored procedure with a name that already exists
             results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
             an existing stored procedure with the same name is overwritten.
+        if_not_exists: Whether to skip creation of a stored procedure the same procedure is already registered.
+            The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive and a ``SnowparkSQLException``
+            is raised when both are set. If it is ``True`` and a stored procedure is already registered, the registration is skipped.
         session: Use this session to register the stored procedure. If it's not specified, the session that you created before calling this function will be used.
             You need to specify this parameter if you have created multiple sessions before calling this method.
         parallel: The number of threads to use for uploading stored procedure files with the
@@ -3706,6 +3727,7 @@ def sproc(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             statement_params=statement_params,
             execute_as=execute_as,
@@ -3723,6 +3745,7 @@ def sproc(
             imports=imports,
             packages=packages,
             replace=replace,
+            if_not_exists=if_not_exists,
             parallel=parallel,
             statement_params=statement_params,
             execute_as=execute_as,

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -231,12 +231,36 @@ class StoredProcedureRegistration:
             ...     return_type=IntegerType(),
             ...     input_types=[IntegerType(), IntegerType()],
             ...     is_permanent=True,
-            ...     name="mul",
+            ...     name="mul_sp",
             ...     replace=True,
             ...     stage_location="@mystage",
             ... )
-            >>> session.sql("call mul(5, 6)").collect()
-            [Row(MUL=30)]
+            >>> session.sql("call mul_sp(5, 6)").collect()
+            [Row(MUL_SP=30)]
+            >>> # skip stored proc creation if it already exists
+            >>> _ = session.sproc.register(
+            ...     lambda session_, x, y: session_.sql(f"SELECT {x} * {y} + 1").collect()[0][0],
+            ...     return_type=IntegerType(),
+            ...     input_types=[IntegerType(), IntegerType()],
+            ...     is_permanent=True,
+            ...     name="mul_sp",
+            ...     if_not_exists=True,
+            ...     stage_location="@mystage",
+            ... )
+            >>> session.sql("call mul_sp(5, 6)").collect()
+            [Row(MUL_SP=30)]
+            >>> # overwrite stored procedure
+            >>> _ = session.sproc.register(
+            ...     lambda session_, x, y: session_.sql(f"SELECT {x} * {y} + 1").collect()[0][0],
+            ...     return_type=IntegerType(),
+            ...     input_types=[IntegerType(), IntegerType()],
+            ...     is_permanent=True,
+            ...     name="mul_sp",
+            ...     replace=True,
+            ...     stage_location="@mystage",
+            ... )
+            >>> session.sql("call mul_sp(5, 6)").collect()
+            [Row(MUL_SP=31)]
 
     Example 5
         Create a stored procedure with stored-procedure-level imports and call it::

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -333,6 +333,7 @@ class StoredProcedureRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         execute_as: typing.Literal["caller", "owner"] = "owner",
         strict: bool = False,
@@ -383,6 +384,9 @@ class StoredProcedureRegistration:
                 If it is ``False``, attempting to register a stored procedure with a name that already exists
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing stored procedure with the same name is overwritten.
+            if_not_exists: Whether to skip creation of a stored procedure the same procedure is already registered.
+                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive and a ``SnowparkSQLException``
+                is raised when both are set. If it is ``True`` and a stored procedure is already registered, the registration is skipped.
             parallel: The number of threads to use for uploading stored procedure files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
                 command. The default value is 4 and supported values are from 1 to 99.
@@ -431,6 +435,7 @@ class StoredProcedureRegistration:
             imports,
             packages,
             replace,
+            if_not_exists,
             parallel,
             strict,
             statement_params=statement_params,
@@ -451,6 +456,7 @@ class StoredProcedureRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         strict: bool = False,
         *,
@@ -506,6 +512,9 @@ class StoredProcedureRegistration:
                 If it is ``False``, attempting to register a stored procedure with a name that already exists
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing stored procedure with the same name is overwritten.
+            if_not_exists: Whether to skip creation of a stored procedure the same procedure is already registered.
+                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive and a ``SnowparkSQLException``
+                is raised when both are set. If it is ``True`` and a stored procedure is already registered, the registration is skipped.
             parallel: The number of threads to use for uploading stored procedure files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
                 command. The default value is 4 and supported values are from 1 to 99.
@@ -545,6 +554,7 @@ class StoredProcedureRegistration:
             imports,
             packages,
             replace,
+            if_not_exists,
             parallel,
             strict,
             statement_params=statement_params,
@@ -562,6 +572,7 @@ class StoredProcedureRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]],
         packages: Optional[List[Union[str, ModuleType]]],
         replace: bool,
+        if_not_exists: bool,
         parallel: int,
         strict: bool,
         *,
@@ -626,6 +637,7 @@ class StoredProcedureRegistration:
                 all_packages=all_packages,
                 is_temporary=stage_location is None,
                 replace=replace,
+                if_not_exists=if_not_exists,
                 inline_python_code=code,
                 execute_as=execute_as,
                 api_call_source=api_call_source,

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -409,7 +409,7 @@ class StoredProcedureRegistration:
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing stored procedure with the same name is overwritten.
             if_not_exists: Whether to skip creation of a stored procedure the same procedure is already registered.
-                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive and a ``SnowparkSQLException``
+                The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive and a ``ValueError``
                 is raised when both are set. If it is ``True`` and a stored procedure is already registered, the registration is skipped.
             parallel: The number of threads to use for uploading stored procedure files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
@@ -537,7 +537,7 @@ class StoredProcedureRegistration:
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing stored procedure with the same name is overwritten.
             if_not_exists: Whether to skip creation of a stored procedure the same procedure is already registered.
-                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive and a ``SnowparkSQLException``
+                The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive and a ``ValueError``
                 is raised when both are set. If it is ``True`` and a stored procedure is already registered, the registration is skipped.
             parallel: The number of threads to use for uploading stored procedure files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -536,8 +536,8 @@ class UDFRegistration:
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDF with the same name is overwritten.
             if_not_exists: Whether to skip creation of a UDF when one with the same signature already exists.
-                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
-                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDF with
+                The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive
+                and a ``ValueError`` is raised when both are set. If it is ``True`` and a UDF with
                 the same signature exists, the UDF creation is skipped.
             parallel: The number of threads to use for uploading UDF files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
@@ -673,8 +673,8 @@ class UDFRegistration:
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDF with the same name is overwritten.
             if_not_exists: Whether to skip creation of a UDF when one with the same signature already exists.
-                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
-                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDF with
+                The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive
+                and a ``ValueError`` is raised when both are set. If it is ``True`` and a UDF with
                 the same signature exists, the UDF creation is skipped.
             parallel: The number of threads to use for uploading UDF files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -276,13 +276,26 @@ class UDFRegistration:
             ...     is_permanent=True, name="mul", replace=True,
             ...     stage_location="@mystage",
             ... )
-            >>> session.sql("select mul(5, 6)").show()
-            ---------------
-            |"MUL(5, 6)"  |
-            ---------------
-            |30           |
-            ---------------
-            <BLANKLINE>
+            >>> session.sql("select mul(5, 6) as mul").collect()
+            [Row(MUL=30)]
+            >>> # skip udf creation if it already exists
+            >>> _ = session.udf.register(
+            ...     lambda x, y: x * y + 1, return_type=IntegerType(),
+            ...     input_types=[IntegerType(), IntegerType()],
+            ...     is_permanent=True, name="mul", if_not_exists=True,
+            ...     stage_location="@mystage",
+            ... )
+            >>> session.sql("select mul(5, 6) as mul").collect()
+            [Row(MUL=30)]
+            >>> # overwrite udf definition when it already exists
+            >>> _ = session.udf.register(
+            ...     lambda x, y: x * y + 1, return_type=IntegerType(),
+            ...     input_types=[IntegerType(), IntegerType()],
+            ...     is_permanent=True, name="mul", replace=True,
+            ...     stage_location="@mystage",
+            ... )
+            >>> session.sql("select mul(5, 6) as mul").collect()
+            [Row(MUL=31)]
 
     Example 4
         Create a UDF with UDF-level imports and apply it to a dataframe::

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -465,6 +465,7 @@ class UDFRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         max_batch_size: Optional[int] = None,
         strict: bool = False,
@@ -521,6 +522,10 @@ class UDFRegistration:
                 If it is ``False``, attempting to register a UDF with a name that already exists
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDF with the same name is overwritten.
+            if_not_exists: Whether to skip creation of a UDF when one with the same signature already exists.
+                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
+                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDF with
+                the same signature exists, the UDF creation is skipped.
             parallel: The number of threads to use for uploading UDF files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
                 command. The default value is 4 and supported values are from 1 to 99.
@@ -569,6 +574,7 @@ class UDFRegistration:
             imports,
             packages,
             replace,
+            if_not_exists,
             parallel,
             max_batch_size,
             _from_pandas,
@@ -592,6 +598,7 @@ class UDFRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         strict: bool = False,
         secure: bool = False,
@@ -652,6 +659,10 @@ class UDFRegistration:
                 If it is ``False``, attempting to register a UDF with a name that already exists
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDF with the same name is overwritten.
+            if_not_exists: Whether to skip creation of a UDF when one with the same signature already exists.
+                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
+                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDF with
+                the same signature exists, the UDF creation is skipped.
             parallel: The number of threads to use for uploading UDF files with the
                 `PUT <https://docs.snowflake.com/en/sql-reference/sql/put.html#put>`_
                 command. The default value is 4 and supported values are from 1 to 99.
@@ -693,6 +704,7 @@ class UDFRegistration:
             imports,
             packages,
             replace,
+            if_not_exists,
             parallel,
             strict,
             secure,
@@ -711,6 +723,7 @@ class UDFRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         max_batch_size: Optional[int] = None,
         from_pandas_udf_function: bool = False,
@@ -781,6 +794,7 @@ class UDFRegistration:
                 all_packages=all_packages,
                 is_temporary=stage_location is None,
                 replace=replace,
+                if_not_exists=if_not_exists,
                 inline_python_code=code,
                 api_call_source=api_call_source,
                 strict=strict,

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -322,6 +322,7 @@ class UDTFRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         strict: bool = False,
         secure: bool = False,
@@ -369,6 +370,10 @@ class UDTFRegistration:
                 If it is ``False``, attempting to register a UDTF with a name that already exists
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDTF with the same name is overwritten.
+            if_not_exists: Whether to skip creation of a UDTF when one with the same signature already exists.
+                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
+                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDTF with
+                the same signature exists, the UDTF creation is skipped.
             session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
                 You need to specify this parameter if you have created multiple sessions before calling this method.
             parallel: The number of threads to use for uploading UDTF files with the
@@ -407,6 +412,7 @@ class UDTFRegistration:
             imports,
             packages,
             replace,
+            if_not_exists,
             parallel,
             strict,
             secure,
@@ -426,6 +432,7 @@ class UDTFRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         strict: bool = False,
         secure: bool = False,
@@ -479,6 +486,10 @@ class UDTFRegistration:
                 If it is ``False``, attempting to register a UDTF with a name that already exists
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDTF with the same name is overwritten.
+            if_not_exists: Whether to skip creation of a UDTF when one with the same signature already exists.
+                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
+                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDTF with
+                the same signature exists, the UDTF creation is skipped.
             session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
                 You need to specify this parameter if you have created multiple sessions before calling this method.
             parallel: The number of threads to use for uploading UDTF files with the
@@ -518,6 +529,7 @@ class UDTFRegistration:
             imports,
             packages,
             replace,
+            if_not_exists,
             parallel,
             strict,
             secure,
@@ -535,6 +547,7 @@ class UDTFRegistration:
         imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
         packages: Optional[List[Union[str, ModuleType]]] = None,
         replace: bool = False,
+        if_not_exists: bool = False,
         parallel: int = 4,
         strict: bool = False,
         secure: bool = False,
@@ -662,6 +675,7 @@ class UDTFRegistration:
                 all_packages=all_packages,
                 is_temporary=stage_location is None,
                 replace=replace,
+                if_not_exists=if_not_exists,
                 inline_python_code=code,
                 api_call_source=api_call_source,
                 strict=strict,

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -371,8 +371,8 @@ class UDTFRegistration:
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDTF with the same name is overwritten.
             if_not_exists: Whether to skip creation of a UDTF when one with the same signature already exists.
-                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
-                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDTF with
+                The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive
+                and a ``ValueError`` is raised when both are set. If it is ``True`` and a UDTF with
                 the same signature exists, the UDTF creation is skipped.
             session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
                 You need to specify this parameter if you have created multiple sessions before calling this method.
@@ -487,8 +487,8 @@ class UDTFRegistration:
                 results in a ``SnowparkSQLException`` exception being thrown. If it is ``True``,
                 an existing UDTF with the same name is overwritten.
             if_not_exists: Whether to skip creation of a UDTF when one with the same signature already exists.
-                The default is ``False``. ``if_not_exists`` and ``replace`` are used mutually exclusive
-                and a ``SnowparkSQLException`` is raised when both are set. If it is ``True`` and a UDTF with
+                The default is ``False``. ``if_not_exists`` and ``replace`` are mutually exclusive
+                and a ``ValueError`` is raised when both are set. If it is ``True`` and a UDTF with
                 the same signature exists, the UDTF creation is skipped.
             session: Use this session to register the UDTF. If it's not specified, the session that you created before calling this function will be used.
                 You need to specify this parameter if you have created multiple sessions before calling this method.

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -799,7 +799,7 @@ def test_sp_if_not_exists(session):
     assert add_sp(1, 2) == 3
 
     # Try to register sp without if-exists check and expect failure.
-    with pytest.raises(SnowparkSQLException, match="SQL compilation error"):
+    with pytest.raises(SnowparkSQLException, match="already exists"):
         add_sp = session.sproc.register(
             lambda session_, x, y: session_.sql(f"SELECT {x} + {y}").collect()[0][0],
             name="test_sp_if_not_exists_add",
@@ -809,7 +809,10 @@ def test_sp_if_not_exists(session):
         )
 
     # Try to register sp with replace and if-exists check and expect failure.
-    with pytest.raises(SnowparkSQLException, match="SQL compilation error"):
+    with pytest.raises(
+        SnowparkSQLException,
+        match="options IF NOT EXISTS and OR REPLACE are incompatible",
+    ):
         add_sp = session.sproc.register(
             lambda session_, x, y: session_.sql(f"SELECT {x} + {y}").collect()[0][0],
             name="test_sp_if_not_exists_add",

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -810,8 +810,8 @@ def test_sp_if_not_exists(session):
 
     # Try to register sp with replace and if-exists check and expect failure.
     with pytest.raises(
-        SnowparkSQLException,
-        match="options IF NOT EXISTS and OR REPLACE are incompatible",
+        ValueError,
+        match="options replace and if_not_exists are incompatible",
     ):
         add_sp = session.sproc.register(
             lambda session_, x, y: session_.sql(f"SELECT {x} + {y}").collect()[0][0],

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1204,8 +1204,8 @@ def test_udf_if_not_exists(session):
 
     # Try to register UDF with replace and if-exists check and expect failure.
     with pytest.raises(
-        SnowparkSQLException,
-        match="options IF NOT EXISTS and OR REPLACE are incompatible",
+        ValueError,
+        match="options replace and if_not_exists are incompatible",
     ):
         add_udf = session.udf.register(
             lambda x, y: x + y,

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1193,7 +1193,7 @@ def test_udf_if_not_exists(session):
     )
 
     # Try to register UDF without if-exists check and expect failure.
-    with pytest.raises(SnowparkSQLException, match="SQL compilation error"):
+    with pytest.raises(SnowparkSQLException, match="already exists"):
         add_udf = session.udf.register(
             lambda x, y: x + y,
             name="test_udf_if_not_exist_add",

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1154,6 +1154,78 @@ def test_udf_replace(session):
     )
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
+)
+def test_udf_if_not_exists(session):
+    df = session.create_dataframe([[1, 2], [3, 4]]).to_df("a", "b")
+
+    # Register named UDF and expect that it works.
+    add_udf = session.udf.register(
+        lambda x, y: x + y,
+        name="test_udf_if_not_exist_add",
+        return_type=IntegerType(),
+        input_types=[IntegerType(), IntegerType()],
+        if_not_exists=True,
+    )
+    Utils.check_answer(
+        df.select(add_udf("a", "b")).collect(),
+        [
+            Row(3),
+            Row(7),
+        ],
+    )
+
+    # Replace named UDF with different one and expect that data is not changed.
+    add_udf = session.udf.register(
+        lambda x, y: x + y + 1,
+        name="test_udf_if_not_exist_add",
+        return_type=IntegerType(),
+        input_types=[IntegerType(), IntegerType()],
+        if_not_exists=True,
+    )
+    Utils.check_answer(
+        df.select(add_udf("a", "b")).collect(),
+        [
+            Row(3),
+            Row(7),
+        ],
+    )
+
+    # Try to register UDF without if-exists check and expect failure.
+    with pytest.raises(SnowparkSQLException, match="SQL compilation error"):
+        add_udf = session.udf.register(
+            lambda x, y: x + y,
+            name="test_udf_if_not_exist_add",
+            return_type=IntegerType(),
+            input_types=[IntegerType(), IntegerType()],
+            if_not_exists=False,
+        )
+
+    # Try to register UDF with replace and if-exists check and expect failure.
+    with pytest.raises(
+        SnowparkSQLException,
+        match="options IF NOT EXISTS and OR REPLACE are incompatible",
+    ):
+        add_udf = session.udf.register(
+            lambda x, y: x + y,
+            name="test_udf_if_not_exist_add",
+            return_type=IntegerType(),
+            input_types=[IntegerType(), IntegerType()],
+            replace=True,
+            if_not_exists=True,
+        )
+
+    # Expect first UDF version to still be there.
+    Utils.check_answer(
+        df.select(add_udf("a", "b")).collect(),
+        [
+            Row(3),
+            Row(7),
+        ],
+    )
+
+
 def test_udf_parallel(session):
     for i in [1, 50, 99]:
         udf(

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -275,8 +275,8 @@ def test_if_not_exists_udtf(session):
 
     # error is raised when we try to recreate udtf without if_not_exists set
     with pytest.raises(
-        SnowparkSQLException,
-        match="options IF NOT EXISTS and OR REPLACE are incompatible",
+        ValueError,
+        match="options replace and if_not_exists are incompatible",
     ):
 
         @udtf(

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -7,6 +7,7 @@ from typing import Iterable, Tuple
 import pytest
 
 from snowflake.snowpark import Row
+from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import lit, udtf
 from snowflake.snowpark.types import (
     BinaryType,
@@ -18,7 +19,7 @@ from snowflake.snowpark.types import (
     StructField,
     StructType,
 )
-from tests.utils import TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 pytestmark = pytest.mark.udf
 
@@ -226,3 +227,67 @@ def test_secure_udtf(session):
     )
     ddl_sql = f"select get_ddl('function', '{UDTFEcho.name}(int)')"
     assert "SECURE" in session.sql(ddl_sql).collect()[0][0]
+
+
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
+)
+def test_if_not_exists_udtf(session):
+    @udtf(name="test_if_not_exists", output_schema=["num"], if_not_exists=True)
+    class UDTFEcho:
+        def process(
+            self,
+            num: int,
+        ) -> Iterable[Tuple[int]]:
+            return [(num,)]
+
+    df = session.table_function(UDTFEcho(lit(1)))
+    Utils.check_answer(
+        df,
+        [Row(1)],
+    )
+
+    # register UDTF with updated return value and don't expect changes
+    @udtf(name="test_if_not_exists", output_schema=["num"], if_not_exists=True)
+    class UDTFEcho:
+        def process(
+            self,
+            num: int,
+        ) -> Iterable[Tuple[int]]:
+            return [(num + 1,)]
+
+    df = session.table_function(UDTFEcho(lit(1)))
+    Utils.check_answer(
+        df,
+        [Row(1)],
+    )
+
+    # error is raised when we try to recreate udtf without if_not_exists set
+    with pytest.raises(SnowparkSQLException, match="SQL compilation error"):
+
+        @udtf(name="test_if_not_exists", output_schema=["num"], if_not_exists=False)
+        class UDTFEcho:
+            def process(
+                self,
+                num: int,
+            ) -> Iterable[Tuple[int]]:
+                return [(num,)]
+
+    # error is raised when we try to recreate udtf without if_not_exists set
+    with pytest.raises(
+        SnowparkSQLException,
+        match="options IF NOT EXISTS and OR REPLACE are incompatible",
+    ):
+
+        @udtf(
+            name="test_if_not_exists",
+            output_schema=["num"],
+            replace=True,
+            if_not_exists=True,
+        )
+        class UDTFEcho:
+            def process(
+                self,
+                num: int,
+            ) -> Iterable[Tuple[int]]:
+                return [(num,)]

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -263,7 +263,7 @@ def test_if_not_exists_udtf(session):
     )
 
     # error is raised when we try to recreate udtf without if_not_exists set
-    with pytest.raises(SnowparkSQLException, match="SQL compilation error"):
+    with pytest.raises(SnowparkSQLException, match="already exists"):
 
         @udtf(name="test_if_not_exists", output_schema=["num"], if_not_exists=False)
         class UDTFEcho:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-706842

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Adding a parameter `if_not_exists` in sp/udf/udtf registration so that users can skip creating procedure or function in the case when one is already registered.
