### PR TITLE
SNOW-947875 Add sql_error_code and raw_message into SnowparkSQLException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - The `format` argument changed from optional to required.
   - The returned result changed from a date object to a date-formatted string.
 - When a window function, or a sequence-dependent data generator (`normal`, `zipf`, `uniform`, `seq1`, `seq2`, `seq4`, `seq8`) function is used, the sort and filter operation will no longer be flattened when generating the query.
+- Add `sql_error_code` and `raw_message` attributes to `SnowflakeSQLException` when it is caused by a SQL exception.
 
 ## 1.9.0 (2023-10-13)
 

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -309,13 +309,26 @@ class SnowparkClientExceptionMessages:
         query = None
         if "query" in pe.__dict__:
             query = pe.__getattribute__("query")
-        return SnowparkSQLException(pe.msg, "1304", pe.sfqid, query)
+        return SnowparkSQLException(
+            pe.msg,
+            "1304",
+            pe.sfqid,
+            query,
+            sql_error_code=pe.errno,
+            raw_message=pe.raw_msg,
+        )
 
     @staticmethod
     def SQL_EXCEPTION_FROM_OPERATIONAL_ERROR(
         oe: OperationalError,
     ) -> SnowparkSQLException:
-        return SnowparkSQLException(oe.msg, "1305", oe.sfqid)
+        return SnowparkSQLException(
+            oe.msg,
+            "1305",
+            oe.sfqid,
+            sql_error_code=oe.errno,
+            raw_message=oe.raw_msg,
+        )
 
     # Server Error Messages 04XX
 

--- a/src/snowflake/snowpark/exceptions.py
+++ b/src/snowflake/snowpark/exceptions.py
@@ -79,12 +79,16 @@ class SnowparkSQLException(SnowparkClientException):
         error_code: Optional[str] = None,
         sfqid: Optional[str] = None,
         query: Optional[str] = None,
+        sql_error_code: Optional[int] = None,
+        raw_message: Optional[str] = None,
     ) -> None:
         self.message: str = message
         self.error_code: Optional[str] = error_code
         self.sfqid: Optional[str] = sfqid
         self.query: Optional[str] = query
         self.telemetry_message: str = message
+        self.sql_error_code = sql_error_code
+        self.raw_message = raw_message
 
         pretty_error_code = f"({self.error_code}): " if self.error_code else ""
         pretty_sfqid = f"{self.sfqid}: " if self.sfqid else ""

--- a/tests/unit/test_error_message.py
+++ b/tests/unit/test_error_message.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+from snowflake.connector import ProgrammingError
+from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
+
+
+def test_programming_error_sql_exception_attributes():
+    pe = ProgrammingError(
+        msg="errmsg",
+        errno=123456,
+        sqlstate="P0000",
+        sfqid="the_query_id",
+        query="select * from foo",
+    )
+    sql_exception = (
+        SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(pe)
+    )
+    assert sql_exception.sql_error_code == 123456
+    assert sql_exception.raw_message == "errmsg"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-947875. When there is a parent stored procedure calling a child stored procedure, the parent stored procedure needs to determine the error code in the child query to determine how to format its error message. (See SNOW-800808 for more context.) Currently, the only way to do this when the parent is a Python sproc is to parse `SnowflakeSQLException.message`. It's slightly nicer and less error prone to have this information exposed directly in the exception class.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Adds raw message and error code attributes from ProgrammingError and OperationalError
