### PR TITLE
SNOW-742344 Allow python version >=3.8 in internal recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: {{ os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_BUILD_NUMBER', 0) }}
-  skip: True  # [py<38 or py>=39 or win32 or s390x]
+  skip: True  # [py<38 or win32 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:


### PR DESCRIPTION
Description

This helps us building internal snapshot packages for regression tests, and gets us prepared for stored proc testing when server supports py39

Testing

N/A

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-742344

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This helps us building internal snapshot packages for regression tests, and gets us prepared for stored proc testing when server supports py39
