### PR TITLE
SNOW-656580 support geometry data type in snowpark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.6.0 (TBD)
+
+### New Features
+
+- Added support for Geometry data.
+
+### Dependency updates
+
+- Updated `snowflake-connector-python` to 3.0.4.
+
 ## 1.5.0 (TBD)
 
 ### New Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,12 +11,13 @@ make html
 
 If you get warnings, like "WARNING: [autosummary] failed to import 'snowpark.dataframe': no module named snowpark.dataframe", try reinstalling the Snowpark API:
 
-```
+```bash
 python -m pip install ".[development, pandas]"
 ```
 
-You might need to install Sphinx: 
-```
+You might need to install Sphinx:
+
+```bash
 python -m pip install sphinx
 ```
 
@@ -28,18 +29,21 @@ Important files and directories:
 `docs/source/conf.py`: The configuration parameters for Sphinx and autosummary.
 `docs/source/_templates/`: Directory containing JINJA templates used by autosummary.
 `docs/source/_themes/snowflake_rtd_theme/layout.html`: All of the theme stuff is the same as the snowflake_rtd_theme in the normal Snowflake doc repo. This layout file is the only thing I modified.
-`docs/source/util.py`: A utility script that generates a rst for a module or a list of classes within the same module. This should be used for reference only. 
-Example usage: 
-```
+`docs/source/util.py`: A utility script that generates a rst for a module or a list of classes within the same module. This should be used for reference only.
+Example usage:
+
+```bash
 ./doc_gen.py snowflake.snowpark -c DataFrame DataFrameNaFunctions DataFrameStatFunctions
 ./doc_gen.py snowflake.snowpark.functions
 ./doc_gen.py snowflake.snowpark.table_function -c TableFunctionCall -t "Table Function" -f "table_function.rst"
 ```
+
 Note: You need to check what classes are present in a file by specifying the file as a module, e.g. `./doc_gen.py snowflake.snowpark.column`.
 When you use this script to update the existing rst, note that:
-- In `types.rst`, you need to manually move `Geography` and `Variant` from `Attributes` to `Classes`.
+
+- In `types.rst`, you need to manually move `Geography`, `Geometry` and `Variant` from `Attributes` to `Classes`.
 - Still in `types.rst`, change the rubric text to `Classes/Type Hints`.
 - The script currently does not preserve any comments/literal markdown, remember to copy those over to the newly generated rst.
 
-To start from scratch and regenerate the autosummary files that are generated for each module, delete everything in the <root>/snowpark-python/docs/source/api. 
+To start from scratch and regenerate the autosummary files that are generated for each module, delete everything in the <root>/snowpark-python/docs/source/api.
 You might need to do this if you restructure your code or add new classes.

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -275,6 +275,7 @@ Functions
     to_date
     to_decimal
     to_geography
+    to_geometry
     to_json
     to_object
     to_time

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -23,6 +23,8 @@ This package contains all Snowpark logical types.
     FloatType
     Geography
     GeographyType
+    Geometry
+    GeometryType
     IntegerType
     LongType
     MapType

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
-CONNECTOR_DEPENDENCY_VERSION = ">=2.7.12, <4.0.0"
+CONNECTOR_DEPENDENCY_VERSION = ">=3.0.4, <4.0.0"
 REQUIRED_PYTHON_VERSION = "==3.8.*"
 if os.getenv("SNOWFLAKE_IS_PYTHON_RUNTIME_TEST", False):
     REQUIRED_PYTHON_VERSION = ">=3.8"

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -21,6 +21,7 @@ from snowflake.snowpark.types import (
     DateType,
     DecimalType,
     GeographyType,
+    GeometryType,
     MapType,
     NullType,
     StringType,
@@ -48,7 +49,7 @@ def to_sql(value: Any, datatype: DataType, from_values_statement: bool = False) 
     # Handle null values
     if isinstance(
         datatype,
-        (NullType, ArrayType, MapType, StructType, GeographyType),
+        (NullType, ArrayType, MapType, StructType, GeographyType, GeometryType),
     ):
         if value is None:
             return "NULL"
@@ -142,6 +143,8 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
     if is_nullable:
         if isinstance(data_type, GeographyType):
             return "TRY_TO_GEOGRAPHY(NULL)"
+        if isinstance(data_type, GeometryType):
+            return "TRY_TO_GEOMETRY(NULL)"
         if isinstance(data_type, ArrayType):
             return "PARSE_JSON('NULL') :: ARRAY"
         if isinstance(data_type, MapType):
@@ -172,6 +175,8 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
         return "to_variant(0)"
     if isinstance(data_type, GeographyType):
         return "to_geography('POINT(-122.35 37.55)')"
+    if isinstance(data_type, GeometryType):
+        return "to_geometry('POINT(-122.35 37.55)')"
     raise Exception(f"Unsupported data type: {data_type.__class__.__name__}")
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -158,7 +158,7 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
     if isinstance(data_type, StringType):
         return f"'a' :: {analyzer_utils.string(data_type.length)}"
     if isinstance(data_type, BinaryType):
-        return "to_binary(hex_encode(1))"
+        return "'01' :: BINARY"
     if isinstance(data_type, DateType):
         return "date('2020-9-16')"
     if isinstance(data_type, BooleanType):

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -43,6 +43,8 @@ from snowflake.snowpark.types import (
     FloatType,
     Geography,
     GeographyType,
+    Geometry,
+    GeometryType,
     IntegerType,
     LongType,
     MapType,
@@ -87,6 +89,8 @@ def convert_sf_to_sp_type(
         return MapType(StringType(), StringType())
     if column_type_name == "GEOGRAPHY":
         return GeographyType()
+    if column_type_name == "GEOMETRY":
+        return GeometryType()
     if column_type_name == "BOOLEAN":
         return BooleanType()
     if column_type_name == "BINARY":
@@ -173,6 +177,8 @@ def convert_sp_to_sf_type(datatype: DataType) -> str:
         return "VARIANT"
     if isinstance(datatype, GeographyType):
         return "GEOGRAPHY"
+    if isinstance(datatype, GeometryType):
+        return "GEOMETRY"
     raise TypeError(f"Unsupported data type: {datatype.__class__.__name__}")
 
 
@@ -475,6 +481,9 @@ def python_type_to_snow_type(tp: Union[str, Type]) -> Tuple[DataType, bool]:
     if tp == Geography:
         return GeographyType(), False
 
+    if tp == Geometry:
+        return GeometryType(), False
+
     raise TypeError(f"invalid type {tp}")
 
 
@@ -490,6 +499,7 @@ def snow_type_to_dtype_str(snow_type: DataType) -> str:
             TimestampType,
             TimeType,
             GeographyType,
+            GeometryType,
             VariantType,
         ),
     ):

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3124,6 +3124,29 @@ def to_geography(e: ColumnOrName) -> Column:
     return builtin("to_geography")(c)
 
 
+def to_geometry(e: ColumnOrName) -> Column:
+    """Parses an input and returns a value of type GEOMETRY. Supported inputs are strings in
+
+        - WKT (well-known text).
+        - WKB (well-known binary) in hexadecimal format (without a leading 0x).
+        - EWKT (extended well-known text).
+        - EWKB (extended well-known binary) in hexadecimal format (without a leading 0x).
+        - GeoJSON.
+
+    format.
+
+    Example::
+        >>> df = session.create_dataframe(['POINT(-122.35 37.55)', 'POINT(20.92 43.33)'], schema=['a'])
+        >>> df.select(to_geometry(col("a"))).collect(statement_params={"GEOMETRY_OUTPUT_FORMAT": "WKT"})
+        [Row(TO_GEOMETRY("A")='POINT(-122.35 37.55)'), Row(TO_GEOMETRY("A")='POINT(20.92 43.33)')]
+
+    Besides strings, binary representation in WKB and EWKB format can be parsed, or objects adhering to GeoJSON format.
+    For all supported formats confer https://docs.snowflake.com/en/sql-reference/data-types-geospatial#supported-geospatial-object-types.
+    """
+    c = _to_col_if_str(e, "to_geometry")
+    return builtin("to_geometry")(c)
+
+
 def arrays_overlap(array1: ColumnOrName, array2: ColumnOrName) -> Column:
     """Compares whether two ARRAYs have at least one element in common. Returns TRUE
     if there is at least one element in common; otherwise returns FALSE. The function

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -6263,7 +6263,8 @@ def udf(
 
             - You can use use :attr:`~snowflake.snowpark.types.Variant` to
               annotate a variant, and use :attr:`~snowflake.snowpark.types.Geography`
-              to annotate a geography when defining a UDF.
+              or :attr:`~snowflake.snowpark.types.Geometry` to annotate geospatial
+              types when defining a UDF.
 
             - You can use use :attr:`~snowflake.snowpark.types.PandasSeries` to annotate
               a Pandas Series, and use :attr:`~snowflake.snowpark.types.PandasDataFrame`
@@ -6448,7 +6449,8 @@ def udtf(
 
             - You can use use :attr:`~snowflake.snowpark.types.Variant` to
               annotate a variant, and use :attr:`~snowflake.snowpark.types.Geography`
-              to annotate a geography when defining a UDTF.
+              or :attr:`~snowflake.snowpark.types.Geometry` to annotate geospatial
+              types when defining a UDTF.
 
             - :class:`typing.Union` is not a valid type annotation for UDTFs,
               but :class:`typing.Optional` can be used to indicate the optional type.
@@ -6897,7 +6899,8 @@ def sproc(
 
             - You can use :attr:`~snowflake.snowpark.types.Variant` to
               annotate a variant, and use :attr:`~snowflake.snowpark.types.Geography`
-              to annotate a geography when defining a stored procedure.
+              or :attr:`~snowflake.snowpark.types.Geometry` to annotate geospatial
+              types when defining a stored procedure.
 
             - :class:`typing.Union` is not a valid type annotation for stored procedures,
               but :class:`typing.Optional` can be used to indicate the optional type.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1582,7 +1582,7 @@ class Session:
             attrs.append(Attribute(quoted_name, sf_type, field.nullable))
             data_types.append(field.datatype)
 
-        # convert all variant/time/geography/array/map data to string
+        # convert all variant/time/geospatial/array/map data to string
         converted = []
         for row in rows:
             converted_row = []

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -98,6 +98,7 @@ from snowflake.snowpark.functions import (
     to_date,
     to_decimal,
     to_geography,
+    to_geometry,
     to_object,
     to_time,
     to_timestamp,
@@ -116,6 +117,7 @@ from snowflake.snowpark.types import (
     DateType,
     DecimalType,
     GeographyType,
+    GeometryType,
     MapType,
     StringType,
     StructType,
@@ -1572,6 +1574,7 @@ class Session:
                         DateType,
                         TimestampType,
                         GeographyType,
+                        GeometryType,
                     ),
                 )
                 else field.datatype
@@ -1614,6 +1617,8 @@ class Session:
                     converted_row.append(json.dumps(value, cls=PythonObjJSONEncoder))
                 elif isinstance(data_type, GeographyType):
                     converted_row.append(value)
+                elif isinstance(data_type, GeometryType):
+                    converted_row.append(value)
                 else:
                     raise TypeError(
                         f"Cannot cast {type(value)}({value}) to {str(data_type)}."
@@ -1641,6 +1646,8 @@ class Session:
                 project_columns.append(to_variant(parse_json(column(name))).as_(name))
             elif isinstance(field.datatype, GeographyType):
                 project_columns.append(to_geography(column(name)).as_(name))
+            elif isinstance(field.datatype, GeometryType):
+                project_columns.append(to_geometry(column(name)).as_(name))
             elif isinstance(field.datatype, ArrayType):
                 project_columns.append(to_array(parse_json(column(name))).as_(name))
             elif isinstance(field.datatype, MapType):

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -361,6 +361,12 @@ class GeographyType(DataType):
     pass
 
 
+class GeometryType(DataType):
+    """Geometry data type. This maps to the GEOMETRY data type in Snowflake."""
+
+    pass
+
+
 class _PandasType(DataType):
     pass
 
@@ -387,6 +393,9 @@ Variant = TypeVar("Variant")
 
 #: The type hint for annotating Geography data when registering UDFs.
 Geography = TypeVar("Geography")
+
+#: The type hint for annotating Geometry data when registering UDFs.
+Geometry = TypeVar("Geometry")
 
 
 if installed_pandas:  # pragma: no cover

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -44,6 +44,7 @@ from snowflake.snowpark.types import (
     DoubleType,
     FloatType,
     GeographyType,
+    GeometryType,
     IntegerType,
     LongType,
     MapType,
@@ -1607,11 +1608,12 @@ def test_createDataFrame_with_given_schema_array_map_variant(session):
             StructField("map", MapType(None, None)),
             StructField("variant", VariantType()),
             StructField("geography", GeographyType()),
+            StructField("geometry", GeometryType()),
         ]
     )
     data = [
-        Row(["'", 2], {"'": 1}, 1, "POINT(30 10)"),
-        Row(None, None, None, None),
+        Row(["'", 2], {"'": 1}, 1, "POINT(30 10)", "LINESTRING(120 40, -120 19)"),
+        Row(None, None, None, None, None),
     ]
     df = session.create_dataframe(data, schema)
     assert (
@@ -1619,7 +1621,8 @@ def test_createDataFrame_with_given_schema_array_map_variant(session):
         == "StructType([StructField('ARRAY', ArrayType(StringType()), nullable=True), "
         "StructField('MAP', MapType(StringType(), StringType()), nullable=True), "
         "StructField('VARIANT', VariantType(), nullable=True), "
-        "StructField('GEOGRAPHY', GeographyType(), nullable=True)])"
+        "StructField('GEOGRAPHY', GeographyType(), nullable=True), "
+        "StructField('GEOMETRY', GeometryType(), nullable=True)])"
     )
     df.show()
     geography_string = """{
@@ -1629,9 +1632,22 @@ def test_createDataFrame_with_given_schema_array_map_variant(session):
   ],
   "type": "Point"
 }"""
+    geometry_string = """{
+  "coordinates": [
+    [
+      1.200000000000000e+02,
+      4.000000000000000e+01
+    ],
+    [
+      -1.200000000000000e+02,
+      1.900000000000000e+01
+    ]
+  ],
+  "type": "LineString"
+}"""
     expected = [
-        Row('[\n  "\'",\n  2\n]', '{\n  "\'": 1\n}', "1", geography_string),
-        Row(None, None, None, None),
+        Row('[\n  "\'",\n  2\n]', '{\n  "\'": 1\n}', "1", geography_string, geometry_string),
+        Row(None, None, None, None, None),
     ]
     Utils.check_answer(df, expected, sort=False)
 

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -176,8 +176,8 @@ def test_dtypes(session):
 
     assert df.dtypes == [
         ("VAR", "variant"),
-        ("GEOMETRY", "geography"),
-        ("GEOGRAPHY", "geometry"),
+        ("GEOGRAPHY", "geography"),
+        ("GEOMETRY", "geometry"),
         ("DATE", "date"),
         ("TIME", "time"),
         ("TIMESTAMP", "timestamp"),

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -18,6 +18,7 @@ from snowflake.snowpark.types import (
     DoubleType,
     FloatType,
     GeographyType,
+    GeometryType,
     IntegerType,
     LongType,
     MapType,
@@ -36,7 +37,8 @@ def test_verify_datatypes_reference(session):
     schema = StructType(
         [
             StructField("var", VariantType()),
-            StructField("geo", GeographyType()),
+            StructField("geography", GeographyType()),
+            StructField("geometry", GeometryType()),
             StructField("date", DateType()),
             StructField("time", TimeType()),
             StructField("timestamp", TimestampType()),
@@ -63,6 +65,7 @@ def test_verify_datatypes_reference(session):
                 None,
                 None,
                 None,
+                None,
                 "a",
                 True,
                 None,
@@ -82,7 +85,8 @@ def test_verify_datatypes_reference(session):
 
     assert (
         str(df.schema.fields) == "[StructField('VAR', VariantType(), nullable=True), "
-        "StructField('GEO', GeographyType(), nullable=True), "
+        "StructField('GEOGRAPHY', GeographyType(), nullable=True), "
+        "StructField('GEOMETRY', GeometryType(), nullable=True), "
         "StructField('DATE', DateType(), nullable=True), "
         "StructField('TIME', TimeType(), nullable=True), "
         "StructField('TIMESTAMP', TimestampType(), nullable=True), "
@@ -124,7 +128,8 @@ def test_dtypes(session):
     schema = StructType(
         [
             StructField("var", VariantType()),
-            StructField("geo", GeographyType()),
+            StructField("geography", GeographyType()),
+            StructField("geometry", GeometryType()),
             StructField("date", DateType()),
             StructField("time", TimeType()),
             StructField("timestamp", TimestampType()),
@@ -151,6 +156,7 @@ def test_dtypes(session):
                 None,
                 None,
                 None,
+                None,
                 "a",
                 True,
                 None,
@@ -170,7 +176,8 @@ def test_dtypes(session):
 
     assert df.dtypes == [
         ("VAR", "variant"),
-        ("GEO", "geography"),
+        ("GEOMETRY", "geography"),
+        ("GEOGRAPHY", "geometry"),
         ("DATE", "date"),
         ("TIME", "time"),
         ("TIMESTAMP", "timestamp"),

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -178,6 +178,7 @@ from snowflake.snowpark.functions import (
     to_array,
     to_date,
     to_geography,
+    to_geometry,
     to_json,
     to_object,
     to_timestamp,
@@ -2670,6 +2671,26 @@ def test_to_geography(session):
 
     # same as above, but pass str instead of Column
     assert geography.select(to_geography("a")).collect()[0][0] == geography_string
+
+
+def test_to_geometry(session):
+    geometry_string = """{
+  "coordinates": [
+    3.000000000000000e+01,
+    1.000000000000000e+01
+  ],
+  "type": "Point"
+}"""
+    geometry = TestData.geometry(session)
+    Utils.check_answer(
+        geometry.select(to_geometry(col("a"))),
+        [Row(geometry_string)],
+        sort=False,
+    )
+    assert geometry.select(to_geometry(col("a"))).collect()[0][0] == geometry_string
+
+    # same as above, but pass str instead of Column
+    assert geometry.select(to_geometry("a")).collect()[0][0] == geometry_string
 
 
 @pytest.mark.parametrize("a", ["a", col("a")])

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -20,6 +20,7 @@ from snowflake.snowpark.types import (
     DoubleType,
     FloatType,
     GeographyType,
+    GeometryType,
     IntegerType,
     LongType,
     MapType,
@@ -189,15 +190,16 @@ def test_create_dataframe_for_large_values_array_map_variant(session):
             StructField("map", MapType(None, None)),
             StructField("variant", VariantType()),
             StructField("geography", GeographyType()),
+            StructField("geometry", GeometryType()),
         ]
     )
 
     row_count = 350
     large_data = [
-        Row(i, ["'", 2], {"'": 1}, {"a": "foo"}, "POINT(30 10)")
+        Row(i, ["'", 2], {"'": 1}, {"a": "foo"}, "POINT(30 10)", "POINT(20 81)")
         for i in range(row_count)
     ]
-    large_data.append(Row(row_count, None, None, None, None))
+    large_data.append(Row(row_count, None, None, None, None, None))
     df = session.create_dataframe(large_data, schema)
     assert [type(field.datatype) for field in df.schema.fields] == [
         LongType,
@@ -205,12 +207,21 @@ def test_create_dataframe_for_large_values_array_map_variant(session):
         MapType,
         VariantType,
         GeographyType,
+        GeometryType,
     ]
     geography_string = """\
 {
   "coordinates": [
     30,
     10
+  ],
+  "type": "Point"
+}"""
+    geometry_string = """\
+{
+  "coordinates": [
+    2.000000000000000e+01,
+    8.100000000000000e+01
   ],
   "type": "Point"
 }"""
@@ -221,8 +232,9 @@ def test_create_dataframe_for_large_values_array_map_variant(session):
             '{\n  "\'": 1\n}',
             '{\n  "a": "foo"\n}',
             geography_string,
+            geometry_string,
         )
         for i in range(row_count)
     ]
-    expected.append(Row(row_count, None, None, None, None))
+    expected.append(Row(row_count, None, None, None, None, None))
     assert df.sort("id").collect() == expected

--- a/tests/integ/scala/test_table_suite.py
+++ b/tests/integ/scala/test_table_suite.py
@@ -13,6 +13,7 @@ from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.types import (
     ArrayType,
     GeographyType,
+    GeometryType,
     MapType,
     StringType,
     VariantType,
@@ -42,12 +43,12 @@ def table_name_4(session: Session):
 def semi_structured_table(session: Session):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(
-        session, table_name, "a1 array, o1 object, v1 variant, g1 geography"
+        session, table_name, "a1 array, o1 object, v1 variant, g1 geography, g2 geometry"
     )
     query = (
         f"insert into {table_name} select parse_json(a), parse_json(b), "
-        "parse_json(a), to_geography(c) from values('[1,2]', '{a:1}', 'POINT(-122.35 37.55)'),"
-        "('[1,2,3]', '{b:2}', 'POINT(-12 37)') as T(a,b,c)"
+        "parse_json(a), to_geography(c), to_geometry(c) from values('[1,2]', '{a:1}', "
+        "'POINT(-122.35 37.55)'), ('[1,2,3]', '{b:2}', 'POINT(-12 37)') as T(a,b,c)"
     )
     session._run_query(query)
     yield table_name
@@ -206,12 +207,13 @@ def test_quotes_upper_and_lower_case_name(session, table_name_1):
 def test_table_with_semi_structured_types(session, semi_structured_table):
     df = session.table(semi_structured_table)
     types = [s.datatype for s in df.schema.fields]
-    assert len(types) == 4
+    assert len(types) == 5
     expected_types = [
         ArrayType(StringType()),
         MapType(StringType(), StringType()),
         VariantType(),
         GeographyType(),
+        GeometryType(),
     ]
     assert all([t in expected_types for t in types])
     Utils.check_answer(
@@ -222,15 +224,18 @@ def test_table_with_semi_structured_types(session, semi_structured_table):
                 '{\n  "a": 1\n}',
                 "[\n  1,\n  2\n]",
                 '{\n  "coordinates": [\n    -122.35,\n    37.55\n  ],\n  "type": "Point"\n}',
+                'POINT(-122.35 37.55)',
             ),
             Row(
                 "[\n  1,\n  2,\n  3\n]",
                 '{\n  "b": 2\n}',
                 "[\n  1,\n  2,\n  3\n]",
                 '{\n  "coordinates": [\n    -12,\n    37\n  ],\n  "type": "Point"\n}',
+                'POINT(-12 37)',
             ),
         ],
         sort=False,
+        statement_params={"GEOMETRY_OUTPUT_FORMAT": "WKT"}
     )
 
 

--- a/tests/integ/scala/test_table_suite.py
+++ b/tests/integ/scala/test_table_suite.py
@@ -239,11 +239,6 @@ def test_table_with_semi_structured_types(session, semi_structured_table):
     )
 
 
-@pytest.mark.skip("To port from scala after Python implements Geography")
-def test_row_with_geography(session):
-    pass
-
-
 def test_table_with_time_type(session, table_with_time):
     df = session.table(table_with_time)
     # snowflake time has accuracy to 0.99999999. Python has accuracy to 0.999999.

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -56,6 +56,8 @@ from snowflake.snowpark.types import (
     FloatType,
     Geography,
     GeographyType,
+    Geometry,
+    GeometryType,
     IntegerType,
     MapType,
     PandasDataFrame,
@@ -819,6 +821,10 @@ def test_type_hints(session):
     def return_geography_dict_udf(g: Geography) -> Dict[str, str]:
         return g
 
+    @udf
+    def return_geometry_dict_udf(g: Geometry) -> Dict[str, str]:
+        return g
+
     df = session.create_dataframe([[1, 4], [2, 3]]).to_df("a", "b")
     Utils.check_answer(
         df.select(
@@ -841,6 +847,11 @@ def test_type_hints(session):
     Utils.check_answer(
         TestData.geography_type(session).select(return_geography_dict_udf("geo")),
         [Row('{\n  "coordinates": [\n    30,\n    10\n  ],\n  "type": "Point"\n}')],
+    )
+
+    Utils.check_answer(
+        TestData.geometry_type(session).select(return_geometry_dict_udf("geo")),
+        [Row('{\n  "coordinates": [\n    20,\n    81\n  ],\n  "type": "Point"\n}')],
     )
 
 
@@ -1196,6 +1207,20 @@ def test_udf_geography_type(session):
 
     Utils.check_answer(
         TestData.geography_type(session).select(geography_udf(col("geo"))).collect(),
+        [Row("<class 'dict'>")],
+    )
+
+
+def test_udf_geometry_type(session):
+    def get_type(g):
+        return str(type(g))
+
+    geometry_udf = udf(
+        get_type, return_type=StringType(), input_types=[GeometryType()]
+    )
+
+    Utils.check_answer(
+        TestData.geometry_type(session).select(geometry_udf(col("geo"))).collect(),
         [Row("<class 'dict'>")],
     )
 
@@ -1706,6 +1731,7 @@ def test_pandas_udf_type_hints(session):
             ("datetime64[ns]",),
         ),
         (GeographyType, [["POINT(30 10)"]], (dict,), ("object",)),
+        (GeometryType, [["POINT(30 10)"]], (dict,), ("object",)),
         (MapType, [[{1: 2}]], (dict,), ("object",)),
     ],
 )
@@ -1837,6 +1863,7 @@ def test_pandas_udf_input_variant(session):
             ("datetime64[ns]",),
         ),
         (GeographyType, [["POINT(30 10)"]], (dict,), ("object",)),
+        (GeometryType, [["POINT(30 10)"]], (dict,), ("object",)),
         (MapType, [[{1: 2}]], (dict,), ("object",)),
     ],
 )
@@ -1854,7 +1881,7 @@ def test_pandas_udf_return_types(session, _type, data, expected_types, expected_
     )
     result_df = df.select(series_udf("a")).to_pandas()
     result_val = result_df.iloc[0][0]
-    if _type in (ArrayType, MapType, GeographyType):  # TODO: SNOW-573478
+    if _type in (ArrayType, MapType, GeographyType, GeometryType):  # TODO: SNOW-573478
         result_val = json.loads(result_val)
     assert isinstance(
         result_val, expected_types

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -175,4 +175,4 @@ def test_schema_expression():
     assert schema_expression(DateType(), False) == "date('2020-9-16')"
     assert schema_expression(TimeType(), False) == "to_time('04:15:29.999')"
     assert schema_expression(TimestampType(), False) == "to_timestamp_ntz('2020-09-16 06:30:00')"
-    assert schema_expression(BinaryType(), False) == "to_binary(hex_encode(1))"
+    assert schema_expression(BinaryType(), False) == "'01' :: BINARY"

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 import pytest
 
 from snowflake.snowpark._internal.analyzer.datatype_mapper import (
+    schema_expression,
     to_sql,
     to_sql_without_cast,
 )
@@ -30,7 +31,9 @@ from snowflake.snowpark.types import (
     ShortType,
     StringType,
     StructType,
+    TimeType,
     TimestampType,
+    VariantType,
 )
 
 
@@ -131,3 +134,45 @@ def test_to_sql_without_cast():
     assert to_sql_without_cast(123, IntegerType()) == "123"
     assert to_sql_without_cast(0.2, FloatType()) == "0.2"
     assert to_sql_without_cast(0.2, DoubleType()) == "0.2"
+
+
+def test_schema_expression():
+    assert schema_expression(GeographyType(), True) == "TRY_TO_GEOGRAPHY(NULL)"
+    assert schema_expression(GeometryType(), True) == "TRY_TO_GEOMETRY(NULL)"
+    assert schema_expression(ArrayType(None), True) == "PARSE_JSON('NULL') :: ARRAY"
+    assert schema_expression(MapType(IntegerType(), ByteType()), True) == "PARSE_JSON('NULL') :: OBJECT"
+    assert schema_expression(VariantType(), True) == "PARSE_JSON('NULL') :: VARIANT"
+    assert schema_expression(IntegerType(), True) == "NULL :: INT"
+    assert schema_expression(ShortType(), True) == "NULL :: SMALLINT"
+    assert schema_expression(ByteType(), True) == "NULL :: BYTEINT"
+    assert schema_expression(LongType(), True) == "NULL :: BIGINT"
+    assert schema_expression(FloatType(), True) == "NULL :: FLOAT"
+    assert schema_expression(DoubleType(), True) == "NULL :: DOUBLE"
+    assert schema_expression(StringType(), True) == "NULL :: STRING"
+    assert schema_expression(StringType(19), True) == "NULL :: STRING(19)"
+    assert schema_expression(NullType(), True) == "NULL :: STRING"
+    assert schema_expression(BooleanType(), True) == "NULL :: BOOLEAN"
+    assert schema_expression(DateType(), True) == "NULL :: DATE"
+    assert schema_expression(TimeType(), True) == "NULL :: TIME"
+    assert schema_expression(TimestampType(), True) == "NULL :: TIMESTAMP"
+    assert schema_expression(BinaryType(), True) == "NULL :: BINARY"
+
+
+    assert schema_expression(GeographyType(), False) == "to_geography('POINT(-122.35 37.55)')"
+    assert schema_expression(GeometryType(), False) == "to_geometry('POINT(-122.35 37.55)')"
+    assert schema_expression(ArrayType(None), False) == "to_array(0)"
+    assert schema_expression(MapType(IntegerType(), ByteType()), False) == "to_object(parse_json('0'))"
+    assert schema_expression(VariantType(), False) == "to_variant(0)"
+    assert schema_expression(IntegerType(), False) == "0 :: INT"
+    assert schema_expression(ShortType(), False) == "0 :: SMALLINT"
+    assert schema_expression(ByteType(), False) == "0 :: BYTEINT"
+    assert schema_expression(LongType(), False) == "0 :: BIGINT"
+    assert schema_expression(FloatType(), False) == "0 :: FLOAT"
+    assert schema_expression(DoubleType(), False) == "0 :: DOUBLE"
+    assert schema_expression(StringType(), False) == "'a' :: STRING"
+    assert schema_expression(StringType(19), False) == "'a' ::  STRING (19)"
+    assert schema_expression(BooleanType(), False) == "true"
+    assert schema_expression(DateType(), False) == "date('2020-9-16')"
+    assert schema_expression(TimeType(), False) == "to_time('04:15:29.999')"
+    assert schema_expression(TimestampType(), False) == "to_timestamp_ntz('2020-09-16 06:30:00')"
+    assert schema_expression(BinaryType(), False) == "to_binary(hex_encode(1))"

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -22,6 +22,7 @@ from snowflake.snowpark.types import (
     DoubleType,
     FloatType,
     GeographyType,
+    GeometryType,
     IntegerType,
     LongType,
     MapType,
@@ -40,6 +41,7 @@ def test_to_sql():
     assert to_sql(None, MapType(IntegerType(), ByteType())) == "NULL"
     assert to_sql(None, StructType([])) == "NULL"
     assert to_sql(None, GeographyType()) == "NULL"
+    assert to_sql(None, GeometryType()) == "NULL"
 
     assert to_sql(None, IntegerType()) == "NULL :: INT"
     assert to_sql(None, ShortType()) == "NULL :: INT"

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -36,6 +36,8 @@ from snowflake.snowpark.types import (
     FloatType,
     Geography,
     GeographyType,
+    Geometry,
+    GeometryType,
     IntegerType,
     LongType,
     MapType,
@@ -396,6 +398,7 @@ def test_python_type_to_snow_type():
     )
     check_type(Variant, VariantType(), False)
     check_type(Geography, GeographyType(), False)
+    check_type(Geometry, GeometryType(), False)
     check_type(pandas.Series, PandasSeriesType(None), False)
     check_type(pandas.DataFrame, PandasDataFrameType(()), False)
     check_type(PandasSeries, PandasSeriesType(None), False)
@@ -596,6 +599,7 @@ def test_convert_sf_to_sp_type_basic():
     assert isinstance(convert_sf_to_sp_type("VARIANT", 0, 0, 0), VariantType)
     assert isinstance(convert_sf_to_sp_type("OBJECT", 0, 0, 0), MapType)
     assert isinstance(convert_sf_to_sp_type("GEOGRAPHY", 0, 0, 0), GeographyType)
+    assert isinstance(convert_sf_to_sp_type("GEOMETRY", 0, 0, 0), GeometryType)
     assert isinstance(convert_sf_to_sp_type("BOOLEAN", 0, 0, 0), BooleanType)
     assert isinstance(convert_sf_to_sp_type("BINARY", 0, 0, 0), BinaryType)
     assert isinstance(convert_sf_to_sp_type("TEXT", 0, 0, 0), StringType)
@@ -666,6 +670,7 @@ def test_convert_sp_to_sf_type():
     assert convert_sp_to_sf_type(MapType()) == "OBJECT"
     assert convert_sp_to_sf_type(VariantType()) == "VARIANT"
     assert convert_sp_to_sf_type(GeographyType()) == "GEOGRAPHY"
+    assert convert_sp_to_sf_type(GeometryType()) == "GEOMETRY"
     with pytest.raises(TypeError, match="Unsupported data type"):
         convert_sp_to_sf_type(None)
 
@@ -701,6 +706,7 @@ def test_snow_type_to_dtype_str():
     assert snow_type_to_dtype_str(TimestampType()) == "timestamp"
     assert snow_type_to_dtype_str(TimeType()) == "time"
     assert snow_type_to_dtype_str(GeographyType()) == "geography"
+    assert snow_type_to_dtype_str(GeometryType()) == "geometry"
     assert snow_type_to_dtype_str(VariantType()) == "variant"
     assert snow_type_to_dtype_str(ByteType()) == "tinyint"
     assert snow_type_to_dtype_str(ShortType()) == "smallint"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -203,12 +203,13 @@ class Utils:
         actual: Union[Row, List[Row], DataFrame],
         expected: Union[Row, List[Row], DataFrame],
         sort=True,
+        statement_params=None,
     ) -> None:
         def get_rows(input_data: Union[Row, List[Row], DataFrame]):
             if isinstance(input_data, list):
                 rows = input_data
             elif isinstance(input_data, DataFrame):
-                rows = input_data.collect()
+                rows = input_data.collect(statement_params=statement_params)
             elif isinstance(input_data, Row):
                 rows = [input_data]
             else:
@@ -587,6 +588,38 @@ class TestData:
                 "coordinates": [
                   30,
                   10
+                ],
+                "type": "Point"
+            }') as T(a)
+            """
+        )
+
+    @classmethod
+    def geometry(cls, session: "Session") -> DataFrame:
+        return session.sql(
+            """
+            select *
+            from values
+            ('{
+                "coordinates": [
+                  30,
+                  10
+                ],
+                "type": "Point"
+            }') as T(a)
+            """
+        )
+
+    @classmethod
+    def geometry_type(cls, session: "Session") -> DataFrame:
+        return session.sql(
+            """
+            select to_geometry(a) as geo
+            from values
+            ('{
+                "coordinates": [
+                  20,
+                  81
                 ],
                 "type": "Point"
             }') as T(a)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,6 +30,7 @@ from snowflake.snowpark.types import (
     DecimalType,
     DoubleType,
     GeographyType,
+    GeometryType,
     LongType,
     MapType,
     StringType,
@@ -890,4 +891,5 @@ TYPE_MAP = [
     TypeMap("object", "object", MapType(StringType(), StringType())),
     TypeMap("array", "array", ArrayType(StringType())),
     TypeMap("geography", "geography", GeographyType()),
+    TypeMap("geometry", "geometry", GeometryType()),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ source = src/snowflake/snowpark
          */src/snowflake/snowpark
          *\src\snowflake\snowpark
          */fips_env/lib/python*/site-packages/snowflake/snowpark
+[coverage:html]
+show_contexts = true
 
 [tox]
 minversion = 3.7
@@ -39,7 +41,7 @@ setenv =
     parallel: SNOWFLAKE_PYTEST_OPTS = {env:SNOWFLAKE_PYTEST_OPTS:} -n auto
     # Add common parts into pytest command
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml
-    SNOWFLAKE_PYTEST_COV_CMD = --cov snowflake.snowpark --junitxml {env:SNOWFLAKE_PYTEST_COV_LOCATION} --cov-report=
+    SNOWFLAKE_PYTEST_COV_CMD = --cov snowflake.snowpark --cov-context=test --junitxml {env:SNOWFLAKE_PYTEST_COV_LOCATION} --cov-report=
     SNOWFLAKE_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_OPTS:} {env:SNOWFLAKE_PYTEST_COV_CMD}
 passenv =
     AWS_ACCESS_KEY_ID
@@ -74,7 +76,7 @@ setenv = COVERAGE_FILE={toxworkdir}/.coverage
 commands = coverage combine
            coverage report -m
            coverage xml -o {env:COV_REPORT_DIR:{toxworkdir}}/coverage.xml
-           coverage html -d {env:COV_REPORT_DIR:{toxworkdir}}/htmlcov
+           coverage html -d {env:COV_REPORT_DIR:{toxworkdir}}/htmlcov --show-contexts
 depends = py38, py39, py310
 
 [testenv:docs]


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-656580

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Geometry support was added to python connector in release 3.0.4. This PR update snowpark to use leverage the connector changes and add support for Geometry type.
