### PR TITLE
SNOW-809689 Use snowflake only when no current database exists

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -863,7 +863,7 @@ class Session:
         package_table = "information_schema.packages"
         # TODO: Use the database from fully qualified UDF name
         if not self.get_current_database():
-            package_table = "snowflake." + package_table
+            package_table = f"snowflake.{package_table}"
 
         valid_packages = (
             {

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -860,10 +860,15 @@ class Session:
             )
             package_dict[package] = (package_name, use_local_version, package_req)
 
+        package_table = "information_schema.packages"
+        # TODO: Use the database from fully qualified UDF name
+        if not self.get_current_database():
+            package_table = "snowflake." + package_table
+
         valid_packages = (
             {
                 p[0]: json.loads(p[1])
-                for p in self.table("snowflake.information_schema.packages")
+                for p in self.table(package_table)
                 .filter(
                     (col("language") == "python")
                     & (col("package_name").in_([v[0] for v in package_dict.values()]))

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -126,15 +126,16 @@ def test_resolve_package_current_database(has_current_database):
         return "db" if has_current_database else None
 
     def mock_get_information_schema_packages(table_name: str):
-        if (has_current_database and table_name == "information_schema.packages") or (
-            not has_current_database
-            and table_name == "snowflake.information_schema.packages"
-        ):
-            result = MagicMock()
-            result.filter().group_by().agg()._internal_collect_with_tag.return_value = [
-                ("random_package_name", json.dumps(["1.0.0"]))
-            ]
-            return result
+        if has_current_database:
+            assert table_name == "information_schema.packages"
+        else:
+            assert table_name == "snowflake.information_schema.packages"
+
+        result = MagicMock()
+        result.filter().group_by().agg()._internal_collect_with_tag.return_value = [
+            ("random_package_name", json.dumps(["1.0.0"]))
+        ]
+        return result
 
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,8 +1,9 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
-
+import json
 import os
+from typing import Optional
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -119,13 +120,41 @@ def test_resolve_import_path_ignore_import_path(tmp_path_factory):
         os.remove(a_temp_file)
 
 
+@pytest.mark.parametrize("has_current_database", (True, False))
+def test_resolve_package_current_database(has_current_database):
+    def mock_get_current_parameter(param: str, quoted: bool = True) -> Optional[str]:
+        return "db" if has_current_database else None
+
+    def mock_get_information_schema_packages(table_name: str):
+        if (has_current_database and table_name == "information_schema.packages") or (
+            not has_current_database
+            and table_name == "snowflake.information_schema.packages"
+        ):
+            result = MagicMock()
+            result.filter().group_by().agg()._internal_collect_with_tag.return_value = [
+                ("random_package_name", json.dumps(["1.0.0"]))
+            ]
+            return result
+
+    fake_connection = mock.create_autospec(ServerConnection)
+    fake_connection._conn = mock.Mock()
+    fake_connection._get_current_parameter = mock_get_current_parameter
+    session = Session(fake_connection)
+    session.table = MagicMock(name="session.table")
+    session.table.side_effect = mock_get_information_schema_packages
+
+    session._resolve_packages(
+        ["random_package_name"], validate_package=True, include_pandas=False
+    )
+
+
 def test_resolve_package_terms_not_accepted():
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()
     session = Session(fake_connection)
 
     def get_information_schema_packages(table_name: str):
-        if table_name == "snowflake.information_schema.packages":
+        if table_name == "information_schema.packages":
             result = MagicMock()
             result.filter().group_by().agg()._internal_collect_with_tag.return_value = (
                 []


### PR DESCRIPTION
Description

Some internal accounts do not have snowflake as database. Use snowflake by default will cause problems for these accounts

Testing

internal test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-809689

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Some internal accounts do not have snowflake as database. Use snowflake by default will cause problems for these accounts
