### PR TITLE
SNOW-841405  Fix df copy and enable basic diamond shaped joins for simplifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Fixed a bug where automatic package upload would raise `ValueError` even when compatible package version were added in `session.add_packages`.
 - Fixed a bug where table stored procedures were not registered correctly when using `register_from_file`.
+- Fixed a bug where dataframe joins failed with `invalid_identifier` error.
+- Fixed a bug where `DataFrame.copy` disables SQL simplfier for the returned copy.
 
 ## 1.7.0 (2023-08-28)
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 from collections import UserDict, defaultdict
-from copy import copy
+from copy import copy, deepcopy
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -262,9 +262,7 @@ class Selectable(LogicalPlan, ABC):
         """A dictionary that contains the column states of a query.
         Refer to class ColumnStateDict.
         """
-        self._column_states = copy(value)
-        if value is not None:
-            self._column_states.projection = [copy(attr) for attr in value.projection]
+        self._column_states = deepcopy(value)
 
 
 class SelectableEntity(Selectable):

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -710,7 +710,7 @@ class DataFrame:
         )
 
     def __copy__(self) -> "DataFrame":
-        return DataFrame(self._session, copy.copy(self._plan))
+        return DataFrame(self._session, copy.copy(self._select_statement or self._plan))
 
     if installed_pandas:
         import pandas  # pragma: no cover

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -3218,3 +3218,12 @@ def test_dataframe_result_cache_changing_schema(session):
     old_cached_df = df.cache_result()
     session.use_schema("public")  # schema change
     old_cached_df.show()
+
+
+def test_dataframe_diamond_join(session):
+    session.sql_simplifier_enabled = True  # use False behavior
+    df1 = session.create_dataframe([[1, 2], [3, 4], [5, 6]], schema=["a", "b"])
+    df2 = df1.filter(col("a") > 3)
+    assert df1.a._expression.expr_id != df2.a._expression.expr_id
+    df3 = df1.join(df2, df1.a == df2.a)
+    df3.select(df1.a, df2.a).show()

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -3218,12 +3218,3 @@ def test_dataframe_result_cache_changing_schema(session):
     old_cached_df = df.cache_result()
     session.use_schema("public")  # schema change
     old_cached_df.show()
-
-
-def test_dataframe_diamond_join(session):
-    session.sql_simplifier_enabled = True  # use False behavior
-    df1 = session.create_dataframe([[1, 2], [3, 4], [5, 6]], schema=["a", "b"])
-    df2 = df1.filter(col("a") > 3)
-    assert df1.a._expression.expr_id != df2.a._expression.expr_id
-    df3 = df1.join(df2, df1.a == df2.a)
-    df3.select(df1.a, df2.a).show()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Also fixes #875 and #886

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fixes `DataFrame.copy` for simplifier path by make sure attributes are copied from the subquery so that `NamedExpression.expr_id` is regenerated. As a result, `df1.filter(col("a") > 1).a` has a different expression id than `df1.a`, which enables basic diamond shaped joins like 
  ```
  df2 = df1.filter(col("a") > 1).sort("b")
  df1.join(df2, df1.a == df2.a)
  ```