### PR TITLE
SNOW-857185: Give an option to log on exception when calling sp with …

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2366,11 +2366,9 @@ class Session:
                 if isinstance(arg, Column):
                     expr = arg._expression
                     if isinstance(expr, Cast):
-                        arg_types.append(convert_sp_to_sf_type(arg._expression.to))
+                        arg_types.append(convert_sp_to_sf_type(expr.to))
                     else:
-                        arg_types.append(
-                            convert_sp_to_sf_type(arg._expression.datatype)
-                        )
+                        arg_types.append(convert_sp_to_sf_type(expr.datatype))
                 else:
                     arg_types.append(convert_sp_to_sf_type(infer_type(arg)))
             func_signature = f"{sproc_name.upper()}({', '.join(arg_types)})"


### PR DESCRIPTION
…optional args

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-857185

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Don't log warning messages when trying to infer if stored proc has table return type unless users explicitly request it.
