### PR TITLE
SNOW-748484 Fix documentation issue when creating a `Session` object from existing Python connector connection

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -183,7 +183,7 @@ class Session:
 
     To create a :class:`Session` object from an existing Python Connector connection::
 
-        >>> session = Session.builder.configs(connection=<your python connector connection>).create() # doctest: +SKIP
+        >>> session = Session.builder.configs({"connection": <your python connector connection>}).create() # doctest: +SKIP
 
     :class:`Session` contains functions to construct a :class:`DataFrame` like :meth:`table`,
     :meth:`sql` and :attr:`read`, etc.


### PR DESCRIPTION
https://github.com/snowflakedb/snowpark-python/issues/688

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #688
2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   My solution changes the documentation in the doc-string to match the source code of the configs() method of the SessionBuilder class.
