### PR TITLE
SNOW-791242 Use multistatement query for async multi-query plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.6.0 (TBD)
+
+### New Features
+
+- Added support for async execution of multi-query dataframe containing binding variables.
+
+### Dependency updates
+
+- Updated ``snowflake-connector-python`` to 3.0.4.
+
 ## 1.5.1 (2023-06-20)
 
 ### New Features

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
-CONNECTOR_DEPENDENCY_VERSION = ">=2.7.12, <4.0.0"
+CONNECTOR_DEPENDENCY_VERSION = ">=3.0.4, <4.0.0"
 REQUIRED_PYTHON_VERSION = ">=3.8, <3.11"
 if os.getenv("SNOWFLAKE_IS_PYTHON_RUNTIME_TEST", False):
     REQUIRED_PYTHON_VERSION = ">=3.8"

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -182,6 +182,7 @@ class AsyncJob:
         post_actions: Optional[List[Query]] = None,
         log_on_exception: bool = False,
         case_sensitive: bool = True,
+        num_statements: Optional[int] = None,
         **kwargs,
     ) -> None:
         self.query_id: str = query_id  #: The query ID of the executed query
@@ -193,6 +194,7 @@ class AsyncJob:
         self._post_actions = post_actions if post_actions else []
         self._log_on_exception = log_on_exception
         self._case_sensitive = case_sensitive
+        self._num_statements = num_statements
         self._parameters = kwargs
         self._result_meta = None
         self._inserted = False
@@ -331,6 +333,15 @@ class AsyncJob:
             _AsyncResultType(result_type.lower()) if result_type else self._result_type
         )
         self._cursor.get_results_from_sfqid(self.query_id)
+        if self._num_statements is not None:
+            for _ in range(self._num_statements - 1):
+                self._cursor.nextset()
+            # TODO: Once we support fetch_pandas_all for multi-statement query in connector, we could remove this
+            #   workaround.
+            self._cursor.execute(
+                f"select * from table(result_scan('{self._cursor.sfqid}'))"
+            )
+
         if result_type == _AsyncResultType.NO_RESULT:
             result = None
         elif result_type == _AsyncResultType.PANDAS:

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -285,6 +285,9 @@ def test_multiple_queries(session, resources_path):
     Utils.check_answer(async_job.result(), df)
 
     Utils.check_answer(session.create_dataframe(df.to_pandas(block=False).result()), df)
+    Utils.check_answer(
+        session.create_dataframe(next(df.to_pandas_batches(block=False).result())), df
+    )
 
     # make sure temp object is dropped
     temp_object = async_job._post_actions[0].sql.split(" ")[-1]

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -284,6 +284,8 @@ def test_multiple_queries(session, resources_path):
     async_job = df.collect_nowait()
     Utils.check_answer(async_job.result(), df)
 
+    Utils.check_answer(session.create_dataframe(df.to_pandas(block=False).result()), df)
+
     # make sure temp object is dropped
     temp_object = async_job._post_actions[0].sql.split(" ")[-1]
     with pytest.raises(SnowparkSQLException, match="does not exist or not authorized"):

--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -4,6 +4,7 @@
 #
 
 import datetime
+import os.path
 
 import pytest
 
@@ -79,13 +80,12 @@ def test_async(session, resources_path):
         session, "@" + stage_name, test_files.test_file_csv, compress=False
     )
     df_read = session.read.schema(user_schema).csv(
-        f"@{stage_name}/{test_files.test_file_csv}"
+        f"@{stage_name}/{os.path.basename(test_files.test_file_csv)}"
     )
-    with pytest.raises(
-        NotImplementedError,
-        match="Async multi-query dataframe using bind variable is not supported yet",
-    ):
-        df.join(df_read, on="a").collect_nowait().result()
+    Utils.check_answer(
+        df.join(df_read, on="a").collect_nowait().result(),
+        [Row(1, "a", "one", 1.2), Row(2, "b", "two", 2.2)],
+    )
 
 
 def test_to_local_iterator(session):


### PR DESCRIPTION
Description

Currently we use SQL stored proc for multi-query plan during async collect. This is not binding friendly, so we want to migrate to use multistatement that we already support in the connector.

Testing

integ test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
