### PR TITLE
SNOW-841487 [Local Testing] Raise NotImplementedError for unsupported features

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1248,6 +1248,7 @@ class DataFrame:
                 )
 
         if self._select_statement:
+
             return self._with_plan(self._select_statement.sort(sort_exprs))
         return self._with_plan(Sort(sort_exprs, self._plan))
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -422,6 +422,7 @@ class DataFrameReader:
         return self
 
     def _read_semi_structured_file(self, path: str, format: str) -> DataFrame:
+
         if self._user_schema:
             raise ValueError(f"Read {format} does not support user schema")
         self._file_path = path

--- a/src/snowflake/snowpark/file_operation.py
+++ b/src/snowflake/snowpark/file_operation.py
@@ -255,8 +255,21 @@ class FileOperation:
             An object of :class:`PutResult` which represents the results of an uploaded file.
         """
         stage_location = _validate_stage_location(stage_location)
-        cursor = self._session._conn._cursor
-        if is_in_stored_procedure():  # pragma: no cover
+
+        if not is_in_stored_procedure():
+            stage_with_prefix, dest_filename = stage_location.rsplit("/", maxsplit=1)
+            put_result = self._session._conn.upload_stream(
+                input_stream=input_stream,
+                stage_location=stage_with_prefix,
+                dest_filename=dest_filename,
+                parallel=parallel,
+                compress_data=auto_compress,
+                source_compression=source_compression,
+                overwrite=overwrite,
+            )
+            result_data = put_result["data"]
+        else:
+            cursor = self._session._conn._cursor
             try:
                 options = {
                     "parallel": parallel,
@@ -272,19 +285,8 @@ class FileOperation:
                     pe
                 )
                 raise ne.with_traceback(tb) from None
-        else:
-            stage_with_prefix, dest_filename = stage_location.rsplit("/", maxsplit=1)
-            put_result = self._session._conn.upload_stream(
-                input_stream=input_stream,
-                stage_location=stage_with_prefix,
-                dest_filename=dest_filename,
-                parallel=parallel,
-                compress_data=auto_compress,
-                source_compression=source_compression,
-                overwrite=overwrite,
-            )
-            result_data = put_result["data"]
 
+        cursor = self._session._conn._cursor
         result_meta = cursor.description
         put_result = result_set_to_rows(result_data, result_meta)[0]
         return PutResult(**put_result.asDict())

--- a/src/snowflake/snowpark/mock/file_operation.py
+++ b/src/snowflake/snowpark/mock/file_operation.py
@@ -48,7 +48,9 @@ SUPPORTED_CSV_READ_OPTIONS = (
 )
 
 
-def put(local_file_name: str, stage_location: str) -> TableEmulator:
+def put(
+    local_file_name: str, stage_location: str, auto_compress: bool = True
+) -> TableEmulator:
     """
     Put a file into in memory map, key being stage location and value being the local file path
     """

--- a/src/snowflake/snowpark/mock/mock_analyzer.py
+++ b/src/snowflake/snowpark/mock/mock_analyzer.py
@@ -114,8 +114,6 @@ from snowflake.snowpark._internal.analyzer.unary_plan_node import (
     Aggregate,
     CreateViewCommand,
     Filter,
-    LocalTempView,
-    PersistedView,
     Pivot,
     Project,
     Sample,
@@ -724,45 +722,13 @@ class MockAnalyzer:
             )
 
         if isinstance(logical_plan, CreateViewCommand):
-            if isinstance(logical_plan.view_type, PersistedView):
-                is_temp = False
-            elif isinstance(logical_plan.view_type, LocalTempView):
-                is_temp = True
-            else:
-                raise SnowparkClientExceptionMessages.PLAN_ANALYZER_UNSUPPORTED_VIEW_TYPE(
-                    str(logical_plan.view_type)
-                )
-
-            return self.plan_builder.create_or_replace_view(
-                logical_plan.name, resolved_children[logical_plan.child], is_temp
+            raise NotImplementedError(
+                "[Local Testing] Creating views is currently not supported."
             )
 
         if isinstance(logical_plan, CopyIntoTableNode):
-            format_type_options = (
-                logical_plan.format_type_options.copy()
-                if logical_plan.format_type_options
-                else {}
-            )
-            format_name = logical_plan.cur_options.get("FORMAT_NAME")
-            if format_name is not None:
-                format_type_options["FORMAT_NAME"] = format_name
-            return self.plan_builder.copy_into_table(
-                path=logical_plan.file_path,
-                table_name=logical_plan.table_name,
-                files=logical_plan.files,
-                pattern=logical_plan.pattern,
-                file_format=logical_plan.file_format,
-                format_type_options=format_type_options,
-                copy_options=logical_plan.copy_options,
-                validation_mode=logical_plan.validation_mode,
-                column_names=logical_plan.column_names,
-                transformations=[
-                    self.analyze(x, expr_to_alias) for x in logical_plan.transformations
-                ]
-                if logical_plan.transformations
-                else None,
-                user_schema=logical_plan.user_schema,
-                create_table_from_infer_schema=logical_plan.create_table_from_infer_schema,
+            raise NotImplementedError(
+                "[Local Testing] Copy into table is currently not supported."
             )
 
         if isinstance(logical_plan, CopyIntoLocationNode):
@@ -804,12 +770,8 @@ class MockAnalyzer:
             )
 
         if isinstance(logical_plan, TableMerge):
-            return self.plan_builder.merge(
-                logical_plan.table_name,
-                resolved_children.get(logical_plan.source),
-                self.analyze(logical_plan.join_expr, expr_to_alias),
-                [self.analyze(c, expr_to_alias) for c in logical_plan.clauses],
-                logical_plan,
+            raise NotImplementedError(
+                "[Local Testing] Table merge is currently not implemented."
             )
 
         if isinstance(logical_plan, MockSelectable):

--- a/src/snowflake/snowpark/mock/mock_connection.py
+++ b/src/snowflake/snowpark/mock/mock_connection.py
@@ -20,6 +20,7 @@ from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.errors import NotSupportedError, ProgrammingError
 from snowflake.connector.network import ReauthenticationRequest
 from snowflake.connector.options import pandas
+from snowflake.snowpark import QueryHistory
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     escape_quotes,
     quote_name_without_upper_casing,
@@ -178,7 +179,6 @@ class MockServerConnection:
 
     def __init__(self) -> None:
         self._conn = Mock()
-        self.add_query_listener = Mock()
         self.remove_query_listener = Mock()
         self._telemetry_client = Mock()
         self.table_registry = MockServerConnection.TableRegistry(self)
@@ -480,6 +480,11 @@ $$"""
         # get the iterator such that the data is not fetched
         result_set, _ = self.get_result_set(plan, to_iter=True, **kwargs)
         return result_set["sfqid"]
+
+    def add_query_listener(self, listener: QueryHistory) -> None:
+        raise NotImplementedError(
+            "[Local Testing] Query history is currently not supported."
+        )
 
 
 def _fix_pandas_df_integer(

--- a/src/snowflake/snowpark/mock/mock_connection.py
+++ b/src/snowflake/snowpark/mock/mock_connection.py
@@ -20,7 +20,6 @@ from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.errors import NotSupportedError, ProgrammingError
 from snowflake.connector.network import ReauthenticationRequest
 from snowflake.connector.options import pandas
-from snowflake.snowpark import QueryHistory
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     escape_quotes,
     quote_name_without_upper_casing,
@@ -180,6 +179,7 @@ class MockServerConnection:
     def __init__(self) -> None:
         self._conn = Mock()
         self.remove_query_listener = Mock()
+        self.add_query_listener = Mock()
         self._telemetry_client = Mock()
         self.table_registry = MockServerConnection.TableRegistry(self)
 
@@ -480,11 +480,6 @@ $$"""
         # get the iterator such that the data is not fetched
         result_set, _ = self.get_result_set(plan, to_iter=True, **kwargs)
         return result_set["sfqid"]
-
-    def add_query_listener(self, listener: QueryHistory) -> None:
-        raise NotImplementedError(
-            "[Local Testing] Query history is currently not supported."
-        )
 
 
 def _fix_pandas_df_integer(

--- a/src/snowflake/snowpark/mock/mock_plan.py
+++ b/src/snowflake/snowpark/mock/mock_plan.py
@@ -279,7 +279,7 @@ def execute_mock_plan(
                 )
             else:
                 raise NotImplementedError(
-                    f"[Local Testing] SetStatement operator {operator} is not implemented."
+                    f"[Local Testing] SetStatement operator {operator} is currently not implemented."
                 )
         return res_df
     if isinstance(source_plan, MockSelectableEntity):
@@ -569,6 +569,10 @@ def execute_mock_plan(
     if isinstance(source_plan, MockFileOperation):
         return execute_file_operation(source_plan, analyzer)
     if isinstance(source_plan, SnowflakeCreateTable):
+        if source_plan.column_names is not None:
+            raise NotImplementedError(
+                "[Local Testing] Inserting data into table by matching column names is currently not supported."
+            )
         table_registry = analyzer.session._conn.table_registry
         res_df = execute_mock_plan(source_plan.query)
         return table_registry.write_table(

--- a/src/snowflake/snowpark/mock/mock_select_statement.py
+++ b/src/snowflake/snowpark/mock/mock_select_statement.py
@@ -361,7 +361,7 @@ class MockSelectStatement(MockSelectable):
             new.order_by = cols
             new._column_states = self._column_states
         else:
-            new = SelectStatement(
+            new = MockSelectStatement(
                 from_=self.to_subqueryable(), order_by=cols, analyzer=self.analyzer
             )
         return new

--- a/src/snowflake/snowpark/mock/plan_builder.py
+++ b/src/snowflake/snowpark/mock/plan_builder.py
@@ -11,6 +11,11 @@ from snowflake.snowpark.mock.mock_plan import MockExecutionPlan, MockFileOperati
 
 
 class MockSnowflakePlanBuilder(SnowflakePlanBuilder):
+    def create_temp_table(self, *args, **kwargs):
+        raise NotImplementedError(
+            "[Local Testing] DataFrame.cache_result is currently not implemented."
+        )
+
     def read_file(
         self,
         path: str,
@@ -21,6 +26,10 @@ class MockSnowflakePlanBuilder(SnowflakePlanBuilder):
         schema_to_cast: Optional[List[Tuple[str, str]]] = None,
         transformations: Optional[List[str]] = None,
     ) -> MockExecutionPlan:
+        if format.upper() != "CSV":
+            raise NotImplementedError(
+                "[Local Testing] Reading non CSV data into dataframe is not currently supported."
+            )
         return MockExecutionPlan(
             source_plan=MockFileOperation(
                 session=self.session,
@@ -36,6 +45,12 @@ class MockSnowflakePlanBuilder(SnowflakePlanBuilder):
     def file_operation_plan(
         self, command: str, file_name: str, stage_location: str, options: Dict[str, str]
     ) -> MockExecutionPlan:
+        if options.get("auto_compress", False):
+            raise NotImplementedError(
+                "[Local Testing] PUT with auto_compress=True is currently not supported."
+            )
+        if command == "get":
+            raise NotImplementedError("[Local Testing] GET is currently not supported.")
         return MockExecutionPlan(
             source_plan=MockFileOperation(
                 session=self.session,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -103,6 +103,8 @@ from snowflake.snowpark.functions import (
     to_variant,
 )
 from snowflake.snowpark.mock.mock_analyzer import MockAnalyzer
+from snowflake.snowpark.mock.mock_connection import MockServerConnection
+from snowflake.snowpark.mock.plan_builder import MockSnowflakePlanBuilder
 from snowflake.snowpark.query_history import QueryHistory
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.stored_procedure import StoredProcedureRegistration
@@ -347,7 +349,11 @@ class Session:
         self._udf_registration = UDFRegistration(self)
         self._udtf_registration = UDTFRegistration(self)
         self._sp_registration = StoredProcedureRegistration(self)
-        self._plan_builder = SnowflakePlanBuilder(self)
+        self._plan_builder = (
+            SnowflakePlanBuilder(self)
+            if isinstance(self._conn, ServerConnection)
+            else MockSnowflakePlanBuilder(self)
+        )
         self._last_action_id = 0
         self._last_canceled_id = 0
         self._use_scoped_temp_objects: bool = (
@@ -1211,6 +1217,11 @@ class Session:
                 "Bind variable in stored procedure is not supported yet"
             )
 
+        if isinstance(self._conn, MockServerConnection):
+            raise NotImplementedError(
+                "[Local Testing] `Session.sql` is currently not supported."
+            )
+
         if self.sql_simplifier_enabled:
             d = DataFrame(
                 self,
@@ -1717,6 +1728,10 @@ class Session:
             raise NotImplementedError(
                 "Async query is not supported in stored procedure yet"
             )
+        if isinstance(self._conn, MockServerConnection):
+            raise NotImplementedError(
+                "[Local Testing] Async query is currently not supported."
+            )
         return AsyncJob(query_id, None, self)
 
     def get_current_account(self) -> Optional[str]:
@@ -1862,6 +1877,8 @@ class Session:
         Returns a :class:`udf.UDFRegistration` object that you can use to register UDFs.
         See details of how to use this object in :class:`udf.UDFRegistration`.
         """
+        if isinstance(self._conn, MockServerConnection):
+            raise NotImplementedError("[Local Testing] UDF is not currently supported.")
         return self._udf_registration
 
     @property

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2080,6 +2080,7 @@ class Session:
         ...     res = df.collect()
         >>> assert len(query_history.queries) == 1
         """
+
         query_listener = QueryHistory(self)
         self._conn.add_query_listener(query_listener)
         return query_listener

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -31,6 +31,12 @@ from tests.utils import TestFiles, Utils
 test_file_csv = "testCSV.csv"
 tmp_stage_name1 = Utils.random_stage_name()
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def test_async_collect_common(session):
     df = session.create_dataframe(
@@ -338,6 +344,10 @@ def test_async_place_holder(session):
     Utils.check_answer(async_job.result(), exp)
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Use of _execute_and_get_query_id",
+)
 @pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
 def test_create_async_job(session, create_async_job_from_query_id):
     df = session.range(3)
@@ -423,6 +433,10 @@ def test_get_query_from_async_job_negative(session, caplog):
         assert "result is empty" in caplog.text
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Use of _execute_and_get_query_id",
+)
 @pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
 def test_async_job_to_df(session, create_async_job_from_query_id):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])

--- a/tests/integ/scala/test_complex_dataframe_suite.py
+++ b/tests/integ/scala/test_complex_dataframe_suite.py
@@ -17,6 +17,11 @@ from snowflake.snowpark.types import (
 from tests.utils import IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_combination_of_multiple_operators(session):
     df1 = session.create_dataframe([1, 2]).to_df("a")
     df2 = session.create_dataframe([[i, f"test{i}"] for i in [1, 2]]).to_df("a", "b")
@@ -47,6 +52,11 @@ def test_combination_of_multiple_operators(session):
     ]
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_combination_of_multiple_operators_with_filters(session):
     df1 = session.create_dataframe([i for i in range(1, 11)]).to_df("a")
     df2 = session.create_dataframe([[i, f"test{i}"] for i in range(1, 11)]).to_df(
@@ -74,6 +84,7 @@ def test_combination_of_multiple_operators_with_filters(session):
     assert df.collect() == [Row(i, f"test{i}") for i in range(1, 11)]
 
 
+@pytest.mark.localtest
 def test_join_on_top_of_unions(session):
     df1 = session.create_dataframe([i for i in range(1, 6)]).to_df("a")
     df2 = session.create_dataframe([i for i in range(6, 11)]).to_df("a")
@@ -88,6 +99,11 @@ def test_join_on_top_of_unions(session):
     assert res == [Row(i, f"test{i}") for i in range(1, 11)]
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="need resources")
 def test_combination_of_multiple_data_sources(session, resources_path):
     test_files = TestFiles(resources_path)
@@ -102,30 +118,23 @@ def test_combination_of_multiple_data_sources(session, resources_path):
         ]
     )
 
-    try:
-        Utils.create_table(session, tmp_table_name, "num int")
-        session.sql(f"insert into {tmp_table_name} values(1),(2),(3)").collect()
-        session.sql(f"CREATE TEMPORARY STAGE {tmp_stage_name}").collect()
-        Utils.upload_to_stage(
-            session, "@" + tmp_stage_name, test_files.test_file_csv, compress=False
-        )
+    Utils.create_table(session, tmp_table_name, "num int", is_temporary=True)
+    session.sql(f"insert into {tmp_table_name} values(1),(2),(3)").collect()
+    session.sql(f"CREATE TEMPORARY STAGE {tmp_stage_name}").collect()
+    Utils.upload_to_stage(
+        session, "@" + tmp_stage_name, test_files.test_file_csv, compress=False
+    )
 
-        test_file_on_stage = f"@{tmp_stage_name}/{test_file_csv}"
-        df1 = session.read.schema(user_schema).csv(test_file_on_stage)
-        df2 = session.table(tmp_table_name)
+    test_file_on_stage = f"@{tmp_stage_name}/{test_file_csv}"
+    df1 = session.read.schema(user_schema).csv(test_file_on_stage)
+    df2 = session.table(tmp_table_name)
 
-        Utils.check_answer(
-            df2.join(df1, df1["a"] == df2["num"]),
-            [Row(1, 1, "one", 1.2), Row(2, 2, "two", 2.2)],
-        )
+    Utils.check_answer(
+        df2.join(df1, df1["a"] == df2["num"]),
+        [Row(1, 1, "one", 1.2), Row(2, 2, "two", 2.2)],
+    )
 
-        Utils.check_answer(
-            df2.filter(col("num") == 1).join(
-                df1.select("a", "b"), df1["a"] == df2["num"]
-            ),
-            [Row(1, 1, "one")],
-        )
-
-    finally:
-        Utils.drop_table(session, tmp_table_name)
-        Utils.drop_stage(session, tmp_stage_name)
+    Utils.check_answer(
+        df2.filter(col("num") == 1).join(df1.select("a", "b"), df1["a"] == df2["num"]),
+        [Row(1, 1, "one")],
+    )

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -75,25 +75,27 @@ pytestmark = pytest.mark.xfail(
 
 
 @pytest.fixture(scope="module")
-def tmp_stage_name1(session):
+def tmp_stage_name1(session, local_testing_mode):
     stage_name = Utils.random_stage_name()
-    # Utils.create_stage(session, stage_name)
+    if not local_testing_mode:
+        Utils.create_stage(session, stage_name)
     try:
         yield stage_name
     finally:
-        pass
-        # Utils.drop_stage(session, stage_name)
+        if not local_testing_mode:
+            Utils.drop_stage(session, stage_name)
 
 
 @pytest.fixture(scope="module")
-def tmp_stage_name2(session):
+def tmp_stage_name2(session, local_testing_mode):
     stage_name = Utils.random_stage_name()
-    # Utils.create_stage(session, stage_name)
+    if not local_testing_mode:
+        Utils.create_stage(session, stage_name)
     try:
         yield stage_name
     finally:
-        # Utils.drop_stage(session, stage_name)
-        pass
+        if not local_testing_mode:
+            Utils.drop_stage(session, stage_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integ/scala/test_dataframe_range_suite.py
+++ b/tests/integ/scala/test_dataframe_range_suite.py
@@ -35,6 +35,7 @@ def test_empty_result_and_negative_start_end_step(session):
     assert session.range(10, 3, -3).collect() == [Row(i) for i in range(10, 3, -3)]
 
 
+# TODO: enable for local testing after fixing dataframe.count for 0 rows
 def test_range_api(session):
     res3 = session.range(1, -2).select("id")
     assert res3.count() == 0
@@ -64,6 +65,7 @@ def test_range_api(session):
     assert res16.count() == 500
 
 
+@pytest.mark.local
 def test_range_with_randomized_parameters(session):
     MAX_NUM_STEPS = 10 * 1000
     MAX_VALUE = 2**31 - 1

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -73,18 +73,6 @@ tmp_stage_name2 = Utils.random_stage_name()
 
 @pytest.fixture(scope="module", autouse=True)
 def setup(session, resources_path, local_testing_mode):
-    # if local_testing_mode:
-    #    test_files = TestFiles(resources_path)
-    #    session.file.put(test_files.test_file_csv, f"@{tmp_stage_name1}", auto_compress=False)
-    #    session.file.put(test_files.test_file_csv_various_data, f"@{tmp_stage_name1}", auto_compress=False)
-    #    session.file.put(test_files.test_file2_csv, f"@{tmp_stage_name1}", auto_compress=False)
-    #    session.file.put(test_files.test_file_csv_colon, f"@{tmp_stage_name1}", auto_compress=False)
-    #    session.file.put(test_files.test_file_csv_quotes, f"@{tmp_stage_name1}", auto_compress=False)
-    #    session.file.put(test_files.test_broken_csv, f"@{tmp_stage_name1}", auto_compress=False)
-    #    session.file.put(test_files.test_file_csv, f"@{tmp_stage_name2}", auto_compress=False)
-    #    yield
-    #    return
-
     test_files = TestFiles(resources_path)
     if not local_testing_mode:
         Utils.create_stage(session, tmp_stage_name1, is_temporary=True)

--- a/tests/integ/scala/test_dataframe_set_operations_suite.py
+++ b/tests/integ/scala/test_dataframe_set_operations_suite.py
@@ -84,6 +84,11 @@ def test_union_all_with_filters(session):
     check(lit(2).cast(IntegerType()), col("c") != 2, list())
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_except(session):
     lower_case_data = TestData.lower_case_data(session)
     upper_case_data = TestData.upper_case_data(session)
@@ -124,6 +129,11 @@ def test_except(session):
     Utils.check_answer(all_nulls.filter(lit(0) == 1).except_(all_nulls), [])
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_except_between_two_projects_without_references_used_in_filter(session):
     df = session.create_dataframe(((1, 2, 4), (1, 3, 5), (2, 2, 3), (2, 4, 5))).to_df(
         "a", "b", "c"
@@ -151,6 +161,11 @@ def test_union_unionall_unionbyname_unionallbyname_in_one_case(session):
     Utils.check_answer(df1.union_all_by_name(df3), [Row(1, 2, 3), Row(3, 1, 2)])
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_nondeterministic_expressions_should_not_be_pushed_down(session):
     df1 = session.create_dataframe([(i,) for i in range(1, 21)]).to_df("i")
     df2 = session.create_dataframe([(i,) for i in range(1, 11)]).to_df("i")
@@ -255,6 +270,7 @@ def test_unionall_by_quoted_name(session):
         df1.union_by_name(df2)
 
 
+# TODO: Fix this, `MockExecutionPlan.attributes` are ignoring nullability for now
 def test_intersect_nullability(session):
     non_nullable_ints = session.create_dataframe([[1], [3]]).to_df("a")
     null_ints = TestData.null_ints(session)
@@ -288,6 +304,11 @@ def test_intersect_nullability(session):
     assert all(not i.nullable for i in df4.schema.fields)
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_performing_set_ops_on_non_native_types(session):
     dates = session.create_dataframe(
         [
@@ -345,6 +366,11 @@ def test_unionall_by_name_check_name_duplication(session):
         df1.union_all_by_name(df2)
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_intersect(session):
     lcd = TestData.lower_case_data(session)
     res = lcd.intersect(lcd).collect()
@@ -372,6 +398,11 @@ def test_intersect(session):
     assert res == [Row("id", 1), Row("id1", 1), Row("id1", 2)]
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_project_should_not_be_pushed_down_through_intersect_or_except(session):
     df1 = session.create_dataframe([[i] for i in range(1, 101)]).to_df("i")
     df2 = session.create_dataframe([[i] for i in range(1, 31)]).to_df("i")
@@ -380,6 +411,7 @@ def test_project_should_not_be_pushed_down_through_intersect_or_except(session):
     assert df1.except_(df2).count() == 70
 
 
+# TODO: Fix this, `MockExecutionPlan.attributes` are ignoring nullability for now
 def test_except_nullability(session):
     non_nullable_ints = session.create_dataframe(((11,), (3,))).to_df("a")
     for attribute in non_nullable_ints.schema._to_attributes():
@@ -407,12 +439,22 @@ def test_except_nullability(session):
         assert not attribute.nullable
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_except_distinct_sql_compliance(session):
     df_left = session.create_dataframe([(1,), (2,), (2,), (3,), (3,), (4,)]).to_df("id")
     df_right = session.create_dataframe([(1,), (3,)]).to_df("id")
     Utils.check_answer(df_left.except_(df_right), [Row(2), Row(4)])
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_mix_set_operator(session):
     df1 = session.create_dataframe([1]).to_df("a")
     df2 = session.create_dataframe([2]).to_df("a")

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -19,9 +19,22 @@ from snowflake.snowpark.types import (
 from tests.utils import TestFiles, Utils
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_write_with_target_column_name_order(session):
     table_name = Utils.random_table_name()
-    Utils.create_table(session, table_name, "a int, b int", is_temporary=True)
+    session.create_dataframe(
+        [],
+        schema=StructType(
+            [
+                StructField("a", IntegerType()),
+                StructField("b", IntegerType()),
+            ]
+        ),
+    ).write.save_as_table(table_name, table_type="temporary")
     try:
         df1 = session.create_dataframe([[1, 2]], schema=["b", "a"])
 
@@ -48,7 +61,7 @@ def test_write_with_target_column_name_order(session):
         df1.write.saveAsTable(table_name, mode="append", column_order="name")
         Utils.check_answer(session.table(table_name), [Row(1, 2)])
     finally:
-        Utils.drop_table(session, table_name)
+        session.table(table_name).drop_table()
 
     # column name and table name with special characters
     special_table_name = '"test table name"'
@@ -65,6 +78,9 @@ def test_write_with_target_column_name_order(session):
         Utils.drop_table(session, special_table_name)
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="Testing SQL-only feature"
+)
 def test_write_with_target_table_autoincrement(
     session,
 ):  # Scala doesn't support this yet.
@@ -82,9 +98,19 @@ def test_write_with_target_table_autoincrement(
         Utils.drop_table(session, table_name)
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_negative_write_with_target_column_name_order(session):
     table_name = Utils.random_table_name()
-    Utils.create_table(session, table_name, "a int, b int", is_temporary=True)
+    session.create_dataframe(
+        [],
+        schema=StructType(
+            [StructField("a", IntegerType()), StructField("b", IntegerType())]
+        ),
+    ).write.save_as_table(table_name, table_type="temporary")
     try:
         df1 = session.create_dataframe([[1, 2]], schema=["a", "c"])
         # The "columnOrder = name" needs the DataFrame has the same column name set
@@ -104,14 +130,24 @@ def test_negative_write_with_target_column_name_order(session):
                     table_type="temp",
                 )
     finally:
-        Utils.drop_table(session, table_name)
+        session.table(table_name).drop_table()
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 def test_write_with_target_column_name_order_all_kinds_of_dataframes(
     session, resources_path
 ):
     table_name = Utils.random_table_name()
-    Utils.create_table(session, table_name, "a int, b int", is_temporary=True)
+    session.create_dataframe(
+        [],
+        schema=StructType(
+            [StructField("a", IntegerType()), StructField("b", IntegerType())]
+        ),
+    ).write.save_as_table(table_name, table_type="temporary")
     try:
         df1 = session.create_dataframe([[1, 2]], schema=["b", "a"])
         # DataFrame.cache_result()
@@ -140,7 +176,7 @@ def test_write_with_target_column_name_order_all_kinds_of_dataframes(
         for row in rows:
             assert row["B"] == 1 and row["A"] == 2
     finally:
-        Utils.drop_table(session, table_name)
+        session.table(table_name).drop_table()
 
     # show tables
     # Create a DataFrame from SQL `show tables` and then filter on it not supported yet. Enable the following test after it's supported.
@@ -208,20 +244,23 @@ def test_write_with_target_column_name_order_all_kinds_of_dataframes(
         Utils.drop_stage(session, target_stage_name)
 
 
+@pytest.mark.localtest
 def test_write_table_names(session, db_parameters):
     schema = quote_name(db_parameters["schema"])
 
     def create_and_append_check_answer(table_name, full_table_name=None):
         try:
-            assert session._table_exists(table_name) is False
-            Utils.create_table(session, full_table_name or table_name, "a int, b int")
-            assert session._table_exists(table_name) is True
-
+            session.create_dataframe(
+                [],
+                schema=StructType(
+                    [StructField("a", IntegerType()), StructField("b", IntegerType())]
+                ),
+            ).write.save_as_table(full_table_name or table_name)
             df = session.create_dataframe([[1, 2]], schema=["a", "b"])
             df.write.save_as_table(table_name, mode="append", table_type="temp")
             Utils.check_answer(session.table(table_name), [Row(1, 2)])
         finally:
-            session.sql(f"drop table if exists {full_table_name or table_name}")
+            session.table(full_table_name or table_name).drop_table()
 
     # basic scenario
     table_name = f"{Utils.random_table_name()}"

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -16,6 +16,12 @@ from snowflake.snowpark.exceptions import (
 )
 from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def random_alphanumeric_name():
     return "".join(
@@ -79,12 +85,12 @@ def temp_stage(session, resources_path):
     tmp_stage_name = Utils.random_stage_name()
     test_files = TestFiles(resources_path)
 
-    Utils.create_stage(session, tmp_stage_name, is_temporary=True)
+    # Utils.create_stage(session, tmp_stage_name, is_temporary=True)
     Utils.upload_to_stage(
         session, tmp_stage_name, test_files.test_file_parquet, compress=False
     )
     yield tmp_stage_name
-    Utils.drop_stage(session, tmp_stage_name)
+    # Utils.drop_stage(session, tmp_stage_name)
 
 
 def test_put_with_one_file(session, temp_stage, path1, path2, path3):

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -81,16 +81,18 @@ def path4(temp_source_directory):
 
 
 @pytest.fixture(scope="module")
-def temp_stage(session, resources_path):
+def temp_stage(session, resources_path, local_testing_mode):
     tmp_stage_name = Utils.random_stage_name()
     test_files = TestFiles(resources_path)
 
-    # Utils.create_stage(session, tmp_stage_name, is_temporary=True)
+    if not local_testing_mode:
+        Utils.create_stage(session, tmp_stage_name, is_temporary=True)
     Utils.upload_to_stage(
         session, tmp_stage_name, test_files.test_file_parquet, compress=False
     )
     yield tmp_stage_name
-    # Utils.drop_stage(session, tmp_stage_name)
+    if not local_testing_mode:
+        Utils.drop_stage(session, tmp_stage_name)
 
 
 def test_put_with_one_file(session, temp_stage, path1, path2, path3):

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -33,6 +33,11 @@ from snowflake.snowpark.types import (
 )
 
 
+@pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
 @pytest.mark.xfail(reason="SNOW-754118 flaky test", strict=False)
 def test_to_local_iterator_should_not_load_all_data_at_once(session):
     df = (
@@ -90,6 +95,9 @@ def test_limit_on_order_by(session, is_sample_data_available):
         assert int(e1[0]) < int(e2[0])
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="Testing SQL generation"
+)
 @pytest.mark.parametrize("use_scoped_temp_objects", [True, False])
 def test_create_dataframe_for_large_values_check_plan(session, use_scoped_temp_objects):
     origin_use_scoped_temp_objects_setting = session._use_scoped_temp_objects
@@ -119,6 +127,7 @@ def test_create_dataframe_for_large_values_check_plan(session, use_scoped_temp_o
         session._use_scoped_temp_objects = origin_use_scoped_temp_objects_setting
 
 
+# TODO: enable for local testing after emulating sf data types
 def test_create_dataframe_for_large_values_basic_types(session):
     schema = StructType(
         [
@@ -181,6 +190,7 @@ def test_create_dataframe_for_large_values_basic_types(session):
     assert df.sort("id").collect() == large_data
 
 
+# TODO: enable for local testing after emulating sf data types
 def test_create_dataframe_for_large_values_array_map_variant(session):
     schema = StructType(
         [

--- a/tests/integ/scala/test_permanent_udf_suite.py
+++ b/tests/integ/scala/test_permanent_udf_suite.py
@@ -19,7 +19,14 @@ from snowflake.snowpark.exceptions import (
 from snowflake.snowpark.functions import call_udf, col
 from tests.utils import TempObjectType, TestFiles, Utils
 
-pytestmark = pytest.mark.udf
+pytestmark = [
+    pytest.mark.udf,
+    pytest.mark.xfail(
+        condition="config.getvalue('local_testing_mode')",
+        raises=NotImplementedError,
+        strict=True,
+    ),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/integ/scala/test_result_attributes_suite.py
+++ b/tests/integ/scala/test_result_attributes_suite.py
@@ -25,6 +25,11 @@ from snowflake.snowpark.types import (
 )
 from tests.utils import IS_IN_STORED_PROC, Utils
 
+pytestmark = pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing session._get_result_attributes",
+)
+
 
 def get_table_attributes(session: Session, name: str) -> List[Attribute]:
     return session._get_result_attributes(f"select * from {name}")

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -26,7 +26,10 @@ from snowflake.snowpark.types import IntegerType, StringType, StructField, Struc
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, Utils
 
 
-@pytest.mark.localtest
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing session parameters",
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="creating new session is not allowed in stored proc"
 )

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -26,6 +26,7 @@ from snowflake.snowpark.types import IntegerType, StringType, StructField, Struc
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, Utils
 
 
+@pytest.mark.localtest
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="creating new session is not allowed in stored proc"
 )
@@ -43,6 +44,10 @@ def test_invalid_configs(session, db_parameters):
             assert "Incorrect username or password was specified" in str(ex_info)
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing database specific operations",
+)
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="db_parameters is not available")
 def test_current_database_and_schema(session, db_parameters):
     database = quote_name(db_parameters["database"])
@@ -101,6 +106,10 @@ def test_create_dataframe_namedtuple(session):
 # and the public role has the privilege to access the current database and
 # schema of the current role
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Not enough privilege to run this test")
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing database specific operations",
+)
 def test_get_schema_database_works_after_use_role(session):
     current_role = session._conn._get_string_datum("select current_role()")
     try:
@@ -130,6 +139,10 @@ def test_negative_test_for_missing_required_parameter_schema(
 
 
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="client is regression test specific")
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing database specific operations",
+)
 def test_select_current_client(session):
     current_client = session.sql("select current_client()")._show_string(10)
     assert get_application_name() in current_client
@@ -145,6 +158,7 @@ def test_negative_test_to_invalid_table_name(session):
     )
 
 
+# TODO: should be enabled after emulating snowflake types
 def test_create_dataframe_from_seq_none(session):
     assert session.create_dataframe([None, 1]).to_df("int").collect() == [
         Row(None),
@@ -156,6 +170,7 @@ def test_create_dataframe_from_seq_none(session):
     ]
 
 
+# should be enabled after emulating snowflake types
 def test_create_dataframe_from_array(session):
     data = [Row(1, "a"), Row(2, "b")]
     schema = StructType(
@@ -214,6 +229,10 @@ def test_session_info(session):
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="creating new session is not allowed in stored proc"
 )
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing database specific operations",
+)
 def test_dataframe_close_session(session, db_parameters):
     new_session = Session.builder.configs(db_parameters).create()
     new_session.sql_simplifier_enabled = session.sql_simplifier_enabled
@@ -233,6 +252,10 @@ def test_dataframe_close_session(session, db_parameters):
 
 
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing database specific operations",
+)
 def test_create_temp_table_no_commit(session):
     # test large local relation
     session.sql("begin").collect()

--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -13,6 +13,12 @@ from snowflake.snowpark.functions import col
 from snowflake.snowpark.types import LongType, StructField, StructType
 from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,

--- a/tests/integ/scala/test_udtf_suite.py
+++ b/tests/integ/scala/test_udtf_suite.py
@@ -36,6 +36,12 @@ pytestmark = pytest.mark.udf
 
 wordcount_table_name = Utils.random_table_name()
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_data(session):

--- a/tests/integ/scala/test_view_suite.py
+++ b/tests/integ/scala/test_view_suite.py
@@ -15,6 +15,12 @@ from snowflake.snowpark.functions import col, sql_expr, sum
 from snowflake.snowpark.types import LongType
 from tests.utils import TestData, Utils
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def test_create_view(session):
     view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)

--- a/tests/integ/scala/test_window_spec_suite.py
+++ b/tests/integ/scala/test_window_spec_suite.py
@@ -41,6 +41,12 @@ from snowflake.snowpark.functions import (
 )
 from tests.utils import TestData, Utils
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def test_partition_by_order_by_rows_between(session):
     df = session.create_dataframe(

--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -20,6 +20,12 @@ from snowflake.snowpark.types import (
 from tests.integ.scala.test_dataframe_suite import SAMPLING_DEVIATION
 from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def test_basic_query(session):
     df1 = session.sql("select * from values (?, ?), (?, ?)", params=[1, "a", 2, "b"])
@@ -423,6 +429,10 @@ def test_explain(session):
     df.explain()
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')",
+    reason="Testing stored proc only feature",
+)
 def test_stored_proc_not_supported(session):
     import snowflake.snowpark._internal.utils as internal_utils
 

--- a/tests/integ/test_column_names.py
+++ b/tests/integ/test_column_names.py
@@ -27,6 +27,12 @@ from snowflake.snowpark.functions import (
 )
 from tests.utils import Utils
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def get_metadata_names(session, df):
     description = session._conn._cursor.describe(df.queries["queries"][-1])
@@ -258,6 +264,9 @@ def test_rank_related_function_expression(session):
     )
 
 
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="Relies on DUAL table"
+)
 def test_literal(session):
     df1 = session.table("dual")
     df2 = df1.select(lit("a"), lit(1), lit(True), lit([1]))

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -143,11 +143,9 @@ def test_read_stage_file_show(session, resources_path, local_testing_mode):
     try:
         if not local_testing_mode:
             Utils.create_stage(session, tmp_stage_name, is_temporary=True)
-            Utils.upload_to_stage(
-                session, "@" + tmp_stage_name, test_files.test_file_csv, compress=False
-            )
-        else:
-            session.file.put(test_files.test_file_csv, f"@{tmp_stage_name}")
+        Utils.upload_to_stage(
+            session, "@" + tmp_stage_name, test_files.test_file_csv, compress=False
+        )
         user_schema = StructType(
             [
                 StructField("a", IntegerType()),

--- a/tests/integ/test_df_sort.py
+++ b/tests/integ/test_df_sort.py
@@ -8,6 +8,7 @@ import pytest
 from snowflake.snowpark import Column
 
 
+@pytest.mark.localtest
 def test_sort_different_inputs(session):
     df = session.create_dataframe(
         [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3)]
@@ -48,6 +49,7 @@ def test_sort_different_inputs(session):
         )
 
 
+@pytest.mark.localtest
 def test_sort_invalid_inputs(session):
     df = session.create_dataframe(
         [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3)]

--- a/tests/integ/test_query_history.py
+++ b/tests/integ/test_query_history.py
@@ -7,6 +7,12 @@ import pytest
 from snowflake.snowpark._internal.analyzer.analyzer import ARRAY_BIND_THRESHOLD
 from tests.utils import IS_IN_STORED_PROC
 
+pytestmark = pytest.mark.xfail(
+    condition="config.getvalue('local_testing_mode')",
+    raises=NotImplementedError,
+    strict=True,
+)
+
 
 def test_query_history(session):
     with session.query_history() as query_listener:

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -236,9 +236,15 @@ def test_list_files_in_stage(session, resources_path):
         assert os.path.basename(test_files.test_file_csv) in files6
 
         Utils.create_stage(session, single_quoted_name, is_temporary=False)
-        Utils.upload_to_stage(
-            session, single_quoted_name, test_files.test_file_csv, compress=False
+        session._conn.upload_file(
+            stage_location=single_quoted_name,
+            path=test_files.test_file_csv,
+            compress_data=False,
         )
+        # TODO: investigate ^ would break for
+        # Utils.upload_to_stage(
+        #    session, single_quoted_name, test_files.test_file_csv, compress=False
+        # )
         files7 = session._list_files_in_stage(single_quoted_name)
         assert len(files7) == 1
         assert os.path.basename(test_files.test_file_csv) in files7

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -130,9 +130,6 @@ class Utils:
         session.file.put(
             local_file_name=filename, stage_location=stage_name, auto_compress=compress
         )
-        # session._conn.upload_file(
-        #    stage_location=stage_name, path=filename, compress_data=compress
-        # )
 
     @staticmethod
     def equals_ignore_case(a: str, b: str) -> bool:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -127,9 +127,12 @@ class Utils:
     def upload_to_stage(
         session: "Session", stage_name: str, filename: str, compress: bool
     ):
-        session._conn.upload_file(
-            stage_location=stage_name, path=filename, compress_data=compress
+        session.file.put(
+            local_file_name=filename, stage_location=stage_name, auto_compress=compress
         )
+        # session._conn.upload_file(
+        #    stage_location=stage_name, path=filename, compress_data=compress
+        # )
 
     @staticmethod
     def equals_ignore_case(a: str, b: str) -> bool:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR aims to go over half of the integ tests under `/scala` and make sure that tests either 

- (1) can run in local testing mode (`@pytest.mark.localtest`) **or** 
- (2) raise NotImplementedError with meaningful error messages (`pytest.mark.xfail(raises=NotImplementedError`) **or** 
- (3) is not applicable skipped because it's testing SQL-only features (`pyest.skipif`).

    A few existing issues to address:
    - [ ] Preserve nullability of columns in result schema
    - [ ] Emulate snowflake data types
    - [ ] Fix DataFrame.count() for dataframes with 0 rows
