### PR TITLE
mark xfail on if_not_exist tests 

### DIFF
--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -773,6 +773,7 @@ def test_sp_replace(session):
     assert add_sp(1, 2) == 3
 
 
+@pytest.mark.xfail(reason="SNOW-757054 flaky test", strict=False)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Named temporary procedure is not supported in stored proc",
@@ -784,7 +785,7 @@ def test_sp_if_not_exists(session):
         name="test_sp_if_not_exists_add",
         return_type=IntegerType(),
         input_types=[IntegerType(), IntegerType()],
-        replace=True,
+        if_not_exists=True,
     )
     assert add_sp(1, 2) == 3
 

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -784,7 +784,7 @@ def test_sp_if_not_exists(session):
         name="test_sp_if_not_exists_add",
         return_type=IntegerType(),
         input_types=[IntegerType(), IntegerType()],
-        if_not_exists=True,
+        replace=True,
     )
     assert add_sp(1, 2) == 3
 

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1154,6 +1154,7 @@ def test_udf_replace(session):
     )
 
 
+@pytest.mark.xfail(reason="SNOW-757054 flaky test", strict=False)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
 )
@@ -1166,7 +1167,7 @@ def test_udf_if_not_exists(session):
         name="test_udf_if_not_exist_add",
         return_type=IntegerType(),
         input_types=[IntegerType(), IntegerType()],
-        replace=True,
+        if_not_exists=True,
     )
     Utils.check_answer(
         df.select(add_udf("a", "b")).collect(),

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1166,7 +1166,7 @@ def test_udf_if_not_exists(session):
         name="test_udf_if_not_exist_add",
         return_type=IntegerType(),
         input_types=[IntegerType(), IntegerType()],
-        if_not_exists=True,
+        replace=True,
     )
     Utils.check_answer(
         df.select(add_udf("a", "b")).collect(),

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -233,7 +233,7 @@ def test_secure_udtf(session):
     IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
 )
 def test_if_not_exists_udtf(session):
-    @udtf(name="test_if_not_exists", output_schema=["num"], if_not_exists=True)
+    @udtf(name="test_if_not_exists", output_schema=["num"], replace=True)
     class UDTFEcho:
         def process(
             self,

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -229,11 +229,12 @@ def test_secure_udtf(session):
     assert "SECURE" in session.sql(ddl_sql).collect()[0][0]
 
 
+@pytest.mark.xfail(reason="SNOW-757054 flaky test", strict=False)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="Named temporary udf is not supported in stored proc"
 )
 def test_if_not_exists_udtf(session):
-    @udtf(name="test_if_not_exists", output_schema=["num"], replace=True)
+    @udtf(name="test_if_not_exists", output_schema=["num"], if_not_exists=True)
     class UDTFEcho:
         def process(
             self,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Tests that are testing `if_not_exists` show flaky behavior and fail error messages like with `Unknown function TEST_SP_IF_NOT_EXISTS_ADD` on first invocation of sp/udf after being registered with `if_not_exists=True`. Updating the first isntance of registration with `replace=True` instead of `if_not_exists` to test whether it fixes the flakiness.
