### PR TITLE
SNOW-861532 Remove sp check for params in session.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added support for async execution of multi-query dataframe containing binding variables.
 - Added support for renaming multiple columns in `DataFrame.rename`.
 - Added support for Geometry datatypes.
+- Added support for `params` in `session.sql()` in stored procedures.
 
 ### Improvements
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1367,12 +1367,6 @@ class Session:
             >>> df.collect()
             [Row(1/2=Decimal('0.500000'))]
         """
-        # TODO(SNOW-796947): Remove this limit once stored proc match parity with client
-        if is_in_stored_procedure() and params:
-            raise NotImplementedError(
-                "Bind variable in stored procedure is not supported yet"
-            )
-
         if self.sql_simplifier_enabled:
             d = DataFrame(
                 self,

--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -9,6 +9,7 @@ import os.path
 import pytest
 
 from snowflake.snowpark import Row
+from snowflake.snowpark._internal.utils import is_in_stored_procedure
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import col, lit, max, table_function
 from snowflake.snowpark.types import (
@@ -350,7 +351,6 @@ def test_first(session):
         params=[1, "a", 2, "b", 3, "c", 4, "d"],
     )
     Utils.check_answer(df.sort("column1").first(), [Row(1, "a")])
-    Utils.check_answer(df.sort("column1").first(block=False).result(), [Row(1, "a")])
     Utils.check_answer(
         df.sort("column1").first(3), [Row(1, "a"), Row(2, "b"), Row(3, "c")]
     )
@@ -358,6 +358,10 @@ def test_first(session):
         df.sort("column1").first(-1),
         [Row(1, "a"), Row(2, "b"), Row(3, "c"), Row(4, "d")],
     )
+    if not is_in_stored_procedure():
+        Utils.check_answer(
+            df.sort("column1").first(block=False).result(), [Row(1, "a")]
+        )
 
 
 def test_na(session):
@@ -432,21 +436,3 @@ def test_explain(session):
         params=[1, "a", 2, "b"],
     )
     df.explain()
-
-
-def test_stored_proc_not_supported(session):
-    import snowflake.snowpark._internal.utils as internal_utils
-
-    original_platform = internal_utils.PLATFORM
-    internal_utils.PLATFORM = "XP"
-    try:
-        with pytest.raises(
-            NotImplementedError,
-            match=".*Bind variable in stored procedure is not supported yet.*",
-        ):
-            session.sql(
-                "select * from values (?, ?), (?, ?)",
-                params=[1, "a", 2, "b"],
-            )
-    finally:
-        internal_utils.PLATFORM = original_platform


### PR DESCRIPTION
Description

The change in Snowflake and the connector was checked in to reach full parity as far as integ/test_bind_variable.sql goes. We could remove this restriction from snowpark.

Testing

regression test with test_bind_variable.sql

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-861532

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The change in Snowflake and the connector was checked in to reach full parity as far as integ/test_bind_variable.sql goes. We could remove this restriction from snowpark.
