### PR TITLE
Fix stdout logging

### DIFF
--- a/tests/perf/long_runner.py
+++ b/tests/perf/long_runner.py
@@ -133,11 +133,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     log_folder = args.log_folder
-    output_file_path = f"{log_folder if log_folder and log_folder[-1] == '/' else log_folder + '/'}long_running_{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
     logger = logging.getLogger("long-running")
     logger.setLevel(logging.INFO)
     if log_folder:
-        logger.addHandler(logging.FileHandler(output_file_path))
+        log_file_path = f"{log_folder if log_folder[-1] == '/' else log_folder + '/'}long_running_{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
+        logger.addHandler(logging.FileHandler(log_file_path))
     else:
         logger.addHandler(logging.StreamHandler(sys.stdout))
     log_header = {


### PR DESCRIPTION
When the log folder is not specified, the test runner currently fails saying that None can't be added to a string for obvious reasons.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #929097

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The code path was relevant only to the case when `log_folder != None`. Otherwise, it failed with an exception.