### PR TITLE
[Local Testing] SNOW-915624 Fix DataFrame.sort where the orderby expression is not an Attribute

### DIFF
--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -199,8 +199,15 @@ def handle_order_by_clause(
     sort_columns_array = []
     sort_orders_array = []
     null_first_last_array = []
+    added_columns = []
     for exp in order_by:
-        sort_columns_array.append(analyzer.analyze(exp.child, expr_to_alias))
+        exp_name = analyzer.analyze(exp.child, expr_to_alias)
+        if exp_name not in result_df.columns:
+            result_df[exp_name] = calculate_expression(
+                exp.child, result_df, analyzer, expr_to_alias
+            )
+            added_columns.append(exp_name)
+        sort_columns_array.append(exp_name)
         sort_orders_array.append(isinstance(exp.direction, Ascending))
         null_first_last_array.append(
             isinstance(exp.null_ordering, NullsFirst) or exp.null_ordering == NullsFirst
@@ -210,6 +217,7 @@ def handle_order_by_clause(
     ):
         comparator = partial(custom_comparator, ascending, null_first)
         result_df = result_df.sort_values(by=column, key=comparator)
+    result_df = result_df.drop(columns=added_columns)
     return result_df
 
 
@@ -382,7 +390,6 @@ def execute_mock_plan(
                 res_df.sf_types = cur_df.sf_types
             elif operator in (EXCEPT, INTERSECT):
                 # NaN == NaN evaluates to False in pandas, so we need to manually process rows that are all None/NaN
-
                 if (
                     res_df.isnull().all(axis=1).where(lambda x: x).count() > 1
                 ):  # Dedup rows that are all None/NaN


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously something like `df.sort(col("a")*col("b"))` would not work because the expression is not an existing column in the dataframe. This PR fixes the issue by modifying the implementation of `handle_order_by_clause ` to temporarily add the column `col("a")*col("b")` during sorting.
