### PR TITLE
Add statement params to dataframe as a property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added support for `functions.hash()` to accept a variable number of input expressions.
 - Added API `Session.RuntimeConfig` for getting/setting/checking the mutability of any runtime configuration.
 - Added support managing case sensitivity in `Row` results from `DataFrame.collect` using `case_sensitive` parameter.
+- Added the property `DataFrame.statement_params` to allow statement parameters.
 
 ### Bug Fixes
 
@@ -47,7 +48,6 @@ is enabled by default, turn off by specifying `source_code_display=False` at reg
   - `functions.date_format()` for `functions.to_date()`.
   - `functions.monotonically_increasing_id()` for `functions.seq8()`
   - `functions.from_unixtime()` for `functions.to_timestamp()`
-- Added the property `DataFrame.statement_params` to allow statement parameters.
 
 ### Bug Fixes:
 - Fixed a bug in SQL simplifier that didn’t handle Column alias and join well in some cases. See https://github.com/snowflakedb/snowpark-python/issues/658 for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ is enabled by default, turn off by specifying `source_code_display=False` at reg
   - `functions.date_format()` for `functions.to_date()`.
   - `functions.monotonically_increasing_id()` for `functions.seq8()`
   - `functions.from_unixtime()` for `functions.to_timestamp()`
+- Added the property `DataFrame.statement_params` to return statement parameters.
 
 ### Bug Fixes:
 - Fixed a bug in SQL simplifier that didn’t handle Column alias and join well in some cases. See https://github.com/snowflakedb/snowpark-python/issues/658 for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ is enabled by default, turn off by specifying `source_code_display=False` at reg
   - `functions.date_format()` for `functions.to_date()`.
   - `functions.monotonically_increasing_id()` for `functions.seq8()`
   - `functions.from_unixtime()` for `functions.to_timestamp()`
-- Added the property `DataFrame.statement_params` to return statement parameters.
+- Added the property `DataFrame.statement_params` to allow statement parameters.
 
 ### Bug Fixes:
 - Fixed a bug in SQL simplifier that didn’t handle Column alias and join well in some cases. See https://github.com/snowflakedb/snowpark-python/issues/658 for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 - Added support for managing case sensitivity in `Row` results from `DataFrame.collect` using `case_sensitive` parameter.
 - Added indexer support for `snowflake.snowpark.types.StructType`.
 - Added a keyword argument `log_on_exception` to `Dataframe.collect` and `Dataframe.collect_no_wait` to optionally disable error logging for SQL exceptions.
-- Added the property `DataFrame.statement_params` to allow statement parameters.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -521,6 +521,14 @@ class DataFrame:
         self.replace = self._na.replace
 
     @property
+    def statement_params(self) -> Optional[Dict[str, Any]]:
+        return self._statement_params
+
+    @statement_params.setter
+    def query_tag(self, statement_params: Optional[Dict[str, Any]]) -> None:
+        self._statement_params = statement_params
+
+    @property
     def stat(self) -> DataFrameStatFunctions:
         return self._stat
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -521,14 +521,6 @@ class DataFrame:
         self.replace = self._na.replace
 
     @property
-    def statement_params(self) -> Optional[Dict[str, Any]]:
-        return self._statement_params
-
-    @statement_params.setter
-    def statement_params(self, statement_params: Optional[Dict[str, Any]]) -> None:
-        self._statement_params = statement_params
-
-    @property
     def stat(self) -> DataFrameStatFunctions:
         return self._stat
 
@@ -3479,6 +3471,14 @@ Query List:
             for name, field in zip(self.schema.names, self.schema.fields)
         ]
         return dtypes
+
+    @property
+    def statement_params(self) -> Optional[Dict[str, Any]]:
+        return self._statement_params
+
+    @statement_params.setter
+    def statement_params(self, statement_params: Optional[Dict[str, Any]]) -> None:
+        self._statement_params = statement_params
 
     def _with_plan(self, plan):
         return DataFrame(self._session, plan)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3478,14 +3478,6 @@ Query List:
         ]
         return dtypes
 
-    @property
-    def statement_params(self) -> Optional[Dict[str, Any]]:
-        return self._statement_params
-
-    @statement_params.setter
-    def statement_params(self, statement_params: Optional[Dict[str, Any]]) -> None:
-        self._statement_params = statement_params
-
     def _with_plan(self, plan):
         return DataFrame(self._session, plan)
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -502,6 +502,7 @@ class DataFrame:
             plan.expr_to_alias.update(self._plan.expr_to_alias)
         else:
             self._select_statement = None
+        self._statement_params = None
         self.is_cached: bool = is_cached  #: Whether the dataframe is cached.
 
         self._reader: Optional["snowflake.snowpark.DataFrameReader"] = None
@@ -620,7 +621,9 @@ class DataFrame:
             block=block,
             data_type=data_type,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_THREE
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_THREE,
             ),
             log_on_exception=log_on_exception,
             case_sensitive=case_sensitive,
@@ -638,7 +641,9 @@ class DataFrame:
         return self._session._conn.get_result_query_id(
             self._plan,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_THREE
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_THREE,
             ),
         )
 
@@ -684,7 +689,9 @@ class DataFrame:
             block=block,
             data_type=_AsyncResultType.ITERATOR,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_THREE
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_THREE,
             ),
         )
 
@@ -746,7 +753,9 @@ class DataFrame:
             block=block,
             data_type=_AsyncResultType.PANDAS,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_TWO
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
             ),
             **kwargs,
         )
@@ -826,7 +835,9 @@ class DataFrame:
             block=block,
             data_type=_AsyncResultType.PANDAS_BATCH,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_TWO
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
             ),
             **kwargs,
         )
@@ -2702,7 +2713,9 @@ class DataFrame:
                 n,
                 max_width,
                 _statement_params=create_or_update_statement_params_with_query_tag(
-                    statement_params, self._session.query_tag, SKIP_LEVELS_TWO
+                    statement_params if statement_params else self._statement_params,
+                    self._session.query_tag,
+                    SKIP_LEVELS_TWO,
                 ),
             )
         )
@@ -2919,7 +2932,9 @@ class DataFrame:
             formatted_name,
             PersistedView(),
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_TWO
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
             ),
         )
 
@@ -2960,7 +2975,9 @@ class DataFrame:
             formatted_name,
             LocalTempView(),
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_TWO
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
             ),
         )
 
@@ -3306,7 +3323,9 @@ class DataFrame:
         self._session._conn.execute(
             create_temp_table,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params, self._session.query_tag, SKIP_LEVELS_TWO
+                statement_params if statement_params else self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
             ),
         )
         cached_df = self._session.table(temp_table_name)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -525,7 +525,7 @@ class DataFrame:
         return self._statement_params
 
     @statement_params.setter
-    def query_tag(self, statement_params: Optional[Dict[str, Any]]) -> None:
+    def statement_params(self, statement_params: Optional[Dict[str, Any]]) -> None:
         self._statement_params = statement_params
 
     @property

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -623,7 +623,7 @@ class DataFrame:
             block=block,
             data_type=data_type,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_THREE,
             ),
@@ -643,7 +643,7 @@ class DataFrame:
         return self._session._conn.get_result_query_id(
             self._plan,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_THREE,
             ),
@@ -691,7 +691,7 @@ class DataFrame:
             block=block,
             data_type=_AsyncResultType.ITERATOR,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_THREE,
             ),
@@ -755,7 +755,7 @@ class DataFrame:
             block=block,
             data_type=_AsyncResultType.PANDAS,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_TWO,
             ),
@@ -837,7 +837,7 @@ class DataFrame:
             block=block,
             data_type=_AsyncResultType.PANDAS_BATCH,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_TWO,
             ),
@@ -2719,7 +2719,7 @@ class DataFrame:
                 n,
                 max_width,
                 _statement_params=create_or_update_statement_params_with_query_tag(
-                    statement_params if statement_params else self._statement_params,
+                    statement_params or self._statement_params,
                     self._session.query_tag,
                     SKIP_LEVELS_TWO,
                 ),
@@ -2938,7 +2938,7 @@ class DataFrame:
             formatted_name,
             PersistedView(),
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_TWO,
             ),
@@ -2981,7 +2981,7 @@ class DataFrame:
             formatted_name,
             LocalTempView(),
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_TWO,
             ),
@@ -3329,7 +3329,7 @@ class DataFrame:
         self._session._conn.execute(
             create_temp_table,
             _statement_params=create_or_update_statement_params_with_query_tag(
-                statement_params if statement_params else self._statement_params,
+                statement_params or self._statement_params,
                 self._session.query_tag,
                 SKIP_LEVELS_TWO,
             ),


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use dataframe's statement params at query execution if no statement params are specified (eg in `collect`). We need this to track credit consumption from dataframes with snowml contributions. cc: @sfc-gh-pdorairaj 
