### PR TITLE
SNOW-628569 Implement DataFrame.alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 - Added support for registering and calling Stored Procedures with `TABLE` return type.
 - Added support for parameter `length` in `StringType()` to specify the maximum number of characters that can be stored by the column.
 - Added the alias `functions.element_at()` for `functions.get()`.
-- Set default reviewer.
-- Add the alias `Column.contains` for `functions.contains`.
+- Added the alias `Column.contains` for `functions.contains`.
+- Added experimental feature `DataFrame.alias`.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -335,13 +335,10 @@ class Analyzer:
                 return "*"
             else:
                 return ",".join(
-                    list(
-                        map(
-                            self.analyze,
-                            fake_col_name_to_real_col_name,
-                            expr.expressions,
-                        )
-                    )
+                    [
+                        self.analyze(e, fake_col_name_to_real_col_name)
+                        for e in expr.expressions
+                    ]
                 )
 
         if isinstance(expr, SnowflakeUDF):
@@ -654,7 +651,7 @@ class Analyzer:
 
         if isinstance(logical_plan, Selectable):
             # Selectable doesn't have children. It already has the expr_to_alias dict.
-            self.alias_maps_to_use = logical_plan.expr_to_alias
+            self.alias_maps_to_use = logical_plan.expr_to_alias.copy()
         else:
             use_maps = {}
             # get counts of expr_to_alias keys

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -144,36 +144,51 @@ from snowflake.snowpark.types import _NumericType
 ARRAY_BIND_THRESHOLD = 512
 
 
-class Analyzer:  # Why is analyzer session scoped
+class Analyzer:
     def __init__(self, session: "snowflake.snowpark.session.Session") -> None:
         self.session = session
         self.plan_builder = SnowflakePlanBuilder(self.session)
-        self.subquery_plans = []  # reset in resolve, technically plan-scoped
-        # Used to track expression id to alias
-        self.alias_maps_to_use = (
-            None  # reset in do_resolve, technically dataframe-scoped
-        )
-        self.generated_alias_maps = {}  # reset in resolve, technically dataframe-scoped
-        self.fake_col_name_to_real_col_name = {}  # TODO: use a parameter instead
+        self.subquery_plans = []
+        self.alias_maps_to_use = None
+        self.generated_alias_maps = {}
 
     def analyze(
-        self, expr: Union[Expression, NamedExpression], parse_local_name=False
+        self,
+        expr: Union[Expression, NamedExpression],
+        fake_col_name_to_real_col_name: Dict[str, str],
+        parse_local_name=False,
     ) -> str:
         if isinstance(expr, GroupingSetsExpression):
             return grouping_set_expression(
-                [[self.analyze(a, parse_local_name) for a in arg] for arg in expr.args]
+                [
+                    [
+                        self.analyze(
+                            a, fake_col_name_to_real_col_name, parse_local_name
+                        )
+                        for a in arg
+                    ]
+                    for arg in expr.args
+                ]
             )
 
         if isinstance(expr, Like):
             return like_expression(
-                self.analyze(expr.expr, parse_local_name),
-                self.analyze(expr.pattern, parse_local_name),
+                self.analyze(
+                    expr.expr, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                self.analyze(
+                    expr.pattern, fake_col_name_to_real_col_name, parse_local_name
+                ),
             )
 
         if isinstance(expr, RegExp):
             return regexp_expression(
-                self.analyze(expr.expr, parse_local_name),
-                self.analyze(expr.pattern, parse_local_name),
+                self.analyze(
+                    expr.expr, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                self.analyze(
+                    expr.pattern, fake_col_name_to_real_col_name, parse_local_name
+                ),
             )
 
         if isinstance(expr, Collate):
@@ -181,25 +196,39 @@ class Analyzer:  # Why is analyzer session scoped
                 expr.collation_spec.upper() if parse_local_name else expr.collation_spec
             )
             return collate_expression(
-                self.analyze(expr.expr, parse_local_name), collation_spec
+                self.analyze(
+                    expr.expr, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                collation_spec,
             )
 
         if isinstance(expr, (SubfieldString, SubfieldInt)):
             field = expr.field
             if parse_local_name and isinstance(field, str):
                 field = field.upper()
-            return subfield_expression(self.analyze(expr.expr, parse_local_name), field)
+            return subfield_expression(
+                self.analyze(
+                    expr.expr, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                field,
+            )
 
         if isinstance(expr, CaseWhen):
             return case_when_expression(
                 [
                     (
-                        self.analyze(condition, parse_local_name),
-                        self.analyze(value, parse_local_name),
+                        self.analyze(
+                            condition, fake_col_name_to_real_col_name, parse_local_name
+                        ),
+                        self.analyze(
+                            value, fake_col_name_to_real_col_name, parse_local_name
+                        ),
                     )
                     for condition, value in expr.branches
                 ],
-                self.analyze(expr.else_value, parse_local_name)
+                self.analyze(
+                    expr.else_value, fake_col_name_to_real_col_name, parse_local_name
+                )
                 if expr.else_value
                 else "NULL",
             )
@@ -207,33 +236,53 @@ class Analyzer:  # Why is analyzer session scoped
         if isinstance(expr, MultipleExpression):
             return block_expression(
                 [
-                    self.analyze(expression, parse_local_name)
+                    self.analyze(
+                        expression, fake_col_name_to_real_col_name, parse_local_name
+                    )
                     for expression in expr.expressions
                 ]
             )
 
         if isinstance(expr, InExpression):
             return in_expression(
-                self.analyze(expr.columns, parse_local_name),
+                self.analyze(
+                    expr.columns, fake_col_name_to_real_col_name, parse_local_name
+                ),
                 [
-                    self.analyze(expression, parse_local_name)
+                    self.analyze(
+                        expression, fake_col_name_to_real_col_name, parse_local_name
+                    )
                     for expression in expr.values
                 ],
             )
 
         if isinstance(expr, GroupingSet):
-            return self.grouping_extractor(expr)
+            return self.grouping_extractor(expr, fake_col_name_to_real_col_name)
 
         if isinstance(expr, WindowExpression):
             return window_expression(
-                self.analyze(expr.window_function, parse_local_name),
-                self.analyze(expr.window_spec, parse_local_name),
+                self.analyze(
+                    expr.window_function,
+                    fake_col_name_to_real_col_name,
+                    parse_local_name,
+                ),
+                self.analyze(
+                    expr.window_spec, fake_col_name_to_real_col_name, parse_local_name
+                ),
             )
         if isinstance(expr, WindowSpecDefinition):
             return window_spec_expression(
-                [self.analyze(x, parse_local_name) for x in expr.partition_spec],
-                [self.analyze(x, parse_local_name) for x in expr.order_spec],
-                self.analyze(expr.frame_spec, parse_local_name),
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name, parse_local_name)
+                    for x in expr.partition_spec
+                ],
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name, parse_local_name)
+                    for x in expr.order_spec
+                ],
+                self.analyze(
+                    expr.frame_spec, fake_col_name_to_real_col_name, parse_local_name
+                ),
             )
         if isinstance(expr, SpecifiedWindowFrame):
             return specified_window_frame_expression(
@@ -258,7 +307,7 @@ class Analyzer:  # Why is analyzer session scoped
 
         if isinstance(expr, UnresolvedAttribute):
             if expr.df_alias:
-                return self.fake_col_name_to_real_col_name.get(expr.name, expr.name)
+                return fake_col_name_to_real_col_name.get(expr.name, expr.name)
             return expr.name
 
         if isinstance(expr, FunctionExpression):
@@ -277,7 +326,15 @@ class Analyzer:  # Why is analyzer session scoped
             if not expr.expressions:
                 return "*"
             else:
-                return ",".join(list(map(self.analyze, expr.expressions)))
+                return ",".join(
+                    list(
+                        map(
+                            self.analyze,
+                            fake_col_name_to_real_col_name,
+                            expr.expressions,
+                        )
+                    )
+                )
 
         if isinstance(expr, SnowflakeUDF):
             if expr.api_call_source is not None:
@@ -287,7 +344,10 @@ class Analyzer:  # Why is analyzer session scoped
             func_name = expr.udf_name.upper() if parse_local_name else expr.udf_name
             return function_expression(
                 func_name,
-                [self.analyze(x, parse_local_name) for x in expr.children],
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name, parse_local_name)
+                    for x in expr.children
+                ],
                 False,
             )
 
@@ -296,25 +356,37 @@ class Analyzer:  # Why is analyzer session scoped
                 self.session._conn._telemetry_client.send_function_usage_telemetry(
                     expr.api_call_source, TelemetryField.FUNC_CAT_USAGE.value
                 )
-            return self.table_function_expression_extractor(expr)
+            return self.table_function_expression_extractor(
+                expr, fake_col_name_to_real_col_name
+            )
 
         if isinstance(expr, TableFunctionPartitionSpecDefinition):
             return table_function_partition_spec(
                 expr.over,
-                [self.analyze(x, parse_local_name) for x in expr.partition_spec]
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name, parse_local_name)
+                    for x in expr.partition_spec
+                ]
                 if expr.partition_spec
                 else [],
-                [self.analyze(x, parse_local_name) for x in expr.order_spec]
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name, parse_local_name)
+                    for x in expr.order_spec
+                ]
                 if expr.order_spec
                 else [],
             )
 
         if isinstance(expr, UnaryExpression):
-            return self.unary_expression_extractor(expr, parse_local_name)
+            return self.unary_expression_extractor(
+                expr, fake_col_name_to_real_col_name, parse_local_name
+            )
 
         if isinstance(expr, SortOrder):
             return order_expression(
-                self.analyze(expr.child, parse_local_name),
+                self.analyze(
+                    expr.child, fake_col_name_to_real_col_name, parse_local_name
+                ),
                 expr.direction.sql,
                 expr.null_ordering.sql,
             )
@@ -325,34 +397,54 @@ class Analyzer:  # Why is analyzer session scoped
 
         if isinstance(expr, WithinGroup):
             return within_group_expression(
-                self.analyze(expr.expr, parse_local_name),
-                [self.analyze(e) for e in expr.order_by_cols],
+                self.analyze(
+                    expr.expr, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                [
+                    self.analyze(e, fake_col_name_to_real_col_name)
+                    for e in expr.order_by_cols
+                ],
             )
 
         if isinstance(expr, BinaryExpression):
-            return self.binary_operator_extractor(expr, parse_local_name)
+            return self.binary_operator_extractor(
+                expr, fake_col_name_to_real_col_name, parse_local_name
+            )
 
         if isinstance(expr, InsertMergeExpression):
             return insert_merge_statement(
-                self.analyze(expr.condition) if expr.condition else None,
-                [self.analyze(k) for k in expr.keys],
-                [self.analyze(v) for v in expr.values],
+                self.analyze(expr.condition, fake_col_name_to_real_col_name)
+                if expr.condition
+                else None,
+                [self.analyze(k, fake_col_name_to_real_col_name) for k in expr.keys],
+                [self.analyze(v, fake_col_name_to_real_col_name) for v in expr.values],
             )
 
         if isinstance(expr, UpdateMergeExpression):
             return update_merge_statement(
-                self.analyze(expr.condition) if expr.condition else None,
-                {self.analyze(k): self.analyze(v) for k, v in expr.assignments.items()},
+                self.analyze(expr.condition, fake_col_name_to_real_col_name)
+                if expr.condition
+                else None,
+                {
+                    self.analyze(k, fake_col_name_to_real_col_name): self.analyze(
+                        v, fake_col_name_to_real_col_name
+                    )
+                    for k, v in expr.assignments.items()
+                },
             )
 
         if isinstance(expr, DeleteMergeExpression):
             return delete_merge_statement(
-                self.analyze(expr.condition) if expr.condition else None
+                self.analyze(expr.condition, fake_col_name_to_real_col_name)
+                if expr.condition
+                else None
             )
 
         if isinstance(expr, ListAgg):
             return list_agg(
-                self.analyze(expr.col, parse_local_name),
+                self.analyze(
+                    expr.col, fake_col_name_to_real_col_name, parse_local_name
+                ),
                 str_to_sql(expr.delimiter),
                 expr.is_distinct,
             )
@@ -360,9 +452,15 @@ class Analyzer:  # Why is analyzer session scoped
         if isinstance(expr, RankRelatedFunctionExpression):
             return rank_related_function_expression(
                 expr.sql,
-                self.analyze(expr.expr, parse_local_name),
+                self.analyze(
+                    expr.expr, fake_col_name_to_real_col_name, parse_local_name
+                ),
                 expr.offset,
-                self.analyze(expr.default, parse_local_name) if expr.default else None,
+                self.analyze(
+                    expr.default, fake_col_name_to_real_col_name, parse_local_name
+                )
+                if expr.default
+                else None,
                 expr.ignore_nulls,
             )
 
@@ -371,11 +469,16 @@ class Analyzer:  # Why is analyzer session scoped
         )  # pragma: no cover
 
     def table_function_expression_extractor(
-        self, expr: TableFunctionExpression, parse_local_name=False
+        self,
+        expr: TableFunctionExpression,
+        fake_col_name_to_real_col_name: Dict[str, str],
+        parse_local_name=False,
     ) -> str:
         if isinstance(expr, FlattenFunction):
             return flatten_expression(
-                self.analyze(expr.input, parse_local_name),
+                self.analyze(
+                    expr.input, fake_col_name_to_real_col_name, parse_local_name
+                ),
                 expr.path,
                 expr.outer,
                 expr.recursive,
@@ -384,14 +487,19 @@ class Analyzer:  # Why is analyzer session scoped
         elif isinstance(expr, PosArgumentsTableFunction):
             sql = function_expression(
                 expr.func_name,
-                [self.analyze(x, parse_local_name) for x in expr.args],
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name, parse_local_name)
+                    for x in expr.args
+                ],
                 False,
             )
         elif isinstance(expr, (NamedArgumentsTableFunction, GeneratorTableFunction)):
             sql = named_arguments_function(
                 expr.func_name,
                 {
-                    key: self.analyze(value, parse_local_name)
+                    key: self.analyze(
+                        value, fake_col_name_to_real_col_name, parse_local_name
+                    )
                     for key, value in expr.args.items()
                 },
             )
@@ -401,12 +509,17 @@ class Analyzer:  # Why is analyzer session scoped
                 "NamedArgumentsTableFunction, GeneratorTableFunction, or FlattenFunction."
             )
         partition_spec_sql = (
-            self.analyze(expr.partition_spec) if expr.partition_spec else ""
+            self.analyze(expr.partition_spec, fake_col_name_to_real_col_name)
+            if expr.partition_spec
+            else ""
         )
         return f"{sql} {partition_spec_sql}"
 
     def unary_expression_extractor(
-        self, expr: UnaryExpression, parse_local_name=False
+        self,
+        expr: UnaryExpression,
+        fake_col_name_to_real_col_name: Dict[str, str],
+        parse_local_name=False,
     ) -> str:
         if isinstance(expr, Alias):
             quoted_name = quote_name(expr.name)
@@ -415,54 +528,79 @@ class Analyzer:  # Why is analyzer session scoped
                 for k, v in self.alias_maps_to_use.items():
                     if v == expr.child.name:
                         self.generated_alias_maps[k] = quoted_name
-                for k, v in self.fake_col_name_to_real_col_name.items():
+                for k, v in fake_col_name_to_real_col_name.items():
                     if v == expr.child.name:
-                        self.fake_col_name_to_real_col_name[k] = quoted_name
+                        fake_col_name_to_real_col_name[k] = quoted_name
             return alias_expression(
-                self.analyze(expr.child, parse_local_name), quoted_name
+                self.analyze(
+                    expr.child, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                quoted_name,
             )
         if isinstance(expr, UnresolvedAlias):
-            expr_str = self.analyze(expr.child, parse_local_name)
+            expr_str = self.analyze(
+                expr.child, fake_col_name_to_real_col_name, parse_local_name
+            )
             if parse_local_name:
                 expr_str = expr_str.upper()
             return expr_str
         elif isinstance(expr, Cast):
             return cast_expression(
-                self.analyze(expr.child, parse_local_name), expr.to, expr.try_
+                self.analyze(
+                    expr.child, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                expr.to,
+                expr.try_,
             )
         else:
             return unary_expression(
-                self.analyze(expr.child, parse_local_name),
+                self.analyze(
+                    expr.child, fake_col_name_to_real_col_name, parse_local_name
+                ),
                 expr.sql_operator,
                 expr.operator_first,
             )
 
     def binary_operator_extractor(
-        self, expr: BinaryExpression, parse_local_name=False
+        self,
+        expr: BinaryExpression,
+        fake_col_name_to_real_col_name,
+        parse_local_name=False,
     ) -> str:
         if isinstance(expr, BinaryArithmeticExpression):
             return binary_arithmetic_expression(
                 expr.sql_operator,
-                self.analyze(expr.left, parse_local_name),
-                self.analyze(expr.right, parse_local_name),
+                self.analyze(
+                    expr.left, fake_col_name_to_real_col_name, parse_local_name
+                ),
+                self.analyze(
+                    expr.right, fake_col_name_to_real_col_name, parse_local_name
+                ),
             )
         else:
             return function_expression(
                 expr.sql_operator,
                 [
-                    self.analyze(expr.left, parse_local_name),
-                    self.analyze(expr.right, parse_local_name),
+                    self.analyze(
+                        expr.left, fake_col_name_to_real_col_name, parse_local_name
+                    ),
+                    self.analyze(
+                        expr.right, fake_col_name_to_real_col_name, parse_local_name
+                    ),
                 ],
                 False,
             )
 
-    def grouping_extractor(self, expr: GroupingSet) -> str:
+    def grouping_extractor(
+        self, expr: GroupingSet, fake_col_name_to_real_col_name
+    ) -> str:
         return self.analyze(
             FunctionExpression(
                 expr.pretty_name.upper(),
                 [c.child if isinstance(c, Alias) else c for c in expr.children],
                 False,
-            )
+            ),
+            fake_col_name_to_real_col_name,
         )
 
     def window_frame_boundary(self, offset: str) -> str:
@@ -472,24 +610,23 @@ class Analyzer:  # Why is analyzer session scoped
         except Exception:
             return offset
 
-    def to_sql_avoid_offset(self, expr: Expression, parse_local_name=False) -> str:
+    def to_sql_avoid_offset(
+        self, expr: Expression, fake_col_name_to_real_col_name, parse_local_name=False
+    ) -> str:
         # if expression is a numeric literal, return the number without casting,
         # otherwise process as normal
         if isinstance(expr, Literal) and isinstance(expr.datatype, _NumericType):
             return to_sql_without_cast(expr.value, expr.datatype)
         else:
-            return self.analyze(expr, parse_local_name)
+            return self.analyze(expr, fake_col_name_to_real_col_name, parse_local_name)
 
     def resolve(self, logical_plan: LogicalPlan) -> SnowflakePlan:
         self.subquery_plans = []
-        self.generated_alias_maps = {}  # shorter lifespan than self.alias_maps_to_use
-        result: SnowflakePlan = self.do_resolve(logical_plan)
+        self.generated_alias_maps = {}
+
+        result = self.do_resolve(logical_plan)
 
         result.add_aliases(self.generated_alias_maps)
-        result.fake_col_name_to_real_col_name = {
-            **result.fake_col_name_to_real_col_name,
-            **self.fake_col_name_to_real_col_name,
-        }
 
         if self.subquery_plans:
             result = result.with_subqueries(self.subquery_plans)
@@ -498,15 +635,14 @@ class Analyzer:  # Why is analyzer session scoped
 
     def do_resolve(self, logical_plan: LogicalPlan) -> SnowflakePlan:
         resolved_children = {}
-        fake_col_name_to_real_col_name = {}
+        fake_col_name_to_real_col_name: Dict[str, str] = {}
 
-        for c in logical_plan.children:  # post-order traversal of the
-            if isinstance(c, SnowflakePlan):
-                fake_col_name_to_real_col_name = {
-                    **fake_col_name_to_real_col_name,
-                    **c.fake_col_name_to_real_col_name,
-                }
-            resolved_children[c] = self.resolve(c)
+        for c in logical_plan.children:  # post-order traversal of the tree
+            resolved = self.resolve(c)
+            fake_col_name_to_real_col_name.update(
+                resolved.fake_col_name_to_real_col_name
+            )
+            resolved_children[c] = resolved
 
         if isinstance(logical_plan, Selectable):
             # Selectable doesn't have children. It already has the expr_to_alias dict.
@@ -529,32 +665,43 @@ class Analyzer:  # Why is analyzer session scoped
 
             self.alias_maps_to_use = use_maps
 
-        self.fake_col_name_to_real_col_name = fake_col_name_to_real_col_name
-        return self.do_resolve_with_resolved_children(logical_plan, resolved_children)
+        res = self.do_resolve_with_resolved_children(
+            logical_plan, resolved_children, fake_col_name_to_real_col_name
+        )
+        res.fake_col_name_to_real_col_name.update(fake_col_name_to_real_col_name)
+        return res
 
     def do_resolve_with_resolved_children(
         self,
         logical_plan: LogicalPlan,
         resolved_children: Dict[LogicalPlan, SnowflakePlan],
+        fake_col_name_to_real_col_name: Dict[str, str],
     ) -> SnowflakePlan:
         if isinstance(logical_plan, SnowflakePlan):
             return logical_plan
 
         if isinstance(logical_plan, TableFunctionJoin):
             return self.plan_builder.join_table_function(
-                self.analyze(logical_plan.table_function),
+                self.analyze(
+                    logical_plan.table_function, fake_col_name_to_real_col_name
+                ),
                 resolved_children[logical_plan.children[0]],
                 logical_plan,
             )
 
         if isinstance(logical_plan, TableFunctionRelation):
             return self.plan_builder.from_table_function(
-                self.analyze(logical_plan.table_function), logical_plan
+                self.analyze(
+                    logical_plan.table_function, fake_col_name_to_real_col_name
+                ),
+                logical_plan,
             )
 
         if isinstance(logical_plan, Lateral):
             return self.plan_builder.lateral(
-                self.analyze(logical_plan.table_function),
+                self.analyze(
+                    logical_plan.table_function, fake_col_name_to_real_col_name
+                ),
                 resolved_children[logical_plan.children[0]],
                 logical_plan,
             )
@@ -562,21 +709,31 @@ class Analyzer:  # Why is analyzer session scoped
         if isinstance(logical_plan, Aggregate):
             return self.plan_builder.aggregate(
                 list(map(self.to_sql_avoid_offset, logical_plan.grouping_expressions)),
-                list(map(self.analyze, logical_plan.aggregate_expressions)),
+                list(
+                    map(
+                        lambda x: self.analyze(x, fake_col_name_to_real_col_name),
+                        logical_plan.aggregate_expressions,
+                    )
+                ),
                 resolved_children[logical_plan.child],
                 logical_plan,
             )
 
         if isinstance(logical_plan, Project):
             return self.plan_builder.project(
-                list(map(self.analyze, logical_plan.project_list)),
+                list(
+                    map(
+                        lambda x: self.analyze(x, fake_col_name_to_real_col_name),
+                        logical_plan.project_list,
+                    )
+                ),
                 resolved_children[logical_plan.child],
                 logical_plan,
             )
 
         if isinstance(logical_plan, Filter):
             return self.plan_builder.filter(
-                self.analyze(logical_plan.condition),
+                self.analyze(logical_plan.condition, fake_col_name_to_real_col_name),
                 resolved_children[logical_plan.child],
                 logical_plan,
             )
@@ -595,14 +752,21 @@ class Analyzer:  # Why is analyzer session scoped
                 resolved_children[logical_plan.left],
                 resolved_children[logical_plan.right],
                 logical_plan.join_type,
-                self.analyze(logical_plan.condition) if logical_plan.condition else "",
+                self.analyze(logical_plan.condition, fake_col_name_to_real_col_name)
+                if logical_plan.condition
+                else "",
                 logical_plan,
                 self.session.conf.get("use_constant_subquery_alias", False),
             )
 
         if isinstance(logical_plan, Sort):
             return self.plan_builder.sort(
-                list(map(self.analyze, logical_plan.order)),
+                list(
+                    map(
+                        lambda x: self.analyze(x, fake_col_name_to_real_col_name),
+                        logical_plan.order,
+                    )
+                ),
                 resolved_children[logical_plan.child],
                 logical_plan,
             )
@@ -672,9 +836,14 @@ class Analyzer:  # Why is analyzer session scoped
 
         if isinstance(logical_plan, Pivot):
             return self.plan_builder.pivot(
-                self.analyze(logical_plan.pivot_column),
-                [self.analyze(pv) for pv in logical_plan.pivot_values],
-                self.analyze(logical_plan.aggregates[0]),
+                self.analyze(logical_plan.pivot_column, fake_col_name_to_real_col_name),
+                [
+                    self.analyze(pv, fake_col_name_to_real_col_name)
+                    for pv in logical_plan.pivot_values
+                ],
+                self.analyze(
+                    logical_plan.aggregates[0], fake_col_name_to_real_col_name
+                ),
                 resolved_children[logical_plan.child],
                 logical_plan,
             )
@@ -683,7 +852,10 @@ class Analyzer:  # Why is analyzer session scoped
             return self.plan_builder.unpivot(
                 logical_plan.value_column,
                 logical_plan.name_column,
-                [self.analyze(c) for c in logical_plan.column_list],
+                [
+                    self.analyze(c, fake_col_name_to_real_col_name)
+                    for c in logical_plan.column_list
+                ],
                 resolved_children[logical_plan.child],
                 logical_plan,
             )
@@ -729,7 +901,10 @@ class Analyzer:  # Why is analyzer session scoped
                 copy_options=logical_plan.copy_options,
                 validation_mode=logical_plan.validation_mode,
                 column_names=logical_plan.column_names,
-                transformations=[self.analyze(x) for x in logical_plan.transformations]
+                transformations=[
+                    self.analyze(x, fake_col_name_to_real_col_name)
+                    for x in logical_plan.transformations
+                ]
                 if logical_plan.transformations
                 else None,
                 user_schema=logical_plan.user_schema,
@@ -740,7 +915,9 @@ class Analyzer:  # Why is analyzer session scoped
             return self.plan_builder.copy_into_location(
                 query=resolved_children[logical_plan.child],
                 stage_location=logical_plan.stage_location,
-                partition_by=self.analyze(logical_plan.partition_by)
+                partition_by=self.analyze(
+                    logical_plan.partition_by, fake_col_name_to_real_col_name
+                )
                 if logical_plan.partition_by
                 else None,
                 file_format_name=logical_plan.file_format_name,
@@ -754,10 +931,12 @@ class Analyzer:  # Why is analyzer session scoped
             return self.plan_builder.update(
                 logical_plan.table_name,
                 {
-                    self.analyze(k): self.analyze(v)
+                    self.analyze(k, fake_col_name_to_real_col_name): self.analyze(
+                        v, fake_col_name_to_real_col_name
+                    )
                     for k, v in logical_plan.assignments.items()
                 },
-                self.analyze(logical_plan.condition)
+                self.analyze(logical_plan.condition, fake_col_name_to_real_col_name)
                 if logical_plan.condition
                 else None,
                 resolved_children.get(logical_plan.source_data, None),
@@ -767,7 +946,7 @@ class Analyzer:  # Why is analyzer session scoped
         if isinstance(logical_plan, TableDelete):
             return self.plan_builder.delete(
                 logical_plan.table_name,
-                self.analyze(logical_plan.condition)
+                self.analyze(logical_plan.condition, fake_col_name_to_real_col_name)
                 if logical_plan.condition
                 else None,
                 resolved_children.get(logical_plan.source_data, None),
@@ -778,8 +957,11 @@ class Analyzer:  # Why is analyzer session scoped
             return self.plan_builder.merge(
                 logical_plan.table_name,
                 resolved_children.get(logical_plan.source),
-                self.analyze(logical_plan.join_expr),
-                [self.analyze(c) for c in logical_plan.clauses],
+                self.analyze(logical_plan.join_expr, fake_col_name_to_real_col_name),
+                [
+                    self.analyze(c, fake_col_name_to_real_col_name)
+                    for c in logical_plan.clauses
+                ],
                 logical_plan,
             )
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
+
 from collections import Counter
 from typing import Dict, Union
 
@@ -148,9 +149,9 @@ class Analyzer:
     def __init__(self, session: "snowflake.snowpark.session.Session") -> None:
         self.session = session
         self.plan_builder = SnowflakePlanBuilder(self.session)
+        self.generated_alias_maps = {}
         self.subquery_plans = []
         self.alias_maps_to_use = None
-        self.generated_alias_maps = {}
 
     def analyze(
         self,

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
-
+import copy
 from collections import Counter
 from typing import Dict, Union
 
@@ -145,13 +145,20 @@ from snowflake.snowpark.types import _NumericType
 ARRAY_BIND_THRESHOLD = 512
 
 
-class Analyzer:
+class Analyzer:  # Why is analyzer session scoped
     def __init__(self, session: "snowflake.snowpark.session.Session") -> None:
         self.session = session
         self.plan_builder = SnowflakePlanBuilder(self.session)
-        self.generated_alias_maps = {}
-        self.subquery_plans = []
-        self.alias_maps_to_use = None
+        self.subquery_plans = []  # reset in resolve, technically plan-scoped
+        # Used to track expression id to alias
+        self.alias_maps_to_use = (
+            None  # reset in do_resolve, technically dataframe-scoped
+        )
+        self.generated_alias_maps = {}  # reset in resolve, technically dataframe-scoped
+        self.aliased_cols_to_expr_id = (
+            {}
+        )  # reset in resolve, technically dataframe-scoped
+        self.expr_to_alias = {}  # should be dataframe-scoped
 
     def analyze(
         self, expr: Union[Expression, NamedExpression], parse_local_name=False
@@ -254,6 +261,8 @@ class Analyzer:
             return quote_name(name)
 
         if isinstance(expr, UnresolvedAttribute):
+            if expr.df_alias:
+                return self.expr_to_alias[self.aliased_cols_to_expr_id[expr.name]]
             return expr.name
 
         if isinstance(expr, FunctionExpression):
@@ -473,10 +482,13 @@ class Analyzer:
             return self.analyze(expr, parse_local_name)
 
     def resolve(self, logical_plan: LogicalPlan) -> SnowflakePlan:
+        # why execute this for SnowflakePlan, why not early termination?
         self.subquery_plans = []
-        self.generated_alias_maps = {}
-        result = self.do_resolve(logical_plan)
+        self.generated_alias_maps = {}  # shorter lifespan than self.alias_maps_to_use
+        result: SnowflakePlan = self.do_resolve(logical_plan)
 
+        result.aliased_cols_to_expr_id = copy.copy(self.aliased_cols_to_expr_id)
+        result.expr_to_alias = copy.copy(self.expr_to_alias)
         result.add_aliases(self.generated_alias_maps)
 
         if self.subquery_plans:
@@ -486,14 +498,25 @@ class Analyzer:
 
     def do_resolve(self, logical_plan: LogicalPlan) -> SnowflakePlan:
         resolved_children = {}
-        for c in logical_plan.children:
+        aliased_cols_to_expr_id = {}
+        expr_to_alias = {}
+
+        for c in logical_plan.children:  # post-order traversal of the
+            if isinstance(c, SnowflakePlan):
+                aliased_cols_to_expr_id = {
+                    **aliased_cols_to_expr_id,
+                    **c.aliased_cols_to_expr_id,
+                }
+                expr_to_alias = {**expr_to_alias, **c.expr_to_alias}
+
             resolved_children[c] = self.resolve(c)
+            # get combined aliased_cols_to_expr_id from here, pass to analyze
 
         if isinstance(logical_plan, Selectable):
             # Selectable doesn't have children. It already has the expr_to_alias dict.
             self.alias_maps_to_use = logical_plan.expr_to_alias
         else:
-            use_maps = {}
+            use_maps = copy.copy(expr_to_alias)
             # get counts of expr_to_alias keys
             counts = Counter()
             for v in resolved_children.values():
@@ -509,6 +532,10 @@ class Analyzer:
                     )
 
             self.alias_maps_to_use = use_maps
+
+        print(f"aliased_cols_to_expr_id: {aliased_cols_to_expr_id}")
+        self.aliased_cols_to_expr_id = aliased_cols_to_expr_id
+        self.expr_to_alias = expr_to_alias
         return self.do_resolve_with_resolved_children(logical_plan, resolved_children)
 
     def do_resolve_with_resolved_children(

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -651,7 +651,7 @@ class Analyzer:
 
         if isinstance(logical_plan, Selectable):
             # Selectable doesn't have children. It already has the expr_to_alias dict.
-            self.alias_maps_to_use = logical_plan.expr_to_alias.copy()
+            self.alias_maps_to_use = logical_plan.expr_to_alias
         else:
             use_maps = {}
             # get counts of expr_to_alias keys

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -616,7 +616,10 @@ class Analyzer:
             return offset
 
     def to_sql_avoid_offset(
-        self, expr: Expression, fake_col_name_to_real_col_name, parse_local_name=False
+        self,
+        expr: Expression,
+        fake_col_name_to_real_col_name: Dict[str, str],
+        parse_local_name: bool = False,
     ) -> str:
         # if expression is a numeric literal, return the number without casting,
         # otherwise process as normal
@@ -767,12 +770,10 @@ class Analyzer:
 
         if isinstance(logical_plan, Sort):
             return self.plan_builder.sort(
-                list(
-                    map(
-                        lambda x: self.analyze(x, fake_col_name_to_real_col_name),
-                        logical_plan.order,
-                    )
-                ),
+                [
+                    self.analyze(x, fake_col_name_to_real_col_name)
+                    for x in logical_plan.order
+                ],
                 resolved_children[logical_plan.child],
                 logical_plan,
             )

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -173,7 +173,6 @@ class UnresolvedAttribute(Expression, NamedExpression):
         if self.df_alias:
             self.name = self.df_alias + "." + self.name
         self.is_sql_text = is_sql_text
-        self.df_alias = df_alias
         if "$" in name:
             # $n refers to a column by index. We don't consider column index yet.
             # even though "$" isn't necessarily used to refer to a column by index. We're conservative here.

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -173,8 +173,6 @@ class UnresolvedAttribute(Expression, NamedExpression):
         super().__init__()
         self.df_alias = df_alias
         self.name = name
-        if self.df_alias:
-            self.name = self.df_alias + "." + self.name
         self.is_sql_text = is_sql_text
         if "$" in name:
             # $n refers to a column by index. We don't consider column index yet.

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -164,10 +164,16 @@ class Star(Expression):
 
 
 class UnresolvedAttribute(Expression, NamedExpression):
-    def __init__(self, name: str, is_sql_text: bool = False) -> None:
+    def __init__(
+        self, name: str, is_sql_text: bool = False, df_alias: Optional[str] = None
+    ) -> None:
         super().__init__()
+        self.df_alias = df_alias
         self.name = name
+        if self.df_alias:
+            self.name = self.df_alias + "." + self.name
         self.is_sql_text = is_sql_text
+        self.df_alias = df_alias
         if "$" in name:
             # $n refers to a column by index. We don't consider column index yet.
             # even though "$" isn't necessarily used to refer to a column by index. We're conservative here.
@@ -191,7 +197,7 @@ class UnresolvedAttribute(Expression, NamedExpression):
         return hash(self.name)
 
     def dependent_column_names(self) -> Optional[Set[str]]:
-        return self._dependent_column_names
+        return self._dependent_column_names  # TODO: stan
 
 
 class Literal(Expression):

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -196,7 +196,7 @@ class UnresolvedAttribute(Expression, NamedExpression):
         return hash(self.name)
 
     def dependent_column_names(self) -> Optional[Set[str]]:
-        return self._dependent_column_names  # TODO: stan
+        return self._dependent_column_names
 
 
 class Literal(Expression):

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -155,9 +155,12 @@ class Attribute(Expression, NamedExpression):
 
 
 class Star(Expression):
-    def __init__(self, expressions: List[Attribute]) -> None:
+    def __init__(
+        self, expressions: List[Attribute], df_alias: Optional[str] = None
+    ) -> None:
         super().__init__()
         self.expressions = expressions
+        self.df_alias = df_alias
 
     def dependent_column_names(self) -> Optional[Set[str]]:
         return derive_dependent_columns(*self.expressions)

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -215,7 +215,7 @@ class Selectable(LogicalPlan, ABC):
                 self.schema_query,
                 post_actions=self.post_actions,
                 session=self.analyzer.session,
-                expr_to_alias=self.expr_to_alias,
+                expr_to_alias=self.expr_to_alias.copy(),
                 fake_col_name_to_real_col_name=self.fake_col_name_to_real_col_name.copy(),
                 source_plan=self,
             )
@@ -421,6 +421,7 @@ class SelectStatement(Selectable):
         new.flatten_disabled = False  # by default a SelectStatement can be flattened.
         new._api_calls = self._api_calls.copy() if self._api_calls is not None else None
         new.fake_col_name_to_real_col_name = self.fake_col_name_to_real_col_name.copy()
+        new.expr_to_alias = self.expr_to_alias.copy()
         return new
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -856,8 +856,6 @@ def parse_column_name(
                 column, df_aliased_col_name_to_real_col_name, parse_local_name=True
             ).strip(" ")
         if isinstance(column, UnresolvedAttribute):
-            if column.df_alias:
-                return analyzer.analyze(column, df_aliased_col_name_to_real_col_name)
             if not column.is_sql_text:
                 return column.name
         if isinstance(column, UnresolvedAlias):

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -215,7 +215,7 @@ class Selectable(LogicalPlan, ABC):
                 self.schema_query,
                 post_actions=self.post_actions,
                 session=self.analyzer.session,
-                expr_to_alias=self.expr_to_alias.copy(),
+                expr_to_alias=self.expr_to_alias,
                 fake_col_name_to_real_col_name=self.fake_col_name_to_real_col_name.copy(),
                 source_plan=self,
             )
@@ -421,7 +421,6 @@ class SelectStatement(Selectable):
         new.flatten_disabled = False  # by default a SelectStatement can be flattened.
         new._api_calls = self._api_calls.copy() if self._api_calls is not None else None
         new.fake_col_name_to_real_col_name = self.fake_col_name_to_real_col_name.copy()
-        new.expr_to_alias = self.expr_to_alias.copy()
         return new
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -163,6 +163,7 @@ class Selectable(LogicalPlan, ABC):
         self._column_states: Optional[ColumnStateDict] = None
         self._snowflake_plan: Optional[SnowflakePlan] = None
         self.expr_to_alias = {}
+        self.fake_col_name_to_real_col_name: Dict[str, str] = {}
         self._api_calls = api_calls.copy() if api_calls is not None else None
 
     @property
@@ -215,6 +216,7 @@ class Selectable(LogicalPlan, ABC):
                 post_actions=self.post_actions,
                 session=self.analyzer.session,
                 expr_to_alias=self.expr_to_alias,
+                fake_col_name_to_real_col_name=self.fake_col_name_to_real_col_name.copy(),
                 source_plan=self,
             )
             # set api_calls to self._snowflake_plan outside of the above constructor
@@ -230,7 +232,9 @@ class Selectable(LogicalPlan, ABC):
         """
         if self._column_states is None:
             self._column_states = initiate_column_states(
-                self.snowflake_plan.attributes, self.analyzer
+                self.snowflake_plan.attributes,
+                self.analyzer,
+                self.fake_col_name_to_real_col_name,
             )
         return self._column_states
 
@@ -333,6 +337,10 @@ class SelectSnowflakePlan(Selectable):
             else analyzer.resolve(snowflake_plan)
         )
         self.expr_to_alias.update(self._snowflake_plan.expr_to_alias)
+        self.fake_col_name_to_real_col_name.update(
+            self._snowflake_plan.fake_col_name_to_real_col_name
+        )
+
         self.pre_actions = self._snowflake_plan.queries[:-1]
         self.post_actions = self._snowflake_plan.post_actions
         self._api_calls = self._snowflake_plan.api_calls
@@ -366,7 +374,7 @@ class SelectStatement(Selectable):
         self,
         *,
         projection: Optional[List[Expression]] = None,
-        from_: Optional["Selectable"] = None,
+        from_: Optional[Union[LogicalPlan, Selectable]] = None,
         where: Optional[Expression] = None,
         order_by: Optional[List[Expression]] = None,
         limit_: Optional[int] = None,
@@ -387,6 +395,9 @@ class SelectStatement(Selectable):
         self._projection_in_str = None
         self._query_params = None
         self.expr_to_alias.update(self.from_.expr_to_alias)
+        self.fake_col_name_to_real_col_name.update(
+            self.from_.fake_col_name_to_real_col_name
+        )
         self.api_calls = (
             self.from_.api_calls.copy() if self.from_.api_calls is not None else None
         )  # will be replaced by new api calls if any operation.
@@ -409,6 +420,7 @@ class SelectStatement(Selectable):
         new._snowflake_plan = None
         new.flatten_disabled = False  # by default a SelectStatement can be flattened.
         new._api_calls = self._api_calls.copy() if self._api_calls is not None else None
+        new.fake_col_name_to_real_col_name = self.fake_col_name_to_real_col_name.copy()
         return new
 
     @property
@@ -438,7 +450,8 @@ class SelectStatement(Selectable):
         if not self._projection_in_str:
             self._projection_in_str = (
                 analyzer_utils.COMMA.join(
-                    self.analyzer.analyze(x) for x in self.projection
+                    self.analyzer.analyze(x, self.fake_col_name_to_real_col_name)
+                    for x in self.projection
                 )
                 if self.projection
                 else analyzer_utils.STAR
@@ -454,12 +467,12 @@ class SelectStatement(Selectable):
             return self._sql_query
         from_clause = self.from_.sql_in_subquery
         where_clause = (
-            f"{analyzer_utils.WHERE}{self.analyzer.analyze(self.where)}"
+            f"{analyzer_utils.WHERE}{self.analyzer.analyze(self.where, self.fake_col_name_to_real_col_name)}"
             if self.where is not None
             else analyzer_utils.EMPTY_STRING
         )
         order_by_clause = (
-            f"{analyzer_utils.ORDER_BY}{analyzer_utils.COMMA.join(self.analyzer.analyze(x) for x in self.order_by)}"
+            f"{analyzer_utils.ORDER_BY}{analyzer_utils.COMMA.join(self.analyzer.analyze(x, self.fake_col_name_to_real_col_name) for x in self.order_by)}"
             if self.order_by
             else analyzer_utils.EMPTY_STRING
         )
@@ -790,7 +803,9 @@ class SetStatement(Selectable):
     def column_states(self) -> Optional[ColumnStateDict]:
         if not self._column_states:
             self._column_states = initiate_column_states(
-                self.set_operands[0].selectable.column_states.projection, self.analyzer
+                self.set_operands[0].selectable.column_states.projection,
+                self.analyzer,
+                self.fake_col_name_to_real_col_name,
             )
         return self._column_states
 
@@ -809,7 +824,11 @@ class DeriveColumnDependencyError(Exception):
     """When deriving column dependencies from the subquery."""
 
 
-def parse_column_name(column: Expression, analyzer: "Analyzer") -> Optional[str]:
+def parse_column_name(
+    column: Expression,
+    analyzer: "Analyzer",
+    fake_col_name_to_real_col_name: Dict[str, str],
+) -> Optional[str]:
     if isinstance(column, Expression):
         if isinstance(column, Attribute):
             # Use analyze for the case of
@@ -820,12 +839,18 @@ def parse_column_name(column: Expression, analyzer: "Analyzer") -> Optional[str]
             # some expressions converted to SQL text with extra preceeding and trailing spaces.
             # Snowflake SQL removes the spaces in the returned column names.
             # So we remove it at the client too.
-            return analyzer.analyze(column, parse_local_name=True).strip(" ")
+            return analyzer.analyze(
+                column, fake_col_name_to_real_col_name, parse_local_name=True
+            ).strip(" ")
         if isinstance(column, UnresolvedAttribute):
+            if column.df_alias:
+                return analyzer.analyze(column, fake_col_name_to_real_col_name)
             if not column.is_sql_text:
                 return column.name
         if isinstance(column, UnresolvedAlias):
-            return analyzer.analyze(column, parse_local_name=True).strip(" ")
+            return analyzer.analyze(
+                column, fake_col_name_to_real_col_name, parse_local_name=True
+            ).strip(" ")
         if isinstance(column, Alias):
             return column.name
     # We can parse column name from a column's SQL expression in the future.
@@ -919,12 +944,16 @@ def can_clause_dependent_columns_flatten(
 
 
 def initiate_column_states(
-    column_attrs: List[Attribute], analyzer: "Analyzer"
+    column_attrs: List[Attribute],
+    analyzer: "Analyzer",
+    fake_col_name_to_real_col_name: Dict[str, str],
 ) -> ColumnStateDict:
     column_states = ColumnStateDict()
     for attr in column_attrs:
         # review later. should use parse_column_name
-        name = analyzer.analyze(attr, parse_local_name=True).strip(" ")
+        name = analyzer.analyze(
+            attr, fake_col_name_to_real_col_name, parse_local_name=True
+        ).strip(" ")
         column_states[name] = ColumnState(
             name,
             change_state=ColumnChangeState.UNCHANGED_EXP,
@@ -975,10 +1004,14 @@ def derive_column_states_from_subquery(
                 columns_from_star = [copy(e) for e in c.child.expressions]
             else:
                 columns_from_star = [copy(e) for e in from_.column_states.projection]
-            column_states.update(initiate_column_states(columns_from_star, analyzer))
+            column_states.update(
+                initiate_column_states(
+                    columns_from_star, analyzer, from_.fake_col_name_to_real_col_name
+                )
+            )
             column_states.projection.extend(columns_from_star)
             continue
-        c_name = parse_column_name(c, analyzer)
+        c_name = parse_column_name(c, analyzer, from_.fake_col_name_to_real_col_name)
         if c_name is None:
             return None
         quoted_c_name = analyzer_utils.quote_name(c_name)
@@ -990,7 +1023,9 @@ def derive_column_states_from_subquery(
         from_c_state = from_.column_states.get(quoted_c_name)
         if from_c_state and from_c_state.change_state != ColumnChangeState.DROPPED:
             # review later. should use parse_column_name
-            if c_name != analyzer.analyze(c, parse_local_name=True).strip(" "):
+            if c_name != analyzer.analyze(
+                c, from_.fake_col_name_to_real_col_name, parse_local_name=True
+            ).strip(" "):
                 column_states[quoted_c_name] = ColumnState(
                     quoted_c_name,
                     ColumnChangeState.CHANGED_EXP,

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -315,6 +315,7 @@ class SnowflakePlanBuilder:
             source_plan,
             is_ddl_on_temp_object,
             api_calls=select_child.api_calls,
+            df_aliased_col_name_to_real_col_name=child.df_aliased_col_name_to_real_col_name,
         )
 
     @SnowflakePlan.Decorator.wrap_exception

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -190,6 +190,7 @@ class SnowflakePlan(LogicalPlan):
         source_plan: Optional[LogicalPlan] = None,
         is_ddl_on_temp_object: bool = False,
         api_calls: Optional[List[Dict]] = None,
+        fake_col_name_to_real_col_name: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__()
         self.queries = queries
@@ -204,7 +205,7 @@ class SnowflakePlan(LogicalPlan):
         self.api_calls = api_calls.copy() if api_calls else []
         self._output_dict = None
         # Used for dataframe alias
-        self.aliased_cols_to_expr_id = {}
+        self.fake_col_name_to_real_col_name = {}
 
     def with_subqueries(self, subquery_plans: List["SnowflakePlan"]) -> "SnowflakePlan":
         pre_queries = self.queries[:-1]
@@ -232,6 +233,7 @@ class SnowflakePlan(LogicalPlan):
             session=self.session,
             source_plan=self.source_plan,
             api_calls=api_calls,
+            fake_col_name_to_real_col_name=self.fake_col_name_to_real_col_name.copy(),
         )
 
     @cached_property
@@ -262,6 +264,9 @@ class SnowflakePlan(LogicalPlan):
             self.source_plan,
             self.is_ddl_on_temp_object,
             self.api_calls.copy() if self.api_calls else None,
+            self.fake_col_name_to_real_col_name.copy()
+            if self.fake_col_name_to_real_col_name
+            else None,
         )
 
     def add_aliases(self, to_add: Dict) -> None:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -205,7 +205,9 @@ class SnowflakePlan(LogicalPlan):
         self.api_calls = api_calls.copy() if api_calls else []
         self._output_dict = None
         # Used for dataframe alias
-        self.fake_col_name_to_real_col_name = {}
+        self.fake_col_name_to_real_col_name = (
+            fake_col_name_to_real_col_name or {}
+        ).copy()
 
     def with_subqueries(self, subquery_plans: List["SnowflakePlan"]) -> "SnowflakePlan":
         pre_queries = self.queries[:-1]
@@ -264,9 +266,7 @@ class SnowflakePlan(LogicalPlan):
             self.source_plan,
             self.is_ddl_on_temp_object,
             self.api_calls.copy() if self.api_calls else None,
-            self.fake_col_name_to_real_col_name.copy()
-            if self.fake_col_name_to_real_col_name
-            else None,
+            self.fake_col_name_to_real_col_name.copy(),
         )
 
     def add_aliases(self, to_add: Dict) -> None:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -190,7 +190,7 @@ class SnowflakePlan(LogicalPlan):
         source_plan: Optional[LogicalPlan] = None,
         is_ddl_on_temp_object: bool = False,
         api_calls: Optional[List[Dict]] = None,
-        fake_col_name_to_real_col_name: Optional[Dict[str, str]] = None,
+        df_aliased_col_name_to_real_col_name: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__()
         self.queries = queries
@@ -205,8 +205,8 @@ class SnowflakePlan(LogicalPlan):
         self.api_calls = api_calls.copy() if api_calls else []
         self._output_dict = None
         # Used for dataframe alias
-        self.fake_col_name_to_real_col_name = (
-            fake_col_name_to_real_col_name or {}
+        self.df_aliased_col_name_to_real_col_name = (
+            df_aliased_col_name_to_real_col_name or {}
         ).copy()
 
     def with_subqueries(self, subquery_plans: List["SnowflakePlan"]) -> "SnowflakePlan":
@@ -235,7 +235,7 @@ class SnowflakePlan(LogicalPlan):
             session=self.session,
             source_plan=self.source_plan,
             api_calls=api_calls,
-            fake_col_name_to_real_col_name=self.fake_col_name_to_real_col_name.copy(),
+            df_aliased_col_name_to_real_col_name=self.df_aliased_col_name_to_real_col_name.copy(),
         )
 
     @cached_property
@@ -266,7 +266,7 @@ class SnowflakePlan(LogicalPlan):
             self.source_plan,
             self.is_ddl_on_temp_object,
             self.api_calls.copy() if self.api_calls else None,
-            self.fake_col_name_to_real_col_name.copy(),
+            self.df_aliased_col_name_to_real_col_name.copy(),
         )
 
     def add_aliases(self, to_add: Dict) -> None:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -203,6 +203,8 @@ class SnowflakePlan(LogicalPlan):
         # previous SnowflakePlan objects
         self.api_calls = api_calls.copy() if api_calls else []
         self._output_dict = None
+        # Used for dataframe alias
+        self.aliased_cols_to_expr_id = {}
 
     def with_subqueries(self, subquery_plans: List["SnowflakePlan"]) -> "SnowflakePlan":
         pre_queries = self.queries[:-1]

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -239,7 +239,7 @@ class SnowparkClientExceptionMessages:
     @staticmethod
     def DF_ALIAS_NOT_RECOGNIZED(alias: str) -> SnowparkDataframeException:
         return SnowparkDataframeException(
-            f"DataFrame alias unrecognized. A subset of columns corresponding to Dataframe alias {alias} can not be found. "
+            f"DataFrame alias unrecognized. A subset of columns corresponding to Dataframe alias '{alias}' can not be found. "
             "1208",
         )
 

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -237,6 +237,13 @@ class SnowparkClientExceptionMessages:
         )
 
     @staticmethod
+    def DF_ALIAS_NOT_RECOGNIZED(alias: str) -> SnowparkDataframeException:
+        return SnowparkDataframeException(
+            f"DataFrame alias unrecognized. A subset of columns corresponding to Dataframe alias {alias} can not be found. "
+            "1208",
+        )
+
+    @staticmethod
     def PLAN_CREATE_DYNAMIC_TABLE_FROM_SELECT_ONLY() -> SnowparkCreateDynamicTableException:
         return SnowparkCreateDynamicTableException(
             "Creating dynamic tables from SELECT queries supported only.", "1208"

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -769,7 +769,7 @@ def generate_call_python_sp_sql(
     sql_args = []
     for arg in args:
         if isinstance(arg, snowflake.snowpark.Column):
-            sql_args.append(session._analyzer.analyze(arg._expression))
+            sql_args.append(session._analyzer.analyze(arg._expression, {}))
         else:
             sql_args.append(to_sql(arg, infer_type(arg)))
     return f"CALL {sproc_name}({', '.join(sql_args)})"

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -225,10 +225,11 @@ class Column:
         if expr2 is not None:
             if isinstance(expr1, str) and isinstance(expr2, str):
                 if expr2 == "*":
-                    raise NotImplementedError("<df_alias>.* is not supported yet")
-                self._expression = UnresolvedAttribute(
-                    quote_name(expr2), df_alias=expr1
-                )
+                    self._expression = Star([], df_alias=expr1)
+                else:
+                    self._expression = UnresolvedAttribute(
+                        quote_name(expr2), df_alias=expr1
+                    )
             else:
                 raise ValueError(
                     "When Column constructor gets two arguments, both need to be <str>"

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import quote_name
@@ -219,12 +219,17 @@ class Column:
     This class has methods for the most frequently used column transformations and operators. Module :mod:`snowflake.snowpark.functions` defines many functions to transform columns.
     """
 
-    def __init__(self, expr: Union[str, Expression]) -> None:
+    def __init__(self, expr: Union[str, Expression, Tuple[str, str]]) -> None:
         if isinstance(expr, str):
             if expr == "*":
                 self._expression = Star([])
             else:
                 self._expression = UnresolvedAttribute(quote_name(expr))
+        elif isinstance(expr, tuple):
+            # TODO: handle star
+            self._expression = UnresolvedAttribute(
+                quote_name(expr[1]), df_alias=expr[0]
+            )
         elif isinstance(expr, Expression):
             self._expression = expr
         else:  # pragma: no cover

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import quote_name
@@ -219,17 +219,22 @@ class Column:
     This class has methods for the most frequently used column transformations and operators. Module :mod:`snowflake.snowpark.functions` defines many functions to transform columns.
     """
 
-    def __init__(self, expr: Union[str, Expression, Tuple[str, str]]) -> None:
-        if isinstance(expr, str):
+    def __init__(
+        self, expr: Union[str, Expression], expr2: Optional[str] = None
+    ) -> None:
+        if expr2 is not None:
+            if isinstance(expr, str) and isinstance(expr2, str):
+                # TODO: handle *
+                self._expression = UnresolvedAttribute(quote_name(expr2), df_alias=expr)
+            else:
+                raise ValueError(
+                    "When Column constructor gets two arguments, both need to be <str>"
+                )
+        elif isinstance(expr, str):
             if expr == "*":
                 self._expression = Star([])
             else:
                 self._expression = UnresolvedAttribute(quote_name(expr))
-        elif isinstance(expr, tuple):
-            # TODO: handle star
-            self._expression = UnresolvedAttribute(
-                quote_name(expr[1]), df_alias=expr[0]
-            )
         elif isinstance(expr, Expression):
             self._expression = expr
         else:  # pragma: no cover

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -220,23 +220,26 @@ class Column:
     """
 
     def __init__(
-        self, expr: Union[str, Expression], expr2: Optional[str] = None
+        self, expr1: Union[str, Expression], expr2: Optional[str] = None
     ) -> None:
         if expr2 is not None:
-            if isinstance(expr, str) and isinstance(expr2, str):
-                # TODO: handle *
-                self._expression = UnresolvedAttribute(quote_name(expr2), df_alias=expr)
+            if isinstance(expr1, str) and isinstance(expr2, str):
+                if expr2 == "*":
+                    raise NotImplementedError("<df_alias>.* is not supported yet")
+                self._expression = UnresolvedAttribute(
+                    quote_name(expr2), df_alias=expr1
+                )
             else:
                 raise ValueError(
                     "When Column constructor gets two arguments, both need to be <str>"
                 )
-        elif isinstance(expr, str):
-            if expr == "*":
+        elif isinstance(expr1, str):
+            if expr1 == "*":
                 self._expression = Star([])
             else:
-                self._expression = UnresolvedAttribute(quote_name(expr))
-        elif isinstance(expr, Expression):
-            self._expression = expr
+                self._expression = UnresolvedAttribute(quote_name(expr1))
+        elif isinstance(expr1, Expression):
+            self._expression = expr1
         else:  # pragma: no cover
             raise TypeError("Column constructor only accepts str or expression.")
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -234,6 +234,8 @@ def _disambiguate(
         # We use the session of the LHS DataFrame to report this telemetry
         lhs._session._conn._telemetry_client.send_alias_in_join_telemetry()
 
+    lsuffix = lsuffix or lhs._alias
+    rsuffix = rsuffix or rhs._alias
     suffix_provided = lsuffix or rsuffix
     lhs_prefix = _generate_prefix("l") if not suffix_provided else ""
     rhs_prefix = _generate_prefix("r") if not suffix_provided else ""
@@ -523,6 +525,8 @@ class DataFrame:
         self.dropna = self._na.drop
         self.fillna = self._na.fill
         self.replace = self._na.replace
+
+        self._alias = None
 
     @property
     def stat(self) -> DataFrameStatFunctions:
@@ -1252,12 +1256,11 @@ class DataFrame:
 
     def alias(self, name: str):
         _copy = copy.copy(self)
-        _copy.alias = name
+        _copy._alias = name
         for attr in self._plan.attributes:
-            _copy._plan.aliased_cols_to_expr_id[
+            _copy._plan.fake_col_name_to_real_col_name[
                 f"{name}.{attr}"
-            ] = attr.expr_id  # attr is quoted already
-            _copy._plan.expr_to_alias[attr.expr_id] = attr.name
+            ] = attr.name  # attr is quoted already
         return _copy
 
     @df_api_usage

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1302,12 +1302,12 @@ class DataFrame:
         _copy._alias = name
         for attr in self._plan.attributes:
             if _copy._select_statement:
-                _copy._select_statement.df_aliased_col_name_to_real_col_name[
-                    f"{name}.{attr}"
+                _copy._select_statement.df_aliased_col_name_to_real_col_name[name][
+                    attr.name
                 ] = attr.name  # attr is quoted already
-            _copy._plan.df_aliased_col_name_to_real_col_name[
-                f"{name}.{attr}"
-            ] = attr.name  # attr is quoted already
+            _copy._plan.df_aliased_col_name_to_real_col_name[name][
+                attr.name
+            ] = attr.name
         return _copy
 
     @df_api_usage

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -708,7 +708,7 @@ class DataFrame:
         )
 
     def __copy__(self) -> "DataFrame":
-        return DataFrame(self._session, copy.copy(self._select_statement or self._plan))
+        return DataFrame(self._session, copy.copy(self._plan))
 
     if installed_pandas:
         import pandas  # pragma: no cover

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -530,7 +530,7 @@ class DataFrame:
         self.fillna = self._na.fill
         self.replace = self._na.replace
 
-        self._alias = None  # TODO: this needs to be checked
+        self._alias: Optional[str] = None
 
     @property
     def stat(self) -> DataFrameStatFunctions:

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -287,7 +287,9 @@ class DataFrameReader:
         self._user_schema = schema
         return self
 
-    def with_metadata(self, *metadata_cols: Iterable[_MetadataColumn]) -> "DataFrameReader":
+    def with_metadata(
+        self, *metadata_cols: Iterable[_MetadataColumn]
+    ) -> "DataFrameReader":
         """Define the metadata columns that need to be selected from stage files.
 
         Returns:
@@ -327,7 +329,7 @@ class DataFrameReader:
 
         if self._metadata_cols:
             metadata_project = [
-                self._session._analyzer.analyze(col._expression)
+                self._session._analyzer.analyze(col._expression, {})
                 for col in self._metadata_cols
             ]
         else:
@@ -560,7 +562,7 @@ class DataFrameReader:
 
         if self._metadata_cols:
             metadata_project = [
-                self._session._analyzer.analyze(col._expression)
+                self._session._analyzer.analyze(col._expression, {})
                 for col in self._metadata_cols
             ]
         else:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -215,7 +215,7 @@ except ImportError:
     from collections.abc import Iterable
 
 
-def col(col_name: str) -> Column:
+def col(name1: str, name2: Optional[str] = None) -> Column:
     """Returns the :class:`~snowflake.snowpark.Column` with the specified name.
 
     Example::
@@ -223,7 +223,10 @@ def col(col_name: str) -> Column:
         >>> df.select(col("a")).collect()
         [Row(A=1)]
     """
-    return Column(col_name)
+    if name2 is None:
+        return Column(name1)
+    else:
+        return Column(name1, name2)
 
 
 def column(col_name: str) -> Column:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -215,7 +215,8 @@ except ImportError:
     from collections.abc import Iterable
 
 
-def col(name1: str, name2: Optional[str] = None) -> Column:
+@overload
+def col(col_name: str) -> Column:
     """Returns the :class:`~snowflake.snowpark.Column` with the specified name.
 
     Example::
@@ -223,12 +224,29 @@ def col(name1: str, name2: Optional[str] = None) -> Column:
         >>> df.select(col("a")).collect()
         [Row(A=1)]
     """
+    ...  # pragma: no cover
+
+
+@overload
+def col(df_alias: str, col_name: str) -> Column:
+    """Returns the :class:`~snowflake.snowpark.Column` with the specified dataframe alias and column name.
+
+    Example::
+        >>> df = session.sql("select 1 as a")
+        >>> df.alias("df").select(col("df", "a")).collect()
+        [Row(A=1)]
+    """
+    ...  # pragma: no cover
+
+
+def col(name1: str, name2: Optional[str] = None) -> Column:
     if name2 is None:
         return Column(name1)
     else:
         return Column(name1, name2)
 
 
+@overload
 def column(col_name: str) -> Column:
     """Returns a :class:`~snowflake.snowpark.Column` with the specified name. Alias for col.
 
@@ -237,7 +255,26 @@ def column(col_name: str) -> Column:
         >>> df.select(column("a")).collect()
         [Row(A=1)]
     """
-    return Column(col_name)
+    ...  # pragma: no cover
+
+
+@overload
+def column(df_alias: str, col_name: str) -> Column:
+    """Returns a :class:`~snowflake.snowpark.Column` with the specified name and dataframe alias name. Alias for col.
+
+    Example::
+        >>> df = session.sql("select 1 as a")
+        >>> df.alias("df").select(column("df", "a")).collect()
+        [Row(A=1)]
+    """
+    ...  # pragma: no cover
+
+
+def column(name1: str, name2: Optional[str] = None) -> Column:
+    if name2 is None:
+        return Column(name1)
+    else:
+        return Column(name1, name2)
 
 
 def lit(literal: LiteralType) -> Column:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1163,7 +1163,7 @@ class Session:
         if timelimit != 0:
             named_args["timelimit"] = lit(timelimit)._expression
 
-        operators = [self._analyzer.analyze(col._expression) for col in columns]
+        operators = [self._analyzer.analyze(col._expression, {}) for col in columns]
         func_expr = GeneratorTableFunction(args=named_args, operators=operators)
 
         if self.sql_simplifier_enabled:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -26,6 +26,7 @@ from snowflake.snowpark.exceptions import (
     SnowparkColumnException,
     SnowparkCreateDynamicTableException,
     SnowparkCreateViewException,
+    SnowparkDataframeException,
     SnowparkSQLException,
 )
 from snowflake.snowpark.functions import (
@@ -2906,3 +2907,12 @@ def test_dataframe_alias(session):
         .join(df2.alias("df2"), col("df2", "col1") == col("df3", "col1")),
         df1.join(df3, df1.col1 == df3.col1).join(df2, df2.col1 == df3.col1),
     )
+
+
+def test_dataframe_alias_negative(session):
+    df = session.sql("select 1 as a")
+    with pytest.raises(SnowparkDataframeException):
+        df.alias("df").select(col("non_existent", "a"))
+
+    with pytest.raises(SnowparkDataframeException):
+        df.alias("b c.d").select(col("d", "a"))

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2839,9 +2839,8 @@ def test_nested_joins(session):
 
 def test_dataframe_alias(session):
     """Test `dataframe.alias`"""
-    session.sql_simplifier_enabled = False
-    df1 = session.create_dataframe([[1, 6], [3, 8]], schema=["col1", "col2"])
-    df2 = session.create_dataframe([[1, 2], [3, 4]], schema=["col1", "col2"])
+    df1 = session.create_dataframe([[1, 6], [3, 8], [7, 7]], schema=["col1", "col2"])
+    df2 = session.create_dataframe([[1, 2], [3, 4], [5, 5]], schema=["col1", "col2"])
 
     # Test select aliased df's columns
     Utils.check_answer(
@@ -2869,4 +2868,14 @@ def test_dataframe_alias(session):
         .join(df1.alias("R"), on="col1")
         .select(col("L", "col1"), col("R", "col2")),
         df1.join(df1_copy, on="col1").select(df1["col1"], df1_copy["col2"]),
+    )
+
+    # Test dropping columns from aliased dataframe
+    Utils.check_answer(df1.alias("df1").drop(col("df1", "col1")), df1.select("col2"))
+    Utils.check_answer(df2.alias("df2").drop(col("df2", "col2")), df2.select("col1"))
+
+    # Test renaming columns from aliased dataframe
+    Utils.check_answer(
+        df1.alias("df1").with_column_renamed(col("df1", "col1"), "col3"),
+        df1.with_column_renamed("col1", "col3"),
     )

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2835,3 +2835,31 @@ def test_nested_joins(session):
         key=lambda r: r[0],
     )
     assert res1 == res2 == res3
+
+
+def test_dataframe_alias(session):
+    session.sql_simplifier_enabled = False
+    df1 = session.create_dataframe([[1, 6], [3, 8]], schema=["col1", "col2"])
+    df2 = session.create_dataframe([[1, 2], [3, 4]], schema=["col1", "col2"])
+
+    df1.alias("A").select(col(("A", "col1")), col(("A", "col2"))).show()
+
+    # df1.alias("A").select("*").select(col(("A", "col1")), col(("A", "col2"))).show()
+    # df1.alias("L").join(df2.alias("R")).select(col(("A", "col1"))).show()
+
+    # df1.join(df2).select(df1["col1"]).show()
+
+    # is dataframe.alias just one step further than hiding internal alias? Such that, df1.alias("L").join(df2).select("L.col1") works?
+
+    # print(df1.alias("A").select(col(("A", "col1"))).queries) # select col("col1") should also work
+
+    # JOIN
+    # common use case
+    q = df1.alias("L").join(df2.alias("R"), col(("L", "col1")) == col(("R", "col1")))
+    print(q.queries)
+    q.show()
+    q.select(col(("L", "col1"))).show()
+    # df1.alias("L").join(df2.alias("R"), col("L", "col1") == col("R", "col1")).select(col("L", "col2")).show()
+
+    # self join
+    # df1.alias("L").join(df1.alias("R"), on="col1").select(col("L", "col2"))

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
-
+import copy
 import datetime
 import json
 import logging
@@ -2838,28 +2838,35 @@ def test_nested_joins(session):
 
 
 def test_dataframe_alias(session):
+    """Test `dataframe.alias`"""
     session.sql_simplifier_enabled = False
     df1 = session.create_dataframe([[1, 6], [3, 8]], schema=["col1", "col2"])
     df2 = session.create_dataframe([[1, 2], [3, 4]], schema=["col1", "col2"])
 
-    df1.alias("A").select(col(("A", "col1")), col(("A", "col2"))).show()
+    # Test select aliased df's columns
+    Utils.check_answer(
+        df1.alias("A").select(col("A", "col1"), col("A", "col2")), df1.select("*")
+    )
 
-    # df1.alias("A").select("*").select(col(("A", "col1")), col(("A", "col2"))).show()
-    # df1.alias("L").join(df2.alias("R")).select(col(("A", "col1"))).show()
+    # Test join with one aliased datafeame
+    Utils.check_answer(
+        df1.alias("L").join(df2, col("L", "col1") == col("col1")),
+        df1.join(df2, df1["col1"] == df2["col1"]),
+    )
 
-    # df1.join(df2).select(df1["col1"]).show()
+    # Test join with two aliased dataframes
+    Utils.check_answer(
+        df1.alias("L")
+        .join(df2.alias("R"), col("L", "col1") == col("R", "col1"))
+        .select(col("L", "col1"), col("R", "col2")),
+        df1.join(df2, df1["col1"] == df2["col1"]).select(df1["col1"], df2["col2"]),
+    )
 
-    # is dataframe.alias just one step further than hiding internal alias? Such that, df1.alias("L").join(df2).select("L.col1") works?
-
-    # print(df1.alias("A").select(col(("A", "col1"))).queries) # select col("col1") should also work
-
-    # JOIN
-    # common use case
-    q = df1.alias("L").join(df2.alias("R"), col(("L", "col1")) == col(("R", "col1")))
-    print(q.queries)
-    q.show()
-    q.select(col(("L", "col1"))).show()
-    # df1.alias("L").join(df2.alias("R"), col("L", "col1") == col("R", "col1")).select(col("L", "col2")).show()
-
-    # self join
-    # df1.alias("L").join(df1.alias("R"), on="col1").select(col("L", "col2"))
+    # Test self join with aliased dataframe
+    df1_copy = copy.copy(df1)
+    Utils.check_answer(
+        df1.alias("L")
+        .join(df1.alias("R"), on="col1")
+        .select(col("L", "col1"), col("R", "col2")),
+        df1.join(df1_copy, on="col1").select(df1["col1"], df1_copy["col2"]),
+    )

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2879,3 +2879,30 @@ def test_dataframe_alias(session):
         df1.alias("df1").with_column_renamed(col("df1", "col1"), "col3"),
         df1.with_column_renamed("col1", "col3"),
     )
+
+    # Test alias, join, with_column
+    Utils.check_answer(
+        df1.alias("L")
+        .join(df2.alias("R"), col("L", "col1") == col("R", "col1"))
+        .with_columns(
+            ["L_mean", "R_sum"],
+            [
+                (col("L", "col1") + col("L", "col2")) / 2,
+                col("R", "col1") + col("R", "col2"),
+            ],
+        ),
+        df1.join(df2, df1["col1"] == df2["col1"]).with_columns(
+            ["L_mean", "R_sum"],
+            [(df1["col1"] + df1["col2"]) / 2, df2["col1"] + df2["col2"]],
+        ),
+    )
+
+    df3 = session.create_dataframe([[1, 2], [3, 4], [5, 5]], schema=["col1", "col4"])
+
+    # Test nested alias, join
+    Utils.check_answer(
+        df1.alias("df1")
+        .join(df3.alias("df3"), col("df1", "col1") == col("df3", "col1"))
+        .join(df2.alias("df2"), col("df2", "col1") == col("df3", "col1")),
+        df1.join(df3, df1.col1 == df3.col1).join(df2, df2.col1 == df3.col1),
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-629569

2. Fill out the following pre-review checklist:

   - [c] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Implement dataframe.alias to enable (1) joining two dataframes with duplicate columns w/o specifying suffix, (2) self join (3) referring to columns with syntax `col(<df alias name>, <col name>)` after such joins.
   
   **TODO:**
    - Add `col(<df alias name>, "*")` support
    - Make df.copy preserve `df._select_statement`, such that self join queries can be flattened.



   

