### PR TITLE
Clear pytest errors for tests/resource dir

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -241,7 +241,7 @@ jobs:
             .tox/coverage.xml
 
   test-no-pandas:
-    name: Test when pandas is not installed
+    name: Test when pandas is not installed ${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}
     needs: build
     runs-on: ${{ matrix.os.image_name }}
     strategy:

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ deps =
     pytest-timeout
     pyarrow
     .[development]
-commands = {env:SNOWFLAKE_PYTEST_CMD} -vvv --ignore=tests/resources -m "integ or unit" {posargs:}  tests
+commands = {env:SNOWFLAKE_PYTEST_CMD} -vvv -m "integ or unit" {posargs:}  tests
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ setenv =
     # Add common parts into pytest command
     SNOWFLAKE_PYTEST_COV_LOCATION = {env:JUNIT_REPORT_DIR:{toxworkdir}}/junit.{envname}-{env:cloud_provider:dev}.xml
     SNOWFLAKE_PYTEST_COV_CMD = --cov snowflake.snowpark --junitxml {env:SNOWFLAKE_PYTEST_COV_LOCATION} --cov-report=
-    SNOWFLAKE_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD}
+    SNOWFLAKE_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources
 
 passenv =
     AWS_ACCESS_KEY_ID
@@ -79,7 +79,7 @@ deps =
     pytest-timeout
     pyarrow
     .[development]
-commands = {env:SNOWFLAKE_PYTEST_CMD} -m "integ or unit" {posargs:}  tests
+commands = {env:SNOWFLAKE_PYTEST_CMD} -vvv --ignore=tests/resources -m "integ or unit" {posargs:}  tests
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The current `Test when pandas is not installed macos-3.8-aws` fails because pytest runs the `test_*.py` files in `tests/resource` which are used for registering UDF from files. This PR fixes this issue.
