### PR TITLE
SNOW-838017 Bump libffi version to 3.4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,9 @@ requirements:
     - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python
     - typing-extensions >=4.1.0
-    # need to pin libffi to <3.4.2 because of problems in cryptography
-    - libffi <3.4.2
+    # need to pin libffi because of problems in cryptography.
+    # This might no longer hold true but keep it just to avoid it from biting us again
+    - libffi <=3.4.4
 
 test:
   imports:


### PR DESCRIPTION
In the local test env, the old upper bound is giving conda solver some headache to solve to the latest snowpark version

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
