### PR TITLE
Adding dataFrame.printSchema

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3771,9 +3771,19 @@ Query List:
         exprs = [convert(col) for col in parse_positional_args_to_list(*cols)]
         return exprs
 
+    def printSchema(self) -> str:
+        return "root\n%s" % (
+            "\n".join(
+                [
+                    f" |-- {attr.name}: {attr.datatype} (nullable = {str(attr.nullable)})"
+                    for attr in self._plan.attributes
+                ]
+            )
+        )
+
     where = filter
 
-    # Add the following lines so API docs have themm
+    # Add the following lines so API docs have them
     approxQuantile = approx_quantile = DataFrameStatFunctions.approx_quantile
     corr = DataFrameStatFunctions.corr
     cov = DataFrameStatFunctions.cov

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3771,7 +3771,7 @@ Query List:
         exprs = [convert(col) for col in parse_positional_args_to_list(*cols)]
         return exprs
 
-    def print_schema(self) -> str:
+    def print_schema(self) -> None:
         schema_tmp_str = "\n".join(
             [
                 f" |-- {attr.name}: {attr.datatype} (nullable = {str(attr.nullable)})"

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3773,7 +3773,7 @@ Query List:
 
     where = filter
 
-    # Add the following lines so API docs have them
+    # Add the following lines so API docs have themm
     approxQuantile = approx_quantile = DataFrameStatFunctions.approx_quantile
     corr = DataFrameStatFunctions.corr
     cov = DataFrameStatFunctions.cov

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3771,15 +3771,14 @@ Query List:
         exprs = [convert(col) for col in parse_positional_args_to_list(*cols)]
         return exprs
 
-    def printSchema(self) -> str:
-        return "root\n%s" % (
-            "\n".join(
-                [
-                    f" |-- {attr.name}: {attr.datatype} (nullable = {str(attr.nullable)})"
-                    for attr in self._plan.attributes
-                ]
-            )
+    def print_schema(self) -> str:
+        schema_tmp_str = "\n".join(
+            [
+                f" |-- {attr.name}: {attr.datatype} (nullable = {str(attr.nullable)})"
+                for attr in self._plan.attributes
+            ]
         )
+        print(f"root\n{schema_tmp_str}")
 
     where = filter
 
@@ -3812,6 +3811,7 @@ Query List:
     randomSplit = random_split
     order_by = sort
     orderBy = order_by
+    printSchema = print_schema
 
     # These methods are not needed for code migration. So no aliases for them.
     # groupByGrouping_sets = group_by_grouping_sets

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -15,10 +15,12 @@ from snowflake.snowpark import (
     DataFrameStatFunctions,
 )
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
+from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlanBuilder
 from snowflake.snowpark._internal.server_connection import ServerConnection
 from snowflake.snowpark.dataframe import _get_unaliased
 from snowflake.snowpark.exceptions import SnowparkCreateDynamicTableException
+from snowflake.snowpark.types import IntegerType, StringType
 
 
 def test_get_unaliased():
@@ -279,11 +281,14 @@ def test_dataFrame_printSchema(capfd):
     mock_connection = mock.create_autospec(ServerConnection)
     mock_connection._conn = mock.MagicMock()
     session = snowflake.snowpark.session.Session(mock_connection)
-    session._conn._telemetry_client = mock.MagicMock()
-    df = session.create_dataframe([[1, 2], [3, None]], schema=["a", "b"])
+    df = session.create_dataframe([[1, ""], [3, None]])
+    df._plan.attributes = [
+        Attribute("A", IntegerType(), False),
+        Attribute("B", StringType()),
+    ]
     df.printSchema()
     out, err = capfd.readouterr()
     assert (
         out
-        == 'root\n |-- "A": LongType() (nullable = False)\n |-- "B": StringType() (nullable = True)'
+        == "root\n |-- A: IntegerType() (nullable = False)\n |-- B: StringType() (nullable = True)\n"
     )

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -273,3 +273,16 @@ def test_statement_params():
         param in kwargs["_statement_params"].items()
         for param in statement_params.items()
     )
+
+
+def test_dataFrame_printSchema():
+    mock_connection = mock.create_autospec(ServerConnection)
+    mock_connection._conn = mock.MagicMock()
+    session = snowflake.snowpark.session.Session(mock_connection)
+    session._conn._telemetry_client = mock.MagicMock()
+    df = session.create_dataframe([[1, 2], [3, None]], schema=["a", "b"])
+    df_schema_print = df.printSchema()
+    assert (
+        df_schema_print
+        == 'root\n |-- "A": LongType() (nullable = False)\n |-- "B": StringType() (nullable = True)'
+    )

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -275,14 +275,15 @@ def test_statement_params():
     )
 
 
-def test_dataFrame_printSchema():
+def test_dataFrame_printSchema(capfd):
     mock_connection = mock.create_autospec(ServerConnection)
     mock_connection._conn = mock.MagicMock()
     session = snowflake.snowpark.session.Session(mock_connection)
     session._conn._telemetry_client = mock.MagicMock()
     df = session.create_dataframe([[1, 2], [3, None]], schema=["a", "b"])
-    df_schema_print = df.printSchema()
+    df.printSchema()
+    out, err = capfd.readouterr()
     assert (
-        df_schema_print
+        out
         == 'root\n |-- "A": LongType() (nullable = False)\n |-- "B": StringType() (nullable = True)'
     )


### PR DESCRIPTION
Overview: Adding `printSchema` method for printing a human readable version of dataFrame schema. Note that the jira asks for print_schema and printSchema(alias), but in the parent jira and pySpark we only have `printSchema`. I can make changes is we actually need the two methods mentioned in the jira ticket.

Precommit test link: https://ci-dev-142.int.snowflakecomputing.com/job/PythonStoredProcBuildPrecommitTest/545/

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-859941

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
