### PR TITLE
use pandas.testing for assert_frame_equal

### DIFF
--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -8,7 +8,7 @@ from time import sleep, time
 
 import pandas as pd
 import pytest
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from snowflake.connector.errors import DatabaseError
 from snowflake.snowpark import Row

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -8,7 +8,7 @@ from typing import Iterator
 import pandas as pd
 import pytest
 from pandas import DataFrame as PandasDF, Series as PandasSeries
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkFetchDataException


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Our tests are breaking due to pandas import `pandas.utils.testing`. Use `pandas.testing` instead.
   
   See Also: https://github.com/pydata/pandas-datareader/issues/775
   