### PR TITLE
SNOW-767996 Run full test suites on python3.9/3.10

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -115,9 +115,19 @@ jobs:
           PYTEST_ADDOPTS: --color=yes --tb=short
           TOX_PARALLEL_NO_SPINNER: 1
         shell: bash
-      - if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
-        name: Run tests (excluding udf and doctest tests)
-        run: python -m tox -e "py${PYTHON_VERSION/\./}-notudfdoctest"
+      - if: ${{ (matrix.python-version == '3.9' || matrix.python-version == '3.10') && contains('macos', matrix.os.download_name) }}
+        name: Run tests (including doctest tests)
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-udf"
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          cloud_provider: ${{ matrix.cloud-provider }}
+          PYTEST_ADDOPTS: --color=yes --tb=short
+          TOX_PARALLEL_NO_SPINNER: 1
+          SNOWFLAKE_IS_PYTHON_RUNTIME_TEST: 1
+        shell: bash
+      - if: ${{ (matrix.python-version == '3.9' || matrix.python-version == '3.10') && false == contains('macos', matrix.os.download_name) }}
+        name: Run tests (excluding doctest tests)
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-notdoctest"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
@@ -234,9 +244,19 @@ jobs:
           PYTEST_ADDOPTS: --color=yes --tb=short
           TOX_PARALLEL_NO_SPINNER: 1
         shell: bash
-      - if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
-        name: Run tests ((excluding udf and doctest tests))
-        run: python -m tox -e "py${PYTHON_VERSION/\./}-notudfdoctest"
+      - if: ${{ (matrix.python-version == '3.9' || matrix.python-version == '3.10') && contains('macos', matrix.os.download_name) }}
+        name: Run tests (including doctest tests)
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-udf"
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          cloud_provider: ${{ matrix.cloud-provider }}
+          PYTEST_ADDOPTS: --color=yes --tb=short
+          TOX_PARALLEL_NO_SPINNER: 1
+          SNOWFLAKE_IS_PYTHON_RUNTIME_TEST: 1
+        shell: bash
+      - if: ${{ (matrix.python-version == '3.9' || matrix.python-version == '3.10') && false == contains('macos', matrix.os.download_name) }}
+        name: Run tests (excluding doctest tests)
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-notdoctest"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -722,7 +722,7 @@ class Session:
             >>> # add numpy with the latest version on Snowflake Anaconda
             >>> # and pandas with the version "1.3.*"
             >>> # and dateutil with the local version in your environment
-            >>> session.add_packages("numpy", "pandas==1.3.*", dateutil)
+            >>> session.add_packages("numpy", "pandas==1.4.*", dateutil)
             >>> @udf
             ... def get_package_name_udf() -> list:
             ...     return [numpy.__name__, pandas.__name__, dateutil.__name__]

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1381,10 +1381,10 @@ def test_udf_parallel(session):
     reason="numpy and pandas are required",
 )
 def test_add_packages(session):
-    session.add_packages(["numpy==1.20.1", "pandas==1.3.5", "pandas==1.3.5"])
+    session.add_packages(["numpy==1.23.5", "pandas==1.5.3", "pandas==1.5.3"])
     assert session.get_packages() == {
-        "numpy": "numpy==1.20.1",
-        "pandas": "pandas==1.3.5",
+        "numpy": "numpy==1.23.5",
+        "pandas": "pandas==1.5.3",
     }
 
     # dateutil is a dependency of pandas
@@ -1395,7 +1395,7 @@ def test_add_packages(session):
     session.udf.register(get_numpy_pandas_dateutil_version, name=udf_name)
     # don't need to check the version of dateutil, as it can be changed on the server side
     assert (
-        session.sql(f"select {udf_name}()").collect()[0][0].startswith("1.20.1/1.3.5")
+        session.sql(f"select {udf_name}()").collect()[0][0].startswith("1.23.5/1.5.3")
     )
 
     # only add numpy, which will overwrite the previously added packages
@@ -1514,8 +1514,8 @@ def test_add_requirements(session, resources_path):
 
     session.add_requirements(test_files.test_requirements_file)
     assert session.get_packages() == {
-        "numpy": "numpy==1.21.2",
-        "pandas": "pandas==1.3.5",
+        "numpy": "numpy==1.23.5",
+        "pandas": "pandas==1.5.3",
     }
 
     udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
@@ -1524,7 +1524,7 @@ def test_add_requirements(session, resources_path):
     def get_numpy_pandas_version() -> str:
         return f"{numpy.__version__}/{pandas.__version__}"
 
-    Utils.check_answer(session.sql(f"select {udf_name}()"), [Row("1.21.2/1.3.5")])
+    Utils.check_answer(session.sql(f"select {udf_name}()"), [Row("1.23.5/1.5.3")])
 
     session.clear_packages()
 

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2075,7 +2075,7 @@ def test_udf_pickle_failure(session):
     with pytest.raises(TypeError) as ex_info:
         session.udf.register(lambda: len(d), return_type=IntegerType())
     assert (
-        "cannot pickle 'weakref' object: you might have to save the unpicklable object in the "
+        "you might have to save the unpicklable object in the "
         "local environment first, add it to the UDF with session.add_import(), and read it from "
         "the UDF." in str(ex_info)
     )

--- a/tests/resources/test_requirements.txt
+++ b/tests/resources/test_requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.21.2
-pandas==1.3.5
+numpy==1.23.5
+pandas==1.5.3


### PR DESCRIPTION
Description

Production is running on 7.13 now and we enabled python 3.9 for test account. We could start testing the full suites including udf tests.

Testing

Existing tests

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-767996

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Production is running on 7.13 now and we enabled python 3.9 for test account. We could start testing the full suites including udf tests.
