### PR TITLE
SNOW-619443: Use Column objects for choosing Metadata Columns

### DIFF
--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -818,21 +818,10 @@ class CaseExpr(Column):
     else_ = otherwise
 
 
-class _MetadataColumn(Column):
-    """A special instance of Column type for representing metadata columns for staged files"""
-
-    def __init__(self, expr: str) -> None:
-        super().__init__(expr)
-
-    def name(self, alias: str) -> "_MetadataColumn":
-        """Returns a new renamed Column."""
-        return _MetadataColumn(Alias(self._expression, quote_name(alias)))
-
-
 # We support the metadata columns below based on https://docs.snowflake.com/en/user-guide/querying-metadata
 # If the list changes, we will have to add support for new columns
-METADATA_FILE_ROW_NUMBER = _MetadataColumn("METADATA$FILE_ROW_NUMBER")
-METADATA_FILE_CONTENT_KEY = _MetadataColumn("METADATA$FILE_CONTENT_KEY")
-METADATA_FILE_LAST_MODIFIED = _MetadataColumn("METADATA$FILE_LAST_MODIFIED")
-METADATA_START_SCAN_TIME = _MetadataColumn("METADATA$START_SCAN_TIME")
-METADATA_FILENAME = _MetadataColumn("METADATA$FILENAME")
+METADATA_FILE_ROW_NUMBER = Column("METADATA$FILE_ROW_NUMBER")
+METADATA_FILE_CONTENT_KEY = Column("METADATA$FILE_CONTENT_KEY")
+METADATA_FILE_LAST_MODIFIED = Column("METADATA$FILE_LAST_MODIFIED")
+METADATA_START_SCAN_TIME = Column("METADATA$START_SCAN_TIME")
+METADATA_FILENAME = Column("METADATA$FILENAME")

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -18,14 +18,14 @@ from snowflake.snowpark._internal.analyzer.select_statement import (
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.telemetry import set_api_call_source
-from snowflake.snowpark._internal.type_utils import convert_sf_to_sp_type
+from snowflake.snowpark._internal.type_utils import ColumnOrName, convert_sf_to_sp_type
 from snowflake.snowpark._internal.utils import (
     INFER_SCHEMA_FORMAT_TYPES,
     TempObjectType,
     get_copy_into_table_options,
     random_name_for_temp_object,
 )
-from snowflake.snowpark.column import _MetadataColumn
+from snowflake.snowpark.column import _to_col_if_str
 from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.functions import sql_expr
 from snowflake.snowpark.table import Table
@@ -257,7 +257,7 @@ class DataFrameReader:
         self._cur_options: dict[str, Any] = {}
         self._file_path: Optional[str] = None
         self._file_type: Optional[str] = None
-        self._metadata_cols: Optional[Iterable[_MetadataColumn]] = None
+        self._metadata_cols: Optional[Iterable[ColumnOrName]] = None
         # Infer schema information
         self._infer_schema = False
         self._infer_schema_transformations: Optional[
@@ -288,7 +288,7 @@ class DataFrameReader:
         return self
 
     def with_metadata(
-        self, *metadata_cols: Iterable[_MetadataColumn]
+        self, *metadata_cols: Iterable[ColumnOrName]
     ) -> "DataFrameReader":
         """Define the metadata columns that need to be selected from stage files.
 
@@ -298,18 +298,10 @@ class DataFrameReader:
         See Also:
             https://docs.snowflake.com/en/user-guide/querying-metadata
         """
-        if not all([isinstance(col, _MetadataColumn) for col in metadata_cols]):
-            bad_idx, bad_col = next(
-                (idx, col)
-                for idx, col in enumerate(metadata_cols)
-                if not isinstance(col, _MetadataColumn)
-            )
-            raise TypeError(
-                f"All list elements for 'with_metadata' must be Metadata column from snowflake.snowpark.column. "
-                f"Got: '{type(bad_col)}' at index {bad_idx}"
-            )
-
-        self._metadata_cols = metadata_cols
+        self._metadata_cols = [
+            _to_col_if_str(col, "DataFrameReader.with_metadata")
+            for col in metadata_cols
+        ]
         return self
 
     def csv(self, path: str) -> DataFrame:

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -497,15 +497,12 @@ def test_read_metadata_column_from_stage(session, file_format):
     res = df.collect()
     assert res[0]["FILENAME"] == filename
 
-
-def test_read_metadata_column_from_stage_negative(session):
-    metadata_filename = col("metadata$filename")
-    metadata_file_row_number = col("metadata$file_row_number")
-    with pytest.raises(TypeError, match="All list elements for 'with_metadata' must be Metadata column from snowflake.snowpark.column."):
-        session.read.with_metadata(metadata_filename, metadata_file_row_number)
-
-    with pytest.raises(TypeError, match=f"Got: '<class 'snowflake.snowpark.column.Column'>' at index 1"):
-        session.read.with_metadata(METADATA_FILENAME, metadata_file_row_number)
+    # test that column name with str works
+    reader = session.read.with_metadata("metadata$filename", "metadata$file_row_number")
+    df = get_df_from_reader_and_file_format(reader, file_format)
+    res = df.collect()
+    assert res[0]["METADATA$FILENAME"] == filename
+    assert res[0]["METADATA$FILE_ROW_NUMBER"] >= 0
 
 
 @pytest.mark.parametrize("mode", ["select", "copy"])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-619443

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Use objects from `Column` class to choose metadata columns objects.
