### PR TITLE
SNOW-738785: Add TaskContext for Task API

### DIFF
--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -5,9 +5,26 @@ Context module for Snowpark.
 
 .. currentmodule:: snowflake.snowpark.context
 
+.. rubric:: Classes
+
+.. autosummary::
+    :toctree: api/
+
+        TaskContext
+
+.. rubric:: Functions
 
 .. autosummary::
     :toctree: api/
 
         get_active_session
+
+.. rubric:: Methods
+
+.. autosummary::
+    :toctree: api/
+
+        TaskContext.set_return_value
+        TaskContext.get_predecessor_return_value
+        TaskContext.get_current_task_name
 

--- a/src/snowflake/snowpark/context.py
+++ b/src/snowflake/snowpark/context.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import single_quote
-from snowflake.snowpark._internal.utils import validate_object_name
+from snowflake.snowpark._internal.utils import private_preview, validate_object_name
 
 _use_scoped_temp_objects = True
 
@@ -38,6 +38,7 @@ class TaskContext:
         """
         self._session = session
 
+    @private_preview(version="1.4.0")
     def set_return_value(self, value: Any) -> None:
         """
         Explicitly sets the return value for a task. This value can be retrieved
@@ -52,6 +53,7 @@ class TaskContext:
         """
         self._session.call("system$set_return_value", str(value))
 
+    @private_preview(version="1.4.0")
     def get_predecessor_return_value(self, task_name: Optional[str] = None) -> str:
         """
         Retrieves the return value for the predecessor task in a DAG of tasks.
@@ -75,6 +77,7 @@ class TaskContext:
         else:
             return self._session.call("system$get_predecessor_return_value")
 
+    @private_preview(version="1.4.0")
     def get_current_task_name(self) -> str:
         """
         Returns the name of the task currently executing.

--- a/src/snowflake/snowpark/context.py
+++ b/src/snowflake/snowpark/context.py
@@ -4,7 +4,11 @@
 #
 
 """Context module for Snowpark."""
+from typing import Any, Optional
+
 import snowflake.snowpark
+from snowflake.snowpark._internal.analyzer.analyzer_utils import single_quote
+from snowflake.snowpark._internal.utils import validate_object_name
 
 _use_scoped_temp_objects = True
 
@@ -18,3 +22,62 @@ def get_active_session() -> "snowflake.snowpark.Session":
         A :class:`Session` object for the current session.
     """
     return snowflake.snowpark.session._get_active_session()
+
+
+class TaskContext:
+    """
+    Represents the context in a `Snowflake Task <https://docs.snowflake.com/en/user-guide/tasks-intro>`_.
+    """
+
+    def __init__(self, session: "snowflake.snowpark.Session") -> None:
+        """
+        Initializes a :class:`TaskContext` object.
+
+        Args:
+            session: A Snowpark session
+        """
+        self._session = session
+
+    def set_return_value(self, value: Any) -> None:
+        """
+        Explicitly sets the return value for a task. This value can be retrieved
+        in a child task using :meth:`get_predecessor_return_value`.
+        This method can only be called in a Snowflake task.
+
+        See `SYSTEM$SET_RETURN_VALUE <https://docs.snowflake.com/en/sql-reference/functions/system_set_return_value>`_ for details.
+
+        Args:
+            value: The return value for a task. It will be converted to a ``str``
+                when the underlying SQL system function is called.
+        """
+        self._session.call("system$set_return_value", str(value))
+
+    def get_predecessor_return_value(self, task_name: Optional[str] = None) -> str:
+        """
+        Retrieves the return value for the predecessor task in a DAG of tasks.
+        The return value is explicitly set by the predecessor task using :meth:`set_return_value`.
+        This method can only be called in a Snowflake task.
+
+        See `SYSTEM$GET_PREDECESSOR_RETURN_VALUE <https://docs.snowflake.com/en/sql-reference/functions/system_get_predecessor_return_value>`_ for details.
+
+        Args:
+            task_name: The task name of the predecessor task that sets the return value to be retrieved.
+
+                - If the task has only one predecessor task that is enabled, the argument is optional.
+                  If this argument is omitted, the function retrieves the return value for the only enabled predecessor task.
+                - If the task has multiple predecessor tasks that are enabled, this argument is required.
+        """
+        if task_name:
+            validate_object_name(task_name)
+            return self._session.call(
+                "system$get_predecessor_return_value", single_quote(task_name)
+            )
+        else:
+            return self._session.call("system$get_predecessor_return_value")
+
+    def get_current_task_name(self) -> str:
+        """
+        Returns the name of the task currently executing.
+        This method can only be called in a Snowflake task.
+        """
+        return str(self._session.call("system$current_user_task_name"))

--- a/tests/integ/test_context.py
+++ b/tests/integ/test_context.py
@@ -2,9 +2,31 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
+import pytest
 
-from snowflake.snowpark.context import get_active_session
+from snowflake.snowpark.context import TaskContext, get_active_session
+from snowflake.snowpark.exceptions import (
+    SnowparkInvalidObjectNameException,
+    SnowparkSQLException,
+)
 
 
 def test_get_active_session(session):
     assert session == get_active_session()
+
+
+def test_task_context(session):
+    # we are not able to test it in a real task, so just call functions here
+    task_context = TaskContext(session)
+
+    with pytest.raises(SnowparkSQLException, match="must be called from within a task"):
+        task_context.set_return_value("1")
+
+    with pytest.raises(SnowparkSQLException, match="must be called from within a task"):
+        task_context.get_predecessor_return_value()
+
+    with pytest.raises(SnowparkInvalidObjectNameException):
+        task_context.get_predecessor_return_value("invalid name")
+
+    # this function can actually be called outside of a task...
+    assert not task_context.get_current_task_name()


### PR DESCRIPTION
This class is needed for Task API prpr. Once Task API is public, we will move this class there. For now, this class is not supposed to be used by Snowpark users directly (so no changelog is needed). If you're interested in the design and usage of this class, take a look at this [doc](https://docs.google.com/document/d/1XN3yUCeBbxYVc2aDEHxHWbvFJNV9jfERK_FTlfkBArQ/edit?usp=sharing).