### PR TITLE
SNOW-876999: Add support for timezone-aware type annotation on UDF 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
 - Added support for `params` in `session.sql()` in stored procedures.
 - Added support for UDAF. This feature is currently in private preview.
 - Added support for vectorized UDTF. This feature is currently in public preview.
-- Added support for Timestamp variants, i.e., `TIMESTAMP_NTZ`, `TIMESTAMP_LTZ`, `TIMESTAMP_TZ`
+- Added support for Snowflake Timestamp variants (i.e., `TIMESTAMP_NTZ`, `TIMESTAMP_LTZ`, `TIMESTAMP_TZ`)
+  - Provide `TimestampTimezone` as an argument in `TimestampType` constructor.
+  - Provide type hints `NTZ`, `LTZ`, `TZ` and `Timestamp` to annotate functions when registering UDFs.
 
 ### Improvements
 

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -27,7 +27,9 @@ This package contains all Snowpark logical types.
     GeometryType
     IntegerType
     LongType
+    LTZ
     MapType
+    NTZ
     NullType
     PandasDataFrame
     PandasDataFrameType
@@ -37,7 +39,10 @@ This package contains all Snowpark logical types.
     StringType
     StructField
     StructType
-    TimeType
+    Timestamp
+    TimestampTimeZone
     TimestampType
+    TimeType
+    TZ
     Variant
     VariantType

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -516,7 +516,9 @@ def python_type_to_snow_type(tp: Union[str, Type]) -> Tuple[DataType, bool]:
         elif tp_args[0] == TZ:
             timezone = TimestampTimeZone.TZ
         else:
-            timezone = TimestampTimeZone.DEFAULT
+            raise TypeError(
+                f"Only Timestamp, Timestamp[NTZ], Timestamp[LTZ] and Timestamp[TZ] are allowed, but got {tp}"
+            )
         return TimestampType(timezone), False
 
     raise TypeError(f"invalid type {tp}")

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -32,6 +32,9 @@ from typing import (  # noqa: F401
 import snowflake.snowpark.types  # type: ignore
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.snowpark.types import (
+    LTZ,
+    NTZ,
+    TZ,
     ArrayType,
     BinaryType,
     BooleanType,
@@ -53,6 +56,7 @@ from snowflake.snowpark.types import (
     StringType,
     StructField,
     StructType,
+    Timestamp,
     TimestampTimeZone,
     TimestampType,
     TimeType,
@@ -501,6 +505,19 @@ def python_type_to_snow_type(tp: Union[str, Type]) -> Tuple[DataType, bool]:
 
     if tp == Geometry:
         return GeometryType(), False
+
+    if tp == Timestamp or tp_origin == Timestamp:
+        if not tp_args:
+            timezone = TimestampTimeZone.DEFAULT
+        elif tp_args[0] == NTZ:
+            timezone = TimestampTimeZone.NTZ
+        elif tp_args[0] == LTZ:
+            timezone = TimestampTimeZone.LTZ
+        elif tp_args[0] == TZ:
+            timezone = TimestampTimeZone.TZ
+        else:
+            timezone = TimestampTimeZone.DEFAULT
+        return TimestampType(timezone), False
 
     raise TypeError(f"invalid type {tp}")
 

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -118,8 +118,10 @@ class _NumericType(_AtomicType):
 
 
 class TimestampTimeZone(Enum):
-    # When the TIMESTAMP_* variation is specified by TIMESTAMP_TYPE_MAPPING
-    # see https://docs.snowflake.com/en/sql-reference/parameters#label-timestamp-type-mapping
+    """
+    `Snowflake Timestamp variations <https://docs.snowflake.com/en/sql-reference/data-types-datetime#timestamp-ltz-timestamp-ntz-timestamp-tz>`_.
+    """
+
     DEFAULT = "default"
     # TIMESTAMP_NTZ
     NTZ = "ntz"
@@ -136,7 +138,7 @@ class TimestampType(_AtomicType):
     """Timestamp data type. This maps to the TIMESTAMP data type in Snowflake."""
 
     def __init__(self, timezone: TimestampTimeZone = TimestampTimeZone.DEFAULT) -> None:
-        self.tz = timezone
+        self.tz = timezone  #: Timestamp variations
 
     def __repr__(self) -> str:
         tzinfo = f"tz={self.tz}" if self.tz != TimestampTimeZone.DEFAULT else ""

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -4,6 +4,7 @@
 #
 
 """This package contains all Snowpark logical types."""
+import datetime
 import re
 import sys
 from enum import Enum
@@ -451,9 +452,26 @@ Geography = TypeVar("Geography")
 #: The type hint for annotating Geometry data when registering UDFs.
 Geometry = TypeVar("Geometry")
 
+#: The type hint for annotating TIMESTAMP_NTZ (e.g., ``Timestamp[NTZ]``) data when registering UDFs.
+NTZ = TypeVar("NTZ")
+
+#: The type hint for annotating TIMESTAMP_LTZ (e.g., ``Timestamp[LTZ]``) data when registering UDFs.
+LTZ = TypeVar("LTZ")
+
+#: The type hint for annotating TIMESTAMP_TZ (e.g., ``Timestamp[TZ]``) data when registering UDFs.
+TZ = TypeVar("TZ")
+
+
+_T = TypeVar("_T")
+
+
+class Timestamp(datetime.datetime, Generic[_T]):
+    """The type hint for annotating ``TIMESTAMP_*`` data when registering UDFs."""
+
+    pass
+
 
 if installed_pandas:  # pragma: no cover
-    _T = TypeVar("_T")
 
     class PandasSeries(pandas.Series, Generic[_T]):
         """The type hint for annotating Pandas Series data when registering UDFs."""

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -256,6 +256,11 @@ class UDFRegistration:
         :class:`~snowflake.snowpark.types.PandasDataFrameType` indicate the SQL types
         in a Pandas Series and a Pandas DataFrame.
 
+        4. To annotate the Snowflake specific Timestamp type (TIMESTAMP_NTZ, TIMESTAMP_LTZ and
+        TIMESTAMP_TZ), use :class:`~snowflake.snowpark.types.Timestamp` with
+        :class:`~snowflake.snowpark.types.NTZ`, :class:`~snowflake.snowpark.types.LTZ`,
+        :class:`~snowflake.snowpark.types.TZ` (e.g., ``Timestamp[NTZ]``).
+
     Example 1
         Create a temporary UDF from a lambda and apply it to a dataframe::
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-876999

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously we add support for timestamp variations in data types, but we also need such support for UDFs with type annotations. 
