### PR TITLE
SNOW-729449 Fix DataFrame.result_cache to handle schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Improvements
 
 - Removed redundant dependency `typing-extensions`.
+- `DataFrame.cache_result` now creates temp table fully qualified names under current database and current schema.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3557,7 +3557,8 @@ class DataFrame:
              A :class:`Table` object that holds the cached result in a temporary table.
              All operations on this new DataFrame have no effect on the original.
         """
-        temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
+        temp_table_name = f'{self._session.get_current_database()}.{self._session.get_current_schema()}."{random_name_for_temp_object(TempObjectType.TABLE)}"'
+
         create_temp_table = self._session._plan_builder.create_temp_table(
             temp_table_name,
             self._plan,

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -3075,3 +3075,12 @@ def test_dataframe_alias_negative(session):
 
     with pytest.raises(ValueError):
         col("df", df["a"])
+
+
+def test_dataframe_result_cache_changing_schema(session):
+    df = session.create_dataframe([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]).to_df(
+        ["a", "b"]
+    )
+    old_cached_df = df.cache_result()
+    session.use_schema("public")  # schema change
+    old_cached_df.show()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-729449

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `DataFrame.cache_result` now creates temp tables using fully qualified names under current database and current schema.
