### PR TITLE
Add typing-extension dependency back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.9.0 (TBD)
+
+### Dependency updates
+
+- Added back the dependency of `typing-extensions`.
+
 ## 1.8.0 (2023-09-14)
 
 ### New Features

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ INSTALL_REQ_LIST = [
     "setuptools>=40.6.0",
     "wheel",
     f"snowflake-connector-python{CONNECTOR_DEPENDENCY_VERSION}",
+    # snowpark directly depends on typing-extension, so we should not remove it even if connector also depends on it.
+    "typing-extensions>=4.1.0, <5.0.0",
     "pyyaml",
 ]
 CLOUDPICKLE_REQ_LIST = ["cloudpickle>=1.6.0,<=2.0.0"]


### PR DESCRIPTION
Description

We should not remove this dependency because it is a required dependency for snowpark, and we cannot rely on the fact that python connector also depends on it, because python connector can one day remove the dependency.

Testing

merge gate

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
