### PR TITLE
SNOW-910685: Support creating session from default configuration file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added support for specifying clustering keys when saving dataframes using `DataFrame.save_as_table`.
 - Accept `Iterable` objects input for `schema` when creating dataframes using `Session.create_dataframe`.
+- Added support for creating a Snowpark session from a configuration file or environment variables.
+
+### Dependency updates
+
+- Updated ``snowflake-connector-python`` to 3.2.0.
 
 ### Bug Fixes
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
-CONNECTOR_DEPENDENCY_VERSION = ">=3.0.4, <4.0.0"
+CONNECTOR_DEPENDENCY_VERSION = ">=3.2.0, <4.0.0"
 REQUIRED_PYTHON_VERSION = ">=3.8, <3.11"
 if os.getenv("SNOWFLAKE_IS_PYTHON_RUNTIME_TEST", False):
     REQUIRED_PYTHON_VERSION = ">=3.8"

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -21,6 +21,7 @@ import cloudpickle
 import pkg_resources
 
 from snowflake.connector import ProgrammingError, SnowflakeConnection
+from snowflake.connector.config_manager import _get_default_connection_params
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.connector.pandas_tools import write_pandas
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
@@ -328,6 +329,11 @@ class Session:
         def _create_internal(
             self, conn: Optional[SnowflakeConnection] = None
         ) -> "Session":
+            # If no connection object and no connection parameter is provided,
+            # we read from the default config file
+            if not conn and not self._options:
+                self._options = _get_default_connection_params()
+
             # Set paramstyle to qmark by default to be consistent with previous behavior
             if "paramstyle" not in self._options:
                 self._options["paramstyle"] = "qmark"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-910685

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Bump the connector version of connector so we have the latest change of default config file, and support reading connection parameters from default config file for creating session, and add a test