### PR TITLE
SNOW-856555: Fix get_type_hint exception on numpy ufunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bug Fixes
 
 - Fixed a bug where type check happens on pandas before it is imported
+- Fixed a bug when creating a UDF from numpy.ufunc
 
 ### Behavior Changes
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -93,9 +93,14 @@ def get_types_from_type_hints(
         # For Python 3.10+, the result values of get_type_hints()
         # will become strings, which we have to change the implementation
         # here at that time. https://www.python.org/dev/peps/pep-0563/
-        python_types_dict = get_type_hints(
-            getattr(func, TABLE_FUNCTION_PROCESS_METHOD, func)
-        )
+        try:
+            python_types_dict = get_type_hints(
+                getattr(func, TABLE_FUNCTION_PROCESS_METHOD, func)
+            )
+        except TypeError:
+            # A TypeError will be raised if we try to get type hints from a numpy ufunc
+            # e.g., get_type_hints(np.exp)
+            python_types_dict = {}
     else:
         if object_type == TempObjectType.TABLE_FUNCTION:
             python_types_dict = (

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -98,8 +98,9 @@ def get_types_from_type_hints(
                 getattr(func, TABLE_FUNCTION_PROCESS_METHOD, func)
             )
         except TypeError:
-            # A TypeError will be raised if we try to get type hints from a numpy ufunc
-            # e.g., get_type_hints(np.exp)
+            # if we fail to run get_type_hints on a function (a TypeError will be raised),
+            # return empty type dict. This will fail for functions like numpy.ufunc
+            # (e.g., get_type_hints(np.exp))
             python_types_dict = {}
     else:
         if object_type == TempObjectType.TABLE_FUNCTION:

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2186,3 +2186,20 @@ def test_secure_udf(session):
     )
     ddl_sql = f"select get_ddl('function', '{echo.name}(int)')"
     assert "SECURE" in session.sql(ddl_sql).collect()[0][0]
+
+
+@pytest.mark.skipif(
+    (not is_pandas_and_numpy_available) or IS_IN_STORED_PROC,
+    reason="numpy and pandas are required",
+)
+@pytest.mark.parametrize(
+    "func", [numpy.min, numpy.sqrt, numpy.tan, numpy.sum, numpy.median]
+)
+def test_numpy_udf(session, func):
+    numpy_udf = udf(
+        func, return_type=DoubleType(), input_types=[DoubleType()], packages=["numpy"]
+    )
+    df = session.range(-5, 5).to_df("a")
+    Utils.check_answer(
+        df.select(numpy_udf("a")).collect(), [Row(func(i)) for i in range(-5, 5)]
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-856555

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   A TypeError will be raised if we try to call get_type_hints from a numpy ufunc, e.g., `get_type_hints(np.exp)`. In this case, if it fails, we just assume there are no type hints. This bug blocks supporting series/df.apply on numpy functions in snowpandas.
 