### PR TITLE
Fix SELECT after session.sql() with params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed a bug where automatic package upload would raise `ValueError` even when compatible package version were added in `session.add_packages`.
 - Fixed a bug where table stored procedures were not registered correctly when using `register_from_file`.
+- Fixed a bug where `session.sql().select()` would fail if any parameters are specified to `session.sql()`
 
 ## 1.7.0 (2023-08-28)
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -302,7 +302,7 @@ class SelectSQL(Selectable):
         self.original_sql = sql
         is_select = is_sql_select_statement(sql)
         if not is_select and convert_to_select:
-            self.pre_actions = [Query(sql, params)]
+            self.pre_actions = [Query(sql, params=params)]
             self._sql_query = result_scan_statement(
                 self.pre_actions[0].query_id_place_holder
             )

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1146,7 +1146,6 @@ class SnowflakePlanBuilder:
             new_queries = plan.queries + [
                 Query(
                     result_scan_statement(plan.queries[-1].query_id_place_holder),
-                    None,
                 )
             ]
             return SnowflakePlan(
@@ -1164,6 +1163,7 @@ class Query:
     def __init__(
         self,
         sql: str,
+        *,
         query_id_place_holder: Optional[str] = None,
         is_ddl_on_temp_object: bool = False,
         params: Optional[Sequence[Any]] = None,
@@ -1178,7 +1178,14 @@ class Query:
         self.params = params or []
 
     def __repr__(self) -> str:
-        return f"Query({self.sql!r}, {self.query_id_place_holder!r}, {self.is_ddl_on_temp_object}, {self.params})"
+        return (
+            "Query("
+            + f"{self.sql!r}, "
+            + f"query_id_place_holder={self.query_id_place_holder!r}, "
+            + f"is_ddl_on_temp_object={self.is_ddl_on_temp_object}, "
+            + f"params={self.params}"
+            + ")"
+        )
 
     def __eq__(self, other: "Query") -> bool:
         return (

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -71,6 +71,13 @@ def test_select_1(session):
     assert res == [Row(1)]
 
 
+def test_sql_select_with_params(session):
+    res = (
+        session.sql("EXECUTE IMMEDIATE $$ SELECT ? AS x $$", [1]).select("x").collect()
+    )
+    assert res == [Row(1)]
+
+
 def test_active_session(session):
     assert session == _get_active_session()
 

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -82,8 +82,8 @@ def test_attribute():
 
 
 def test_query():
-    q = Query("select 1", "uuid")
+    q = Query("select 1", query_id_place_holder="uuid")
     assert eval(repr(q)) == q
 
-    q = Query("'select 1'", "'uuid'", True)
+    q = Query("'select 1'", query_id_place_holder="'uuid'", is_ddl_on_temp_object=True)
     assert eval(repr(q)) == q


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   No issue, quick fix

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `Query` constructor was being called with params passed to the wrong argument. This uses the keyword argument correctly. I also changed the `Query` constructor to require any parameters after the SQL string to be keyword arguments, to prevent this in the future.