### PR TITLE
SNOW-737313 Set default parameter chunk_size in create_dataframe/write_pandas

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1206,7 +1206,7 @@ class Session:
             table_name: Name of the table we want to insert into.
             database: Database that the table is in. If not provided, the default one will be used.
             schema: Schema that the table is in. If not provided, the default one will be used.
-            chunk_size: Number of elements to be inserted once. If not provided, all elements will be dumped once.
+            chunk_size: Number of rows to be inserted once. If not provided, all rows will be dumped once.
             compression: The compression used on the Parquet files: gzip or snappy. Gzip gives supposedly a
                 better compression, while snappy is faster. Use whichever is more appropriate.
             on_error: Action to take when COPY INTO statements fail. See details at
@@ -1330,6 +1330,7 @@ class Session:
         self,
         data: Union[List, Tuple, "pandas.DataFrame"],
         schema: Optional[Union[StructType, List[str]]] = None,
+        chunk_size: Optional[int] = 100000,
     ) -> DataFrame:
         """Creates a new DataFrame containing the specified values from the local data.
 
@@ -1349,6 +1350,8 @@ class Session:
                 DataFrame will be inferred from the data across all rows. To improve
                 performance, provide a schema. This avoids the need to infer data types
                 with large data sets.
+            chunk_size: Maximum number of rows in a chunk when `data` is a pandas Dataframe,
+                which is uploaded as a sequence of chunks. Default to 100,000.
 
         Examples::
 
@@ -1409,6 +1412,7 @@ class Session:
                 quote_identifiers=True,
                 auto_create_table=True,
                 table_type="temporary",
+                chunk_size=chunk_size,
             )
             set_api_call_source(t, "Session.create_dataframe[pandas]")
             return t

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -130,6 +130,7 @@ _PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS_STRING = (
     "PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS"
 )
 _PYTHON_SNOWPARK_USE_SQL_SIMPLIFIER_STRING = "PYTHON_SNOWPARK_USE_SQL_SIMPLIFIER"
+WRITE_PANDAS_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
 
 
 def _get_active_session() -> Optional["Session"]:
@@ -1187,7 +1188,7 @@ class Session:
         *,
         database: Optional[str] = None,
         schema: Optional[str] = None,
-        chunk_size: Optional[int] = 100000,
+        chunk_size: Optional[int] = WRITE_PANDAS_CHUNK_SIZE,
         compression: str = "gzip",
         on_error: str = "abort_statement",
         parallel: int = 4,
@@ -1206,7 +1207,8 @@ class Session:
             table_name: Name of the table we want to insert into.
             database: Database that the table is in. If not provided, the default one will be used.
             schema: Schema that the table is in. If not provided, the default one will be used.
-            chunk_size: Number of rows to be inserted once. If not provided, all rows will be dumped once. Default to 100,000.
+            chunk_size: Number of rows to be inserted once. If not provided, all rows will be dumped once.
+                Default to None normally, 100,000 if inside a stored procedure.
             compression: The compression used on the Parquet files: gzip or snappy. Gzip gives supposedly a
                 better compression, while snappy is faster. Use whichever is more appropriate.
             on_error: Action to take when COPY INTO statements fail. See details at

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1187,7 +1187,7 @@ class Session:
         *,
         database: Optional[str] = None,
         schema: Optional[str] = None,
-        chunk_size: Optional[int] = None,
+        chunk_size: Optional[int] = 100000,
         compression: str = "gzip",
         on_error: str = "abort_statement",
         parallel: int = 4,
@@ -1206,7 +1206,7 @@ class Session:
             table_name: Name of the table we want to insert into.
             database: Database that the table is in. If not provided, the default one will be used.
             schema: Schema that the table is in. If not provided, the default one will be used.
-            chunk_size: Number of rows to be inserted once. If not provided, all rows will be dumped once.
+            chunk_size: Number of rows to be inserted once. If not provided, all rows will be dumped once. Default to 100,000.
             compression: The compression used on the Parquet files: gzip or snappy. Gzip gives supposedly a
                 better compression, while snappy is faster. Use whichever is more appropriate.
             on_error: Action to take when COPY INTO statements fail. See details at
@@ -1330,7 +1330,6 @@ class Session:
         self,
         data: Union[List, Tuple, "pandas.DataFrame"],
         schema: Optional[Union[StructType, List[str]]] = None,
-        chunk_size: Optional[int] = 100000,
     ) -> DataFrame:
         """Creates a new DataFrame containing the specified values from the local data.
 
@@ -1350,8 +1349,6 @@ class Session:
                 DataFrame will be inferred from the data across all rows. To improve
                 performance, provide a schema. This avoids the need to infer data types
                 with large data sets.
-            chunk_size: Maximum number of rows in a chunk when `data` is a pandas Dataframe,
-                which is uploaded as a sequence of chunks. Default to 100,000.
 
         Examples::
 
@@ -1412,7 +1409,6 @@ class Session:
                 quote_identifiers=True,
                 auto_create_table=True,
                 table_type="temporary",
-                chunk_size=chunk_size,
             )
             set_api_call_source(t, "Session.create_dataframe[pandas]")
             return t


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-737313

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Set `chunk_size` 100,000 by default in stored procedures.
