### PR TITLE
SNOW-948486 Support specifying input column names for vectorized UDTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - Added support for managing case sensitivity in `DataFrame.to_local_iterator()`.
+- Added support for specifying vectorized UDTF's input column names by using the optional parameter `input_names` in `UDTFRegistration.register/register_file` and `functions.pandas_udtf`. By default, `RelationalGroupedDataFrame.applyInPandas` will infer the column names from current dataframe schema.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -7310,6 +7310,7 @@ def pandas_udtf(
     *,
     output_schema: Union[StructType, List[str], "PandasDataFrameType"],
     input_types: Optional[List[DataType]] = None,
+    input_names: Optional[List[str]] = None,
     name: Optional[Union[str, Iterable[str]]] = None,
     is_permanent: bool = False,
     stage_location: Optional[str] = None,
@@ -7366,14 +7367,14 @@ def pandas_udtf(
         ...     def __init__(self):
         ...         self.multiplier = 10
         ...     def end_partition(self, df):
-        ...         df.columns = ['id', 'col1', 'col2']
         ...         df.col1 = df.col1*self.multiplier
         ...         df.col2 = df.col2*self.multiplier
         ...         yield df
         >>> multiply_udtf = pandas_udtf(
         ...     multiply,
         ...     output_schema=PandasDataFrameType([StringType(), IntegerType(), FloatType()], ["id_", "col1_", "col2_"]),
-        ...     input_types=[PandasDataFrameType([StringType(), IntegerType(), FloatType()])]
+        ...     input_types=[PandasDataFrameType([StringType(), IntegerType(), FloatType()])],
+        ...     input_names=['"id"', '"col1"', '"col2"']
         ... )
         >>> df = session.create_dataframe([['x', 3, 35.9],['x', 9, 20.5]], schema=["id", "col1", "col2"])
         >>> df.select(multiply_udtf("id", "col1", "col2").over(partition_by=["id"])).sort("col1_").show()
@@ -7387,12 +7388,15 @@ def pandas_udtf(
 
     Example::
 
-        >>> @pandas_udtf(output_schema=PandasDataFrameType([StringType(), IntegerType(), FloatType()], ["id_", "col1_", "col2_"]), input_types=[PandasDataFrameType([StringType(), IntegerType(), FloatType()])])
+        >>> @pandas_udtf(
+        ... output_schema=PandasDataFrameType([StringType(), IntegerType(), FloatType()], ["id_", "col1_", "col2_"]),
+        ... input_types=[PandasDataFrameType([StringType(), IntegerType(), FloatType()])],
+        ... input_names=['"id"', '"col1"', '"col2"']
+        ... )
         ... class _multiply:
         ...     def __init__(self):
         ...         self.multiplier = 10
         ...     def end_partition(self, df):
-        ...         df.columns = ['id', 'col1', 'col2']
         ...         df.col1 = df.col1*self.multiplier
         ...         df.col2 = df.col2*self.multiplier
         ...         yield df
@@ -7411,6 +7415,7 @@ def pandas_udtf(
             session.udtf.register,
             output_schema=output_schema,
             input_types=input_types,
+            input_names=input_names,
             name=name,
             is_permanent=is_permanent,
             stage_location=stage_location,
@@ -7431,6 +7436,7 @@ def pandas_udtf(
             handler,
             output_schema=output_schema,
             input_types=input_types,
+            input_names=input_names,
             name=name,
             is_permanent=is_permanent,
             stage_location=stage_location,

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -268,8 +268,8 @@ class RelationalGroupedDataFrame:
         ``kwargs`` are accepted to specify arguments to register the UDTF. Group by clause used must be
         column reference, not a general expression.
 
-        Depends on ``pandas`` being installed in the environment and declared as a dependency using
-        :meth:`~snowflake.snowpark.Session.add_packages` or via ``kwargs["packages"]``.
+        Requires ``pandas`` to be installed in the execution environment and declared as a dependency by either
+        specifying the keyword argument `packages=["pandas]` in this call or calling :meth:`~snowflake.snowpark.Session.add_packages` beforehand.
 
         Args:
             func: A Python native function that accepts a single input argument - a ``pandas.DataFrame``
@@ -355,6 +355,7 @@ class RelationalGroupedDataFrame:
         _apply_in_pandas_udtf = self._df._session.udtf.register(
             _ApplyInPandas,
             output_schema=output_schema,
+            input_names=input_names,
             **kwargs,
         )
         partition_by = [functions.col(expr) for expr in self._grouping_exprs]

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -278,7 +278,7 @@ class RelationalGroupedDataFrame:
             output_schema: A :class:`~snowflake.snowpark.types.StructType` instance that represents the
                 table function's output columns.
             input_names: A list of strings that represents the table function's input column names. Optional,
-                if unspecified, default column names will be ARG1, ARG2, ... ARGN.
+                if unspecified, default column names will be ARG1, ARG2, etc.
             kwargs: Additional arguments to register the vectorized UDTF. See
                 :meth:`~snowflake.snowpark.udtf.UDTFRegistration.register` for all options.
 

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -284,18 +284,18 @@ def test_secure_udtf(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 def test_apply_in_pandas(session):
-    # test with element wise opeartion
+    # test with element wise operation
     def convert(pdf):
-        pdf.columns = ["location", "temp_c"]
         return pdf.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
 
     df = session.createDataFrame(
         [("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)],
-        schema=["location", "temp_c"],
+        schema=['"location"', '"temp_c"'],
     )
 
-    df = df.group_by("location").apply_in_pandas(
+    df = df.group_by('"location"').apply_in_pandas(
         convert,
+        input_names=['"location"', '"temp_c"'],
         output_schema=StructType(
             [
                 StructField("location", StringType()),
@@ -321,12 +321,12 @@ def test_apply_in_pandas(session):
     )
 
     def normalize(pdf):
-        pdf.columns = ["id", "v"]
         v = pdf.v
         return pdf.assign(v=(v - v.mean()) / v.std())
 
     df = df.group_by("id").applyInPandas(
         normalize,
+        input_names=['"id"', '"v"'],
         output_schema=StructType(
             [StructField("id", IntegerType()), StructField("v", DoubleType())]
         ),
@@ -350,7 +350,6 @@ def test_apply_in_pandas(session):
     )
 
     def group_sum(pdf):
-        pdf.columns = ["grade", "division", "value"]
         return pd.DataFrame(
             [
                 (
@@ -363,6 +362,7 @@ def test_apply_in_pandas(session):
 
     df = df.group_by([df.grade, df.division]).applyInPandas(
         group_sum,
+        input_names=['"grade"', '"division"', '"value"'],
         output_schema=StructType(
             [
                 StructField("grade", StringType()),

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -286,16 +286,15 @@ def test_secure_udtf(session):
 def test_apply_in_pandas(session):
     # test with element wise operation
     def convert(pdf):
-        return pdf.assign(temp_f=lambda x: x.temp_c * 9 / 5 + 32)
+        return pdf.assign(TEMP_F=lambda x: x.TEMP_C * 9 / 5 + 32)
 
     df = session.createDataFrame(
         [("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)],
-        schema=['"location"', '"temp_c"'],
+        schema=["location", "temp_c"],
     )
 
-    df = df.group_by('"location"').apply_in_pandas(
+    df = df.group_by("location").apply_in_pandas(
         convert,
-        input_names=['"location"', '"temp_c"'],
         output_schema=StructType(
             [
                 StructField("location", StringType()),
@@ -321,12 +320,11 @@ def test_apply_in_pandas(session):
     )
 
     def normalize(pdf):
-        v = pdf.v
-        return pdf.assign(v=(v - v.mean()) / v.std())
+        V = pdf.V
+        return pdf.assign(V=(V - V.mean()) / V.std())
 
     df = df.group_by("id").applyInPandas(
         normalize,
-        input_names=['"id"', '"v"'],
         output_schema=StructType(
             [StructField("id", IntegerType()), StructField("v", DoubleType())]
         ),
@@ -353,16 +351,15 @@ def test_apply_in_pandas(session):
         return pd.DataFrame(
             [
                 (
-                    pdf.grade.iloc[0],
-                    pdf.division.iloc[0],
-                    pdf.value.sum(),
+                    pdf.GRADE.iloc[0],
+                    pdf.DIVISION.iloc[0],
+                    pdf.VALUE.sum(),
                 )
             ]
         )
 
     df = df.group_by([df.grade, df.division]).applyInPandas(
         group_sum,
-        input_names=['"grade"', '"division"', '"value"'],
         output_schema=StructType(
             [
                 StructField("grade", StringType()),


### PR DESCRIPTION
[SNOW-948486](https://snowflakecomputing.atlassian.net/browse/SNOW-948486)

The PR introduces a new optional parameter `input_names` to `UDTFRegistration.register/register_file` and `functions.py/pandas_udtf`, where we now support specifying input column names for UDTF's. Note this is essentially a NOOP for regular UDTFs since the columns are mapped to function parameters, the feature is only useful for vectorized UDTF where we rely on names to access the columns in the pandas DataFrame. The parameter is set as optional for backwards compatibility, if unspecified, the default column names will be `ARG1`, `ARG2`, etc.

As a result, we now infer the column names from schema in `RelationalGroupedDataFrame.applyInPandas`.

[SNOW-948486]: https://snowflakecomputing.atlassian.net/browse/SNOW-948486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ