### PR TITLE
[Local Testing] SNOW-904981 Support Column bitwise operations and unary minus expression

### DIFF
--- a/src/snowflake/snowpark/mock/plan.py
+++ b/src/snowflake/snowpark/mock/plan.py
@@ -1331,7 +1331,6 @@ def calculate_expression(
             new_column = left**right
         elif isinstance(exp, EqualTo):
             new_column = left == right
-            new_column[new_column.isna() | new_column.isnull()] = False
             if left.hasnans and right.hasnans:
                 new_column[
                     left.apply(lambda x: x is None) & right.apply(lambda x: x is None)
@@ -1341,6 +1340,7 @@ def calculate_expression(
                     & right.apply(lambda x: x is not None and np.isnan(x))
                 ] = True
                 # NaN == NaN evaluates to False in pandas, but True in Snowflake
+            new_column[new_column.isna() | new_column.isnull()] = False
         elif isinstance(exp, NotEqualTo):
             new_column = left != right
         elif isinstance(exp, GreaterThanOrEqual):

--- a/src/snowflake/snowpark/mock/util.py
+++ b/src/snowflake/snowpark/mock/util.py
@@ -29,6 +29,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
     VariantType,
+    _NumericType,
 )
 
 # placeholder map helps convert wildcard to reg. In practice, we convert wildcard to a middle string first,
@@ -250,6 +251,11 @@ def process_string_time_with_fractional_seconds(time: str, fractional_seconds) -
 
 
 def fix_drift_between_column_sf_type_and_dtype(col: ColumnEmulator):
+    if (
+        isinstance(col.sf_type.datatype, _NumericType)
+        and col.apply(lambda x: x is None).any()
+    ):  # non-object dtype converts None to NaN for numeric columns
+        return col
     sf_type_to_dtype = {
         ArrayType: object,
         BinaryType: object,

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -200,7 +200,7 @@ def test_add_subtract_multiply_divide_mod_pow(session):
     res = df.select(df["A"] / df["B"]).collect()
     assert len(res) == 1
     assert len(res[0]) == 1
-    # assert res[0][0].to_eng_string() == "0.846154"  TODO: cast float to decimal in __div__ and fix precision to be 8
+    assert res[0][0].to_eng_string() == "0.846154"
 
     # test reverse operator
     assert df.select(2 + df["B"]).collect() == [Row(15)]
@@ -211,7 +211,7 @@ def test_add_subtract_multiply_divide_mod_pow(session):
     res = df.select(2 / df["B"]).collect()
     assert len(res) == 1
     assert len(res[0]) == 1
-    # assert res[0][0].to_eng_string() == "0.153846"  TODO: cast float to decimal in __div__ and fix precision to be 8
+    assert res[0][0].to_eng_string() == "0.153846"
 
 
 @pytest.mark.localtest

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -66,11 +66,7 @@ def test_column_alias_and_case_sensitive_name(session):
     assert df.select(df["a"].name('"b"')).schema.fields[0].name == '"b"'
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
+@pytest.mark.localtest
 def test_unary_operator(session):
     test_data1 = TestData.test_data1(session)
     # unary minus
@@ -193,10 +189,7 @@ def test_and_or(session):
     ]
 
 
-@pytest.mark.xfail(
-    reason="Divide is expected to return decimal instead of float",
-    raises=AttributeError,
-)
+@pytest.mark.localtest
 def test_add_subtract_multiply_divide_mod_pow(session):
     df = session.create_dataframe([[11, 13]], schema=["a", "b"])
     assert df.select(df["A"] + df["B"]).collect() == [Row(24)]
@@ -207,7 +200,7 @@ def test_add_subtract_multiply_divide_mod_pow(session):
     res = df.select(df["A"] / df["B"]).collect()
     assert len(res) == 1
     assert len(res[0]) == 1
-    assert res[0][0].to_eng_string() == "0.846154"
+    # assert res[0][0].to_eng_string() == "0.846154"  TODO: cast float to decimal in __div__ and fix precision to be 8
 
     # test reverse operator
     assert df.select(2 + df["B"]).collect() == [Row(15)]
@@ -218,7 +211,7 @@ def test_add_subtract_multiply_divide_mod_pow(session):
     res = df.select(2 / df["B"]).collect()
     assert len(res) == 1
     assert len(res[0]) == 1
-    assert res[0][0].to_eng_string() == "0.153846"
+    # assert res[0][0].to_eng_string() == "0.153846"  TODO: cast float to decimal in __div__ and fix precision to be 8
 
 
 @pytest.mark.localtest
@@ -278,11 +271,7 @@ def test_order(session):
     ]
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
+# TODO: enable after aliging dtype and sf_type
 def test_bitwise_operator(session):
     df = session.create_dataframe([[1, 2]], schema=["a", "b"])
     assert df.select(df["A"].bitand(df["B"])).collect() == [Row(0)]
@@ -425,10 +414,8 @@ def test_drop_columns_by_column(session):
     assert df.drop(df2["one"]).schema.fields[0].name == '"One"'
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="sql use is not supported"
 )
 def test_fully_qualified_column_name(session):
     random_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -518,10 +505,8 @@ def test_column_constructors_select(session):
     assert "invalid identifier" in str(ex_info)
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="sql use is not supported"
 )
 def test_sql_expr_column(session):
     df = session.create_dataframe([[1, 2, 3]]).to_df("col", '"col"', "col .")

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -271,7 +271,7 @@ def test_order(session):
     ]
 
 
-# TODO: enable after aliging dtype and sf_type
+@pytest.mark.localtest
 def test_bitwise_operator(session):
     df = session.create_dataframe([[1, 2]], schema=["a", "b"])
     assert df.select(df["A"].bitand(df["B"])).collect() == [Row(0)]

--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -841,6 +841,8 @@ def test_outer_join_conversion(session):
     )
     assert outer_join_2_inner == [Row(1, 2, "1", 1, 3, "1")]
 
+    # breakpoint()
+
     # right -> inner
     right_join_2_inner = (
         df.join(df2, df["int"] == df2["int"], "right").where(df["int"] > 0).collect()

--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -841,8 +841,6 @@ def test_outer_join_conversion(session):
     )
     assert outer_join_2_inner == [Row(1, 2, "1", 1, 3, "1")]
 
-    # breakpoint()
-
     # right -> inner
     right_join_2_inner = (
         df.join(df2, df["int"] == df2["int"], "right").where(df["int"] > 0).collect()


### PR DESCRIPTION
**TODO:**
There are 2 data type issues blocking the PR:
- [x] We need to align `ColumnEmulator.dtype` and `ColumnEmulator.sf_type` to allow pandas operations to succeed.
- [x] We need to align `ColumnEmulator.dtype` and the Python object type of the data inside ColumnEmulator.