### PR TITLE
SNOW-753246 Add Python 3.10 merge gate

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -60,7 +60,7 @@ jobs:
             download_name: macos
           - image_name: windows-latest
             download_name: windows
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         cloud-provider: [aws, azure, gcp]
     steps:
       - name: Checkout Code
@@ -107,7 +107,7 @@ jobs:
           PYTEST_ADDOPTS: --color=yes --tb=short
           TOX_PARALLEL_NO_SPINNER: 1
         shell: bash
-      - if: ${{ matrix.python-version == '3.9' }}
+      - if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
         name: Run tests (excluding udf and doctest tests)
         run: python -m tox -e "py${PYTHON_VERSION/\./}-notudfdoctest"
         env:
@@ -179,7 +179,7 @@ jobs:
         os:
           - image_name: macos-latest
             download_name: macos  # it includes doctest
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         cloud-provider: [aws]
     steps:
       - name: Checkout Code
@@ -226,7 +226,7 @@ jobs:
           PYTEST_ADDOPTS: --color=yes --tb=short
           TOX_PARALLEL_NO_SPINNER: 1
         shell: bash
-      - if: ${{ matrix.python-version == '3.9' }}
+      - if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
         name: Run tests ((excluding udf and doctest tests))
         run: python -m tox -e "py${PYTHON_VERSION/\./}-notudfdoctest"
         env:

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -60,7 +60,7 @@ jobs:
             download_name: macos
           - image_name: windows-latest
             download_name: windows
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
         cloud-provider: [aws, azure, gcp]
     steps:
       - name: Checkout Code
@@ -179,7 +179,7 @@ jobs:
         os:
           - image_name: macos-latest
             download_name: macos  # it includes doctest
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
         cloud-provider: [aws]
     steps:
       - name: Checkout Code

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -4,7 +4,6 @@
 #
 import re
 import typing
-from collections.abc import Iterable
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
@@ -31,6 +30,14 @@ from snowflake.snowpark._internal.utils import (
 )
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import DataType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 LEFT_PARENTHESIS = "("
 RIGHT_PARENTHESIS = ")"

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -4,7 +4,8 @@
 #
 import re
 import typing
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from collections.abc import Iterable
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     Except,

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -4,9 +4,10 @@
 
 from abc import ABC, abstractmethod
 from collections import UserDict
+from collections.abc import Iterable
 from copy import copy
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 from snowflake.snowpark._internal.analyzer.table_function import (
     TableFunctionExpression,

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -4,7 +4,6 @@
 
 from abc import ABC, abstractmethod
 from collections import UserDict
-from collections.abc import Iterable
 from copy import copy
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
@@ -41,6 +40,14 @@ from snowflake.snowpark._internal.analyzer.unary_expression import (
     UnresolvedAlias,
 )
 from snowflake.snowpark._internal.utils import is_sql_select_statement
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 SET_UNION = analyzer_utils.UNION
 SET_UNION_ALL = analyzer_utils.UNION_ALL

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -5,8 +5,9 @@
 import re
 import sys
 import uuid
+from collections.abc import Iterable
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from snowflake.snowpark._internal.analyzer.table_function import GeneratorTableFunction
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -5,7 +5,6 @@
 import re
 import sys
 import uuid
-from collections.abc import Iterable
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
@@ -74,6 +73,14 @@ from snowflake.snowpark._internal.utils import (
 )
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import StructType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class SnowflakePlan(LogicalPlan):

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from collections.abc import Iterable
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -10,6 +9,14 @@ import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.expression import Attribute, Expression
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import StructType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class LogicalPlan:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -2,8 +2,9 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.expression import Attribute, Expression

--- a/src/snowflake/snowpark/_internal/analyzer/table_function.py
+++ b/src/snowflake/snowpark/_internal/analyzer/table_function.py
@@ -2,12 +2,19 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from collections.abc import Iterable
 from typing import Dict, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import Expression
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import LogicalPlan
 from snowflake.snowpark._internal.analyzer.sort_expression import SortOrder
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class TableFunctionPartitionSpecDefinition(Expression):

--- a/src/snowflake/snowpark/_internal/analyzer/table_function.py
+++ b/src/snowflake/snowpark/_internal/analyzer/table_function.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Dict, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import Expression
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import LogicalPlan

--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -11,12 +11,19 @@ import re
 import sys
 import textwrap
 from collections import defaultdict, namedtuple
-from collections.abc import Iterable
 from logging import getLogger
 from types import BuiltinFunctionType, CodeType, FunctionType, ModuleType
 from typing import Any, Dict, List, Set, Tuple, Union
 
 import opcode
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 logger = getLogger(__name__)
 

--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -11,9 +11,10 @@ import re
 import sys
 import textwrap
 from collections import defaultdict, namedtuple
+from collections.abc import Iterable
 from logging import getLogger
 from types import BuiltinFunctionType, CodeType, FunctionType, ModuleType
-from typing import Any, Dict, Iterable, List, Set, Tuple, Union
+from typing import Any, Dict, List, Set, Tuple, Union
 
 import opcode
 

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -13,11 +13,11 @@ import re
 import sys
 import typing  # noqa: F401
 from array import array
+from collections.abc import Iterable  # noqa: F401
 from typing import (  # noqa: F401
     Any,
     Dict,
     Generator,
-    Iterable,
     Iterator,
     List,
     NewType,

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -13,7 +13,6 @@ import re
 import sys
 import typing  # noqa: F401
 from array import array
-from collections.abc import Iterable  # noqa: F401
 from typing import (  # noqa: F401
     Any,
     Dict,
@@ -57,6 +56,14 @@ from snowflake.snowpark.types import (
     VariantType,
     _NumericType,
 )
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable  # noqa: F401
+except ImportError:
+    from collections.abc import Iterable  # noqa: F401
 
 if installed_pandas:
     from snowflake.snowpark.types import (

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -8,7 +8,6 @@ import pickle
 import sys
 import typing
 import zipfile
-from collections.abc import Iterable
 from logging import getLogger
 from types import ModuleType
 from typing import (
@@ -49,6 +48,14 @@ from snowflake.snowpark.types import (
     PandasSeriesType,
     StructType,
 )
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 logger = getLogger(__name__)
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -8,12 +8,12 @@ import pickle
 import sys
 import typing
 import zipfile
+from collections.abc import Iterable
 from logging import getLogger
 from types import ModuleType
 from typing import (
     Callable,
     Dict,
-    Iterable,
     List,
     NamedTuple,
     Optional,

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from collections.abc import Iterable
 from typing import Optional, Union
 
 import snowflake.snowpark
@@ -73,6 +72,14 @@ from snowflake.snowpark._internal.type_utils import (
 from snowflake.snowpark._internal.utils import parse_positional_args_to_list
 from snowflake.snowpark.types import DataType
 from snowflake.snowpark.window import Window, WindowSpec
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 def _to_col_if_lit(

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import quote_name

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -6,7 +6,6 @@ import copy
 import itertools
 import re
 from collections import Counter
-from collections.abc import Iterable
 from functools import cached_property
 from logging import getLogger
 from typing import (
@@ -141,6 +140,14 @@ from snowflake.snowpark.table_function import (
     _get_cols_after_join_table,
 )
 from snowflake.snowpark.types import StringType, StructType, _NumericType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 if TYPE_CHECKING:
     from table import Table  # pragma: no cover

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -6,13 +6,13 @@ import copy
 import itertools
 import re
 from collections import Counter
+from collections.abc import Iterable
 from functools import cached_property
 from logging import getLogger
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    Iterable,
     Iterator,
     List,
     Optional,

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -3,8 +3,9 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import copy
+from collections.abc import Iterable
 from logging import getLogger
-from typing import Dict, Iterable, Optional, Union
+from typing import Dict, Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import quote_name

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import copy
-from collections.abc import Iterable
 from logging import getLogger
 from typing import Dict, Optional, Union
 
@@ -24,6 +23,14 @@ from snowflake.snowpark.types import (
     IntegerType,
     LongType,
 )
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 _logger = getLogger(__name__)
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Any, Dict, Iterable, List, Optional, Union
+from collections.abc import Iterable
+from typing import Any, Dict, List, Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from collections.abc import Iterable
 from typing import Any, Dict, List, Optional, Union
 
 import snowflake.snowpark
@@ -30,6 +29,14 @@ from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.functions import sql_expr
 from snowflake.snowpark.table import Table
 from snowflake.snowpark.types import StructType, VariantType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class DataFrameReader:

--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
+from collections.abc import Iterable
 from functools import reduce
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark import Column

--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from collections.abc import Iterable
 from functools import reduce
 from typing import Dict, List, Optional, Union
 
@@ -20,6 +19,14 @@ from snowflake.snowpark.functions import (
     count_distinct,
     covar_samp,
 )
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 _MAX_COLUMNS_PER_TABLE = 1000
 

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -1,7 +1,8 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Dict, Iterable, List, Literal, Optional, Union, overload
+from collections.abc import Iterable
+from typing import Dict, List, Literal, Optional, Union, overload
 
 import snowflake.snowpark  # for forward references of type hints
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -1,7 +1,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from collections.abc import Iterable
 from typing import Dict, List, Literal, Optional, Union, overload
 
 import snowflake.snowpark  # for forward references of type hints
@@ -26,6 +25,14 @@ from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.functions import sql_expr
 from snowflake.snowpark.row import Row
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class DataFrameWriter:

--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import array
 import io
+from collections.abc import Iterable
 from io import RawIOBase
-from typing import Iterable
 
 from snowflake.snowpark._internal.utils import private_preview
 
@@ -38,7 +38,7 @@ class SnowflakeFile(RawIOBase):
         # The mode of file stream
         self._mode: str = mode
         # Whether it is intended to access owner's files
-        self._is_owner_file = is_owner_file 
+        self._is_owner_file = is_owner_file
         # Whether a non-scoped URL can be accessed
         self._require_scoped_url = require_scoped_url
 
@@ -61,9 +61,9 @@ class SnowflakeFile(RawIOBase):
         Returns a :class:`~snowflake.snowpark.file.SnowflakeFile`.
         In UDF and Stored Procedures, the object works like a Python IOBase object and as a wrapper for an IO stream of remote files. The IO Stream is to support the file operations defined in this class.
 
-	All files are accessed in the context of the UDF owner (with the exception of caller's rights stored procedures which use the caller's context). 
+        All files are accessed in the context of the UDF owner (with the exception of caller's rights stored procedures which use the caller's context).
         UDF callers should use scoped URLs to allow the UDF to access their files. By accepting only scoped URLs the UDF owner can ensure
-        the UDF caller had access to the provided file. Removing the requirement that the URL is a scoped URL (require_scoped_url=false) allows the caller 
+        the UDF caller had access to the provided file. Removing the requirement that the URL is a scoped URL (require_scoped_url=false) allows the caller
         to provide URLs that may be only accessible by the UDF owner.
 
         is_owner_file is marked for deprecation. For Snowflake release 7.8 and onwards please use require_scoped_url instead.
@@ -74,7 +74,9 @@ class SnowflakeFile(RawIOBase):
             is_owner_file: A boolean value, if True, the API is intended to access owner's files and all url/uri are allowed. If False, the API is intended to access files passed into the function by the caller and only scoped url is allowed.
             require_scoped_url: A boolean value, if True, file_location must be a scoped URL. A scoped URL ensures that the caller cannot access the UDF owners files that the caller does not have access to.
         """
-        return cls(file_location, mode, is_owner_file, require_scoped_url=require_scoped_url)
+        return cls(
+            file_location, mode, is_owner_file, require_scoped_url=require_scoped_url
+        )
 
     def close(self) -> None:
         """

--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -7,10 +7,17 @@ from __future__ import annotations
 
 import array
 import io
-from collections.abc import Iterable
 from io import RawIOBase
 
 from snowflake.snowpark._internal.utils import private_preview
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 _DEFER_IMPLEMENTATION_ERR_MSG = "SnowflakeFile currently only works in UDF and Stored Procedures. It doesn't work locally yet."
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -158,7 +158,6 @@ The return type is always ``Column``. The input types tell you the acceptable va
 """
 import functools
 import typing
-from collections.abc import Iterable
 from random import randint
 from types import ModuleType
 from typing import Callable, Dict, List, Optional, Tuple, Union, overload
@@ -201,6 +200,14 @@ from snowflake.snowpark.stored_procedure import StoredProcedure
 from snowflake.snowpark.types import DataType, FloatType, StructType
 from snowflake.snowpark.udf import UserDefinedFunction
 from snowflake.snowpark.udtf import UserDefinedTableFunction
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 def col(col_name: str) -> Column:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -158,9 +158,10 @@ The return type is always ``Column``. The input types tell you the acceptable va
 """
 import functools
 import typing
+from collections.abc import Iterable
 from random import randint
 from types import ModuleType
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union, overload
+from typing import Callable, Dict, List, Optional, Tuple, Union, overload
 
 import snowflake.snowpark
 import snowflake.snowpark.table_function

--- a/src/snowflake/snowpark/row.py
+++ b/src/snowflake/snowpark/row.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Any, Dict, Iterable, Union
+from collections.abc import Iterable
+from typing import Any, Dict, Union
 
 
 def _restore_row_from_pickle(values, named_values, fields):

--- a/src/snowflake/snowpark/row.py
+++ b/src/snowflake/snowpark/row.py
@@ -2,8 +2,15 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from collections.abc import Iterable
 from typing import Any, Dict, Union
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 def _restore_row_from_pickle(values, named_values, fields):

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -8,11 +8,12 @@ import json
 import logging
 import os
 from array import array
+from collections.abc import Iterable
 from functools import reduce
 from logging import getLogger
 from threading import RLock
 from types import ModuleType
-from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 
 import cloudpickle
 import pkg_resources

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 from array import array
-from collections.abc import Iterable
 from functools import reduce
 from logging import getLogger
 from threading import RLock
@@ -122,6 +121,14 @@ from snowflake.snowpark.types import (
 )
 from snowflake.snowpark.udf import UDFRegistration
 from snowflake.snowpark.udtf import UDTFRegistration
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 _logger = getLogger(__name__)
 

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -5,7 +5,6 @@
 """Stored procedures in Snowpark. Refer to :class:`~snowflake.snowpark.stored_procedure.StoredProcedure` for details and sample code."""
 import sys
 import typing
-from collections.abc import Iterable
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -25,6 +24,14 @@ from snowflake.snowpark._internal.udf_utils import (
 )
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.types import DataType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 EXECUTE_AS_WHITELIST = frozenset(["owner", "caller"])
 

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -5,8 +5,9 @@
 """Stored procedures in Snowpark. Refer to :class:`~snowflake.snowpark.stored_procedure.StoredProcedure` for details and sample code."""
 import sys
 import typing
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.connector import ProgrammingError

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Dict, Iterable, List, NamedTuple, Optional, Union, overload
+from collections.abc import Iterable
+from typing import Dict, List, NamedTuple, Optional, Union, overload
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.binary_plan_node import create_join_type

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from collections.abc import Iterable
 from typing import Dict, List, NamedTuple, Optional, Union, overload
 
 import snowflake.snowpark
@@ -26,6 +25,14 @@ from snowflake.snowpark._internal.type_utils import ColumnOrLiteral
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.dataframe import DataFrame, _disambiguate
 from snowflake.snowpark.row import Row
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class UpdateResult(NamedTuple):

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -4,7 +4,8 @@
 #
 """This package contains all Snowpark logical types."""
 import re
-from typing import Generic, Iterable, List, Optional, TypeVar, Union
+from collections.abc import Iterable
+from typing import Generic, List, Optional, TypeVar, Union
 
 import snowflake.snowpark._internal.analyzer.expression as expression
 from snowflake.connector.options import installed_pandas, pandas

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -4,11 +4,18 @@
 #
 """This package contains all Snowpark logical types."""
 import re
-from collections.abc import Iterable
 from typing import Generic, List, Optional, TypeVar, Union
 
 import snowflake.snowpark._internal.analyzer.expression as expression
 from snowflake.connector.options import installed_pandas, pandas
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class DataType:

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -4,7 +4,6 @@
 #
 """User-defined functions (UDFs) in Snowpark. Refer to :class:`~snowflake.snowpark.udf.UDFRegistration` for details and sample code."""
 import sys
-from collections.abc import Iterable
 from types import ModuleType
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -29,6 +28,14 @@ from snowflake.snowpark._internal.utils import (
 )
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.types import DataType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class UserDefinedFunction:

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -4,8 +4,9 @@
 #
 """User-defined functions (UDFs) in Snowpark. Refer to :class:`~snowflake.snowpark.udf.UDFRegistration` for details and sample code."""
 import sys
+from collections.abc import Iterable
 from types import ModuleType
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.connector import ProgrammingError

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -5,11 +5,11 @@
 """User-defined table functions (UDTFs) in Snowpark. Refer to :class:`~snowflake.snowpark.udtf.UDTFRegistration` for details and sample code."""
 import collections.abc
 import sys
+from collections.abc import Iterable
 from types import ModuleType
 from typing import (
     Callable,
     Dict,
-    Iterable,
     List,
     Optional,
     Tuple,

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -5,7 +5,6 @@
 """User-defined table functions (UDTFs) in Snowpark. Refer to :class:`~snowflake.snowpark.udtf.UDTFRegistration` for details and sample code."""
 import collections.abc
 import sys
-from collections.abc import Iterable
 from types import ModuleType
 from typing import (
     Callable,
@@ -42,6 +41,14 @@ from snowflake.snowpark._internal.udf_utils import (
 from snowflake.snowpark._internal.utils import TempObjectType, validate_object_name
 from snowflake.snowpark.table_function import TableFunctionCall
 from snowflake.snowpark.types import DataType, StructField, StructType
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class UserDefinedTableFunction:

--- a/src/snowflake/snowpark/window.py
+++ b/src/snowflake/snowpark/window.py
@@ -4,7 +4,6 @@
 #
 """Window frames in Snowpark."""
 import sys
-from collections.abc import Iterable
 from typing import List, Tuple, Union
 
 import snowflake.snowpark
@@ -24,6 +23,14 @@ from snowflake.snowpark._internal.analyzer.window_expression import (
 )
 from snowflake.snowpark._internal.type_utils import ColumnOrName
 from snowflake.snowpark._internal.utils import parse_positional_args_to_list
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 def _convert_boundary_to_expr(start: int, end: int) -> Tuple[Expression, Expression]:

--- a/src/snowflake/snowpark/window.py
+++ b/src/snowflake/snowpark/window.py
@@ -4,7 +4,8 @@
 #
 """Window frames in Snowpark."""
 import sys
-from typing import Iterable, List, Tuple, Union
+from collections.abc import Iterable
+from typing import List, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.expression import Expression, Literal

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import logging
-from collections import Iterator
+from collections.abc import Iterator
 from time import sleep, time
 
 import pandas as pd

--- a/tests/integ/scala/test_udtf_suite.py
+++ b/tests/integ/scala/test_udtf_suite.py
@@ -5,7 +5,8 @@
 import datetime
 import decimal
 from collections import Counter
-from typing import Dict, Iterable, List, Tuple
+from collections.abc import Iterable
+from typing import Dict, List, Tuple
 
 import pytest
 

--- a/tests/integ/scala/test_udtf_suite.py
+++ b/tests/integ/scala/test_udtf_suite.py
@@ -5,7 +5,6 @@
 import datetime
 import decimal
 from collections import Counter
-from collections.abc import Iterable
 from typing import Dict, List, Tuple
 
 import pytest
@@ -24,6 +23,14 @@ from snowflake.snowpark.types import (
     Variant,
 )
 from tests.utils import Utils
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 pytestmark = pytest.mark.udf
 

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -8,7 +8,6 @@ import logging
 import math
 from array import array
 from collections import namedtuple
-from collections.abc import Iterable
 from decimal import Decimal
 from itertools import product
 from typing import Tuple
@@ -58,6 +57,14 @@ from snowflake.snowpark.types import (
     VariantType,
 )
 from tests.utils import IS_IN_STORED_PROC_LOCALFS, TestData, TestFiles, Utils
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 tmp_stage_name = Utils.random_stage_name()
 test_file_on_stage = f"@{tmp_stage_name}/testCSV.csv"

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -8,9 +8,10 @@ import logging
 import math
 from array import array
 from collections import namedtuple
+from collections.abc import Iterable
 from decimal import Decimal
 from itertools import product
-from typing import Iterable, Tuple
+from typing import Tuple
 
 import pandas as pd
 import pytest

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -1,7 +1,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from collections.abc import Iterable
 from typing import Tuple
 
 import pytest
@@ -24,6 +23,14 @@ from snowflake.snowpark.functions import (
     udtf,
 )
 from tests.utils import TestData, Utils
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -1,7 +1,8 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Iterable, Tuple
+from collections.abc import Iterable
+from typing import Tuple
 
 import pytest
 

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -4,7 +4,6 @@
 #
 
 import decimal
-from collections.abc import Iterable
 from functools import partial
 from typing import Any, Dict, Tuple
 
@@ -27,6 +26,14 @@ from snowflake.snowpark.functions import (
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.types import IntegerType, PandasDataFrameType, PandasSeriesType
 from tests.utils import TestData, TestFiles
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 class TelemetryDataTracker:

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -4,8 +4,9 @@
 #
 
 import decimal
+from collections.abc import Iterable
 from functools import partial
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, Tuple
 
 import pytest
 

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import decimal
-from typing import Iterable, Tuple
+from collections.abc import Iterable
+from typing import Tuple
 
 import pytest
 

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 import decimal
-from collections.abc import Iterable
 from typing import Tuple
 
 import pytest
@@ -21,6 +20,14 @@ from snowflake.snowpark.types import (
     StructType,
 )
 from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 pytestmark = pytest.mark.udf
 

--- a/tests/perf/perf_runner.py
+++ b/tests/perf/perf_runner.py
@@ -6,8 +6,9 @@ import argparse
 import random
 import sys
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, List
+from typing import List
 
 from snowflake.snowpark import DataFrame
 from snowflake.snowpark.functions import col

--- a/tests/perf/perf_runner.py
+++ b/tests/perf/perf_runner.py
@@ -6,7 +6,6 @@ import argparse
 import random
 import sys
 import time
-from collections.abc import Iterable
 from pathlib import Path
 from typing import List
 
@@ -17,6 +16,14 @@ from snowflake.snowpark.session import Session
 connection_parameters_path = str(Path(__file__).absolute().parent.parent)
 sys.path.append(connection_parameters_path)
 from parameters import CONNECTION_PARAMETERS  # noqa: E402
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 def generate_columns(n: int) -> List[str]:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
+import collections
 import os
 import typing
 from array import array
@@ -418,7 +419,7 @@ def test_python_type_to_snow_type():
     with pytest.raises(TypeError):
         python_type_to_snow_type(typing.IO)
     with pytest.raises(TypeError):
-        python_type_to_snow_type(typing.Iterable)
+        python_type_to_snow_type(collections.abc.Iterable)
     with pytest.raises(TypeError):
         python_type_to_snow_type(typing.Generic)
     with pytest.raises(TypeError):

--- a/tests/unit/test_udtf.py
+++ b/tests/unit/test_udtf.py
@@ -1,8 +1,6 @@
 #
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
-
-from collections.abc import Iterable
 from typing import Tuple
 from unittest import mock
 
@@ -13,6 +11,14 @@ from snowflake.snowpark import Session
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import udtf
 from snowflake.snowpark.udtf import UDTFRegistration
+
+# Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
+# Python 3.9 can use both
+# Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
+try:
+    from typing import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 
 @mock.patch("snowflake.snowpark.udtf.cleanup_failed_permanent_registration")

--- a/tests/unit/test_udtf.py
+++ b/tests/unit/test_udtf.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2012-2022 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Iterable, Tuple
+from collections.abc import Iterable
+from typing import Tuple
 from unittest import mock
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands = coverage combine
            coverage report -m
            coverage xml -o {env:COV_REPORT_DIR:{toxworkdir}}/coverage.xml
            coverage html -d {env:COV_REPORT_DIR:{toxworkdir}}/htmlcov
-depends = py38, py39
+depends = py38, py39, py310
 
 [testenv:flake8]
 description = check code style with flake8


### PR DESCRIPTION
There are mainly two issues that need to be fixed to be 3.10 compatible:

- `Iterable` is removed from `typing`. In 3.10 we are supposed to use `collections.abc.Iterables`, but this class is not subscriptable in 3.8. To be backward compatible, we first try to import from `typing`, and fall back to import from `collections.abc` if failed.
- Nested types's `__name__` only has the parent type in 3.10. For example, `Optional[str].__name__` is `Optional`. This breaks some of our type tests in 3.10, which is fixed in this PR as well.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-753246

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   There are mainly two issues that need to be fixed to be 3.10 compatible:

- `Iterable` is removed from `typing`. In 3.10 we are supposed to use `collections.abc.Iterables`, but this class is not subscriptable in 3.8. To be backward compatible, we first try to import from `typing`, and fall back to import from `collections.abc` if failed.
- Nested types's `__name__` only has the parent type in 3.10. For example, `Optional[str].__name__` is `Optional`. This breaks some of our type tests in 3.10, which is fixed in this PR as well.
