### PR TITLE
Add ParsedTableName class

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.expression import Attribute, Expression
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import StructType
 
@@ -42,7 +43,7 @@ class Range(LeafNode):
 
 
 class UnresolvedRelation(LeafNode):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: ParsedTableName) -> None:
         super().__init__()
         self.name = name
 
@@ -64,7 +65,7 @@ class SaveMode(Enum):
 class SnowflakeCreateTable(LogicalPlan):
     def __init__(
         self,
-        table_name: Iterable[str],
+        table_name: ParsedTableName,
         column_names: Optional[Iterable[str]],
         mode: SaveMode,
         query: Optional[LogicalPlan],
@@ -95,7 +96,7 @@ class Limit(LogicalPlan):
 class CopyIntoTableNode(LeafNode):
     def __init__(
         self,
-        table_name: Iterable[str],
+        table_name: ParsedTableName,
         *,
         file_path: Optional[str] = None,
         files: Optional[str] = None,

--- a/src/snowflake/snowpark/_internal/analyzer/table_merge_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/table_merge_expression.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import Expression
 from snowflake.snowpark._internal.analyzer.snowflake_plan import LogicalPlan
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 
 
 class MergeExpression(Expression):
@@ -41,7 +42,7 @@ class InsertMergeExpression(MergeExpression):
 class TableUpdate(LogicalPlan):
     def __init__(
         self,
-        table_name: str,
+        table_name: ParsedTableName,
         assignments: Dict[Expression, Expression],
         condition: Optional[Expression],
         source_data: Optional[LogicalPlan],
@@ -57,7 +58,7 @@ class TableUpdate(LogicalPlan):
 class TableDelete(LogicalPlan):
     def __init__(
         self,
-        table_name: str,
+        table_name: ParsedTableName,
         condition: Optional[Expression],
         source_data: Optional[LogicalPlan],
     ) -> None:
@@ -71,7 +72,7 @@ class TableDelete(LogicalPlan):
 class TableMerge(LogicalPlan):
     def __init__(
         self,
-        table_name: str,
+        table_name: ParsedTableName,
         source: LogicalPlan,
         join_expr: Expression,
         clauses: List[Expression],

--- a/src/snowflake/snowpark/_internal/analyzer/unary_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/unary_plan_node.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 from snowflake.snowpark._internal.analyzer.expression import Expression, NamedExpression
 from snowflake.snowpark._internal.analyzer.snowflake_plan import LogicalPlan
 from snowflake.snowpark._internal.analyzer.sort_expression import SortOrder
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 
 
 class UnaryNode(LogicalPlan):
@@ -112,7 +113,7 @@ class PersistedView(ViewType):
 class CreateViewCommand(UnaryNode):
     def __init__(
         self,
-        name: str,
+        name: ParsedTableName,
         view_type: ViewType,
         child: LogicalPlan,
     ) -> None:
@@ -124,7 +125,7 @@ class CreateViewCommand(UnaryNode):
 class CreateDynamicTableCommand(UnaryNode):
     def __init__(
         self,
-        name: str,
+        name: ParsedTableName,
         warehouse: str,
         lag: str,
         child: LogicalPlan,

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -6,6 +6,7 @@
 from typing import Optional
 
 from snowflake.connector import OperationalError, ProgrammingError
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 from snowflake.snowpark.exceptions import (
     SnowparkColumnException,
     SnowparkCreateDynamicTableException,
@@ -106,7 +107,7 @@ class SnowparkClientExceptionMessages:
 
     @staticmethod
     def DF_COPY_INTO_CANNOT_CREATE_TABLE(
-        table_name: str,
+        table_name: ParsedTableName,
     ) -> SnowparkDataframeReaderException:
         return SnowparkDataframeReaderException(
             f"Cannot create the target table {table_name} because Snowpark cannot determine the column names to use. You should create the table before calling copy_into_table()."

--- a/src/snowflake/snowpark/_internal/parsed_table_name.py
+++ b/src/snowflake/snowpark/_internal/parsed_table_name.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from typing import Iterable, List, Union
+
+
+def _parse_table_name(table_name: str) -> List[str]:
+    """
+    This function implements the algorithm to parse a table name.
+
+    We parse the table name according to the following rules:
+    https://docs.snowflake.com/en/sql-reference/identifiers-syntax
+
+    - Unquoted object identifiers:
+        - Start with a letter (A-Z, a-z) or an underscore (“_”).
+        - Contain only letters, underscores, decimal digits (0-9), and dollar signs (“$”).
+        - Are stored and resolved as uppercase characters (e.g. id is stored and resolved as ID).
+
+    - If you put double quotes around an identifier (e.g. “My identifier with blanks and punctuation.”),
+        the following rules apply:
+        - The case of the identifier is preserved when storing and resolving the identifier (e.g. "id" is
+            stored and resolved as id).
+        - The identifier can contain and start with ASCII, extended ASCII, and non-ASCII characters.
+    """
+    from snowflake.snowpark._internal.utils import validate_object_name
+
+    validate_object_name(table_name)
+    str_len = len(table_name)
+    ret = []
+
+    in_double_quotes = False
+    i = 0
+    cur_word_start_idx = 0
+
+    while i < str_len:
+        cur_char = table_name[i]
+        if cur_char == '"':
+            if in_double_quotes:
+                # we have to check whether this `"` is the ending of a double-quoted identifier
+                # or it's an escaping double quote
+                # to achieve this, we need to preload one more char
+                if i < str_len - 1 and table_name[i + 1] == '"':
+                    # two consecutive '"', this is an escaping double quotes
+                    # the pointer just keeps moving forward
+                    i += 1
+                else:
+                    # the double quotes indicates the ending of an identifier
+                    in_double_quotes = False
+                    # it should be followed by a '.' for splitting, or it should reach the end of the str
+            else:
+                # this is the beginning of another double-quoted identifier
+                in_double_quotes = True
+        elif cur_char == ".":
+            if not in_double_quotes:
+                # this dot is to split db.schema.database
+                # we concatenate the processed chars into a string
+                # and append the string to the return list, and set our cur_word_start_idx to position after the dot
+                ret.append(table_name[cur_word_start_idx:i])
+                cur_word_start_idx = i + 1
+            # else dot is part of the table name
+        # else cur_char is part of the name
+        i += 1
+
+    ret.append(table_name[cur_word_start_idx:i])
+    return ret
+
+
+class ParsedTableName:
+    def __init__(self, table_name: Union[str, Iterable[str]]) -> None:
+        if isinstance(table_name, str):
+            self.parts = _parse_table_name(table_name)
+            assert str(self) == table_name
+        elif isinstance(table_name, Iterable) and all(
+            isinstance(x, str) for x in table_name
+        ):
+            self.parts = list(table_name)
+            assert self.parts == ParsedTableName(str(self)).parts
+        else:
+            raise TypeError(
+                f"table_name should be a str or an Iterable[str], got {type(table_name)}"
+            )
+
+    def __str__(self):
+        return ".".join(self.parts)
+
+    def __eq__(self, other):
+        if isinstance(other, ParsedTableName):
+            return self.parts == other.parts
+        elif isinstance(other, Iterable):
+            return self.parts == list(other)
+        else:
+            return NotImplemented

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -734,65 +734,6 @@ def strip_double_quotes_in_like_statement_in_table_name(table_name: str) -> str:
     return table_name[1:-1] if table_name[0] == table_name[-1] == '"' else table_name
 
 
-def parse_table_name(table_name: str) -> List[str]:
-    """
-    This function implements the algorithm to parse a table name.
-
-    We parse the table name according to the following rules:
-    https://docs.snowflake.com/en/sql-reference/identifiers-syntax
-
-    - Unquoted object identifiers:
-        - Start with a letter (A-Z, a-z) or an underscore (“_”).
-        - Contain only letters, underscores, decimal digits (0-9), and dollar signs (“$”).
-        - Are stored and resolved as uppercase characters (e.g. id is stored and resolved as ID).
-
-    - If you put double quotes around an identifier (e.g. “My identifier with blanks and punctuation.”),
-        the following rules apply:
-        - The case of the identifier is preserved when storing and resolving the identifier (e.g. "id" is
-            stored and resolved as id).
-        - The identifier can contain and start with ASCII, extended ASCII, and non-ASCII characters.
-    """
-    validate_object_name(table_name)
-    str_len = len(table_name)
-    ret = []
-
-    in_double_quotes = False
-    i = 0
-    cur_word_start_idx = 0
-
-    while i < str_len:
-        cur_char = table_name[i]
-        if cur_char == '"':
-            if in_double_quotes:
-                # we have to check whether this `"` is the ending of a double-quoted identifier
-                # or it's an escaping double quote
-                # to achieve this, we need to preload one more char
-                if i < str_len - 1 and table_name[i + 1] == '"':
-                    # two consecutive '"', this is an escaping double quotes
-                    # the pointer just keeps moving forward
-                    i += 1
-                else:
-                    # the double quotes indicates the ending of an identifier
-                    in_double_quotes = False
-                    # it should be followed by a '.' for splitting, or it should reach the end of the str
-            else:
-                # this is the beginning of another double-quoted identifier
-                in_double_quotes = True
-        elif cur_char == ".":
-            if not in_double_quotes:
-                # this dot is to split db.schema.database
-                # we concatenate the processed chars into a string
-                # and append the string to the return list, and set our cur_word_start_idx to position after the dot
-                ret.append(table_name[cur_word_start_idx:i])
-                cur_word_start_idx = i + 1
-            # else dot is part of the table name
-        # else cur_char is part of the name
-        i += 1
-
-    ret.append(table_name[cur_word_start_idx:i])
-    return ret
-
-
 EMPTY_STRING = ""
 DOUBLE_QUOTE = '"'
 ALREADY_QUOTED = re.compile('^(".+")$')

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -22,6 +22,7 @@ from snowflake.snowpark._internal.analyzer.table_merge_expression import (
     UpdateMergeExpression,
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 from snowflake.snowpark._internal.telemetry import add_api_call, set_api_call_source
 from snowflake.snowpark._internal.type_utils import ColumnOrLiteral
 from snowflake.snowpark.column import Column
@@ -264,18 +265,18 @@ class Table(DataFrame):
 
     def __init__(
         self,
-        table_name: str,
+        table_name: ParsedTableName,
         session: Optional["snowflake.snowpark.session.Session"] = None,
     ) -> None:
         super().__init__(
             session, session._analyzer.resolve(UnresolvedRelation(table_name))
         )
         self.is_cached: bool = self.is_cached  #: Whether the table is cached.
-        self.table_name: str = table_name  #: The table name
+        self.table_name = table_name  #: The table name
 
         if self._session.sql_simplifier_enabled:
             self._select_statement = SelectStatement(
-                from_=SelectableEntity(table_name, analyzer=session._analyzer),
+                from_=SelectableEntity(str(table_name), analyzer=session._analyzer),
                 analyzer=session._analyzer,
             )
         # By default, the set the initial API call to say 'Table.__init__' since

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -10,7 +10,8 @@ from textwrap import dedent
 import pytest
 
 from snowflake.snowpark import Row, Session
-from snowflake.snowpark._internal.utils import TempObjectType, parse_table_name
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import (
     SnowparkDataframeException,
     SnowparkDataframeReaderException,
@@ -1234,7 +1235,7 @@ def test_copy_into_table_names(session, db_parameters, tmp_stage_name1):
 
     def create_and_append_check_answer(table_name_input):
         parsed_table_name_array = (
-            parse_table_name(table_name_input)
+            ParsedTableName(table_name_input)
             if isinstance(table_name_input, str)
             else table_name_input
         )

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -7,7 +7,7 @@ import copy
 import pytest
 
 from snowflake.snowpark import Row
-from snowflake.snowpark._internal.utils import parse_table_name
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.types import (
     DoubleType,
@@ -215,7 +215,7 @@ def test_write_table_names(session, db_parameters):
 
     def create_and_append_check_answer(table_name_input):
         parsed_table_name_array = (
-            parse_table_name(table_name_input)
+            ParsedTableName(table_name_input)
             if isinstance(table_name_input, str)
             else table_name_input
         )

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -11,7 +11,8 @@ import pytest
 import snowflake.connector
 from snowflake.connector.errors import ProgrammingError
 from snowflake.snowpark import Row, Session
-from snowflake.snowpark._internal.utils import TempObjectType, parse_table_name
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import (
     SnowparkClientException,
     SnowparkInvalidObjectNameException,
@@ -318,7 +319,7 @@ def test_table_exists(session):
     double_quoted_schema = f'"{schema}.{schema}"'
 
     def check_temp_table(table_name_str):
-        parsed_table_name = parse_table_name(table_name_str)
+        parsed_table_name = ParsedTableName(table_name_str)
         assert session._table_exists(parsed_table_name) is False
         session.sql(f"create temp table {table_name_str}(col_a varchar)").collect()
         assert session._table_exists(parsed_table_name) is True
@@ -328,7 +329,7 @@ def test_table_exists(session):
         # table name start with `"` which doesn't meet the requirement, thus we have this separate process
         # to create and drop temporary table
         try:
-            parsed_table_name = parse_table_name(table_name_str)
+            parsed_table_name = ParsedTableName(table_name_str)
             assert session._table_exists(parsed_table_name) is False
             session.sql(f"create table {table_name_str}(col_a varchar)").collect()
             assert session._table_exists(parsed_table_name) is True

--- a/tests/unit/test_analyzer_util_suite.py
+++ b/tests/unit/test_analyzer_util_suite.py
@@ -17,6 +17,7 @@ from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     LeftAnti,
     UsingJoin,
 )
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 
 
 def test_generate_scoped_temp_objects():
@@ -73,7 +74,7 @@ def test_generate_scoped_temp_objects():
         == f" CREATE  FILE  FORMAT  If  NOT  EXISTS {temp_file_format_name} TYPE  = csv   "
     )
 
-    temp_table_name = "SNOWPARK_TEMP_FILE_FORMAT_E0ZW8Z9WMY"
+    temp_table_name = ParsedTableName("SNOWPARK_TEMP_FILE_FORMAT_E0ZW8Z9WMY")
     temp_schema_name = "TEST_SCHEMA"
     assert (
         create_table_statement(
@@ -154,7 +155,7 @@ def test_generate_scoped_temp_objects():
 
 
 def test_create_or_replace_dynamic_table_statement():
-    dt_name = "my_dt"
+    dt_name = ParsedTableName("my_dt")
     warehouse = "my_warehouse"
     print(
         create_or_replace_dynamic_table_statement(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3,7 +3,7 @@
 #
 import json
 import os
-from typing import Optional, Dict, Union
+from typing import Optional
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -20,8 +20,8 @@ except ImportError:
     is_pandas_available = False
 
 from snowflake.snowpark import Session
+from snowflake.snowpark._internal.parsed_table_name import ParsedTableName
 from snowflake.snowpark._internal.server_connection import ServerConnection
-from snowflake.snowpark._internal.utils import parse_table_name
 from snowflake.snowpark.exceptions import (
     SnowparkInvalidObjectNameException,
     SnowparkSessionException,
@@ -232,17 +232,6 @@ def test_create_dataframe_wrong_type():
         session.create_dataframe([[1]], schema=StructType([StructField("a", str)]))
 
 
-def test_table_exists_invalid_table_name():
-    fake_connection = mock.create_autospec(ServerConnection)
-    fake_connection._conn = mock.Mock()
-    session = Session(fake_connection)
-    with pytest.raises(
-        SnowparkInvalidObjectNameException,
-        match="The object name 'a.b.c.d' is invalid.",
-    ):
-        session._table_exists(["a", "b", "c", "d"])
-
-
 def test_explain_query_error():
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()
@@ -254,61 +243,63 @@ def test_explain_query_error():
 
 def test_parse_table_name():
     # test no double quotes
-    assert parse_table_name("a") == ["a"]
-    assert parse_table_name("a.b") == ["a", "b"]
-    assert parse_table_name("a.b.c") == ["a", "b", "c"]
-    assert parse_table_name("_12$opOW") == ["_12$opOW"]
-    assert parse_table_name("qwE123.z$xC") == ["qwE123", "z$xC"]
-    assert parse_table_name("Wo_89$.d9$dC.z_1Z$") == ["Wo_89$", "d9$dC", "z_1Z$"]
+    assert ParsedTableName("a") == ["a"]
+    assert ParsedTableName("a.b") == ["a", "b"]
+    assert ParsedTableName("a.b.c") == ["a", "b", "c"]
+    assert ParsedTableName("_12$opOW") == ["_12$opOW"]
+    assert ParsedTableName("qwE123.z$xC") == ["qwE123", "z$xC"]
+    assert ParsedTableName("Wo_89$.d9$dC.z_1Z$") == ["Wo_89$", "d9$dC", "z_1Z$"]
 
     # test double quotes
-    assert parse_table_name('"a"') == ['"a"']
-    assert parse_table_name('"a.b"') == ['"a.b"']
-    assert parse_table_name('"a..b"') == ['"a..b"']
-    assert parse_table_name('"a.b".b.c') == ['"a.b"', "b", "c"]
-    assert parse_table_name('"a.b"."b.c"') == ['"a.b"', '"b.c"']
-    assert parse_table_name('"a.b"."b".c') == ['"a.b"', '"b"', "c"]
-    assert parse_table_name('"a.b"."b.b"."c.c"') == ['"a.b"', '"b.b"', '"c.c"']
+    assert ParsedTableName('"a"') == ['"a"']
+    assert ParsedTableName('"a.b"') == ['"a.b"']
+    assert ParsedTableName('"a..b"') == ['"a..b"']
+    assert ParsedTableName('"a.b".b.c') == ['"a.b"', "b", "c"]
+    assert ParsedTableName('"a.b"."b.c"') == ['"a.b"', '"b.c"']
+    assert ParsedTableName('"a.b"."b".c') == ['"a.b"', '"b"', "c"]
+    assert ParsedTableName('"a.b"."b.b"."c.c"') == ['"a.b"', '"b.b"', '"c.c"']
 
-    assert parse_table_name('"@#$!23XM"') == ['"@#$!23XM"']
-    assert parse_table_name('"@#$!23XM._!Mcs"') == ['"@#$!23XM._!Mcs"']
-    assert parse_table_name('"@#$!23XM.._!Mcs"') == ['"@#$!23XM.._!Mcs"']
-    assert parse_table_name('"@#$!23XM._!Mcs".qwE123.z$xC') == [
+    assert ParsedTableName('"@#$!23XM"') == ['"@#$!23XM"']
+    assert ParsedTableName('"@#$!23XM._!Mcs"') == ['"@#$!23XM._!Mcs"']
+    assert ParsedTableName('"@#$!23XM.._!Mcs"') == ['"@#$!23XM.._!Mcs"']
+    assert ParsedTableName('"@#$!23XM._!Mcs".qwE123.z$xC') == [
         '"@#$!23XM._!Mcs"',
         "qwE123",
         "z$xC",
     ]
-    assert parse_table_name('"@#$!23XM._!Mcs".".39Qw$5.c"') == [
+    assert ParsedTableName('"@#$!23XM._!Mcs".".39Qw$5.c"') == [
         '"@#$!23XM._!Mcs"',
         '".39Qw$5.c"',
     ]
-    assert parse_table_name('"@#$!23XM._!Mcs".".39Qw$5.c".z$xC') == [
+    assert ParsedTableName('"@#$!23XM._!Mcs".".39Qw$5.c".z$xC') == [
         '"@#$!23XM._!Mcs"',
         '".39Qw$5.c"',
         "z$xC",
     ]
-    assert parse_table_name('"@#$!23XM._!Mcs".".39Qw$5.c"."2^.z$xC"') == [
+    assert ParsedTableName('"@#$!23XM._!Mcs".".39Qw$5.c"."2^.z$xC"') == [
         '"@#$!23XM._!Mcs"',
         '".39Qw$5.c"',
         '"2^.z$xC"',
     ]
 
     # test escape double quotes
-    assert parse_table_name('"""a.""b"."b.c"') == ['"""a.""b"', '"b.c"']
-    assert parse_table_name('"""a.""b"."b.c".d') == ['"""a.""b"', '"b.c"', "d"]
-    assert parse_table_name('"""a.""b"."b.c"."d"""""') == [
+    assert ParsedTableName('"""a.""b"."b.c"') == ['"""a.""b"', '"b.c"']
+    assert ParsedTableName('"""a.""b"."b.c".d') == ['"""a.""b"', '"b.c"', "d"]
+    assert ParsedTableName('"""a.""b"."b.c"."d"""""') == [
         '"""a.""b"',
         '"b.c"',
         '"d"""""',
     ]
-    assert parse_table_name('"""@#$!23XM._!Mcs""b.39Qw$5.c"."2^.z$xC""%cx_.z"') == [
+    assert ParsedTableName('"""@#$!23XM._!Mcs""b.39Qw$5.c"."2^.z$xC""%cx_.z"') == [
         '"""@#$!23XM._!Mcs""b.39Qw$5.c"',
         '"2^.z$xC""%cx_.z"',
     ]
-    assert parse_table_name(
-        '"""@#$!23XM._!Mcs""b.39Qw$5.c"."2^.z$xC""%cx_.z".z$xC'
-    ) == ['"""@#$!23XM._!Mcs""b.39Qw$5.c"', '"2^.z$xC""%cx_.z"', "z$xC"]
-    assert parse_table_name(
+    assert ParsedTableName('"""@#$!23XM._!Mcs""b.39Qw$5.c"."2^.z$xC""%cx_.z".z$xC') == [
+        '"""@#$!23XM._!Mcs""b.39Qw$5.c"',
+        '"2^.z$xC""%cx_.z"',
+        "z$xC",
+    ]
+    assert ParsedTableName(
         '"""@#$!23XM._!Mcs""b.39Qw$5.c"."2^.z$xC""%cx_.z"."_12$D""""""d"""""'
     ) == [
         '"""@#$!23XM._!Mcs""b.39Qw$5.c"',
@@ -317,17 +308,17 @@ def test_parse_table_name():
     ]
 
     # test no identifier for schema
-    assert parse_table_name("a..b") == ["a", "", "b"]
-    assert parse_table_name('"a.b"..b') == ['"a.b"', "", "b"]
-    assert parse_table_name('"a.b".."b.b"') == ['"a.b"', "", '"b.b"']
+    assert ParsedTableName("a..b") == ["a", "", "b"]
+    assert ParsedTableName('"a.b"..b') == ['"a.b"', "", "b"]
+    assert ParsedTableName('"a.b".."b.b"') == ['"a.b"', "", '"b.b"']
 
-    assert parse_table_name("d9$dC..z$xC") == ["d9$dC", "", "z$xC"]
-    assert parse_table_name('"""@#$!23XM._!Mcs""b.39Qw$5.c"..z$xC') == [
+    assert ParsedTableName("d9$dC..z$xC") == ["d9$dC", "", "z$xC"]
+    assert ParsedTableName('"""@#$!23XM._!Mcs""b.39Qw$5.c"..z$xC') == [
         '"""@#$!23XM._!Mcs""b.39Qw$5.c"',
         "",
         "z$xC",
     ]
-    assert parse_table_name('"""@#$!23XM._!Mcs""b.39Qw$5.c".."_12$D""""""d"""""') == [
+    assert ParsedTableName('"""@#$!23XM._!Mcs""b.39Qw$5.c".."_12$D""""""d"""""') == [
         '"""@#$!23XM._!Mcs""b.39Qw$5.c"',
         "",
         '"_12$D""""""d"""""',
@@ -335,39 +326,39 @@ def test_parse_table_name():
 
     # negative cases
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("12~3")  # ~ unsupported in unquoted id
+        assert ParsedTableName("12~3")  # ~ unsupported in unquoted id
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("123")  # can not start with num in unquoted id
+        assert ParsedTableName("123")  # can not start with num in unquoted id
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("$dab")  # can not start with $ in unquoted id
+        assert ParsedTableName("$dab")  # can not start with $ in unquoted id
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("")  # empty not allowed in unquoted id
+        assert ParsedTableName("")  # empty not allowed in unquoted id
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("   ")  # space not allowed in unquoted id
+        assert ParsedTableName("   ")  # space not allowed in unquoted id
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("a...b")  # unsupported semantic
+        assert ParsedTableName("a...b")  # unsupported semantic
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("a.b.")  # unsupported semantic
+        assert ParsedTableName("a.b.")  # unsupported semantic
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name(".b.")  # unsupported semantic
+        assert ParsedTableName(".b.")  # unsupported semantic
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name("a.b.c.d")  # 4 unquoted ids
+        assert ParsedTableName("a.b.c.d")  # 4 unquoted ids
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('"a"."b"."c"."d"')  # 4 quoted ids
+        assert ParsedTableName('"a"."b"."c"."d"')  # 4 quoted ids
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('"abc"abc')  # id after ending quotes
+        assert ParsedTableName('"abc"abc')  # id after ending quotes
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('"abc""abc')  # no ending quotes
+        assert ParsedTableName('"abc""abc')  # no ending quotes
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('&*%."abc"')  # unsupported chars in unquoted ids
+        assert ParsedTableName('&*%."abc"')  # unsupported chars in unquoted ids
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('"abc"."abc')  # missing double quotes in the end
+        assert ParsedTableName('"abc"."abc')  # missing double quotes in the end
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('"abc".!123~#')  # unsupported chars in unquoted ids
+        assert ParsedTableName('"abc".!123~#')  # unsupported chars in unquoted ids
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('*&^."abc".abc')  # unsupported chars in unquoted ids
+        assert ParsedTableName('*&^."abc".abc')  # unsupported chars in unquoted ids
     with pytest.raises(SnowparkInvalidObjectNameException):
-        assert parse_table_name('."abc".')  # unsupported semantic
+        assert ParsedTableName('."abc".')  # unsupported semantic
 
 
 def test_session_id():
@@ -375,7 +366,7 @@ def test_session_id():
     fake_server_connection.get_session_id = mock.Mock(return_value=123456)
     session = Session(fake_server_connection)
 
-    assert(session.session_id == 123456)
+    assert session.session_id == 123456
 
 
 def test_connection():
@@ -387,6 +378,5 @@ def test_connection():
     server_connection = ServerConnection(fake_options, fake_snowflake_connection)
     session = Session(server_connection)
 
-    assert(session.connection == session._conn._conn)
-    assert(session.connection == fake_snowflake_connection)
-
+    assert session.connection == session._conn._conn
+    assert session.connection == fake_snowflake_connection


### PR DESCRIPTION
I was looking into https://github.com/snowflakedb/snowpark-python/issues/824 before I realised it was fixed, and I noticed a lot of ad-hoc boilerplate for handling parameters representing table names of type `Union[str, Iterabe[str]]`. This is a proposal for a more uniform and elegant way to do that. `ParsedTableName` also acts as a nominal type, asserting that a name has already been validated, and making it clear that it's not just any old string.

This was just meant to be testing an idea but I got carried away, sorry for the huge diff! It occurred to me afterwards that I could make `ParsedTableName` a subclass of `str` to make this less intrusive. But first I want to hear if you think this whole thing is a reasonable idea at all.