### PR TITLE
SNOW-876321: Fix schema_query for union with sql simplifier enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Fixed a bug where type check happens on pandas before it is imported
 - Fixed a bug when creating a UDF from numpy.ufunc
+- Fixed a bug where `DataFrame.union` was not generating the correct `schema_query` when sql simplifier is enabled.
 
 ### Behavior Changes
 

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -177,6 +177,17 @@ def test_union_by_name(session):
     )
 
 
+def test_union_with_cache_result(session):
+    """Created to test regression in SNOW-876321"""
+    df = session.sql("select 1 as A, 2 as B")
+    df1 = df.select(lit("foo").alias("lit_col"))
+    df2 = df.select(lit("eggs").alias("lit_col"))
+    df3 = df1.union(df2)
+
+    df4 = df3.cache_result()
+    Utils.check_answer(df4, [Row(LIT_COL="foo"), Row(LIT_COL="eggs")])
+
+
 def test_set_after_set(session):
     df = session.createDataFrame([(1, "one"), (2, "two"), (3, "one"), (4, "two")])
     df2 = session.createDataFrame([(3, "one"), (4, "two")])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-876321

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   A regression was identified in the attached SNOW ticket. The root cause is that the schema_query generated when sql simplifier is enabled only took the first operand of union into consideration. This change updates the schema query generation to consider all operands.
