### PR TITLE
SNOW-575699: Fix flaky query tag tests

### DIFF
--- a/src/snowflake/snowpark/query_history.py
+++ b/src/snowflake/snowpark/query_history.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import List, NamedTuple
+from typing import Any, Dict, List, NamedTuple
 
 import snowflake.snowpark
 
@@ -24,6 +24,9 @@ class QueryHistory:
     def __init__(self, session: "snowflake.snowpark.session.Session") -> None:
         self.session = session
         self._queries: List[QueryRecord] = []
+        self._debug_info: List[
+            Dict[str, Any]
+        ] = []  # For test only so it's not public APIs.
 
     def __enter__(self):
         return self
@@ -33,6 +36,9 @@ class QueryHistory:
 
     def _add_query(self, query_record: QueryRecord):
         self._queries.append(query_record)
+
+    def _add_debug_info(self, debug_info: Dict[str, Any]):
+        self._debug_info.append(debug_info)
 
     @property
     def queries(self) -> List[QueryRecord]:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-575699, #574078, #574166, #759410

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
The Snowflake server side query tag has latency so the client tests are flaky.
Instead of retrieving the query's query tag from the server side, we now record what query tags are sent to the server.
