### PR TITLE
Fix UDF value error message when number of arguments and number of parameters mismatch

### DIFF
--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -100,7 +100,7 @@ class UserDefinedFunction:
         if len(exprs) != len(self._input_types):
             raise ValueError(
                 f"Incorrect number of arguments passed to the UDF:"
-                f" Expected: {len(exprs)}, Found: {len(self._input_types)}"
+                f" Expected: {len(self._input_types)}, Found: {len(exprs)}"
             )
         return SnowflakeUDF(
             self.name,

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -282,16 +282,6 @@ def test_udf_function_with_multiple_columns(session):
     )
 
 
-def test_incorrect_number_of_args(session):
-    df = session.table(table2)
-    string_udf = udf(
-        lambda x: f"Hello{x}", return_type=StringType(), input_types=[IntegerType()]
-    )
-    with pytest.raises(ValueError) as ex_info:
-        assert df.with_column("c", string_udf("a", "b"))
-    assert "Incorrect number of arguments passed to the UDF" in str(ex_info)
-
-
 def test_call_udf_api(session):
     df = session.table(table1)
     function_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -887,7 +887,10 @@ def test_udf_negative(session):
     udf1 = udf(f, return_type=IntegerType(), input_types=[IntegerType()])
     with pytest.raises(ValueError) as ex_info:
         udf1("a", "")
-    assert "Incorrect number of arguments passed to the UDF" in str(ex_info)
+    assert (
+        "Incorrect number of arguments passed to the UDF: Expected: 1, Found: 2"
+        in str(ex_info)
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         session.sql("select f(1)").collect()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The current code swaps the two expressions. Reference: [scala API](https://github.com/snowflakedb/snowpark-java-scala/blob/6bc35743456bf384a643b7ab32dac97ee011c41f/src/main/scala/com/snowflake/snowpark/UserDefinedFunction.scala#L44-L44). This PR fixes that and removes duplicate tests.

