### PR TITLE
SNOW-937665 fix unsupported column name $1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug in `DataFrame.to_pandas()` where converting snowpark dataframes to pandas dataframes was losing precision on integers with more than 19 digits.
 - Fixed a bug that `session.add_packages` can not handle requirement specifier that contains project name with underscore and version.
 - Fixed a bug in `DataFrame.limit()` when `offset` is used and the parent `DataFrame` uses `limit`. Now the `offset` won't impact the parent DataFrame's `limit`.
+- Fixed a bug in `DataFrame.write.save_as_table` where dataframes created from read api could not save data into snowflake because of invalid column name `$1`.
 
 ### Behavior change
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -570,7 +570,17 @@ class SnowflakePlanBuilder:
         child: SnowflakePlan,
     ) -> SnowflakePlan:
         full_table_name = ".".join(table_name)
+
+        # here get the column definition from the child attributes. In certain cases we have
+        # the attributes set to ($1, VariantType()) which cannot be used as valid column name
+        # in save as table. So we rename ${number} with COL{number}.
+        hidden_column_pattern = r"\$(\d+)"
         column_definition = attribute_to_schema_string(child.attributes)
+        column_definition = re.sub(
+            hidden_column_pattern,
+            lambda match: f"COL{match.group(1)}",
+            column_definition,
+        )
 
         def get_create_and_insert_plan(child: SnowflakePlan, replace=False, error=True):
             create_table = create_table_statement(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -575,11 +575,13 @@ class SnowflakePlanBuilder:
         # the attributes set to ($1, VariantType()) which cannot be used as valid column name
         # in save as table. So we rename ${number} with COL{number}.
         hidden_column_pattern = r"\$(\d+)"
-        column_definition = attribute_to_schema_string(child.attributes)
+        column_definition_with_hidden_columns = attribute_to_schema_string(
+            child.attributes
+        )
         column_definition = re.sub(
             hidden_column_pattern,
             lambda match: f"COL{match.group(1)}",
-            column_definition,
+            column_definition_with_hidden_columns,
         )
 
         def get_create_and_insert_plan(child: SnowflakePlan, replace=False, error=True):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-937665

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Fix a bug where `Dataframe.write.save_as_table` would throw an error for dataframe created from file api due to invalid column name `$1` error. This PR analyzes the column names to be saved and renames them in case they have name `${number}`.
