### PR TITLE
SNOW-834932: Added execute_as parameter to StoredProcedureRegistration.register_from_file() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added experimental feature `DataFrame.alias`.
 - Added support for querying metadata columns from stage when creating `DataFrame` using `DataFrameReader`.
 - Added support for `StructType.add` to append more fields to existing `StructType` objects.
+- Added support for parameter `execute_as` in `StoredProcedureRegistration.register_from_file()` to specify stored proc caller rights.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -73,6 +73,8 @@ _MAX_INLINE_CLOSURE_SIZE_BYTES = 8192
 # Every table function handler class must define the process method.
 TABLE_FUNCTION_PROCESS_METHOD = "process"
 
+EXECUTE_AS_WHITELIST = frozenset(["owner", "caller"])
+
 
 class UDFColumn(NamedTuple):
     datatype: DataType
@@ -170,6 +172,17 @@ def check_register_args(
     if parallel < 1 or parallel > 99:
         raise ValueError(
             "Supported values of parallel are from 1 to 99, " f"but got {parallel}"
+        )
+
+
+def check_execute_as_arg(execute_as: typing.Literal["caller", "owner"]):
+    if (
+        not isinstance(execute_as, str)
+        or execute_as.lower() not in EXECUTE_AS_WHITELIST
+    ):
+        raise TypeError(
+            f"'execute_as' value '{execute_as}' is invalid, choose from "
+            f"{', '.join(EXECUTE_AS_WHITELIST, )}"
         )
 
 


### PR DESCRIPTION
Added execute_as parameter to StoredProcedureRegistration.register_from_file() function

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
N/A

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Added execute_as parameter to StoredProcedureRegistration.register_from_file() function. This allows the stored procedure to be called with either 'owner' or 'caller' rights.