### PR TITLE
SNOW-791241 Use python version check for module import

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -4,6 +4,7 @@
 #
 
 import re
+import sys
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -35,9 +36,9 @@ from snowflake.snowpark.types import DataType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 LEFT_PARENTHESIS = "("
@@ -1298,14 +1299,10 @@ def number(precision: int = 38, scale: int = 0) -> str:
         + RIGHT_PARENTHESIS
     )
 
+
 def string(length: Optional[int] = None) -> str:
     if length:
-        return (
-            STRING
-            + LEFT_PARENTHESIS
-            + str(length)
-            + RIGHT_PARENTHESIS
-        )
+        return STRING + LEFT_PARENTHESIS + str(length) + RIGHT_PARENTHESIS
     return STRING.strip()
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
         Analyzer,
     )  # pragma: no cover
 
+import sys
+
 from snowflake.snowpark._internal.analyzer import analyzer_utils
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
 from snowflake.snowpark._internal.analyzer.binary_expression import And
@@ -54,9 +56,9 @@ from snowflake.snowpark._internal.utils import is_sql_select_statement
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 SET_UNION = analyzer_utils.UNION

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -91,9 +91,9 @@ from snowflake.snowpark.types import StructType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
@@ -14,9 +15,9 @@ from snowflake.snowpark.types import StructType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/table_function.py
+++ b/src/snowflake/snowpark/_internal/analyzer/table_function.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Dict, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import Expression
@@ -11,9 +12,9 @@ from snowflake.snowpark._internal.analyzer.sort_expression import SortOrder
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -20,9 +20,9 @@ import opcode
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 logger = getLogger(__name__)

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -55,9 +55,9 @@ from snowflake.snowpark.types import (
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 logger = getLogger(__name__)

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Optional, Union
 
 import snowflake.snowpark
@@ -77,9 +78,9 @@ from snowflake.snowpark.window import Window, WindowSpec
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -6,6 +6,7 @@
 import copy
 import itertools
 import re
+import sys
 from collections import Counter
 from functools import cached_property
 from logging import getLogger
@@ -151,9 +152,9 @@ from snowflake.snowpark.types import StringType, StructType, _NumericType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 if TYPE_CHECKING:
@@ -2129,7 +2130,11 @@ class DataFrame:
                 and len(using_columns) > 0
                 and not all([isinstance(col, str) for col in using_columns])
             ):
-                bad_idx, bad_col = next((idx, col) for idx, col in enumerate(using_columns) if not isinstance(col, str))
+                bad_idx, bad_col = next(
+                    (idx, col)
+                    for idx, col in enumerate(using_columns)
+                    if not isinstance(col, str)
+                )
                 raise TypeError(
                     f"All list elements for 'on' or 'using_columns' must be string type. "
                     f"Got: '{type(bad_col)}' at index {bad_idx}"

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -4,6 +4,7 @@
 #
 
 import copy
+import sys
 from logging import getLogger
 from typing import Dict, Optional, Union
 
@@ -28,9 +29,9 @@ from snowflake.snowpark.types import (
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 _logger = getLogger(__name__)

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Any, Dict, List, Optional, Union
 
 import snowflake.snowpark
@@ -34,9 +35,9 @@ from snowflake.snowpark.types import StructType, VariantType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from functools import reduce
 from typing import Dict, List, Optional, Union
 
@@ -23,9 +24,9 @@ from snowflake.snowpark.functions import (
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 _MAX_COLUMNS_PER_TABLE = 1000

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Dict, List, Literal, Optional, Union, overload
 
 import snowflake.snowpark  # for forward references of type hints
@@ -30,9 +31,9 @@ from snowflake.snowpark.row import Row
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import array
 import io
+import sys
 from io import RawIOBase
 
 from snowflake.snowpark._internal.utils import private_preview
@@ -19,9 +20,9 @@ from snowflake.snowpark._internal.utils import private_preview
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 _DEFER_IMPLEMENTATION_ERR_MSG = "SnowflakeFile currently only works in UDF and Stored Procedures. It doesn't work locally yet."

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -160,6 +160,7 @@ The return type is always ``Column``. The input types tell you the acceptable va
     <BLANKLINE>
 """
 import functools
+import sys
 import typing
 from random import randint
 from types import ModuleType
@@ -209,9 +210,9 @@ from snowflake.snowpark.udtf import UserDefinedTableFunction
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/row.py
+++ b/src/snowflake/snowpark/row.py
@@ -3,14 +3,15 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Any, Dict, Union
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -8,6 +8,7 @@ import decimal
 import json
 import logging
 import os
+import sys
 from array import array
 from functools import reduce
 from logging import getLogger
@@ -130,9 +131,9 @@ from snowflake.snowpark.udtf import UDTFRegistration
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 _logger = getLogger(__name__)

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -32,9 +32,9 @@ from snowflake.snowpark.types import DataType, StructType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Dict, List, NamedTuple, Optional, Union, overload
 
 import snowflake.snowpark
@@ -30,9 +31,9 @@ from snowflake.snowpark.row import Row
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -5,6 +5,7 @@
 
 """This package contains all Snowpark logical types."""
 import re
+import sys
 from typing import Generic, List, Optional, TypeVar, Union
 
 import snowflake.snowpark._internal.analyzer.expression as expression
@@ -13,9 +14,9 @@ from snowflake.connector.options import installed_pandas, pandas
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -33,9 +33,9 @@ from snowflake.snowpark.types import DataType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -46,9 +46,9 @@ from snowflake.snowpark.types import DataType, StructField, StructType
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/src/snowflake/snowpark/window.py
+++ b/src/snowflake/snowpark/window.py
@@ -28,9 +28,9 @@ from snowflake.snowpark._internal.utils import parse_positional_args_to_list
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/tests/integ/scala/test_udtf_suite.py
+++ b/tests/integ/scala/test_udtf_suite.py
@@ -4,6 +4,7 @@
 
 import datetime
 import decimal
+import sys
 from collections import Counter
 from typing import Dict, List, Tuple
 
@@ -27,9 +28,9 @@ from tests.utils import Utils
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 pytestmark = pytest.mark.udf

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import math
+import sys
 from array import array
 from collections import namedtuple
 from decimal import Decimal
@@ -72,9 +73,9 @@ from tests.utils import (
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 tmp_stage_name = Utils.random_stage_name()

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Tuple
 
 import pytest
@@ -29,9 +30,9 @@ from tests.utils import TestData, Utils
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -4,6 +4,7 @@
 #
 
 import decimal
+import sys
 from functools import partial
 from typing import Any, Dict, Tuple
 
@@ -12,6 +13,7 @@ import pytest
 from snowflake.snowpark import Row
 from snowflake.snowpark._internal.telemetry import TelemetryField
 from snowflake.snowpark._internal.utils import generate_random_alphanumeric
+from snowflake.snowpark.exceptions import SnowparkColumnException
 from snowflake.snowpark.functions import (
     call_udf,
     col,
@@ -30,9 +32,9 @@ from tests.utils import TestData, TestFiles
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 
@@ -287,7 +289,7 @@ def test_drop_api_calls(session):
     ]
 
     # Raise exception and make sure the new API call isn't added to the list
-    with pytest.raises(Exception):
+    with pytest.raises(SnowparkColumnException, match=" Cannot drop all columns"):
         drop_id.drop("id_prime")
     assert drop_id._plan.api_calls == [
         {"name": "Session.range"},
@@ -321,7 +323,7 @@ def test_to_df_api_calls(session):
     ]
 
     # Raise exception and make sure api call list doesn't change
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="The number of columns doesn't match"):
         df.to_df(["new_name"])
     assert df._plan.api_calls == [
         {"name": "Session.range"},

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -3,6 +3,7 @@
 #
 
 import decimal
+import sys
 from typing import Tuple
 
 import pytest
@@ -25,9 +26,9 @@ from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 pytestmark = pytest.mark.udf

--- a/tests/perf/perf_runner.py
+++ b/tests/perf/perf_runner.py
@@ -20,9 +20,9 @@ from parameters import CONNECTION_PARAMETERS  # noqa: E402
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -4,6 +4,7 @@
 #
 
 import os
+import sys
 import typing
 from array import array
 from collections import defaultdict
@@ -61,9 +62,9 @@ from tests.utils import IS_WINDOWS, TestFiles
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 resources_path = os.path.normpath(

--- a/tests/unit/test_udtf.py
+++ b/tests/unit/test_udtf.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
 from typing import Tuple
 from unittest import mock
 
@@ -16,9 +17,9 @@ from snowflake.snowpark.udtf import UDTFRegistration
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
 # Python 3.10 needs to use collections.abc.Iterable because typing.Iterable is removed
-try:
+if sys.version_info <= (3, 9):
     from typing import Iterable
-except ImportError:
+else:
     from collections.abc import Iterable
 
 


### PR DESCRIPTION
Description

pyupgrade can simplify code automatically for python version specific branches. We change the try-except to if-else such that once we drop old python versions, the precommit hook will help us clean the code automatically.

Testing

existing tests

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-791241

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   pyupgrade can simplify code automatically for python version specific branches. We change the try-except to if-else such that once we drop old python versions, the precommit hook will help us clean the code automatically.
