### PR TITLE
Add empty theme

### DIFF
--- a/docs/source/_themes/empty/layout.html
+++ b/docs/source/_themes/empty/layout.html
@@ -1,0 +1,3 @@
+{% block document %}
+  {%block body %}{% endblock %}
+{% endblock %}

--- a/docs/source/_themes/empty/theme.conf
+++ b/docs/source/_themes/empty/theme.conf
@@ -1,0 +1,5 @@
+[theme]
+inherit = default
+stylesheet = style.css
+pygments_style = default
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,7 @@ exclude_patterns = []
 #
 # html_theme = 'alabaster'
 # html_theme = 'sphinx_rtd_theme'
-html_theme = "snowflake_rtd_theme"
+html_theme = "empty"
 
 html_theme_path = [
     "_themes",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #DOC-845

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This change adds an empty theme and specifies it as the theme to use when producing documentation. With the [Snowpark Python API reference documentation being newly integrated into Snowflake's documentation as a first-class citizen](https://docs.snowflake.com/developer-guide/snowpark/reference/python/latest/index), generating the documentation using an empty template is a requirement for embedding.
