### PR TITLE
SNOW-823418 Allow Snowpark client to run on Python 3.9 runtime environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
 CONNECTOR_DEPENDENCY_VERSION = ">=2.7.12, <4.0.0"
-REQUIRED_PYTHON_VERSION = "==3.8.*"
+REQUIRED_PYTHON_VERSION = ">=3.8, <3.10"
 if os.getenv("SNOWFLAKE_IS_PYTHON_RUNTIME_TEST", False):
     REQUIRED_PYTHON_VERSION = ">=3.8"
 
@@ -94,6 +94,7 @@ setup(
         "Programming Language :: SQL",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Database",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-823418

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Adding 3.9 support for snowpark client.
