### PR TITLE
[Release Blocker] Add temporary parameter config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Added support for `delimiters` parameter in `functions.initcap()`.
 - Added support for `functions.hash()` to accept a variable number of input expressions.
+- Added API `Session.RuntimeConfig` for reading/writing runtime configuration.
+- Simplified JOIN queries by using constant subquery alias by default (SNOWPARK_LEFT, SNOWPARK_RIGHT), this could be turned off at runtime with `session.conf.set('use_constant_subquery_alias', False)`
 
 ### Bug Fixes
 - Fixed a bug where a DataFrame set operation(`DataFrame.substract`, `DataFrame.union`, etc.) being called after another DataFrame set operation and `DataFrame.select` or `DataFrame.with_column` throws an exception.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 - Added support for `delimiters` parameter in `functions.initcap()`.
 - Added support for `functions.hash()` to accept a variable number of input expressions.
-- Added API `Session.RuntimeConfig` for reading/writing runtime configuration.
-- Simplified JOIN queries by using constant subquery alias by default (SNOWPARK_LEFT, SNOWPARK_RIGHT), this could be turned off at runtime with `session.conf.set('use_constant_subquery_alias', False)`
+- Added API `Session.RuntimeConfig` for getting/setting/checking the mutability of any runtime configuration.
+- Simplified JOIN queries to use constant subquery aliases (SNOWPARK_LEFT, SNOWPARK_RIGHT) by default , users could disable this at runtime with `session.conf.set('use_constant_subquery_alias', False)` to use randomly generated alias names instead.
 
 ### Bug Fixes
 - Fixed a bug where a DataFrame set operation(`DataFrame.substract`, `DataFrame.union`, etc.) being called after another DataFrame set operation and `DataFrame.select` or `DataFrame.with_column` throws an exception.

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -575,7 +575,7 @@ class Analyzer:
                 logical_plan.join_type,
                 self.analyze(logical_plan.condition) if logical_plan.condition else "",
                 logical_plan,
-                self.session.use_constant_subquery_alias,
+                self.session.conf.get("use_constant_subquery_alias", False),
             )
 
         if isinstance(logical_plan, Sort):

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -493,12 +493,12 @@ def left_semi_or_anti_join_statement(
     use_constant_subquery_alias: bool,
 ) -> str:
     left_alias = (
-        "SNOWPARK_LEFT_"
+        "SNOWPARK_LEFT"
         if use_constant_subquery_alias
         else random_name_for_temp_object(TempObjectType.TABLE)
     )
     right_alias = (
-        "SNOWPARK_RIGHT_"
+        "SNOWPARK_RIGHT"
         if use_constant_subquery_alias
         else random_name_for_temp_object(TempObjectType.TABLE)
     )
@@ -543,12 +543,12 @@ def snowflake_supported_join_statement(
     use_constant_subquery_alias: bool,
 ) -> str:
     left_alias = (
-        "SNOWPARK_LEFT_"
+        "SNOWPARK_LEFT"
         if use_constant_subquery_alias
         else random_name_for_temp_object(TempObjectType.TABLE)
     )
     right_alias = (
-        "SNOWPARK_RIGHT_"
+        "SNOWPARK_RIGHT"
         if use_constant_subquery_alias
         else random_name_for_temp_object(TempObjectType.TABLE)
     )

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -204,16 +204,19 @@ class Session:
     class RuntimeConfig:
         def __init__(self, session: "Session", conf: Dict[str, Any]) -> None:
             self._session = session
+            self._conf = {
+                "use_constant_subquery_alias": True
+            }  # For config that's temporary/to be removed soon
             for key, val in conf.items():
-                if hasattr(Session, key) and self.is_mutable(key):
-                    setattr(session, key, val)
+                if self.is_mutable(key):
+                    self.set(key, val)
 
         def get(self, key: str, default=None) -> Any:
             if hasattr(Session, key):
                 return getattr(self._session, key)
             if hasattr(self._session._conn._conn, key):
                 return getattr(self._session._conn._conn, key)
-            return default
+            return self._conf.get(key, default)
 
         def is_mutable(self, key: str) -> bool:
             if hasattr(Session, key) and isinstance(getattr(Session, key), property):
@@ -222,7 +225,7 @@ class Session:
                 getattr(SnowflakeConnection, key), property
             ):
                 return getattr(SnowflakeConnection, key).fset is not None
-            return False
+            return key in self._conf
 
         def set(self, key: str, value: Any) -> None:
             if self.is_mutable(key):
@@ -230,8 +233,12 @@ class Session:
                     setattr(self._session, key, value)
                 if hasattr(SnowflakeConnection, key):
                     setattr(self._session._conn._conn, key, value)
+                if key in self._conf:
+                    self._conf[key] = value
             else:
-                raise AttributeError(f'Configuration "{key}" is not mutable in runtime')
+                raise AttributeError(
+                    f'Configuration "{key}" does not exist or is not mutable in runtime'
+                )
 
     class SessionBuilder:
         """
@@ -331,7 +338,6 @@ class Session:
         self._sql_simplifier_enabled: bool = self._get_client_side_session_parameter(
             _PYTHON_SNOWPARK_USE_SQL_SIMPLIFIER_STRING, True
         )
-        self._use_constant_subquery_alias: bool = True
         self._conf = self.RuntimeConfig(self, options or {})
 
         _logger.info("Snowpark Session information: %s", self._session_info)
@@ -378,14 +384,6 @@ class Session:
     @property
     def conf(self) -> RuntimeConfig:
         return self._conf
-
-    @property
-    def use_constant_subquery_alias(self) -> bool:
-        return self._use_constant_subquery_alias
-
-    @use_constant_subquery_alias.setter
-    def use_constant_subquery_alias(self, value: bool) -> None:
-        self._use_constant_subquery_alias = value
 
     @property
     def sql_simplifier_enabled(self) -> bool:

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -36,8 +36,8 @@ def test_runtime_config(db_parameters):
     # test conf.get
     assert not session.conf.get("nonexistent_client_side_fix", default=False)
     assert session.conf.get("client_prefetch_threads") == 10
-    assert not session.sql_simplifier_enabled
-    assert not session.use_constant_subquery_alias
+    assert not session.conf.get("session.sql_simplifier_enabled")
+    assert not session.conf.get("use_constant_subquery_alias")
     assert session.conf.get("password") is None
 
     # test conf.is_mutable
@@ -49,13 +49,13 @@ def test_runtime_config(db_parameters):
 
     # test conf.set
     session.conf.set("sql_simplifier_enabled", True)
-    assert session.sql_simplifier_enabled
+    assert session.conf.get("sql_simplifier_enabled")
     session.conf.set("use_constant_subquery_alias", True)
-    assert session.use_constant_subquery_alias
+    assert session.conf.get("use_constant_subquery_alias")
     with pytest.raises(AttributeError) as err:
         session.conf.set("use_openssl_only", False)
     assert (
-        'Configuration "use_openssl_only" is not mutable in runtime'
+        'Configuration "use_openssl_only" does not exist or is not mutable in runtime'
         in err.value.args[0]
     )
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -36,7 +36,8 @@ def test_runtime_config(db_parameters):
     # test conf.get
     assert not session.conf.get("nonexistent_client_side_fix", default=False)
     assert session.conf.get("client_prefetch_threads") == 10
-    assert not session.conf.get("session.sql_simplifier_enabled")
+    assert not session.sql_simplifier_enabled
+    assert not session.conf.get("sql_simplifier_enabled")
     assert not session.conf.get("use_constant_subquery_alias")
     assert session.conf.get("password") is None
 
@@ -49,6 +50,7 @@ def test_runtime_config(db_parameters):
 
     # test conf.set
     session.conf.set("sql_simplifier_enabled", True)
+    assert session.sql_simplifier_enabled
     assert session.conf.get("sql_simplifier_enabled")
     session.conf.set("use_constant_subquery_alias", True)
     assert session.conf.get("use_constant_subquery_alias")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-747658

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously in #669, we exposed `use_constant_subquery_alias` in the public API. This is ideally a temporary parameter that should be hidden from users and removed. This PR addresses the need to store temporary parameters using `Session.RuntimeConfig` and switches `use_constant_subquery_alias` to use the temp param implementation.

