### PR TITLE
SNOW-747608 Make tests compatible with UDAF behavior change

### DIFF
--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1014,7 +1014,8 @@ def test_describe_sp(session, source_code_display):
 
     return1_sp = session.sproc.register(return1)
     describe_res = session.sproc.describe(return1_sp).collect()
-    assert [row[0] for row in describe_res] == [
+    actual_fields = [row[0] for row in describe_res]
+    expected_fields = [
         "signature",
         "returns",
         "language",
@@ -1027,7 +1028,15 @@ def test_describe_sp(session, source_code_display):
         "runtime_version",
         "packages",
         "installed_packages",
+        # This seems like an unintended change from the server, we should remove it once it is removed from server
+        "is_aggregate",
     ]
+    # We use zip such that it is compatible regardless of UDAF is enabled or not on the merge gate accounts
+    for actual_field, expected_field in zip(actual_fields, expected_fields):
+        assert (
+            actual_field == expected_field
+        ), f"Actual: {actual_fields}, Expected: {expected_fields}"
+
     for row in describe_res:
         if row[0] == "packages":
             assert "snowflake-snowpark-python" in row[1]

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1705,7 +1705,8 @@ def test_udf_describe(session):
         get_numpy_pandas_version, packages=["numpy", "pandas"]
     )
     describe_res = session.udf.describe(get_numpy_pandas_version_udf).collect()
-    assert [row[0] for row in describe_res] == [
+    actual_fields = [row[0] for row in describe_res]
+    expected_fields = [
         "signature",
         "returns",
         "language",
@@ -1717,7 +1718,14 @@ def test_udf_describe(session):
         "runtime_version",
         "packages",
         "installed_packages",
+        "is_aggregate",
     ]
+    # We use zip such that it is compatible regardless of UDAF is enabled or not on the merge gate accounts
+    for actual_field, expected_field in zip(actual_fields, expected_fields):
+        assert (
+            actual_field == expected_field
+        ), f"Actual: {actual_fields}, Expected: {expected_fields}"
+
     for row in describe_res:
         if row[0] == "packages":
             assert "numpy" in row[1] and "pandas" in row[1]


### PR DESCRIPTION
Description

Enabling UDAF adds an is_aggregate field when describing a function. We need to make sure our tests work both ways before enabling the feature in the test accounts.

Testing

Tested on an account that has UDAF enabled

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-747608

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Enabling UDAF adds an is_aggregate field when describing a function. We need to make sure our tests work both ways before enabling the feature in the test accounts.
