### PR TITLE
Add LiteralType to type hint of DataFrame.replace

### DIFF
--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -383,7 +383,7 @@ class DataFrameNaFunctions:
             Iterable[LiteralType],
             Dict[LiteralType, LiteralType],
         ],
-        value: Optional[Iterable[LiteralType]] = None,
+        value: Optional[Union[LiteralType, Iterable[LiteralType]]] = None,
         subset: Optional[Iterable[str]] = None,
     ) -> "snowflake.snowpark.dataframe.DataFrame":
         """


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The current type hint only suggests a list of values whereas `replace` can also take a scalar value.
