### PR TITLE
SNOW-756443  Fix chained sort

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -590,7 +590,7 @@ class SelectStatement(Selectable):
             new.from_ = self.from_.to_subqueryable()
             new.pre_actions = new.from_.pre_actions
             new.post_actions = new.from_.post_actions
-            new.order_by = cols
+            new.order_by = cols + (self.order_by or [])
             new._column_states = self._column_states
         else:
             new = SelectStatement(

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -993,3 +993,17 @@ def test_rename_to_existing_column_column(session):
     df4 = df3.withColumn("b", sql_expr("1"))
     assert df4.columns == ["C", "A", "B"]
     Utils.check_answer(df4, [Row(3, 3, 1)])
+
+
+def test_chained_sort(session):
+    session.sql_simplifier_enabled = False
+    df1 = session.create_dataframe([[1, 2], [4, 3]], schema=["a", "b"])
+
+    session.sql_simplifier_enabled = True
+    df2 = session.create_dataframe([[1, 2], [4, 3]], schema=["a", "b"])
+
+    Utils.check_answer(df1.sort("a").sort("b"), df2.sort("a").sort("b"), sort=False)
+    assert (
+        df2.sort("a").sort("b").queries["queries"][0]
+        == df2.sort("b", "a").queries["queries"][0]
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-756443

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The code change fixes chained sort statements (e.g. `df.order_by().order_by()`) by prepending the subquery's expressions with the current query's expressions.
