### PR TITLE
Fix integ/conftest.py to allow running integration tests without optional connection parameters.

### DIFF
--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -53,16 +53,18 @@ def resources_path() -> str:
 
 @pytest.fixture(scope="session")
 def connection(db_parameters):
-    ret = db_parameters
+    _keys = [
+        "user",
+        "password",
+        "host",
+        "port",
+        "database",
+        "account",
+        "protocol",
+        "role",
+    ]
     with snowflake.connector.connect(
-        user=ret.get("user"),
-        password=ret.get("password"),
-        host=ret.get("host"),
-        port=ret.get("port"),
-        database=ret.get("database"),
-        account=ret.get("account"),
-        protocol=ret.get("protocol"),
-        role=ret.get("role"),
+        **{k: db_parameters[k] for k in _keys if k in db_parameters}
     ) as con:
         yield con
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.



2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously, integ/conftest.py fails if some optional fields are not present in the cconnection parameters imported from tests/parameters.py, this change addresses this issue. 
