### PR TITLE
SNOW-796550: Use lit() instead of sql_expr() in functions

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -990,7 +990,7 @@ def approx_percentile(col: ColumnOrName, percentile: float) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(col, "approx_percentile")
-    return builtin("approx_percentile")(c, sql_expr(str(percentile)))
+    return builtin("approx_percentile")(c, lit(percentile))
 
 
 def approx_percentile_accumulate(col: ColumnOrName) -> Column:
@@ -1043,7 +1043,7 @@ def approx_percentile_estimate(state: ColumnOrName, percentile: float) -> Column
         <BLANKLINE>
     """
     c = _to_col_if_str(state, "approx_percentile_estimate")
-    return builtin("approx_percentile_estimate")(c, sql_expr(str(percentile)))
+    return builtin("approx_percentile_estimate")(c, lit(percentile))
 
 
 def approx_percentile_combine(state: ColumnOrName) -> Column:
@@ -1146,7 +1146,7 @@ def explode(col: ColumnOrName) -> TableFunctionCall:
         --------------------------------
         <BLANKLINE>
     """
-    func_call =  _ExplodeFunctionCall(col)
+    func_call = _ExplodeFunctionCall(col)
     func_call._set_api_call_source("functions.explode")
     return func_call
 
@@ -1402,7 +1402,7 @@ def to_decimal(e: ColumnOrName, precision: int, scale: int) -> Column:
         [Row(ANS=Decimal('12.00')), Row(ANS=Decimal('11.30')), Row(ANS=Decimal('-90.12'))]
     """
     c = _to_col_if_str(e, "to_decimal")
-    return builtin("to_decimal")(c, sql_expr(str(precision)), sql_expr(str(scale)))
+    return builtin("to_decimal")(c, lit(precision), lit(scale))
 
 
 def div0(
@@ -4987,9 +4987,9 @@ def _as_decimal_or_number(
     if scale and not precision:
         raise ValueError("Cannot define scale without precision")
     if precision and scale:
-        return builtin(cast_type)(c, sql_expr(str(precision)), sql_expr(str(scale)))
+        return builtin(cast_type)(c, lit(precision), lit(scale))
     elif precision:
-        return builtin(cast_type)(c, sql_expr(str(precision)))
+        return builtin(cast_type)(c, lit(precision))
     else:
         return builtin(cast_type)(c)
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-796550. Using lit() is better than sql_expr() so sql simplifier can flatten SQLs when related functions(approx_percentile, to_decimal, etc) are used. Local testing doesn't work with sql_expr() but does for lit().

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
Change sql_expr() to lit() whenever lit() can be used.
   