### PR TITLE
SNOW-946900: Add internal parameter in stored proc registration to allow forcing inline code

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -809,6 +809,7 @@ def resolve_imports_and_packages(
     source_code_display: bool = False,
     skip_upload_on_content_match: bool = False,
     is_permanent: bool = False,
+    force_inline_code: bool = False,
 ) -> Tuple[str, str, str, str, str, bool]:
     import_only_stage = (
         unwrap_stage_location_single_quote(stage_location)
@@ -884,7 +885,7 @@ def resolve_imports_and_packages(
             max_batch_size,
             source_code_display=source_code_display,
         )
-        if len(code) > _MAX_INLINE_CLOSURE_SIZE_BYTES:
+        if not force_inline_code and len(code) > _MAX_INLINE_CLOSURE_SIZE_BYTES:
             dest_prefix = get_udf_upload_prefix(udf_name)
             upload_file_stage_location = normalize_remote_file_or_dir(
                 f"{upload_and_import_stage}/{dest_prefix}/{udf_file_name}"

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -549,6 +549,9 @@ class StoredProcedureRegistration:
             source_code_display=source_code_display,
             anonymous=kwargs.get("anonymous", False),
             is_permanent=is_permanent,
+            # force_inline_code avoids uploading python file
+            # when we know the code is not too large. This is useful
+            # in Pandas API to create stored procedures not registered by users.
             force_inline_code=kwargs.get("force_inline_code", False),
         )
 

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -549,6 +549,7 @@ class StoredProcedureRegistration:
             source_code_display=source_code_display,
             anonymous=kwargs.get("anonymous", False),
             is_permanent=is_permanent,
+            force_inline_code=kwargs.get("force_inline_code", False),
         )
 
     def register_from_file(
@@ -714,6 +715,7 @@ class StoredProcedureRegistration:
         is_permanent: bool = False,
         external_access_integrations: Optional[List[str]] = None,
         secrets: Optional[Dict[str, str]] = None,
+        force_inline_code: bool = False,
     ) -> StoredProcedure:
         (
             udf_name,
@@ -760,6 +762,7 @@ class StoredProcedureRegistration:
             source_code_display=source_code_display,
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
+            force_inline_code=force_inline_code,
         )
 
         if not custom_python_runtime_version_allowed:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-946900

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This is useful for Pandas API to skip code uploading when the stored procedure is registered by us (not users) and we are pretty sure the function won't be very large. 