### PR TITLE
SNOW-940607: Fix precision loss during to_pandas conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.10.0 (TBD)
 
+### Bug Fixes
+
+- Fixed a bug in `DataFrame.to_pandas()` where the converting snowpark dataframes to pandas dataframes was losing precision on 19-digit numbers.
+
 ### Behavior change
 
 - Changed the behavior of `date_format`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fixed a bug in `DataFrame.to_pandas()` where the converting snowpark dataframes to pandas dataframes was losing precision on 19-digit numbers.
+- Fixed a bug in `DataFrame.to_pandas()` where converting snowpark dataframes to pandas dataframes was losing precision on integers with more than 19 digits.
 
 ### Behavior change
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -668,13 +668,12 @@ def _fix_pandas_df_integer(
             # pandas.to_numeric raises "RuntimeWarning: invalid value encountered in cast"
             # when it tried to downcast and loses precision. In this case, we try to convert to
             # int64 using astype() and fallback to to_numeric if we were unsuccessful.
-            pd_col_with_numeric_downcast = pd_df[pandas_col_name]
             with warnings.catch_warnings(record=True) as warning_list:
                 pd_col_with_numeric_downcast = pandas.to_numeric(
                     pd_df[pandas_col_name], downcast="integer"
                 )
 
-            if len(warning_list) == 0:
+            if not warning_list:
                 pd_df[pandas_col_name] = pd_col_with_numeric_downcast
             else:
                 try:

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -673,12 +673,16 @@ def _fix_pandas_df_integer(
                     pd_df[pandas_col_name], downcast="integer"
                 )
 
-            if not warning_list:
-                pd_df[pandas_col_name] = pd_col_with_numeric_downcast
-            else:
+            if (
+                len(warning_list) == 1
+                and warning_list[0].message
+                == "RuntimeWarning('invalid value encountered in cast')"
+            ):
                 try:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
                 except OverflowError:
                     pd_df[pandas_col_name] = pd_col_with_numeric_downcast
+            else:
+                pd_df[pandas_col_name] = pd_col_with_numeric_downcast
 
     return pd_df

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -674,7 +674,7 @@ def _fix_pandas_df_integer(
                     pd_df[pandas_col_name], downcast="integer"
                 )
 
-            if warning_list is not None:
+            if len(warning_list) == 0:
                 pd_df[pandas_col_name] = pd_col_with_numeric_downcast
             else:
                 try:

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -668,25 +668,18 @@ def _fix_pandas_df_integer(
             # pandas.to_numeric raises "RuntimeWarning: invalid value encountered in cast"
             # when it tried to downcast and loses precision. In this case, we try to convert to
             # int64 using astype() and fallback to to_numeric if we were unsuccessful.
-            can_downcast_without_warning = True
             pd_col_with_numeric_downcast = pd_df[pandas_col_name]
-            with warnings.catch_warnings():
-                warnings.filterwarnings("error")
-                try:
-                    pd_col_with_numeric_downcast = pandas.to_numeric(
-                        pd_df[pandas_col_name], downcast="integer"
-                    )
-                except RuntimeWarning:
-                    can_downcast_without_warning = False
+            with warnings.catch_warnings(record=True) as warning_list:
+                pd_col_with_numeric_downcast = pandas.to_numeric(
+                    pd_df[pandas_col_name], downcast="integer"
+                )
 
-            if can_downcast_without_warning:
+            if warning_list is not None:
                 pd_df[pandas_col_name] = pd_col_with_numeric_downcast
             else:
                 try:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
                 except Exception:
-                    pd_df[pandas_col_name] = pandas.to_numeric(
-                        pd_df[pandas_col_name], downcast="integer"
-                    )
+                    pd_df[pandas_col_name] = pd_col_with_numeric_downcast
 
     return pd_df

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -685,6 +685,8 @@ def _fix_pandas_df_integer(
                 try:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
                 except Exception:
-                    pd_df[pandas_col_name] = pd_col_with_numeric_downcast
+                    pd_df[pandas_col_name] = pandas.to_numeric(
+                        pd_df[pandas_col_name], downcast="integer"
+                    )
 
     return pd_df

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -675,8 +675,9 @@ def _fix_pandas_df_integer(
 
             if (
                 len(warning_list) == 1
-                and warning_list[0].message
-                == "RuntimeWarning('invalid value encountered in cast')"
+                and isinstance(warning_list[0].message, RuntimeWarning)
+                and warning_list[0].message.args
+                == ("invalid value encountered in cast",)
             ):
                 try:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -678,7 +678,7 @@ def _fix_pandas_df_integer(
             else:
                 try:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
-                except Exception:
+                except OverflowError:
                     pd_df[pandas_col_name] = pd_col_with_numeric_downcast
 
     return pd_df

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -93,7 +93,8 @@ def test_to_pandas_cast_integer(session, to_pandas_api):
 
 def test_to_pandas_precision_for_number_38_0(session):
     # Assert that we try to fit into int64 when possible and keep precision
-    df = session.sql("""
+    df = session.sql(
+        """
     SELECT
         CAST(COLUMN1 as NUMBER(38,0)) AS A,
         CAST(COLUMN2 as NUMBER(18,0)) AS B
@@ -107,15 +108,16 @@ def test_to_pandas_precision_for_number_38_0(session):
         (4444444444444444444, 555555555555555555),
         (6666666666666666666, 777777777777777777),
         (-9223372036854775808, 999999999999999999)
-        """)
+        """
+    )
 
     pdf = df.to_pandas()
-    assert pdf['A'][0] == 1111111111111111111
-    assert pdf['B'][0] == 222222222222222222
-    assert pdf['A'].dtype == 'int64'
-    assert pdf['B'].dtype == 'int64'
-    assert pdf['A'].max() == 9223372036854775807
-    assert pdf['A'].min() == -9223372036854775808
+    assert pdf["A"][0] == 1111111111111111111
+    assert pdf["B"][0] == 222222222222222222
+    assert pdf["A"].dtype == "int64"
+    assert pdf["B"].dtype == "int64"
+    assert pdf["A"].max() == 9223372036854775807
+    assert pdf["A"].min() == -9223372036854775808
 
 
 def test_to_pandas_non_select(session):

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -91,6 +91,33 @@ def test_to_pandas_cast_integer(session, to_pandas_api):
     assert str(timestamp_pandas_df.dtypes[0]) == "datetime64[ns]"
 
 
+def test_to_pandas_precision_for_number_38_0(session):
+    # Assert that we try to fit into int64 when possible and keep precision
+    df = session.sql("""
+    SELECT
+        CAST(COLUMN1 as NUMBER(38,0)) AS A,
+        CAST(COLUMN2 as NUMBER(18,0)) AS B
+    FROM VALUES
+        (1111111111111111111, 222222222222222222),
+        (3333333333333333333, 444444444444444444),
+        (5555555555555555555, 666666666666666666),
+        (7777777777777777777, 888888888888888888),
+        (9223372036854775807, 111111111111111111),
+        (2222222222222222222, 333333333333333333),
+        (4444444444444444444, 555555555555555555),
+        (6666666666666666666, 777777777777777777),
+        (-9223372036854775808, 999999999999999999)
+        """)
+
+    pdf = df.to_pandas()
+    assert pdf['A'][0] == 1111111111111111111
+    assert pdf['B'][0] == 222222222222222222
+    assert pdf['A'].dtype == 'int64'
+    assert pdf['B'].dtype == 'int64'
+    assert pdf['A'].max() == 9223372036854775807
+    assert pdf['A'].min() == -9223372036854775808
+
+
 def test_to_pandas_non_select(session):
     # `with ... select ...` is also a SELECT statement
     isinstance(session.sql("select 1").to_pandas(), PandasDF)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-940607

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When using `pandas.to_numeric` to fix https://github.com/snowflakedb/snowflake-connector-python/issues/828 caused precision issues when number of digits contained in the number was high and was interpreted as object instead of int64. We use `.astype('int64')` in a try block to try to convert the pandas column into `int64` if possible. If we hit exception, we fall back to `to_numeric`. Using `.astype('int64')` preserves precision in cases when the column can be converted into an int64 (which will most likely be the case).
