### PR TITLE
[SNOW-743111] Add substring_index support under sqlfunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Flattened generated SQL when `DataFrame.filter()` or `DataFrame.order_by()` is followed by a projection statement (e.g. `DataFrame.select()`, `DataFrame.with_column()`).
 - Added support for creating Dynamic Tables `(in Private Preview)` using `Dataframe.create_or_replace_dynamic_table`
 - Added an optional argument `params` in `session.sql()` to support binding variables. Note that this is not supported in stored procedure yet.
+- Added support for `functions.substring_index`, which is the same as pyspark substring_index
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Flattened generated SQL when `DataFrame.filter()` or `DataFrame.order_by()` is followed by a projection statement (e.g. `DataFrame.select()`, `DataFrame.with_column()`).
 - Added support for creating Dynamic Tables `(in Private Preview)` using `Dataframe.create_or_replace_dynamic_table`
 - Added an optional argument `params` in `session.sql()` to support binding variables. Note that this is not supported in stored procedure yet.
-- Added support for `functions.substring_index`, which is the same as pyspark substring_index
+- Added support for `functions.substring_index`
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2329,7 +2329,7 @@ def substring_index(
     return builtin("array_to_string")(
         builtin("array_slice")(
             strtok_array,
-            0 if count >= 0 else builtin("array_size")(strtok_array) - (-count),
+            0 if count >= 0 else builtin("array_size")(strtok_array) + count,
             count if count >= 0 else builtin("array_size")(strtok_array),
         ),
         delim,

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2294,8 +2294,8 @@ def substring_index(
 ) -> Column:
     """
     Returns the substring from string ``text`` before ``count`` occurrences of the delimiter ``delim``.
-    If ``count`` is positive, everything the left of the final delimiter (counting from left) is
-    returned. If ``count`` is negative, every to the right of the final delimiter (counting from the
+    If ``count`` is positive, everything to the left of the final delimiter (counting from left) is
+    returned. If ``count`` is negative, everything to the right of the final delimiter (counting from the
     right) is returned. If ``count`` is zero, returns empty string.
 
     Example 1::

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2289,12 +2289,12 @@ def substring(
     return builtin("substring")(s, p, length)
 
 
-def substring_index(str: ColumnOrName, delim: str, count: int) -> Column:
+def substring_index(text: ColumnOrName, delim: str, count: int) -> Column:
     """
-    Returns the substring from string str before count occurrences of the delimiter delim.
-    If count is positive, everything the left of the final delimiter (counting from left) is
-    returned. If count is negative, every to the right of the final delimiter (counting from the
-    right) is returned. If count is zero, returns empty string.
+    Returns the substring from string ``text`` before ``count`` occurrences of the delimiter ``delim``.
+    If ``count`` is positive, everything the left of the final delimiter (counting from left) is
+    returned. If ``count`` is negative, every to the right of the final delimiter (counting from the
+    right) is returned. If ``count`` is zero, returns empty string.
 
     Example::
         >>> df = session.create_dataframe(
@@ -2309,7 +2309,7 @@ def substring_index(str: ColumnOrName, delim: str, count: int) -> Column:
         ------------
         <BLANKLINE>
     """
-    s = _to_col_if_str(str, "substring_index")
+    s = _to_col_if_str(text, "substring_index")
     strtok_array = builtin("strtok_to_array")(s, delim)
     return builtin("array_to_string")(
         builtin("array_slice")(

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2289,18 +2289,33 @@ def substring(
     return builtin("substring")(s, p, length)
 
 
-def substring_index(text: ColumnOrName, delim: str, count: int) -> Column:
+def substring_index(
+    text: ColumnOrName, delim: ColumnOrLiteralStr, count: int
+) -> Column:
     """
     Returns the substring from string ``text`` before ``count`` occurrences of the delimiter ``delim``.
     If ``count`` is positive, everything the left of the final delimiter (counting from left) is
     returned. If ``count`` is negative, every to the right of the final delimiter (counting from the
     right) is returned. If ``count`` is zero, returns empty string.
 
-    Example::
+    Example 1::
         >>> df = session.create_dataframe(
         ...     ["a.b.c.d"],
         ...     schema=["S"],
         ... ).select(substring_index(col("S"), ".", 2).alias("result"))
+        >>> df.show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |a.b       |
+        ------------
+        <BLANKLINE>
+
+    Example 2::
+        >>> df = session.create_dataframe(
+        ...     [["a.b.c.d", "."]],
+        ...     schema=["S", "delimiter"],
+        ... ).select(substring_index(col("S"), col("delimiter"), 2).alias("result"))
         >>> df.show()
         ------------
         |"RESULT"  |

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -2289,6 +2289,38 @@ def substring(
     return builtin("substring")(s, p, length)
 
 
+def substring_index(str: ColumnOrName, delim: str, count: int) -> Column:
+    """
+    Returns the substring from string str before count occurrences of the delimiter delim.
+    If count is positive, everything the left of the final delimiter (counting from left) is
+    returned. If count is negative, every to the right of the final delimiter (counting from the
+    right) is returned. If count is zero, returns empty string.
+
+    Example::
+        >>> df = session.create_dataframe(
+        ...     ["a.b.c.d"],
+        ...     schema=["S"],
+        ... ).select(substring_index(col("S"), ".", 2).alias("result"))
+        >>> df.show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |a.b       |
+        ------------
+        <BLANKLINE>
+    """
+    s = _to_col_if_str(str, "substring_index")
+    strtok_array = builtin("strtok_to_array")(s, delim)
+    return builtin("array_to_string")(
+        builtin("array_slice")(
+            strtok_array,
+            0 if count >= 0 else builtin("array_size")(strtok_array) - (-count),
+            count if count >= 0 else builtin("array_size")(strtok_array),
+        ),
+        delim,
+    )
+
+
 def regexp_count(
     subject: ColumnOrName,
     pattern: ColumnOrLiteralStr,

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -525,22 +525,34 @@ def test_basic_string_operations(session):
 
 
 def test_substring_index(session):
-    df = session.create_dataframe(["a.b.c.d", "", None], ["s"])
+    """test calling substring_index with delimiter as string"""
+    df = session.create_dataframe([[0, "a.b.c.d"], [1, ""], [2, None]], ["id", "s"])
     # substring_index when count is positive
-    respos = df.select(substring_index("s", ".", 2)).collect()
+    respos = df.select(substring_index("s", ".", 2), "id").order_by("id").collect()
     assert respos[0][0] == "a.b"
     assert respos[1][0] == ""
     assert respos[2][0] is None
     # substring_index when count is negative
-    resneg = df.select(substring_index("s", ".", -3)).collect()
+    resneg = df.select(substring_index("s", ".", -3), "id").order_by("id").collect()
     assert resneg[0][0] == "b.c.d"
     assert respos[1][0] == ""
     assert respos[2][0] is None
     # substring_index when count is 0, result should be empty string
-    reszero = df.select(substring_index("s", ".", 0)).collect()
+    reszero = df.select(substring_index("s", ".", 0), "id").order_by("id").collect()
     assert reszero[0][0] == ""
     assert respos[1][0] == ""
     assert respos[2][0] is None
+
+
+def test_substring_index_col(session):
+    """test calling substring_index with delimiter as column"""
+    df = session.create_dataframe([["a,b,c,d", ","]], ["s", "delimiter"])
+    res = df.select(substring_index(col("s"), df["delimiter"], 2)).collect()
+    assert res[0][0] == "a,b"
+    res = df.select(substring_index(col("s"), col("delimiter"), 3)).collect()
+    assert res[0][0] == "a,b,c"
+    reslit = df.select(substring_index("s", lit(","), -3)).collect()
+    assert reslit[0][0] == "b,c,d"
 
 
 def test_bitshiftright(session):

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -525,16 +525,22 @@ def test_basic_string_operations(session):
 
 
 def test_substring_index(session):
-    df = session.create_dataframe(["a.b.c.d"], ["s"])
+    df = session.create_dataframe(["a.b.c.d", "", None], ["s"])
     # substring_index when count is positive
     respos = df.select(substring_index("s", ".", 2)).collect()
     assert respos[0][0] == "a.b"
+    assert respos[1][0] == ""
+    assert respos[2][0] is None
     # substring_index when count is negative
     resneg = df.select(substring_index("s", ".", -3)).collect()
     assert resneg[0][0] == "b.c.d"
+    assert respos[1][0] == ""
+    assert respos[2][0] is None
     # substring_index when count is 0, result should be empty string
     reszero = df.select(substring_index("s", ".", 0)).collect()
     assert reszero[0][0] == ""
+    assert respos[1][0] == ""
+    assert respos[2][0] is None
 
 
 def test_bitshiftright(session):

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -121,6 +121,7 @@ from snowflake.snowpark.functions import (
     strtok_to_array,
     struct,
     substring,
+    substring_index,
     to_array,
     to_binary,
     to_char,
@@ -521,6 +522,19 @@ def test_basic_string_operations(session):
     with pytest.raises(TypeError) as ex_info:
         df.select(reverse([1])).collect()
     assert "'REVERSE' expected Column or str, got: <class 'list'>" in str(ex_info)
+
+
+def test_substring_index(session):
+    df = session.create_dataframe(["a.b.c.d"], ["s"])
+    # substring_index when count is positive
+    respos = df.select(substring_index("s", ".", 2)).collect()
+    assert respos[0][0] == "a.b"
+    # substring_index when count is negative
+    resneg = df.select(substring_index("s", ".", -3)).collect()
+    assert resneg[0][0] == "b.c.d"
+    # substring_index when count is 0, result should be empty string
+    reszero = df.select(substring_index("s", ".", 0)).collect()
+    assert reszero[0][0] == ""
 
 
 def test_bitshiftright(session):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
Add function substring_index(str, delim, count) in module snowflake.snowpark.functions. This function returns the substring from string str before count occurrences of the delimiter delim. If count is positive, everything the left of the final delimiter (counting from left) is returned. If count is negative, every to the right of the final delimiter (counting from the right) is returned.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
Providing the functionality with the following generated SQL
```
   array_to_string(array_slice(
            strtok_to_array(s, delim),
            0 if count >= 0 else array_size(strtok_to_array(s, delim)) - (-count),
            count if count >= 0 else array_size(strtok_to_array(s, delim)),
        ),
        delim,
    )
```
