### PR TITLE
SNOW-704094  Flatten select after filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for `explode` function in `snowflake.snowpark.functions`.
 - Added parameter `skip_upload_on_content_match` when creating UDF, UDTF and Stored Procedure using `register_from_file` to skip file uploads to stage in case the files are already present on stage.
+- Flattened generated SQL when `DataFrame.filter()` is followed by a projection statement (e.g. `DataFrame.select()`, `DataFrame.with_column()`).
 
 ## 1.3.0 (2023-03-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added support for `explode` function in `snowflake.snowpark.functions`.
 - Added parameter `skip_upload_on_content_match` when creating UDF, UDTF and Stored Procedure using `register_from_file` to skip file uploads to stage in case the files are already present on stage.
-- Flattened generated SQL when `DataFrame.filter()` is followed by a projection statement (e.g. `DataFrame.select()`, `DataFrame.with_column()`).
+- Flattened generated SQL when `DataFrame.filter()` or `DataFrame.order_by()` is followed by a projection statement (e.g. `DataFrame.select()`, `DataFrame.with_column()`).
 
 ## 1.3.0 (2023-03-28)
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -496,10 +496,10 @@ class SelectStatement(Selectable):
             # We don't flatten when there are duplicate columns.
             can_be_flattened = False
             disable_next_level_flatten = True
-        elif self.flatten_disabled or self.order_by:
+        elif self.flatten_disabled:
             can_be_flattened = False
-        elif self.where and not self.snowflake_plan.session.conf.get(
-            "flatten_select_after_filter"
+        elif self.has_clause_using_columns and not self.snowflake_plan.session.conf.get(
+            "flatten_select_after_filter_and_orderby"
         ):
             # TODO: Clean up, this entire if case is parameter protection
             can_be_flattened = False
@@ -508,6 +508,18 @@ class SelectStatement(Selectable):
             in (COLUMN_DEPENDENCY_DOLLAR, COLUMN_DEPENDENCY_ALL)
             or any(
                 new_column_states[_col].change_state == ColumnChangeState.NEW
+                for _col in subquery_dependent_columns.intersection(
+                    new_column_states.active_columns
+                )
+            )
+        ):
+            can_be_flattened = False
+        elif self.order_by and (
+            (subquery_dependent_columns := derive_dependent_columns(*self.order_by))
+            in (COLUMN_DEPENDENCY_DOLLAR, COLUMN_DEPENDENCY_ALL)
+            or any(
+                new_column_states[_col].change_state
+                in (ColumnChangeState.CHANGED_EXP, ColumnChangeState.NEW)
                 for _col in subquery_dependent_columns.intersection(
                     new_column_states.active_columns
                 )

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -206,7 +206,7 @@ class Session:
             self._session = session
             self._conf = {
                 "use_constant_subquery_alias": True,
-                "flatten_select_after_filter": True,
+                "flatten_select_after_filter_and_orderby": True,
             }  # For config that's temporary/to be removed soon
             for key, val in conf.items():
                 if self.is_mutable(key):

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -205,7 +205,8 @@ class Session:
         def __init__(self, session: "Session", conf: Dict[str, Any]) -> None:
             self._session = session
             self._conf = {
-                "use_constant_subquery_alias": True
+                "use_constant_subquery_alias": True,
+                "flatten_select_after_filter": True,
             }  # For config that's temporary/to be removed soon
             for key, val in conf.items():
                 if self.is_mutable(key):

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -1051,7 +1051,7 @@ def test_chained_sort(session):
             .filter(col("A") > 2),
             'SELECT "A", "B", 12 :: INT AS "TWELVE" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) WHERE (("A" > 1 :: INT) AND ("A" > 2 :: INT))',
         ),
-        # Not flattened, since col("A") > 1 and col("A") > 2 are referring to different columns
+        # Not fully flattened, since col("A") > 1 and col("A") > 2 are referring to different columns
         (
             lambda df: df.filter(col("A") > 1)
             .select((col("B") + 1).alias("A"))

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -7,6 +7,7 @@ from typing import Tuple
 import pytest
 
 from snowflake.snowpark import Row
+from snowflake.snowpark._internal.analyzer.expression import Literal
 from snowflake.snowpark._internal.analyzer.select_statement import (
     SET_EXCEPT,
     SET_INTERSECT,
@@ -691,7 +692,7 @@ def test_filter(session, simplifier_table):
     df5 = df4.select("a")
     assert (
         df5.queries["queries"][-1]
-        == f'SELECT "A" FROM ( SELECT  *  FROM ( SELECT ("A" + 1 :: INT) AS "A", ("B" + 1 :: INT) AS "B" FROM {simplifier_table}) WHERE (("A" > 1 :: INT) AND ("B" > 2 :: INT)))'
+        == f'SELECT "A" FROM ( SELECT ("A" + 1 :: INT) AS "A", ("B" + 1 :: INT) AS "B" FROM {simplifier_table}) WHERE (("A" > 1 :: INT) AND ("B" > 2 :: INT))'
     )
 
     # subquery has sql text so unable to figure out same-level dependency, so assuming d depends on c. No flatten.
@@ -1028,3 +1029,48 @@ def test_chained_sort(session):
         df2.sort("a").sort("b").queries["queries"][0]
         == df2.sort("b", "a").queries["queries"][0]
     )
+
+
+@pytest.mark.parametrize(
+    "operation,simplified_query",
+    [
+        # Flattened
+        (
+            lambda df: df.filter(col("A") > 1).select(col("B") + 1),
+            'SELECT ("B" + 1 :: INT) FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) WHERE ("A" > 1 :: INT)',
+        ),
+        # Flattened, if there are duplicate column names across the parent/child, WHERE is evaluated on subquery first, so we could flatten in this case
+        (
+            lambda df: df.filter(col("A") > 1).select((col("B") + 1).alias("A")),
+            'SELECT ("B" + 1 :: INT) AS "A" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) WHERE ("A" > 1 :: INT)',
+        ),
+        # Flattened
+        (
+            lambda df: df.filter(col("A") > 1)
+            .select(col("A"), col("B"), col(Literal(12)).alias("TWELVE"))
+            .filter(col("A") > 2),
+            'SELECT "A", "B", 12 :: INT AS "TWELVE" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) WHERE (("A" > 1 :: INT) AND ("A" > 2 :: INT))',
+        ),
+        # Not flattened, since col("A") > 1 and col("A") > 2 are referring to different columns
+        (
+            lambda df: df.filter(col("A") > 1)
+            .select((col("B") + 1).alias("A"))
+            .filter(col("A") > 2),
+            'SELECT  *  FROM ( SELECT ("B" + 1 :: INT) AS "A" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) WHERE ("A" > 1 :: INT)) WHERE ("A" > 2 :: INT)',
+        ),
+        # Not flattened, since we cannot detect dependent columns from sql_expr
+        (
+            lambda df: df.filter(sql_expr("A > 1")).select(col("B"), col("A")),
+            'SELECT "B", "A" FROM ( SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) WHERE A > 1)',
+        ),
+    ],
+)
+def test_select_after_filter(session, operation, simplified_query):
+    session.sql_simplifier_enabled = False
+    df1 = session.create_dataframe([[1, -2], [3, -4]], schema=["a", "b"])
+
+    session.sql_simplifier_enabled = True
+    df2 = session.create_dataframe([[1, -2], [3, -4]], schema=["a", "b"])
+
+    Utils.check_answer(operation(df1), operation(df2))
+    assert operation(df2).queries["queries"][0] == simplified_query

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -731,7 +731,7 @@ def test_filter_order_limit_together(session, simplifier_table):
     df2 = df1.select("a")
     assert (
         df2.queries["queries"][-1]
-        == f'SELECT "A" FROM ( SELECT "A", "B" FROM {simplifier_table} WHERE ("B" > 1 :: INT) ORDER BY "A" ASC NULLS FIRST LIMIT 5)'
+        == f'SELECT "A" FROM {simplifier_table} WHERE ("B" > 1 :: INT) ORDER BY "A" ASC NULLS FIRST LIMIT 5'
     )
 
 
@@ -1074,3 +1074,53 @@ def test_select_after_filter(session, operation, simplified_query):
 
     Utils.check_answer(operation(df1), operation(df2))
     assert operation(df2).queries["queries"][0] == simplified_query
+
+
+@pytest.mark.parametrize(
+    "operation,simplified_query,execute_sql",
+    [
+        # Flattened
+        (
+            lambda df: df.order_by(col("A")).select(col("B") + 1),
+            'SELECT ("B" + 1 :: INT) FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) ORDER BY "A" ASC NULLS FIRST',
+            True,
+        ),
+        # Not flattened, unlike filter, current query takes precendence when there are duplicate column names from a ORDERBY clause
+        (
+            lambda df: df.order_by(col("A")).select((col("B") + 1).alias("A")),
+            'SELECT ("B" + 1 :: INT) AS "A" FROM ( SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) ORDER BY "A" ASC NULLS FIRST)',
+            True,
+        ),
+        # Not flattened, since we cannot detect dependent columns from sql_expr
+        (
+            lambda df: df.order_by(sql_expr("A")).select(col("B")),
+            'SELECT "B" FROM ( SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) ORDER BY A ASC NULLS FIRST)',
+            True,
+        ),
+        # Not flattened, skip execution since this would result in SnowparkSQLException
+        (
+            lambda df: df.order_by(col("C")).select((col("A") + col("B")).alias("C")),
+            'SELECT ("A" + "B") AS "C" FROM ( SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) ORDER BY "C" ASC NULLS FIRST)',
+            False,
+        ),
+        # Flattened
+        (
+            lambda df: df.order_by(col("A"))
+            .select(col("B"), col("A"))
+            .order_by(col("B"))
+            .select(col("A")),
+            'SELECT "A" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, -2 :: INT), (3 :: INT, -4 :: INT)) ORDER BY "B" ASC NULLS FIRST, "A" ASC NULLS FIRST',
+            True,
+        ),
+    ],
+)
+def test_select_after_orderby(session, operation, simplified_query, execute_sql):
+    session.sql_simplifier_enabled = False
+    df1 = session.create_dataframe([[1, -2], [3, -4]], schema=["a", "b"])
+
+    session.sql_simplifier_enabled = True
+    df2 = session.create_dataframe([[1, -2], [3, -4]], schema=["a", "b"])
+
+    assert operation(df2).queries["queries"][0] == simplified_query
+    if execute_sql:
+        Utils.check_answer(operation(df1), operation(df2))


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-704094

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The code change checks if the subquery's where clause depends on a column that is NEW in the current query, if it does not, flatten the query. Note that, WHERE is evaluated on the subquery first, so it is safe to flatten when there are columns that are CHANGED between the current query and the subquery.
