### PR TITLE
SNOW-703372: Add indexer for StructType to be on par with pyspark beh…

### DIFF
--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -284,6 +284,23 @@ class StructType(DataType):
     def __repr__(self) -> str:
         return f"StructType([{', '.join(repr(f) for f in self.fields)}])"
 
+    def __getitem__(self, item: Union[str, int, slice]) -> StructField:
+        """Access fields by name, index or slice."""
+        if isinstance(item, str):
+            for field in self.fields:
+                if field.name == item:
+                    return field
+            raise KeyError("No StructField named {0}".format(item))
+        elif isinstance(item, int):
+            return self.fields[item]  # may throw ValueError
+        elif isinstance(item, slice):
+            return StructType(self.fields[item])
+        else:
+            raise TypeError("StructType items should be strings, integers or slices")
+
+    def __setitem__(self, key, value):
+        raise TypeError("StructType object does not support item assignment")
+
     @property
     def names(self) -> List[str]:
         """Returns the list of names of the :class:`StructField`"""

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -296,7 +296,7 @@ class StructType(DataType):
         elif isinstance(item, slice):
             return StructType(self.fields[item])
         else:
-            raise TypeError("StructType items should be strings, integers or slices")
+            raise TypeError(f"StructType items should be strings, integers or slices, but got {type(item).__name__}")
 
     def __setitem__(self, key, value):
         raise TypeError("StructType object does not support item assignment")

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -290,7 +290,7 @@ class StructType(DataType):
             for field in self.fields:
                 if field.name == item:
                     return field
-            raise KeyError("No StructField named {0}".format(item))
+            raise KeyError(f"No StructField named {item}")
         elif isinstance(item, int):
             return self.fields[item]  # may throw ValueError
         elif isinstance(item, slice):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -264,13 +264,13 @@ def test_struct_get_item():
     with pytest.raises(KeyError, match="No StructField named d"):
         st["d"]
 
-    with pytest.raises(IndexError):
+    with pytest.raises(IndexError, match="list index out of range"):
         st[5]
 
     with pytest.raises(TypeError, match="StructType items should be strings, integers or slices"):
         st[5.0]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="StructType object does not support item assignment"):
         st[0] = sfc
 
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -241,6 +241,39 @@ def test_struct_field_name():
     assert sf.column_identifier.name == "integer type"
 
 
+def test_struct_get_item():
+    sfa = StructField("a", IntegerType())
+    sfb = StructField("b", StringType())
+    sfc = StructField("c", LongType())
+
+    st = StructType([sfa, sfb, sfc])
+
+    assert (st[0] == sfa)
+    assert (st[1] == sfb)
+    assert (st[2] == sfc)
+
+    assert (st["a"] == sfa)
+    assert (st["b"] == sfb)
+    assert (st["c"] == sfc)
+
+    assert (st[0:3] == StructType([sfa, sfb, sfc]))
+    assert (st[1:3] == StructType([sfb, sfc]))
+    assert (st[1:2] == StructType([sfb]))
+    assert (st[2:3] == StructType([sfc]))
+
+    with pytest.raises(KeyError, match="No StructField named d"):
+        st["d"]
+
+    with pytest.raises(IndexError):
+        st[5]
+
+    with pytest.raises(TypeError):
+        st[5.0]
+
+    with pytest.raises(TypeError):
+        st[0] = sfc
+
+
 def test_strip_unnecessary_quotes():
     # Get a function reference for brevity
     func = ColumnIdentifier._strip_unnecessary_quotes

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -267,7 +267,7 @@ def test_struct_get_item():
     with pytest.raises(IndexError):
         st[5]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="StructType items should be strings, integers or slices"):
         st[5.0]
 
     with pytest.raises(TypeError):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -242,36 +242,36 @@ def test_struct_field_name():
 
 
 def test_struct_get_item():
-    sfa = StructField("a", IntegerType())
-    sfb = StructField("b", StringType())
-    sfc = StructField("c", LongType())
+    field_a = StructField("a", IntegerType())
+    field_b = StructField("b", StringType())
+    field_c = StructField("c", LongType())
 
-    st = StructType([sfa, sfb, sfc])
+    struct_type = StructType([field_a, field_b, field_c])
 
-    assert (st[0] == sfa)
-    assert (st[1] == sfb)
-    assert (st[2] == sfc)
+    assert (struct_type[0] == field_a)
+    assert (struct_type[1] == field_b)
+    assert (struct_type[2] == field_c)
 
-    assert (st["a"] == sfa)
-    assert (st["b"] == sfb)
-    assert (st["c"] == sfc)
+    assert (struct_type["a"] == field_a)
+    assert (struct_type["b"] == field_b)
+    assert (struct_type["c"] == field_c)
 
-    assert (st[0:3] == StructType([sfa, sfb, sfc]))
-    assert (st[1:3] == StructType([sfb, sfc]))
-    assert (st[1:2] == StructType([sfb]))
-    assert (st[2:3] == StructType([sfc]))
+    assert (struct_type[0:3] == StructType([field_a, field_b, field_c]))
+    assert (struct_type[1:3] == StructType([field_b, field_c]))
+    assert (struct_type[1:2] == StructType([field_b]))
+    assert (struct_type[2:3] == StructType([field_c]))
 
     with pytest.raises(KeyError, match="No StructField named d"):
-        st["d"]
+        struct_type["d"]
 
     with pytest.raises(IndexError, match="list index out of range"):
-        st[5]
+        struct_type[5]
 
-    with pytest.raises(TypeError, match="StructType items should be strings, integers or slices"):
-        st[5.0]
+    with pytest.raises(TypeError, match="StructType items should be strings, integers or slices, but got float"):
+        struct_type[5.0]
 
     with pytest.raises(TypeError, match="StructType object does not support item assignment"):
-        st[0] = sfc
+        struct_type[0] = field_c
 
 
 def test_strip_unnecessary_quotes():


### PR DESCRIPTION
…avior.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-703372

2. Please describe how your code solves the related issue.

   Add __getitem__ and __setitem__ to StructType to handle by string, index or slice range for StructType. 
