### PR TITLE
SNOW-801653: To add COPY GRANTS in DataFrameWriter.save_as_table function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+1.5.0 (TBD)
+New Features
+Added support COPY GRANTS in DataFrameWriter.save_as_table function.
+
 ## 1.4.0 (2023-04-24)
 
 ### New Features

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -635,6 +635,7 @@ class Analyzer:
                 logical_plan.mode,
                 logical_plan.table_type,
                 resolved_children[logical_plan.children[0]],
+                logical_plan.copy_grants,
             )
 
         if isinstance(logical_plan, Limit):

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -150,6 +150,7 @@ UNION = " UNION "
 UNION_ALL = " UNION ALL "
 INTERSECT = f" {Intersect.sql} "
 EXCEPT = f" {Except.sql} "
+COPY_GRANTS = f" COPY GRANTS "
 
 TEMPORARY_STRING_SET = frozenset(["temporary", "temp"])
 
@@ -663,11 +664,15 @@ def create_table_as_select_statement(
     replace: bool = False,
     error: bool = True,
     table_type: str = EMPTY_STRING,
+    copy_grants: bool = False,
 ) -> str:
     return (
         f"{CREATE}{OR + REPLACE if replace else EMPTY_STRING} {table_type.upper()} {TABLE}"
         f"{IF + NOT + EXISTS if not replace and not error else EMPTY_STRING}"
-        f" {table_name}{AS}{project_statement([], child)}"
+        f"{table_name}"
+        f"{COPY_GRANTS if copy_grants else EMPTY_STRING}"
+        f"{AS}"
+        f" {project_statement([], child)}"
     )
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -670,7 +670,7 @@ def create_table_as_select_statement(
         f"{CREATE}{OR + REPLACE if replace else EMPTY_STRING} {table_type.upper()} {TABLE}"
         f"{IF + NOT + EXISTS if not replace and not error else EMPTY_STRING}"
         f"{table_name}"
-        f"{COPY_GRANTS if copy_grants else EMPTY_STRING}"
+        f"{COPY_GRANTS if copy_grants and replace else EMPTY_STRING}"
         f"{AS}"
         f" {project_statement([], child)}"
     )

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -544,6 +544,7 @@ class SnowflakePlanBuilder:
         mode: SaveMode,
         table_type: str,
         child: SnowflakePlan,
+        copy_grants: bool = False
     ) -> SnowflakePlan:
         full_table_name = (
             table_name if isinstance(table_name, str) else ".".join(table_name)
@@ -590,7 +591,7 @@ class SnowflakePlanBuilder:
         elif mode == SaveMode.OVERWRITE:
             return self.build(
                 lambda x: create_table_as_select_statement(
-                    full_table_name, x, replace=True, table_type=table_type
+                    full_table_name, x, replace=True, table_type=table_type, copy_grants=copy_grants
                 ),
                 child,
                 None,
@@ -598,7 +599,7 @@ class SnowflakePlanBuilder:
         elif mode == SaveMode.IGNORE:
             return self.build(
                 lambda x: create_table_as_select_statement(
-                    full_table_name, x, error=False, table_type=table_type
+                    full_table_name, x, error=False, table_type=table_type, copy_grants=copy_grants
                 ),
                 child,
                 None,
@@ -606,7 +607,7 @@ class SnowflakePlanBuilder:
         elif mode == SaveMode.ERROR_IF_EXISTS:
             return self.build(
                 lambda x: create_table_as_select_statement(
-                    full_table_name, x, table_type=table_type
+                    full_table_name, x, table_type=table_type, copy_grants=copy_grants
                 ),
                 child,
                 None,

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -68,6 +68,7 @@ class SnowflakeCreateTable(LogicalPlan):
         mode: SaveMode,
         query: Optional[LogicalPlan],
         table_type: str = "",
+        copy_grants: bool = False,
     ) -> None:
         super().__init__()
         self.table_name = table_name
@@ -76,6 +77,7 @@ class SnowflakeCreateTable(LogicalPlan):
         self.query = query
         self.table_type = table_type
         self.children.append(query)
+        self.copy_grants = copy_grants
 
 
 class Limit(LogicalPlan):

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -86,6 +86,7 @@ class DataFrameWriter:
         table_type: Literal["", "temp", "temporary", "transient"] = "",
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
+        copy_grants: bool = False,
     ) -> None:
         ...  # pragma: no cover
 
@@ -100,6 +101,7 @@ class DataFrameWriter:
         table_type: Literal["", "temp", "temporary", "transient"] = "",
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = False,
+        copy_grants: bool = False,
     ) -> AsyncJob:
         ...  # pragma: no cover
 
@@ -114,6 +116,7 @@ class DataFrameWriter:
         table_type: Literal["", "temp", "temporary", "transient"] = "",
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
+        copy_grants: bool = False,
     ) -> Optional[AsyncJob]:
         """Writes the data to the specified table in a Snowflake database.
 
@@ -145,6 +148,11 @@ class DataFrameWriter:
             block: A bool value indicating whether this function will wait until the result is available.
                 When it is ``False``, this function executes the underlying queries of the dataframe
                 asynchronously and returns an :class:`AsyncJob`.
+            copy_grants: A bool value indicating whether this function will copy the grants from the replaced object.
+                The copy_grants clause is valid only when combined with the REPLACE clause.
+                CTAS with COPY GRANTS allows you to overwrite a table with a new set of data while keeping
+                existing grants on that table.
+
 
         Examples::
 
@@ -191,6 +199,7 @@ class DataFrameWriter:
             save_mode,
             self._dataframe._plan,
             table_type,
+            copy_grants
         )
         session = self._dataframe._session
         snowflake_plan = session._analyzer.resolve(create_table_logic_plan)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-801653

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   I added a copy_grants parameter in DataFrameWriter.save_as_table function. Then, we can define if we would like to copy_grants when we are overwriting a table. 
E.g: 
`df.write.mode("overwrite").save_as_table("table1", copy_grants=True)`
