### PR TITLE
Set pre-commit default language version to Python3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 exclude: '^(.*egg.info.*|.*/parameters.py|docs/).*$'
+default_language_version:
+    python: python3.8
 repos:
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.1


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   On DevVM, the pre-commit by default uses Python 3.6 to run some hooks but they need Python3.7 or above. 
