### PR TITLE
[Local Testing] SNOW-848935 Support VariantType, MapType and ArrayType

### DIFF
--- a/local-testing-docs/README.md
+++ b/local-testing-docs/README.md
@@ -859,8 +859,9 @@ Please note that there will be unaware limitations, in this case please feel fre
   - Error experience
 - For data types Variant, Array and Object, basic capabilities of `parse_json`,
   `to_array`, `to_object` and `to_variant` are provided via Python built-in JSONEncoder and
-  JSONDecoder which only support conversion of primitive Python data types. Advanced data conversion can be achieved by customizing
-  the `snowflake.snowpark.mock.connection._CUSTOM_JSON_ENCODER` and `snowflake.snowpark.mock.functions._CUSTOM_JSON_DECODER`.
-- Coercion is not supported
+  JSONDecoder which only support conversion of primitive Python data types. You could supply custom implementation of
+  JSONEncoder and JSONDecoder by setting module level variables snowflake.snowpark.mock.connection._CUSTOM_JSON_ENCODER
+  and snowflake.snowpark.mock.functions._CUSTOM_JSON_DECODER.
+- Implicit type casting (Coercion) is not supported. In general, please avoid using passing in arguments of different types to functions.
 
 > Snowflake employees can check [this engineering doc](https://snowflakecomputing.atlassian.net/wiki/spaces/EN/pages/2792784931/Snowpark+Local+Testing+Development+Milestone) to see the open tasks and scheduling.

--- a/local-testing-docs/README.md
+++ b/local-testing-docs/README.md
@@ -857,5 +857,10 @@ Please note that there will be unaware limitations, in this case please feel fre
   - Results of calculation regarding the values and data types
   - Columns names
   - Error experience
+- For data types Variant, Array and Object, basic capabilities of `parse_json`,
+  `to_array`, `to_object` and `to_variant` are provided via Python built-in JSONEncoder and
+  JSONDecoder which only support conversion of primitive Python data types. Advanced data conversion can be achieved by customizing
+  the `snowflake.snowpark.mock.connection._CUSTOM_JSON_ENCODER` and `snowflake.snowpark.mock.functions._CUSTOM_JSON_DECODER`.
+- Coercion is not supported
 
 > Snowflake employees can check [this engineering doc](https://snowflakecomputing.atlassian.net/wiki/spaces/EN/pages/2792784931/Snowpark+Local+Testing+Development+Milestone) to see the open tasks and scheduling.

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1254,7 +1254,6 @@ class DataFrame:
                 )
 
         if self._select_statement:
-
             return self._with_plan(self._select_statement.sort(sort_exprs))
         return self._with_plan(Sort(sort_exprs, self._plan))
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1254,6 +1254,7 @@ class DataFrame:
                 )
 
         if self._select_statement:
+
             return self._with_plan(self._select_statement.sort(sort_exprs))
         return self._with_plan(Sort(sort_exprs, self._plan))
 

--- a/src/snowflake/snowpark/mock/connection.py
+++ b/src/snowflake/snowpark/mock/connection.py
@@ -42,6 +42,7 @@ from snowflake.snowpark._internal.utils import (
 )
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.exceptions import SnowparkSQLException
+from snowflake.snowpark.mock.functions import _CUSTOM_JSON_DECODER
 from snowflake.snowpark.mock.plan import MockExecutionPlan, execute_mock_plan
 from snowflake.snowpark.mock.snowflake_data_type import TableEmulator
 from snowflake.snowpark.mock.util import parse_table_name
@@ -57,10 +58,6 @@ snowflake.connector.paramstyle = "qmark"
 PARAM_APPLICATION = "application"
 PARAM_INTERNAL_APPLICATION_NAME = "internal_application_name"
 PARAM_INTERNAL_APPLICATION_VERSION = "internal_application_version"
-
-# The module variable _CUSTOM_JSON_DECODER is used to custom JSONDecoder when dumping python object, to use it, set:
-# snowflake.snowpark.mock.connection._CUSTOM_JSON_DECODER = <CUSTOMIZED_JSON_DECODER_CLASS>
-_CUSTOM_JSON_DECODER = None
 
 
 def _build_put_statement(*args, **kwargs):
@@ -380,7 +377,7 @@ class MockServerConnection:
             for col in res.columns:
                 # TODO: the first check is due to window function doesn't set res.sf_types[col]
                 #  we need to revisit window function sf_type setting
-                if res.sf_types[col] and isinstance(
+                if isinstance(
                     res.sf_types[col].datatype, (ArrayType, MapType, VariantType)
                 ):
                     # snowflake returns Python None instead of the str 'null' for DataType data

--- a/src/snowflake/snowpark/mock/connection.py
+++ b/src/snowflake/snowpark/mock/connection.py
@@ -42,7 +42,6 @@ from snowflake.snowpark._internal.utils import (
 )
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.exceptions import SnowparkSQLException
-from snowflake.snowpark.mock.functions import _CUSTOM_JSON_DECODER
 from snowflake.snowpark.mock.plan import MockExecutionPlan, execute_mock_plan
 from snowflake.snowpark.mock.snowflake_data_type import TableEmulator
 from snowflake.snowpark.mock.util import parse_table_name
@@ -58,6 +57,11 @@ snowflake.connector.paramstyle = "qmark"
 PARAM_APPLICATION = "application"
 PARAM_INTERNAL_APPLICATION_NAME = "internal_application_name"
 PARAM_INTERNAL_APPLICATION_VERSION = "internal_application_version"
+
+# The module variable _CUSTOM_JSON_ENCODER is used to customize JSONEncoder when dumping json object
+# into string, to use it, set:
+# snowflake.snowpark.mock.connection._CUSTOM_JSON_ENCODER = <CUSTOMIZED_JSON_ENCODER_CLASS>
+_CUSTOM_JSON_ENCODER = None
 
 
 def _build_put_statement(*args, **kwargs):
@@ -382,7 +386,7 @@ class MockServerConnection:
                 ):
                     # snowflake returns Python None instead of the str 'null' for DataType data
                     res[col] = res[col].apply(
-                        lambda x: json.dumps(x, cls=_CUSTOM_JSON_DECODER, indent=2)
+                        lambda x: json.dumps(x, cls=_CUSTOM_JSON_ENCODER, indent=2)
                         if x is not None
                         else x
                     )

--- a/src/snowflake/snowpark/mock/connection.py
+++ b/src/snowflake/snowpark/mock/connection.py
@@ -4,6 +4,7 @@
 #
 
 import functools
+import json
 import os
 import sys
 import time
@@ -45,6 +46,7 @@ from snowflake.snowpark.mock.plan import MockExecutionPlan, execute_mock_plan
 from snowflake.snowpark.mock.snowflake_data_type import TableEmulator
 from snowflake.snowpark.mock.util import parse_table_name
 from snowflake.snowpark.row import Row
+from snowflake.snowpark.types import ArrayType, MapType, VariantType
 
 logger = getLogger(__name__)
 
@@ -55,6 +57,10 @@ snowflake.connector.paramstyle = "qmark"
 PARAM_APPLICATION = "application"
 PARAM_INTERNAL_APPLICATION_NAME = "internal_application_name"
 PARAM_INTERNAL_APPLICATION_VERSION = "internal_application_version"
+
+# The module variable _CUSTOM_JSON_DECODER is used to custom JSONDecoder when dumping python object, to use it, set:
+# snowflake.snowpark.mock.connection._CUSTOM_JSON_DECODER = <CUSTOMIZED_JSON_DECODER_CLASS>
+_CUSTOM_JSON_DECODER = None
 
 
 def _build_put_statement(*args, **kwargs):
@@ -370,6 +376,20 @@ class MockServerConnection:
 
         res = execute_mock_plan(plan)
         if isinstance(res, TableEmulator):
+            # stringfy the variant type in the result df
+            for col in res.columns:
+                # TODO: the first check is due to window function doesn't set res.sf_types[col]
+                #  we need to revisit window function sf_type setting
+                if res.sf_types[col] and isinstance(
+                    res.sf_types[col].datatype, (ArrayType, MapType, VariantType)
+                ):
+                    # snowflake returns Python None instead of the str 'null' for DataType data
+                    res[col] = res[col].apply(
+                        lambda x: json.dumps(x, cls=_CUSTOM_JSON_DECODER, indent=2)
+                        if x is not None
+                        else x
+                    )
+
             # when setting output rows, snowpark python running against snowflake don't escape double quotes
             # in column names. while in the local testing calculation, double quotes are preserved.
             # to align with snowflake behavior, we unquote name here

--- a/src/snowflake/snowpark/mock/connection.py
+++ b/src/snowflake/snowpark/mock/connection.py
@@ -379,8 +379,6 @@ class MockServerConnection:
         if isinstance(res, TableEmulator):
             # stringfy the variant type in the result df
             for col in res.columns:
-                # TODO: the first check is due to window function doesn't set res.sf_types[col]
-                #  we need to revisit window function sf_type setting
                 if isinstance(
                     res.sf_types[col].datatype, (ArrayType, MapType, VariantType)
                 ):

--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -234,6 +234,7 @@ def mock_covar_pop(column1: ColumnEmulator, column2: ColumnEmulator) -> ColumnEm
 @patch("listagg")
 def mock_listagg(column: ColumnEmulator, delimiter, is_distinct):
     columns_data = ColumnEmulator(column.unique()) if is_distinct else column
+    # Returns a string that includes all the non-NULL input values, separated by the delimiter.
     return ColumnEmulator(
         data=delimiter.join([str(v) for v in columns_data.dropna()]),
         sf_type=ColumnType(StringType(16777216), column.sf_type.nullable),

--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -806,6 +806,13 @@ def mock_parse_json(expr: ColumnEmulator):
 
 @patch("to_array")
 def mock_to_array(expr: ColumnEmulator):
+    """
+    [x] If the input is an ARRAY, or VARIANT containing an array value, the result is unchanged.
+
+    [ ] For NULL or (TODO:) a JSON null input, returns NULL.
+
+    [x] For any other value, the result is a single-element array containing this value.
+    """
     if isinstance(expr.sf_type.datatype, ArrayType):
         res = expr.copy()
     elif isinstance(expr.sf_type.datatype, VariantType):
@@ -820,6 +827,15 @@ def mock_to_array(expr: ColumnEmulator):
 
 @patch("to_object")
 def mock_to_object(expr: ColumnEmulator):
+    """
+    [x] For a VARIANT value containing an OBJECT, returns the OBJECT.
+
+    [ ] For NULL input, or for (TODO:) a VARIANT value containing only JSON null, returns NULL.
+
+    [x] For an OBJECT, returns the OBJECT itself.
+
+    [x] For all other input values, reports an error.
+    """
     if isinstance(expr.sf_type.datatype, (MapType,)):
         res = expr.copy()
     elif isinstance(expr.sf_type.datatype, VariantType):

--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -234,7 +234,7 @@ def mock_covar_pop(column1: ColumnEmulator, column2: ColumnEmulator) -> ColumnEm
 @patch("listagg")
 def mock_listagg(column: ColumnEmulator, delimiter, is_distinct):
     columns_data = ColumnEmulator(column.unique()) if is_distinct else column
-    # Returns a string that includes all the non-NULL input values, separated by the delimiter.
+    # nit todo: returns a string that includes all the non-NULL input values, separated by the delimiter.
     return ColumnEmulator(
         data=delimiter.join([str(v) for v in columns_data.dropna()]),
         sf_type=ColumnType(StringType(16777216), column.sf_type.nullable),

--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -43,7 +43,7 @@ from .util import (
 RETURN_TYPE = Union[ColumnEmulator, TableEmulator]
 
 _MOCK_FUNCTION_IMPLEMENTATION_MAP = {}
-# The module variable _CUSTOM_JSON_DECODER is used to custom JSONDecoder when parsing string, to use it, set:
+# The module variable _CUSTOM_JSON_DECODER is used to custom JSONDecoder when decoing string, to use it, set:
 # snowflake.snowpark.mock.functions._CUSTOM_JSON_DECODER = <CUSTOMIZED_JSON_DECODER_CLASS>
 _CUSTOM_JSON_DECODER = None
 

--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -4,7 +4,9 @@
 import base64
 import binascii
 import datetime
+import json
 import math
+from copy import copy
 from decimal import Decimal
 from functools import partial
 from numbers import Real
@@ -24,6 +26,7 @@ from snowflake.snowpark.types import (
     DecimalType,
     DoubleType,
     LongType,
+    MapType,
     NullType,
     StringType,
     TimestampType,
@@ -781,4 +784,55 @@ def mock_row_number(window: TableEmulator, row_idx: int):
 def mock_upper(expr: ColumnEmulator):
     res = expr.apply(lambda x: x.upper())
     res.sf_type = ColumnType(StringType(), expr.sf_type.nullable)
+    return res
+
+
+@patch("parse_json")
+def mock_parse_json(expr: ColumnEmulator):
+    if isinstance(expr.sf_type.datatype, StringType):
+        res = expr.apply(lambda x: try_convert(json.loads, False, x))
+    else:
+        res = copy(expr)
+    res.sf_type = ColumnType(VariantType(), expr.sf_type.nullable)
+    return res
+
+
+@patch("to_array")
+def mock_to_array(expr: ColumnEmulator):
+    if isinstance(expr.sf_type.datatype, ArrayType):
+        res = copy(expr)
+    elif isinstance(expr.sf_type.datatype, VariantType):
+        res = expr.apply(
+            lambda x: try_convert(lambda y: y if isinstance(y, list) else [y], False, x)
+        )
+    else:
+        res = expr.apply(lambda x: try_convert(lambda y: [y], False, x))
+    res.sf_type = ColumnType(ArrayType(), expr.sf_type.nullable)
+    return res
+
+
+@patch("to_object")
+def mock_to_object(expr: ColumnEmulator):
+    if isinstance(expr.sf_type.datatype, (MapType,)):
+        res = res = copy(expr)
+    elif isinstance(expr.sf_type.datatype, VariantType):
+        res = expr.apply(
+            lambda x: try_convert(lambda y: y if isinstance(y, dict) else {y}, False, x)
+        )
+    else:
+
+        def raise_exc():
+            raise SnowparkSQLException(
+                f"Invalid type {type(expr.sf_type.datatype)} parameter 'TO_OBJECT'"
+            )
+
+        res = expr.apply(lambda x: try_convert(raise_exc, False, x))
+    res.sf_type = ColumnType(MapType(), expr.sf_type.nullable)
+    return res
+
+
+@patch("to_variant")
+def mock_to_variant(expr: ColumnEmulator):
+    res = copy(expr)
+    res.sf_type = ColumnType(VariantType(), expr.sf_type.nullable)
     return res

--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -1321,8 +1321,8 @@ def calculate_expression(
                         # then we should be safely set the calculated_sf_type to None
                         if not isinstance(sub_window_res.sf_type.datatype, NullType):
                             calculated_sf_type = sub_window_res.sf_type
-                    elif isinstance(
-                        type(calculated_sf_type.datatype),
+                    elif not isinstance(
+                        calculated_sf_type.datatype,
                         type(sub_window_res.sf_type.datatype),
                     ):
                         # the result calculated upon a windows can be None, this is still valid and we can keep
@@ -1339,7 +1339,7 @@ def calculate_expression(
                         w.iloc[[offset_idx]],
                         analyzer,
                         expr_to_alias,
-                    ).iloc[0]
+                    )
                     # we use the whole frame to calculate the type
                     cur_windows_sf_type = calculate_expression(
                         window_function.expr,
@@ -1358,8 +1358,8 @@ def calculate_expression(
                             # then we should be safely set the calculated_sf_type to None
                             if not isinstance(cur_windows_sf_type.datatype, NullType):
                                 calculated_sf_type = cur_windows_sf_type
-                        elif isinstance(
-                            type(calculated_sf_type.datatype),
+                        elif not isinstance(
+                            calculated_sf_type.datatype,
                             type(cur_windows_sf_type.datatype),
                         ):
                             # the result calculated upon a windows can be None, this is still valid and we can keep
@@ -1371,7 +1371,7 @@ def calculate_expression(
                                     f"[Local Testing] Detected type {type(calculated_sf_type.datatype)} and type {type(cur_windows_sf_type.datatype)}"
                                     f" in column, coercion is not currently supported"
                                 )
-                    res_cols.append(sub_window_res)
+                    res_cols.append(sub_window_res.iloc[0])
                 else:
                     # skip rows where expr is NULL
                     delta = 1 if offset > 0 else -1

--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -454,9 +454,14 @@ def execute_mock_plan(
             and not source_plan.grouping_expressions
         ):
             return (
-                child_rf.iloc[0].to_frame().T
+                TableEmulator(child_rf.iloc[0].to_frame().T, sf_types=child_rf.sf_types)
                 if len(child_rf)
-                else TableEmulator(data=None, dtype=object, columns=child_rf.columns)
+                else TableEmulator(
+                    data=None,
+                    dtype=object,
+                    columns=child_rf.columns,
+                    sf_types=child_rf.sf_types,
+                )
             )
         aggregate_columns = [
             plan.session._analyzer.analyze(exp, keep_alias=False)

--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -121,6 +121,7 @@ from snowflake.snowpark.mock.snowflake_data_type import (
 )
 from snowflake.snowpark.mock.util import convert_wildcard_to_regex, custom_comparator
 from snowflake.snowpark.types import (
+    ArrayType,
     BinaryType,
     BooleanType,
     ByteType,
@@ -130,6 +131,7 @@ from snowflake.snowpark.types import (
     FloatType,
     IntegerType,
     LongType,
+    MapType,
     NullType,
     ShortType,
     StringType,
@@ -1112,6 +1114,10 @@ def calculate_expression(
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_double"](
                 column, try_cast=exp.try_
             )
+        elif isinstance(exp.to, MapType):
+            return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_object"](column)
+        elif isinstance(exp.to, ArrayType):
+            return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_array"](column)
         else:
             raise NotImplementedError(
                 f"[Local Testing] Cast to {exp.to} is not supported yet"

--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -1126,6 +1126,8 @@ def calculate_expression(
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_object"](column)
         elif isinstance(exp.to, ArrayType):
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_array"](column)
+        elif isinstance(exp.to, VariantType):
+            return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_variant"](column)
         else:
             raise NotImplementedError(
                 f"[Local Testing] Cast to {exp.to} is not supported yet"

--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -1441,7 +1441,7 @@ def calculate_expression(
                 dtype=object,
                 sf_type=calculate_expression(
                     window_function.expr,
-                    windows[0],
+                    input_data,
                     analyzer,
                     expr_to_alias,
                 ).sf_type,

--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -1313,21 +1313,13 @@ def calculate_expression(
                         expr_to_alias,
                     )
                     if not calculated_sf_type:
-                        # this is defensive code, if calculated_sf_type is not calculated yet or calculated
-                        # being None before, we don't set calculated_sf_type to NullType
-                        # because there could be chances that the first couple windows are indeed
-                        # returning None, but the windows afterwards will generate result of non-None type
-                        # and after we calculate all the windows, if still calculated_sf_type is not set
-                        # then we should be safely set the calculated_sf_type to None
-                        if not isinstance(sub_window_res.sf_type.datatype, NullType):
+                        calculated_sf_type = sub_window_res.sf_type
+                    elif calculated_sf_type.datatype != sub_window_res.sf_type.datatype:
+                        if isinstance(calculated_sf_type.datatype, NullType):
                             calculated_sf_type = sub_window_res.sf_type
-                    elif not isinstance(
-                        calculated_sf_type.datatype,
-                        type(sub_window_res.sf_type.datatype),
-                    ):
                         # the result calculated upon a windows can be None, this is still valid and we can keep
                         # the calculation
-                        if not isinstance(sub_window_res.sf_type.datatype, NullType):
+                        elif not isinstance(sub_window_res.sf_type.datatype, NullType):
                             raise SnowparkSQLException(
                                 f"[Local Testing] Detected type {type(calculated_sf_type.datatype)} and type {type(sub_window_res.sf_type.datatype)}"
                                 f" in column, coercion is not currently supported"
@@ -1349,28 +1341,16 @@ def calculate_expression(
                     ).sf_type
                     if not calculated_sf_type:
                         calculated_sf_type = cur_windows_sf_type
-                        if not calculated_sf_type:
-                            # this is defensive code, if calculated_sf_type is not calculated yet or calculated
-                            # being None before, we don't set calculated_sf_type to NullType
-                            # because there could be chances that the first couple windows are indeed
-                            # returning None, but the windows afterwards will generate result of non-None type
-                            # and after we calculate all the windows, if still calculated_sf_type is not set
-                            # then we should be safely set the calculated_sf_type to None
-                            if not isinstance(cur_windows_sf_type.datatype, NullType):
-                                calculated_sf_type = cur_windows_sf_type
-                        elif not isinstance(
-                            calculated_sf_type.datatype,
-                            type(cur_windows_sf_type.datatype),
-                        ):
-                            # the result calculated upon a windows can be None, this is still valid and we can keep
-                            # the calculation
-                            if not isinstance(
-                                sub_window_res.sf_type.datatype, NullType
-                            ):
-                                raise SnowparkSQLException(
-                                    f"[Local Testing] Detected type {type(calculated_sf_type.datatype)} and type {type(cur_windows_sf_type.datatype)}"
-                                    f" in column, coercion is not currently supported"
-                                )
+                    elif calculated_sf_type.datatype != cur_windows_sf_type.datatype:
+                        if isinstance(calculated_sf_type.datatype, NullType):
+                            calculated_sf_type = sub_window_res.sf_type
+                        # the result calculated upon a windows can be None, this is still valid and we can keep
+                        # the calculation
+                        elif not isinstance(sub_window_res.sf_type.datatype, NullType):
+                            raise SnowparkSQLException(
+                                f"[Local Testing] Detected type {type(calculated_sf_type.datatype)} and type {type(cur_windows_sf_type.datatype)}"
+                                f" in column, coercion is not currently supported"
+                            )
                     res_cols.append(sub_window_res.iloc[0])
                 else:
                     # skip rows where expr is NULL

--- a/src/snowflake/snowpark/mock/snowflake_data_type.py
+++ b/src/snowflake/snowpark/mock/snowflake_data_type.py
@@ -270,7 +270,6 @@ def add_date_and_number(
 
 
 class ColumnEmulator(pd.Series):
-
     _metadata = ["sf_type"]
 
     @property

--- a/src/snowflake/snowpark/mock/snowflake_data_type.py
+++ b/src/snowflake/snowpark/mock/snowflake_data_type.py
@@ -292,6 +292,7 @@ class ColumnEmulator(pd.Series):
         # if we do sub-field v["a"], snowpark python return ['null', None] instead of [None, None]
         # however during the calculation we want to keep using None, so we need extra data structure to store
         # the information of null vs None
+        # check SNOW-960190 for more context
         self._null_rows_idxs = []
 
     def set_sf_type(self, value):

--- a/src/snowflake/snowpark/mock/snowflake_data_type.py
+++ b/src/snowflake/snowpark/mock/snowflake_data_type.py
@@ -204,7 +204,7 @@ def calculate_type(c1: ColumnType, c2: Optional[ColumnType], op: Union[str]):
 
 
 class TableEmulator(pd.DataFrame):
-    _metadata = ["sf_types"]
+    _metadata = ["sf_types", "_null_rows_idxs_map"]
 
     @property
     def _constructor(self):
@@ -219,6 +219,7 @@ class TableEmulator(pd.DataFrame):
     ) -> NoReturn:
         super().__init__(*args, **kwargs)
         self.sf_types = {} if not sf_types else sf_types
+        self._null_rows_idxs_map = {}
 
     def __getitem__(self, item):
         result = super().__getitem__(item)
@@ -237,6 +238,7 @@ class TableEmulator(pd.DataFrame):
         super().__setitem__(key, value)
         if isinstance(value, ColumnEmulator):
             self.sf_types[key] = value.sf_type
+            self._null_rows_idxs_map[key] = value._null_rows_idxs
 
     def sort_values(self, by, **kwargs):
         result = super().sort_values(by, **kwargs)
@@ -270,7 +272,7 @@ def add_date_and_number(
 
 
 class ColumnEmulator(pd.Series):
-    _metadata = ["sf_type"]
+    _metadata = ["sf_type", "_null_rows_idxs"]
 
     @property
     def _constructor(self):
@@ -284,6 +286,13 @@ class ColumnEmulator(pd.Series):
         sf_type = kwargs.pop("sf_type", None)
         super().__init__(*args, **kwargs)
         self.sf_type: ColumnType = sf_type
+        # record which rows should be marked as null instead of None
+        # snowflake SubfieldString has this behavior
+        # suppose there are two Variant objects in table "v": 1. { "a": None } 2. None
+        # if we do sub-field v["a"], snowpark python return ['null', None] instead of [None, None]
+        # however during the calculation we want to keep using None, so we need extra data structure to store
+        # the information of null vs None
+        self._null_rows_idxs = []
 
     def set_sf_type(self, value):
         self.sf_type = value

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -572,7 +572,6 @@ def test_like(session):
     assert TestData.string4(session).where(col("A").like("")).collect() == []
 
 
-@pytest.mark.xfail(reason="JSON and sub-field is not supported.")
 def test_subfield(session):
     assert TestData.null_json1(session).select(col("v")["a"]).collect() == [
         Row("null"),

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -15,16 +15,7 @@ from snowflake.snowpark.exceptions import (
     SnowparkSQLException,
     SnowparkSQLUnexpectedAliasException,
 )
-from snowflake.snowpark.functions import (
-    avg,
-    col,
-    in_,
-    lit,
-    parse_json,
-    sql_expr,
-    to_array,
-    when,
-)
+from snowflake.snowpark.functions import avg, col, in_, lit, parse_json, sql_expr, when
 from snowflake.snowpark.types import StringType
 from tests.utils import TestData, Utils
 
@@ -602,8 +593,10 @@ def test_subfield(session, local_testing_mode):
         ]
     else:
         # TODO: function array_construct is not supported in local testing
-        df = session.create_dataframe(["1"], schema=["a"])
-        assert df.select(to_array("a")[0]).collect() == [Row["1"]]
+        #  we use the array in variant2 for testing purpose
+        assert TestData.variant2(session).select(
+            col("src")["vehicle"][0]["extras"][1]
+        ).collect() == [Row('"paint protection"')]
 
     # Row name is not case-sensitive. field name is case-sensitive
     assert TestData.variant2(session).select(

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -1697,13 +1697,17 @@ def test_createDataFrame_with_given_schema_array_map_variant(session):
     Utils.check_answer(df, expected, sort=False)
 
 
-def test_variant_in_array_and_map(session):
+@pytest.mark.localtest
+def test_variant_in_array_and_map(session, local_testing_mode):
     schema = StructType(
         [StructField("array", ArrayType(None)), StructField("map", MapType(None, None))]
     )
     data = [Row([1, "\"'"], {"a": "\"'"})]
     df = session.create_dataframe(data, schema)
-    Utils.check_answer(df, [Row('[\n  1,\n  "\\"\'"\n]', '{\n  "a": "\\"\'"\n}')])
+    if not local_testing_mode:
+        Utils.check_answer(df, [Row('[\n  1,\n  "\\"\'"\n]', '{\n  "a": "\\"\'"\n}')])
+    else:
+        Utils.check_answer(df, data)
 
 
 @pytest.mark.localtest
@@ -1799,10 +1803,11 @@ def test_schema_inference_binary_type(session):
     )
 
 
-def test_primitive_array(session):
+@pytest.mark.localtest
+def test_primitive_array(session, local_testing_mode):
     schema = StructType([StructField("arr", ArrayType(None))])
     df = session.create_dataframe([Row([1])], schema)
-    Utils.check_answer(df, Row("[\n  1\n]"))
+    Utils.check_answer(df, Row("[\n  1\n]" if not local_testing_mode else [1]))
 
 
 @pytest.mark.skipif(

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -1704,10 +1704,7 @@ def test_variant_in_array_and_map(session, local_testing_mode):
     )
     data = [Row([1, "\"'"], {"a": "\"'"})]
     df = session.create_dataframe(data, schema)
-    if not local_testing_mode:
-        Utils.check_answer(df, [Row('[\n  1,\n  "\\"\'"\n]', '{\n  "a": "\\"\'"\n}')])
-    else:
-        Utils.check_answer(df, data)
+    Utils.check_answer(df, [Row('[\n  1,\n  "\\"\'"\n]', '{\n  "a": "\\"\'"\n}')])
 
 
 @pytest.mark.localtest
@@ -1807,7 +1804,7 @@ def test_schema_inference_binary_type(session):
 def test_primitive_array(session, local_testing_mode):
     schema = StructType([StructField("arr", ArrayType(None))])
     df = session.create_dataframe([Row([1])], schema)
-    Utils.check_answer(df, Row("[\n  1\n]" if not local_testing_mode else [1]))
+    Utils.check_answer(df, Row("[\n  1\n]"))
 
 
 @pytest.mark.skipif(

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -126,12 +126,8 @@ def test_verify_datatypes_reference2(session):
     )
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
 @pytest.mark.xfail(reason="SNOW-815544 Bug in describe result query", strict=False)
+@pytest.mark.localtest
 def test_dtypes(session):
     schema = StructType(
         [

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1191,22 +1191,6 @@ def test_json_extract_path_text(session):
     )
 
 
-def test_parse_json(session):
-    null_json1 = TestData.null_json1(session)
-    Utils.check_answer(
-        null_json1.select(parse_json(col("v"))),
-        [Row('{\n  "a": null\n}'), Row('{\n  "a": "foo"\n}'), Row(None)],
-        sort=False,
-    )
-
-    # same as above, but pass str instead of Column
-    Utils.check_answer(
-        null_json1.select(parse_json("v")),
-        [Row('{\n  "a": null\n}'), Row('{\n  "a": "foo"\n}'), Row(None)],
-        sort=False,
-    )
-
-
 def test_parse_xml(session):
     null_xml1 = TestData.null_xml1(session)
 

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1191,6 +1191,23 @@ def test_json_extract_path_text(session):
     )
 
 
+@pytest.mark.localtest
+def test_parse_json(session):
+    null_json1 = TestData.null_json1(session)
+    Utils.check_answer(
+        null_json1.select(parse_json(col("v"))),
+        [Row('{\n  "a": null\n}'), Row('{\n  "a": "foo"\n}'), Row(None)],
+        sort=False,
+    )
+
+    # same as above, but pass str instead of Column
+    Utils.check_answer(
+        null_json1.select(parse_json("v")),
+        [Row('{\n  "a": null\n}'), Row('{\n  "a": "foo"\n}'), Row(None)],
+        sort=False,
+    )
+
+
 def test_parse_xml(session):
     null_xml1 = TestData.null_xml1(session)
 

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -168,15 +168,15 @@ def test_negative_test_to_invalid_table_name(session):
     )
 
 
-# TODO: should be enabled after emulating snowflake types
-def test_create_dataframe_from_seq_none(session):
+@pytest.mark.localtest
+def test_create_dataframe_from_seq_none(session, local_testing_mode):
     assert session.create_dataframe([None, 1]).to_df("int").collect() == [
         Row(None),
         Row(1),
     ]
     assert session.create_dataframe([None, [[1, 2]]]).to_df("arr").collect() == [
         Row(None),
-        Row("[\n  1,\n  2\n]"),
+        Row("[\n  1,\n  2\n]" if not local_testing_mode else [1, 2]),
     ]
 
 

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -176,7 +176,7 @@ def test_create_dataframe_from_seq_none(session, local_testing_mode):
     ]
     assert session.create_dataframe([None, [[1, 2]]]).to_df("arr").collect() == [
         Row(None),
-        Row("[\n  1,\n  2\n]" if not local_testing_mode else [1, 2]),
+        Row("[\n  1,\n  2\n]"),
     ]
 
 

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -95,26 +95,26 @@ def test_cast_decimal(session, number_word):
     )
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
-def test_cast_map_type(session):
+@pytest.mark.localtest
+def test_cast_map_type(session, local_testing_mode):
     df = session.create_dataframe([['{"key": "1"}']], schema=["a"])
     result = df.select(parse_json(df["a"]).cast("object")).collect()
-    assert json.loads(result[0][0]) == {"key": "1"}
+    assert (
+        json.loads(result[0][0])
+        if not local_testing_mode
+        else result[0][0] == {"key": "1"}
+    )
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
-def test_cast_array_type(session):
+@pytest.mark.localtest
+def test_cast_array_type(session, local_testing_mode):
     df = session.create_dataframe([["[1,2,3]"]], schema=["a"])
     result = df.select(parse_json(df["a"]).cast("array")).collect()
-    assert json.loads(result[0][0]) == [1, 2, 3]
+    assert (
+        json.loads(result[0][0])
+        if not local_testing_mode
+        else result[0][0] == [1, 2, 3]
+    )
 
 
 @pytest.mark.localtest

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -99,14 +99,14 @@ def test_cast_decimal(session, number_word):
 def test_cast_map_type(session):
     df = session.create_dataframe([['{"key": "1"}']], schema=["a"])
     result = df.select(parse_json(df["a"]).cast("object")).collect()
-    assert json.loads(result[0][0])
+    assert json.loads(result[0][0]) == {"key": "1"}
 
 
 @pytest.mark.localtest
 def test_cast_array_type(session):
     df = session.create_dataframe([["[1,2,3]"]], schema=["a"])
     result = df.select(parse_json(df["a"]).cast("array")).collect()
-    assert json.loads(result[0][0])
+    assert json.loads(result[0][0]) == [1, 2, 3]
 
 
 @pytest.mark.localtest

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -96,25 +96,17 @@ def test_cast_decimal(session, number_word):
 
 
 @pytest.mark.localtest
-def test_cast_map_type(session, local_testing_mode):
+def test_cast_map_type(session):
     df = session.create_dataframe([['{"key": "1"}']], schema=["a"])
     result = df.select(parse_json(df["a"]).cast("object")).collect()
-    assert (
-        json.loads(result[0][0])
-        if not local_testing_mode
-        else result[0][0] == {"key": "1"}
-    )
+    assert json.loads(result[0][0])
 
 
 @pytest.mark.localtest
-def test_cast_array_type(session, local_testing_mode):
+def test_cast_array_type(session):
     df = session.create_dataframe([["[1,2,3]"]], schema=["a"])
     result = df.select(parse_json(df["a"]).cast("array")).collect()
-    assert (
-        json.loads(result[0][0])
-        if not local_testing_mode
-        else result[0][0] == [1, 2, 3]
-    )
+    assert json.loads(result[0][0])
 
 
 @pytest.mark.localtest

--- a/tests/integ/test_column_names.py
+++ b/tests/integ/test_column_names.py
@@ -106,13 +106,11 @@ def test_collate(session):
     )
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
+@pytest.mark.localtest
 def test_subfield(session):
-    df1 = session.sql('select [1, 2, 3] as c, parse_json(\'{"a": "b"}\') as "c c"')
+    df1 = session.create_dataframe(
+        data=[[[1, 2, 3], {"a": "b"}]], schema=["c", '"c c"']
+    )
     df2 = df1.select(df1["C"][0], df1["c c"]["a"])
     assert (
         [x.name for x in df2._output]

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1453,7 +1453,7 @@ def test_create_dataframe_with_basic_data_types(session):
 
 
 @pytest.mark.localtets
-def test_create_dataframe_with_semi_structured_data_types(session, local_testing_mode):
+def test_create_dataframe_with_semi_structured_data_types(session):
     data = [
         [
             ["'", 2],
@@ -1478,46 +1478,25 @@ def test_create_dataframe_with_semi_structured_data_types(session, local_testing
         ArrayType,
         MapType,
     ]
-    if not local_testing_mode:
-        Utils.check_answer(
-            df.collect(),
-            [
-                Row(
-                    '[\n  "\'",\n  2\n]',
-                    '[\n  "\'",\n  2\n]',
-                    "[\n  [\n    1,\n    2\n  ],\n  [\n    2,\n    1\n  ]\n]",
-                    "[\n  1,\n  2,\n  3\n]",
-                    '{\n  "\'": 1\n}',
-                ),
-                Row(
-                    '[\n  "\'",\n  3\n]',
-                    '[\n  "\'",\n  3\n]',
-                    "[\n  [\n    1,\n    3\n  ],\n  [\n    3,\n    1\n  ]\n]",
-                    "[\n  1,\n  2,\n  3,\n  4\n]",
-                    '{\n  "\'": 3\n}',
-                ),
-            ],
-        )
-    else:
-        Utils.check_answer(
-            df.collect(),
-            [
-                Row(
-                    ["'", 2],
-                    ["'", 2],
-                    [[1, 2], [2, 1]],
-                    [1, 2, 3],
-                    {"'": 1},
-                ),
-                Row(
-                    ["'", 3],
-                    ["'", 3],
-                    [[1, 3], [3, 1]],
-                    [1, 2, 3, 4],
-                    {"'": 3},
-                ),
-            ],
-        )
+    Utils.check_answer(
+        df.collect(),
+        [
+            Row(
+                '[\n  "\'",\n  2\n]',
+                '[\n  "\'",\n  2\n]',
+                "[\n  [\n    1,\n    2\n  ],\n  [\n    2,\n    1\n  ]\n]",
+                "[\n  1,\n  2,\n  3\n]",
+                '{\n  "\'": 1\n}',
+            ),
+            Row(
+                '[\n  "\'",\n  3\n]',
+                '[\n  "\'",\n  3\n]',
+                "[\n  [\n    1,\n    3\n  ],\n  [\n    3,\n    1\n  ]\n]",
+                "[\n  1,\n  2,\n  3,\n  4\n]",
+                '{\n  "\'": 3\n}',
+            ),
+        ],
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1452,11 +1452,8 @@ def test_create_dataframe_with_basic_data_types(session):
     assert df.select(expected_names).collect() == expected_rows
 
 
-@pytest.mark.skipif(
-    condition="config.getvalue('local_testing_mode')",
-    reason="TODO: enable for local testing after supporting more snowflake data types",
-)
-def test_create_dataframe_with_semi_structured_data_types(session):
+@pytest.mark.localtets
+def test_create_dataframe_with_semi_structured_data_types(session, local_testing_mode):
     data = [
         [
             ["'", 2],
@@ -1481,25 +1478,46 @@ def test_create_dataframe_with_semi_structured_data_types(session):
         ArrayType,
         MapType,
     ]
-    Utils.check_answer(
-        df.collect(),
-        [
-            Row(
-                '[\n  "\'",\n  2\n]',
-                '[\n  "\'",\n  2\n]',
-                "[\n  [\n    1,\n    2\n  ],\n  [\n    2,\n    1\n  ]\n]",
-                "[\n  1,\n  2,\n  3\n]",
-                '{\n  "\'": 1\n}',
-            ),
-            Row(
-                '[\n  "\'",\n  3\n]',
-                '[\n  "\'",\n  3\n]',
-                "[\n  [\n    1,\n    3\n  ],\n  [\n    3,\n    1\n  ]\n]",
-                "[\n  1,\n  2,\n  3,\n  4\n]",
-                '{\n  "\'": 3\n}',
-            ),
-        ],
-    )
+    if not local_testing_mode:
+        Utils.check_answer(
+            df.collect(),
+            [
+                Row(
+                    '[\n  "\'",\n  2\n]',
+                    '[\n  "\'",\n  2\n]',
+                    "[\n  [\n    1,\n    2\n  ],\n  [\n    2,\n    1\n  ]\n]",
+                    "[\n  1,\n  2,\n  3\n]",
+                    '{\n  "\'": 1\n}',
+                ),
+                Row(
+                    '[\n  "\'",\n  3\n]',
+                    '[\n  "\'",\n  3\n]',
+                    "[\n  [\n    1,\n    3\n  ],\n  [\n    3,\n    1\n  ]\n]",
+                    "[\n  1,\n  2,\n  3,\n  4\n]",
+                    '{\n  "\'": 3\n}',
+                ),
+            ],
+        )
+    else:
+        Utils.check_answer(
+            df.collect(),
+            [
+                Row(
+                    ["'", 2],
+                    ["'", 2],
+                    [[1, 2], [2, 1]],
+                    [1, 2, 3],
+                    {"'": 1},
+                ),
+                Row(
+                    ["'", 3],
+                    ["'", 3],
+                    [[1, 3], [3, 1]],
+                    [1, 2, 3, 4],
+                    {"'": 3},
+                ),
+            ],
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -346,25 +346,17 @@ def test_cast_decimal(session, number_word):
 
 
 @pytest.mark.localtest
-def test_cast_map_type(session, local_testing_mode):
+def test_cast_map_type(session):
     df = session.create_dataframe([['{"key": "1"}']], schema=["a"])
     result = df.select(cast(parse_json(df["a"]), "object")).collect()
-    assert (
-        json.loads(result[0][0])
-        if not local_testing_mode
-        else result[0][0] == {"key": "1"}
-    )
+    assert json.loads(result[0][0])
 
 
 @pytest.mark.localtest
-def test_cast_array_type(session, local_testing_mode):
+def test_cast_array_type(session):
     df = session.create_dataframe([["[1,2,3]"]], schema=["a"])
     result = df.select(cast(parse_json(df["a"]), "array")).collect()
-    assert (
-        json.loads(result[0][0])
-        if not local_testing_mode
-        else result[0][0] == [1, 2, 3]
-    )
+    assert json.loads(result[0][0])
 
 
 @pytest.mark.localtest
@@ -932,26 +924,19 @@ def test_is_negative(session):
 
 
 @pytest.mark.localtest
-def test_parse_json(session, local_testing_mode):
-    null_json1 = TestData.null_json1(session)
-    row1 = '{\n  "a": null\n}'
-    row2 = '{\n  "a": "foo"\n}'
-    if local_testing_mode:
-        row1 = json.loads(row1)
-        row2 = json.loads(row2)
-
-    Utils.check_answer(
-        null_json1.select(parse_json(col("v"))),
-        [Row(row1), Row(row2), Row(None)],
-        sort=False,
-    )
+def test_parse_json(session):
+    assert TestData.null_json1(session).select(parse_json(col("v"))).collect() == [
+        Row('{\n  "a": null\n}'),
+        Row('{\n  "a": "foo"\n}'),
+        Row(None),
+    ]
 
     # same as above, but pass str instead of Column
-    Utils.check_answer(
-        null_json1.select(parse_json("v")),
-        [Row(row1), Row(row2), Row(None)],
-        sort=False,
-    )
+    assert TestData.null_json1(session).select(parse_json("v")).collect() == [
+        Row('{\n  "a": null\n}'),
+        Row('{\n  "a": "foo"\n}'),
+        Row(None),
+    ]
 
 
 @pytest.mark.xfail(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -589,25 +589,27 @@ class TestData:
 
     @classmethod
     def variant2(cls, session: "Session") -> DataFrame:
-        return session.sql(
-            """
-            select parse_json(column1) as src
-            from values
-            ('{
-                "date with '' and ." : "2017-04-28",
-                "salesperson" : {
-                  "id": "55",
-                  "name": "Frank Beasley"
-                },
-                "customer" : [
-                  {"name": "Joyce Ridgely", "phone": "16504378889", "address": "San Francisco, CA"}
-                ],
-                "vehicle" : [
-                  {"make": "Honda", "extras":["ext warranty", "paint protection"]}
-                ]
-            }')
-            """
+        df = session.create_dataframe(
+            data=[
+                """\
+{
+    "date with ' and .": "2017-04-28",
+    "salesperson": {
+        "id": "55",
+        "name": "Frank Beasley"
+    },
+    "customer": [
+        {"name": "Joyce Ridgely", "phone": "16504378889", "address": "San Francisco, CA"}
+    ],
+    "vehicle": [
+        {"make": "Honda", "extras": ["ext warranty", "paint protection"]}
+    ]
+}\
+"""
+            ],
+            schema=["values"],
         )
+        return df.select(parse_json("values").as_("src"))
 
     @classmethod
     def geography(cls, session: "Session") -> DataFrame:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,7 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
 )
 from snowflake.snowpark._internal.type_utils import convert_sf_to_sp_type
 from snowflake.snowpark._internal.utils import TempObjectType, is_in_stored_procedure
+from snowflake.snowpark.functions import col, parse_json
 from snowflake.snowpark.types import (
     ArrayType,
     BinaryType,
@@ -642,10 +643,8 @@ class TestData:
 
     @classmethod
     def null_json1(cls, session: "Session") -> DataFrame:
-        return session.sql(
-            'select parse_json(column1) as v from values (\'{"a": null}\'), (\'{"a": "foo"}\'),'
-            " (null)"
-        )
+        res = session.create_dataframe([['{"a": null}'], ['{"a": "foo"}'], ["null"]])
+        return res.select(parse_json(col("_1")).as_("v"))
 
     @classmethod
     def valid_json1(cls, session: "Session") -> DataFrame:


### PR DESCRIPTION

### **Please describe how your code solves the related issue.**

   Support creating dataframes with columns of VariantType, MapType and ArrayType by implementing conversion functions `to_variant`/`to_array`/`to_object`.

**Todo/Questions**

- Should we keep variant type as strings to align with the existing behavior?
- [ ] Support SubfieldString Expression

