### PR TITLE
SNOW-836583 Update `register_from_file` documentation for vectorized UDFs 

### DIFF
--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -207,9 +207,10 @@ class UDFRegistration:
     Series. You can use :func:`~snowflake.snowpark.functions.udf`, :meth:`register` or
     :func:`~snowflake.snowpark.functions.pandas_udf` to create a vectorized UDF by providing
     appropriate return and input types. If you would like to use :meth:`register_from_file` to
-    create a vectorized UDF, you should follow the guide of
-    `Python UDF Batch API <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-batch.html>`_ in
-    your Python source files. See Example 9, 10 and 11 here for registering a vectorized UDF.
+    create a vectorized UDF, you would need to explicitly mark the handler function as vectorized using
+    either the `vectorized` Decorator or a function attribute. Please see
+    `Python UDF Batch API <https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-batch.html>`
+    for examples.
 
     Snowflake supports the following data types for the parameters for a UDF:
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-836583.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The function needs to be marked explicitly as a vectorized UDF handler using (1) `@vectorized` decorator or (2) [function attribute](https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-batch#id2), this PR ~changes `register_from_file` such that **when the udf is a vectorized UDF based on input/return types** AND **the source file does not contain either of the specifications** , it makes a copy of the source file and appends `<handler>._sf_vectorized_input = pandas.DataFrame` to end of the file, PUT the new file to stage for UDF definition.~ updates the documentation to emphasize this.
