### PR TITLE
SNOW-759276 Add xfail to known flaky tests

### DIFF
--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -125,25 +125,6 @@ class AsyncJob:
             >>> async_job.cancel()
 
     Example 9
-        Executing two queries asynchronously is faster than executing two queries one by one::
-
-            >>> from time import time
-            >>> df1 = session.sql("select SYSTEM$WAIT(3)")
-            >>> df2 = session.sql("select SYSTEM$WAIT(3)")
-            >>> start = time()
-            >>> sync_res1 = df1.collect()
-            >>> sync_res2 = df2.collect()
-            >>> time1 = time() - start
-            >>> start = time()
-            >>> async_job1 = df1.collect_nowait()
-            >>> async_job2 = df2.collect_nowait()
-            >>> async_res1 = async_job1.result()
-            >>> async_res2 = async_job2.result()
-            >>> time2 = time() - start
-            >>> time2 < time1
-            True
-
-    Example 10
         Creating an :class:`AsyncJob` from an existing query ID, retrieving results and converting it back to a :class:`DataFrame`:
 
             >>> from snowflake.snowpark.functions import col

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -396,6 +396,7 @@ def test_create_async_job_negative(session):
         async_job.result()
 
 
+@pytest.mark.xfail(reason="SNOW-754115 flaky test", strict=False)
 @pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
 def test_get_query_from_async_job(session, create_async_job_from_query_id):
     query_text = "select 1, 2, 3"

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -30,10 +30,9 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
-from tests.utils import IS_IN_STORED_PROC
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC, reason="flaky test in SP")
+@pytest.mark.xfail(reason="SNOW-754118 flaky test", strict=False)
 def test_to_local_iterator_should_not_load_all_data_at_once(session):
     df = (
         session.range(1000000)

--- a/tests/integ/scala/test_query_tag_suite.py
+++ b/tests/integ/scala/test_query_tag_suite.py
@@ -97,6 +97,7 @@ def test_query_tags_from_trackback(session, code):
     assert len(query_history) == 1
 
 
+@pytest.mark.xfail(reason="SNOW-759410 flaky test", strict=False)
 @pytest.mark.parametrize("data", ["a", "'a'", "\\a", "a\n", r"\ua", " a", '"a'])
 def test_large_local_relation_query_tag_from_traceback(session, data):
     session.create_dataframe(

--- a/tests/integ/scala/test_query_tag_suite.py
+++ b/tests/integ/scala/test_query_tag_suite.py
@@ -60,6 +60,7 @@ def test_query_tags_in_session(session):
         Utils.unset_query_tag(session)
 
 
+@pytest.mark.xfail(reason="SNOW-754166 flaky test", strict=False)
 @pytest.mark.parametrize(
     "code",
     [
@@ -107,6 +108,7 @@ def test_large_local_relation_query_tag_from_traceback(session, data):
     assert len(query_history) > 0  # some hidden SQLs are run so it's not exactly 1.
 
 
+@pytest.mark.xfail(reason="SNOW-754078 flaky test", strict=False)
 def test_query_tag_for_cache_result(session):
     query_tag = Utils.random_name_for_temp_object(TempObjectType.QUERY_TAG)
     session.query_tag = query_tag

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -367,6 +367,7 @@ def test_use_negative_tests(session, obj):
     assert err_msg in exec_info.value.args[0]
 
 
+@pytest.mark.xfail(reason="SNOW-754082 flaky test", strict=False)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="use schema is not allowed in stored proc (owner mode)"
 )


### PR DESCRIPTION
Description

Add xfail to known flaky tests to make merge gate stable, the fix will be in separate PRs.

There are two tests that are treated differently:

1. Doctest snowpark.async_job.AsyncJob. I don't see a good reason for this "two async runs faster than two sync" as a useful doc.
2. Removed a stored proc skip because the reason for skip is flaky

Testing

Existing tests

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-759276

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Add xfail to known flaky tests to make merge gate stable, the fix will be in separate PRs.

There are two tests that are treated differently:

1. Doctest snowpark.async_job.AsyncJob. I don't see a good reason for this "two async runs faster than two sync" as a useful doc.
2. Removed a stored proc skip because the reason for skip is flaky
