### PR TITLE
SNOW-763159 Fix is_sql_select_statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bug Fixes
 
 - Fixed a bug with `strtok_to_array` when a delimiter was passed it was throwing an exception
+- Fixed a bug where anonymous procedures were identified as select statement
 
 ## 1.3.0 (2023-03-28)
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -85,6 +85,11 @@ SNOWFLAKE_SELECT_SQL_PREFIX_PATTERN = re.compile(
     r"^(\s|\()*(select|with)", re.IGNORECASE
 )
 
+# Anonymous stored procedures: https://docs.snowflake.com/en/sql-reference/sql/call-with
+SNOWFLAKE_ANONYMOUS_CALL_WITH_PATTERN = re.compile(
+    r"^\s*with\s+\w+\s+as\s+procedure", re.IGNORECASE
+)
+
 # A set of widely-used packages,
 # whose names in pypi are different from their package name
 PACKAGE_NAME_TO_MODULE_NAME_MAP = {
@@ -224,7 +229,10 @@ def unwrap_single_quote(name: str) -> str:
 
 
 def is_sql_select_statement(sql: str) -> bool:
-    return SNOWFLAKE_SELECT_SQL_PREFIX_PATTERN.match(sql) is not None
+    return (
+        SNOWFLAKE_SELECT_SQL_PREFIX_PATTERN.match(sql) is not None
+        and SNOWFLAKE_ANONYMOUS_CALL_WITH_PATTERN.match(sql) is None
+    )
 
 
 def normalize_path(path: str, is_local: bool) -> str:

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -451,6 +451,12 @@ def test_is_sql_select_statement():
         "SeLeCt 1",
         "WITH t as (select 1) select * from t",
         "WiTh t as (select 1) select * from t",
+        """WITH t AS (
+            SELECT '
+            with anon_sproc as procedure
+            ' as col1
+           ) select col1 from t
+        """
     ]
     for s in select_sqls:
         assert is_sql_select_statement(s)

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -463,6 +463,8 @@ def test_is_sql_select_statement():
         "show tables",
         "lkdfadsk select",
         "ljkfdshdf with",
+        "with anon_sproc0 as procedure ",
+        "  with anon_sproc1 AS  PROCEDURE ",
     ]
     for ns in non_select_sqls:
         assert is_sql_select_statement(ns) is False


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-763159

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `is_sql_select_statement` identifies any SQL query which starts with `select` or `with` as a `SELECT` SQL statement. This is fine in most cases but it mis-identifies anonymous sprocs which have a pattern `with <proc_name> as procedure ...`.