### PR TITLE
Fix Code generation and Types to be compatible with Python 3.11+

### DIFF
--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -180,12 +180,12 @@ def get_class_references(
 
 def extract_func_global_refs(code: CodeType) -> Set[str]:
     # inspired by cloudpickle to recursively extract all the global references used by the target func's code object
-    co_names = code.co_names
+    co_names = set(code.co_names)
     out_names = set()
     for instr in dis.get_instructions(code):
         op = instr.opcode
-        if op in GLOBAL_OPS:
-            out_names.add(co_names[instr.arg])
+        if op in GLOBAL_OPS and instr.argval in co_names:
+            out_names.add(instr.argval)
 
     if code.co_consts:
         for const in code.co_consts:

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -5,6 +5,7 @@
 
 """This package contains all Snowpark logical types."""
 import re
+import sys
 from typing import Generic, List, Optional, TypeVar, Union
 
 import snowflake.snowpark._internal.analyzer.expression as expression
@@ -401,11 +402,23 @@ if installed_pandas:  # pragma: no cover
 
     _TT = TypeVarTuple("_TT")
 
-    class PandasDataFrame(pandas.DataFrame, Generic[_TT]):
-        """
-        The type hint for annotating Pandas DataFrame data when registering UDFs.
-        The input should be a list of data types for all columns in order.
-        It cannot be used to annotate the return value of a Pandas UDF.
-        """
+    if sys.version_info >= (3, 11):
+        from typing import Unpack
+
+        class PandasDataFrame(pandas.DataFrame, Generic[Unpack[_TT]]):
+            """
+            The type hint for annotating Pandas DataFrame data when registering UDFs.
+            The input should be a list of data types for all columns in order.
+            It cannot be used to annotate the return value of a Pandas UDF.
+            """
+
+            pass
+    else:
+        class PandasDataFrame(pandas.DataFrame, Generic[_TT]):
+            """
+            The type hint for annotating Pandas DataFrame data when registering UDFs.
+            The input should be a list of data types for all columns in order.
+            It cannot be used to annotate the return value of a Pandas UDF.
+            """
 
         pass


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes: Not in Jira

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [x] I am fixing code generator on Python 3.11
   - [x] I am adding source code compatibility with Python 3.11

3. Please describe how your code solves the related issue.

   I'm using this project as third-party library to in my project. This project runs on Python 3.10, Python 3.11.
   The only one feature I'm use is generate SQL queries to request data from Snowflake, but project team doesn't support Python 3.9+. To improve my build quality I started run unit tests, but one or two of them failed.
   The issue is in new Python 3.11 commands flow who discovered the error in the extract_func_global_refs method.
   I rewrote it with the correct logic. Additionally I send you patch to fix source codes incompatibility with Python 3.11

   P.S.: All unit tests passed with Python 3.9, Python 3.10, Python 3.11.
