### PR TITLE
Add statement_params to session.call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Added support for `delimiters` parameter in `functions.initcap()`.
 - Added support for `functions.hash()` to accept a variable number of input expressions.
 - Added support managing case sensitivity in `Row` results from `DataFrame.collect` using `case_sensitive` parameter.
-- Added support for `statement_params` parameter in `session.call()`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Improvements
 
 - Simplified JOIN queries to use constant subquery aliases (SNOWPARK_LEFT, SNOWPARK_RIGHT) by default , users could disable this at runtime with `session.conf.set('use_constant_subquery_alias', False)` to use randomly generated alias names instead.
+- Allowed specifying statement parameters in `session.call()`.
 
 
 ## 1.2.0 (2023-03-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for `delimiters` parameter in `functions.initcap()`.
 - Added support for `functions.hash()` to accept a variable number of input expressions.
 - Added support managing case sensitivity in `Row` results from `DataFrame.collect` using `case_sensitive` parameter.
+- Added support for `statement_params` parameter in `session.call()`.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1840,7 +1840,7 @@ class Session:
         self,
         sproc_name: str,
         *args: Any,
-        statement_params: Optional[Dict[str, str]] = None,
+        statement_params: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """Calls a stored procedure by name.
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1836,12 +1836,18 @@ class Session:
         """
         return self._sp_registration
 
-    def call(self, sproc_name: str, *args: Any) -> Any:
+    def call(
+        self,
+        sproc_name: str,
+        *args: Any,
+        statement_params: Optional[Dict[str, str]] = None,
+    ) -> Any:
         """Calls a stored procedure by name.
 
         Args:
             sproc_name: The name of stored procedure in Snowflake.
             args: Arguments should be basic Python types.
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
 
         Example::
 
@@ -1871,7 +1877,7 @@ class Session:
                 sql_args.append(to_sql(arg, infer_type(arg)))
         df = self.sql(f"CALL {sproc_name}({', '.join(sql_args)})")
         set_api_call_source(df, "Session.call")
-        return df.collect()[0][0]
+        return df.collect(statement_params=statement_params)[0][0]
 
     @deprecated(
         version="0.7.0",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add `statement_params` for job telemetry. SProc call triggers execution but cannot be monitored via statement params. cc: @sfc-gh-pdorairaj 
