### PR TITLE
SNOW-767766: describe() fails for non-ascii identifiers

### DIFF
--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Tuple, Union
 from snowflake.snowpark import functions
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
+    FunctionExpression,
     Literal,
     NamedExpression,
     UnresolvedAttribute,
@@ -44,7 +45,7 @@ def _strip_invalid_sf_identifier_chars(identifier: str) -> str:
 def _alias(expr: Expression) -> NamedExpression:
     if isinstance(expr, UnresolvedAttribute):
         return UnresolvedAlias(expr)
-    elif isinstance(expr, NamedExpression):
+    elif isinstance(expr, NamedExpression) or isinstance(expr, FunctionExpression):
         return expr
     else:
         return Alias(

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2085,6 +2085,29 @@ def test_describe(session):
         ],
     )
 
+    mixed_identifiers_dataframe = session.create_dataframe(
+        data=[
+            [1, Decimal('1.0'), "a", 1, 1, "aa"],
+            [2, Decimal('2.0'), "b", None, 2, "bb"]
+        ],
+        schema=["ほげ", "ふが", "a_ほげ", "ふが_1", "a", "b"]
+    )
+
+    assert mixed_identifiers_dataframe.describe().columns == [
+        'SUMMARY', '"ほげ"', '"ふが"', '"a_ほげ"', '"ふが_1"', 'A', 'B'
+    ]
+
+    Utils.check_answer(
+        mixed_identifiers_dataframe.describe(),
+        [
+            Row("count", 2.0, 2.0, "2", 1.0, 2.0, "2"),
+            Row("mean", 1.5, 1.5, None, 1.0, 1.5, None),
+            Row("stddev", 0.7071067811865476, 0.7071067811865476, None, None, 0.7071067811865476, None),
+            Row("min", 1.0, 1.0, "a", 1.0, 1.0, "aa"),
+            Row("max", 2.0, 2.0, "b", 1.0, 2.0, "bb")
+        ]
+    )
+
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data2(session).describe("c")
     assert "invalid identifier" in str(ex_info)


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-767766

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
  
   The FunctionExpressions generated during describe() API calls in DataFrame are stripped of invalid identifier characters (non-alphanumeric) during query generation.
  
   For tables with quoted identifiers entirely using non-ASCII characters, such as with Japanese characters, this leads to multiple duplicate empty identifiers "COUNT()" which fail to execute with the following error:
  
   ```
   ambiguous column name 'COUNT()'
   ```
  
   This change adds FunctionExpression as an exclusion to the logic that attempts to strip away invalid characters and adds a test case that exercises the describe() API with mixed forms of identifiers.
