### PR TITLE
Revert "Improve error message from create_dataframe() when the connec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - Redundant dependency `typing-extensions` removed.
 
+### Bug Fixes
+- Fixed a bug where type check happens on pandas before it is imported
+
 ## 1.5.1 (2023-06-20)
 
 ### New Features

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -20,7 +20,6 @@ import cloudpickle
 import pkg_resources
 
 from snowflake.connector import ProgrammingError, SnowflakeConnection
-from snowflake.connector.errors import MissingDependencyError
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.connector.pandas_tools import write_pandas
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
@@ -1470,16 +1469,12 @@ class Session:
         if isinstance(data, Row):
             raise TypeError("create_dataframe() function does not accept a Row object.")
 
-        if not isinstance(data, (list, tuple, pandas.DataFrame)):
+        if not isinstance(data, (list, tuple)) and (
+            not installed_pandas
+            or (installed_pandas and not isinstance(data, pandas.DataFrame))
+        ):
             raise TypeError(
                 "create_dataframe() function only accepts data as a list, tuple or a pandas DataFrame."
-            )
-
-        if not installed_pandas and isinstance(data, pandas.DataFrame):
-            raise MissingDependencyError(
-                "snowflake-connector-python[pandas]. create_dataframe() function only accepts data as a pandas "
-                "DataFrame when the Snowflake Connector for Python is the Pandas-compatible version. Please install "
-                'it as follow: `pip install "snowflake-connector-python[pandas]"`'
             )
 
         # check to see if it is a Pandas DataFrame and if so, write that to a temp


### PR DESCRIPTION
…tor is n… (#837)"

This reverts commit 549a17c1e0a5134602bbb9150349957f03609b0e.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #910

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

The commit 549a17c1e0a5134602bbb9150349957f03609b0e introduced a bug to check pandas type even if pandas is not imported. It will block users who has no pandas imported. Future work should make sure we have test coverage for Python environment without pandas imported.
