### PR TITLE
SNOW-903873: fix flaky test dynamic table creation

### DIFF
--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2516,6 +2516,9 @@ def test_create_dynamic_table(session, table_name_1):
         df.create_or_replace_dynamic_table(
             dt_name, warehouse=session.get_current_warehouse(), lag="1000 minutes"
         )
+        # scheduled refresh is not deterministic which leads to flakiness that table dynamic table is not initialized
+        # here we manually refresh the dynamic table
+        session.sql(f"alter dynamic table {dt_name} refresh").collect()
         res = session.sql(f"show dynamic tables like '{dt_name}'").collect()
         assert len(res) == 1
     finally:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2516,7 +2516,7 @@ def test_create_dynamic_table(session, table_name_1):
         df.create_or_replace_dynamic_table(
             dt_name, warehouse=session.get_current_warehouse(), lag="1000 minutes"
         )
-        # scheduled refresh is not deterministic which leads to flakiness that table dynamic table is not initialized
+        # scheduled refresh is not deterministic which leads to flakiness that dynamic table is not initialized
         # here we manually refresh the dynamic table
         session.sql(f"alter dynamic table {dt_name} refresh").collect()
         res = session.sql(f"show dynamic tables like '{dt_name}'").collect()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-903873, dynamic table needs refresh to initialize, scheduled refresh is not reliable leading to flaky test failure, here we manually refresh the table 

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
