### PR TITLE
SNOW-872425: fix adding package when the specifier contains name with underscore and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - The `format` argument changed from optional to required.
   - The returned result changed from a date object to a date-formatted string.
 
+### Bug Fixes
+
+- Fixed a bug that `session.add_packages` can not handle requirement specifier that contains project name with underscore and version.
+
 ## 1.9.0 (2023-10-13)
 
 ### New Features

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1035,9 +1035,22 @@ class Session:
             # underscores are discouraged in package names, but are still used in Anaconda channel
             # pkg_resources.Requirement.parse will convert all underscores to dashes
 
-            package_name = (
-                package if not use_local_version and "_" in package else package_req.key
-            )
+            package_name = package_req.key
+            if not use_local_version and "_" in package:
+                # dealing with case that "_" is in the package requirement as well as version restrictions
+                # we only extract the valid package name from the string by following:
+                # https://packaging.python.org/en/latest/specifications/name-normalization/
+                # A valid name consists only of ASCII letters and numbers, period, underscore and hyphen.
+                # It must start and end with a letter or number.
+                # however, we don't validate the pkg name as this is done by pkg_resources.Requirement.parse
+                package_name_array = []
+                for c in package:
+                    if c.isdigit() or c.isalpha() or c in (".", "-", "_"):
+                        package_name_array.append(c)
+                    else:
+                        break
+                package_name = "".join(package_name_array)
+
             package_dict[package] = (package_name, use_local_version, package_req)
 
         package_table = "information_schema.packages"

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1042,11 +1042,10 @@ class Session:
             # It must start and end with a letter or number.
             # however, we don't validate the pkg name as this is done by pkg_resources.Requirement.parse
             # find the index of the first char which is not an valid package name character
-            package_name = (
-                package[: re.search(r"[^0-9a-zA-Z\-_.]", package).start()]
-                if not use_local_version and "_" in package
-                else package_req.key
-            )
+            package_name = package_req.key
+            if not use_local_version and "_" in package:
+                reg_match = re.search(r"[^0-9a-zA-Z\-_.]", package)
+                package_name = package[: reg_match.start()] if reg_match else package
 
             package_dict[package] = (package_name, use_local_version, package_req)
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -8,6 +8,7 @@ import decimal
 import json
 import logging
 import os
+import re
 import sys
 import tempfile
 from array import array
@@ -1034,22 +1035,18 @@ class Session:
             # get the standard package name if there is no underscore
             # underscores are discouraged in package names, but are still used in Anaconda channel
             # pkg_resources.Requirement.parse will convert all underscores to dashes
-
-            package_name = package_req.key
-            if not use_local_version and "_" in package:
-                # dealing with case that "_" is in the package requirement as well as version restrictions
-                # we only extract the valid package name from the string by following:
-                # https://packaging.python.org/en/latest/specifications/name-normalization/
-                # A valid name consists only of ASCII letters and numbers, period, underscore and hyphen.
-                # It must start and end with a letter or number.
-                # however, we don't validate the pkg name as this is done by pkg_resources.Requirement.parse
-                package_name_array = []
-                for c in package:
-                    if c.isdigit() or c.isalpha() or c in (".", "-", "_"):
-                        package_name_array.append(c)
-                    else:
-                        break
-                package_name = "".join(package_name_array)
+            # the regexp is to deal with case that "_" is in the package requirement as well as version restrictions
+            # we only extract the valid package name from the string by following:
+            # https://packaging.python.org/en/latest/specifications/name-normalization/
+            # A valid name consists only of ASCII letters and numbers, period, underscore and hyphen.
+            # It must start and end with a letter or number.
+            # however, we don't validate the pkg name as this is done by pkg_resources.Requirement.parse
+            # find the index of the first char which is not an valid package name character
+            package_name = (
+                package[: re.search(r"[^0-9a-zA-Z\-_.]", package).start()]
+                if not use_local_version and "_" in package
+                else package_req.key
+            )
 
             package_dict[package] = (package_name, use_local_version, package_req)
 

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -283,6 +283,27 @@ def test_add_packages_with_underscore(session):
     Utils.check_answer(session.sql(f"select {udf_name}()").collect(), [Row(True)])
 
 
+@pytest.mark.udf
+def test_add_packages_with_underscore_and_versions(session):
+    session.add_packages(["huggingface_hub==0.15.1"])
+    assert session.get_packages() == {
+        "huggingface_hub": "huggingface_hub==0.15.1",
+    }
+    session.clear_packages()
+
+    session.add_packages(["huggingface_hub>0.14.1"])
+    assert session.get_packages() == {
+        "huggingface_hub": "huggingface_hub>0.14.1",
+    }
+    session.clear_packages()
+
+    session.add_packages(["huggingface_hub<=0.15.1"])
+    assert session.get_packages() == {
+        "huggingface_hub": "huggingface_hub<=0.15.1",
+    }
+    session.clear_packages()
+
+
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="Need certain version of datautil/pandas/numpy"
 )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-872425

fix adding package when the specifier contains name with underscore and version
previously we pass the whole string to the backend, and backend will report packages can not be found because of the version string. only project name shall be passed to the backend

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
