### PR TITLE
SNOW-747658 Add session.conf to store runtime configuration

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -136,7 +136,8 @@ class ServerConnection:
         self._lower_case_parameters = {k.lower(): v for k, v in options.items()}
         self._add_application_name()
         self._conn = conn if conn else connect(**self._lower_case_parameters)
-        self._lower_case_parameters["password"] = None
+        if "password" in self._lower_case_parameters:
+            self._lower_case_parameters["password"] = None
         self._cursor = self._conn.cursor()
         self._telemetry_client = TelemetryClient(self._conn)
         self._query_listener: Set[QueryHistory] = set()

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -136,8 +136,7 @@ class ServerConnection:
         self._lower_case_parameters = {k.lower(): v for k, v in options.items()}
         self._add_application_name()
         self._conn = conn if conn else connect(**self._lower_case_parameters)
-        if "password" in self._lower_case_parameters:
-            self._lower_case_parameters["password"] = None
+        self._lower_case_parameters.pop("password", None)
         self._cursor = self._conn.cursor()
         self._telemetry_client = TelemetryClient(self._conn)
         self._query_listener: Set[QueryHistory] = set()
@@ -149,7 +148,9 @@ class ServerConnection:
         if PARAM_APPLICATION not in self._lower_case_parameters:
             # Mirrored from snowflake-connector-python/src/snowflake/connector/connection.py#L295
             if ENV_VAR_PARTNER in os.environ.keys():
-                self._lower_case_parameters[PARAM_APPLICATION] = os.environ[ENV_VAR_PARTNER]
+                self._lower_case_parameters[PARAM_APPLICATION] = os.environ[
+                    ENV_VAR_PARTNER
+                ]
             elif "streamlit" in sys.modules:
                 self._lower_case_parameters[PARAM_APPLICATION] = "streamlit"
             else:

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -136,7 +136,7 @@ class ServerConnection:
         self._lower_case_parameters = {k.lower(): v for k, v in options.items()}
         self._add_application_name()
         self._conn = conn if conn else connect(**self._lower_case_parameters)
-        self._lower_case_parameters.pop("password", None)
+        self._lower_case_parameters["password"] = None
         self._cursor = self._conn.cursor()
         self._telemetry_client = TelemetryClient(self._conn)
         self._query_listener: Set[QueryHistory] = set()

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -283,7 +283,7 @@ class Session:
     builder: SessionBuilder = SessionBuilder()
 
     def __init__(
-        self, conn: ServerConnection, options: Optional[Dict[str, Any]]
+        self, conn: ServerConnection, options: Optional[Dict[str, Any]] = None
     ) -> None:
         if len(_active_sessions) >= 1 and is_in_stored_procedure():
             raise SnowparkClientExceptionMessages.DONT_CREATE_SESSION_IN_SP()
@@ -318,7 +318,7 @@ class Session:
         self._sql_simplifier_enabled: bool = self._get_client_side_session_parameter(
             _PYTHON_SNOWPARK_USE_SQL_SIMPLIFIER_STRING, True
         )
-        self._conf = self.RuntimeConfig(self, options)
+        self._conf = self.RuntimeConfig(self, options or {})
         _logger.info("Snowpark Session information: %s", self._session_info)
 
     def __enter__(self):

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -195,7 +195,7 @@ class Session:
         def __init__(self, session: "Session", conf: Dict[str, Any]) -> None:
             self._session = session
             for key, val in conf.items():
-                if hasattr(Session, key):
+                if hasattr(Session, key) and self.is_mutable(key):
                     setattr(session, key, val)
 
         def get(self, key: str, default=None) -> Any:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -205,7 +205,7 @@ class Session:
                 return getattr(self._session._conn._conn, key)
             return default
 
-        def is_modifiable(self, key: str) -> bool:
+        def is_mutable(self, key: str) -> bool:
             if hasattr(Session, key) and isinstance(getattr(Session, key), property):
                 return getattr(Session, key).fset is not None
             if hasattr(SnowflakeConnection, key) and isinstance(
@@ -215,13 +215,13 @@ class Session:
             return False
 
         def set(self, key: str, value: Any) -> None:
-            if self.is_modifiable(key):
+            if self.is_mutable(key):
                 if hasattr(Session, key):
                     setattr(self._session, key, value)
                 if hasattr(SnowflakeConnection, key):
                     setattr(self._session._conn._conn, key, value)
             else:
-                raise ValueError(f'Configuration "{key}" is not modifiable in runtime')
+                raise ValueError(f'Configuration "{key}" is not mutable in runtime')
 
     class SessionBuilder:
         """

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -24,6 +24,19 @@ from snowflake.snowpark.session import (
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 
+def test_runtime_config(db_parameters):
+    session = (
+        Session.builder.configs(db_parameters)
+        .config("paramstyle", "numeric")
+        .config("enable_client_side_fix", True)
+        .create()
+    )
+    assert session.conf.get("enable_client_side_fix")
+    assert not session.conf.get("nonexistent_client_side_fix", default=False)
+    assert session._conn._conn._paramstyle == "numeric"
+    assert session.conf.get("password") is None
+
+
 def test_select_1(session):
     res = session.sql("select 1").collect()
     assert res == [Row(1)]

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -27,14 +27,15 @@ from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles,
 def test_runtime_config(db_parameters):
     session = (
         Session.builder.configs(db_parameters)
-        .config("paramstyle", "numeric")
-        .config("enable_client_side_fix", True)
+        .config("client_prefetch_threads", 10)
+        .config("sql_simplifier_enabled", False)
         .create()
     )
-    assert session.conf.get("enable_client_side_fix")
     assert not session.conf.get("nonexistent_client_side_fix", default=False)
-    assert session._conn._conn._paramstyle == "numeric"
+    assert session.conf.get("client_prefetch_threads") == 10
+    assert not session.sql_simplifier_enabled
     assert session.conf.get("password") is None
+
     session.close()
 
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -197,8 +197,8 @@ def test_create_session_from_connection(db_parameters, sql_simplifier_enabled):
     try:
         df = new_session.createDataFrame([[1, 2]], schema=["a", "b"])
         Utils.check_answer(df, [Row(1, 2)])
-        assert "password" not in session_builder._options
-        assert "password" not in new_session._conn._lower_case_parameters
+        assert session_builder._options.get("password") is None
+        assert new_session._conn._lower_case_parameters.get("password") is None
         assert new_session._conn._conn._password is None
     finally:
         new_session.close()
@@ -220,8 +220,8 @@ def test_create_session_from_connection_with_noise_parameters(
         assert new_session._conn._conn == connection
         # Even if we don't use the password field to connect, we should still
         # erase it if it exists
-        assert session_builder._options["password"] is None
-        assert "password" not in new_session._conn._lower_case_parameters
+        assert session_builder._options.get("password") is None
+        assert new_session._conn._lower_case_parameters.get("password") is None
         assert new_session._conn._conn._password is None
     finally:
         new_session.close()

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -31,10 +31,27 @@ def test_runtime_config(db_parameters):
         .config("sql_simplifier_enabled", False)
         .create()
     )
+    # test conf.get
     assert not session.conf.get("nonexistent_client_side_fix", default=False)
     assert session.conf.get("client_prefetch_threads") == 10
     assert not session.sql_simplifier_enabled
     assert session.conf.get("password") is None
+
+    # test conf.is_mutable
+    assert session.conf.is_mutable("telemetry_enabled")
+    assert session.conf.is_mutable("sql_simplifier_enabled")
+    assert not session.conf.is_mutable("host")
+    assert not session.conf.is_mutable("is_pyformat")
+
+    # test conf.set
+    session.conf.set("sql_simplifier_enabled", True)
+    assert session.sql_simplifier_enabled
+    with pytest.raises(ValueError) as err:
+        session.conf.set("use_openssl_only", False)
+    assert (
+        'Configuration "use_openssl_only" is not mutable in runtime'
+        in err.value.args[0]
+    )
 
     session.close()
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -35,6 +35,7 @@ def test_runtime_config(db_parameters):
     assert not session.conf.get("nonexistent_client_side_fix", default=False)
     assert session._conn._conn._paramstyle == "numeric"
     assert session.conf.get("password") is None
+    session.close()
 
 
 def test_select_1(session):
@@ -179,8 +180,8 @@ def test_create_session_from_parameters(db_parameters, sql_simplifier_enabled):
     try:
         df = new_session.createDataFrame([[1, 2]], schema=["a", "b"])
         Utils.check_answer(df, [Row(1, 2)])
-        assert session_builder._options["password"] is None
-        assert new_session._conn._lower_case_parameters["password"] is None
+        assert session_builder._options.get("password") is None
+        assert new_session._conn._lower_case_parameters.get("password") is None
         assert new_session._conn._conn._password is None
     finally:
         new_session.close()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-747658

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

`Session.conf` lets users to lookup runtime config parameters. Previously, options passed into configs are not preserved for future lookup. E.g. users who want to make sure paramstyle is pyformat cannot easily confirm this. With this change, users can easily access these configs with `session.conf`.

Reference: https://spark.apache.org/docs/3.1.3/api/python/reference/api/pyspark.sql.SparkSession.conf.html#pyspark.sql.SparkSession.conf
