### PR TITLE
Add RelationalGroupedDataFrame.pivot()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.11.0 (TBD)
+
+## New Features
+
+- Added support for `RelationalGroupedDataframe.pivot()` to access `pivot` in the following pattern `Dataframe.group_by(...).pivot(...)`.
+
 ## 1.10.0 (2023-11-03)
 
 ### New Features

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -934,6 +934,7 @@ class Analyzer:
             if (
                 len(logical_plan.grouping_columns) != 0
                 and len(logical_plan.aggregates) != 0
+                and logical_plan.aggregates[0] is not None
             ):
                 # Currently snowflake pivot creates a group by from all columns outside of
                 # pivot column and aggregate column. In order to implement df.group_by().pivot(),

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -931,7 +931,10 @@ class Analyzer:
             )
 
         if isinstance(logical_plan, Pivot):
-            if len(logical_plan.grouping_columns) != 0:
+            if (
+                len(logical_plan.grouping_columns) != 0
+                and len(logical_plan.aggregates) != 0
+            ):
                 # Currently snowflake pivot creates a group by from all columns outside of
                 # pivot column and aggregate column. In order to implement df.group_by().pivot(),
                 # we need to first select only the columns that need to be involved in this

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -933,8 +933,7 @@ class Analyzer:
         if isinstance(logical_plan, Pivot):
             if (
                 len(logical_plan.grouping_columns) != 0
-                and len(logical_plan.aggregates) != 0
-                and logical_plan.aggregates[0] is not None
+                and logical_plan.aggregates[0].children is not None
             ):
                 # Currently snowflake pivot creates a group by from all columns outside of
                 # pivot column and aggregate column. In order to implement df.group_by().pivot(),

--- a/src/snowflake/snowpark/_internal/analyzer/unary_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/unary_plan_node.py
@@ -49,12 +49,14 @@ class Aggregate(UnaryNode):
 class Pivot(UnaryNode):
     def __init__(
         self,
+        grouping_columns: List[Expression],
         pivot_column: Expression,
         pivot_values: List[Expression],
         aggregates: List[Expression],
         child: LogicalPlan,
     ) -> None:
         super().__init__(child)
+        self.grouping_columns = grouping_columns
         self.pivot_column = pivot_column
         self.pivot_values = pivot_values
         self.aggregates = aggregates

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -663,21 +663,30 @@ class DataFrame:
 
     @overload
     def to_local_iterator(
-        self, *, statement_params: Optional[Dict[str, str]] = None, block: bool = True,
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        block: bool = True,
         case_sensitive: bool = True,
     ) -> Iterator[Row]:
         ...  # pragma: no cover
 
     @overload
     def to_local_iterator(
-        self, *, statement_params: Optional[Dict[str, str]] = None, block: bool = False,
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        block: bool = False,
         case_sensitive: bool = True,
     ) -> AsyncJob:
         ...  # pragma: no cover
 
     @df_collect_api_telemetry
     def to_local_iterator(
-        self, *, statement_params: Optional[Dict[str, str]] = None, block: bool = True,
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        block: bool = True,
         case_sensitive: bool = True,
     ) -> Union[Iterator[Row], AsyncJob]:
         """Executes the query representing this DataFrame and returns an iterator
@@ -700,7 +709,7 @@ class DataFrame:
                 When it is ``False``, this function executes the underlying queries of the dataframe
                 asynchronously and returns an :class:`AsyncJob`.
             case_sensitive: A bool value which controls the case sensitivity of the fields in the
-                :class:`Row` objects returned by the ``to_local_iterator``. Defaults to ``True``. 
+                :class:`Row` objects returned by the ``to_local_iterator``. Defaults to ``True``.
         """
         return self._session._conn.execute(
             self._plan,
@@ -712,7 +721,7 @@ class DataFrame:
                 self._session.query_tag,
                 SKIP_LEVELS_THREE,
             ),
-            case_sensitive=case_sensitive
+            case_sensitive=case_sensitive,
         )
 
     def __copy__(self) -> "DataFrame":
@@ -1624,6 +1633,8 @@ class DataFrame:
             pivot_col: The column or name of the column to use.
             values: A list of values in the column.
         """
+        if not values:
+            raise ValueError("values cannot be None or empty")
         pc = self._convert_cols_to_exprs("pivot()", pivot_col)
         value_exprs = [
             v._expression if isinstance(v, Column) else Literal(v) for v in values

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1634,7 +1634,7 @@ class DataFrame:
             values: A list of values in the column.
         """
         if not values:
-            raise ValueError("values cannot be None or empty")
+            raise ValueError("values cannot be empty")
         pc = self._convert_cols_to_exprs("pivot()", pivot_col)
         value_exprs = [
             v._expression if isinstance(v, Column) else Literal(v) for v in values

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Callable, Dict, Iterable, List, Self, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Tuple, Union
 
 from snowflake.connector.options import pandas
 from snowflake.snowpark import functions
@@ -368,7 +368,7 @@ class RelationalGroupedDataFrame:
 
     def pivot(
         self, pivot_col: ColumnOrName, values: Iterable[LiteralType]
-    ) -> Self:
+    ) -> "RelationalGroupedDataFrame":
         """Rotates this DataFrame by turning unique values from one column in the input
         expression into multiple columns and aggregating results where required on any
         remaining column values.

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Tuple, Union
 
 from snowflake.connector.options import pandas
 from snowflake.snowpark import functions
@@ -367,21 +367,17 @@ class RelationalGroupedDataFrame:
     applyInPandas = apply_in_pandas
 
     def pivot(
-        self, pivot_col: ColumnOrName, values: Optional[Iterable[LiteralType]] = None
+        self, pivot_col: ColumnOrName, values: Iterable[LiteralType]
     ) -> "RelationalGroupedDataFrame":
         """Rotates this DataFrame by turning unique values from one column in the input
         expression into multiple columns and aggregating results where required on any
         remaining column values.
 
-        When ``values`` argument is not specified, distinct values from pivot column are
-        inferred by calculating the distinct values in the pivot column. This is a less
-        efficient method and therefore not recommended.
-
         Only one aggregate is supported with pivot.
 
         Args:
             pivot_col: The column or name of the column to use.
-            values: An optional list of values in the column.
+            values: A list of values in the column.
 
         Example::
 
@@ -415,6 +411,8 @@ class RelationalGroupedDataFrame:
             ----------------------------------------
             <BLANKLINE>
         """
+        if not values:
+            raise ValueError("values cannot be None or empty")
         pc = self._df._convert_cols_to_exprs(
             "RelationalGroupedDataFrame.pivot()", pivot_col
         )

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -404,39 +404,6 @@ class RelationalGroupedDataFrame:
             -------------------------------
             <BLANKLINE>
 
-        Example::
-
-            >>> create_result = session.sql('''create or replace temp table monthly_sales(empid int, team text, amount int, month text)
-            ... as select * from values
-            ... (1, 'A', 10000, 'JAN'),
-            ... (1, 'B', 400, 'JAN'),
-            ... (2, 'A', 4500, 'JAN'),
-            ... (2, 'A', 35000, 'JAN'),
-            ... (1, 'B', 5000, 'FEB'),
-            ... (1, 'A', 3000, 'FEB'),
-            ... (2, 'B', 200, 'FEB') ''').collect()
-            >>> df = session.table("monthly_sales")
-            >>> df.group_by("empid").pivot("month").sum("amount").sort(df["empid"]).show()
-            -------------------------------
-            |"EMPID"  |"'JAN'"  |"'FEB'"  |
-            -------------------------------
-            |1        |10400    |8000     |
-            |2        |39500    |200      |
-            -------------------------------
-            <BLANKLINE>
-
-        Example::
-
-            >>> create_result = session.sql('''create or replace temp table monthly_sales(empid int, team text, amount int, month text)
-            ... as select * from values
-            ... (1, 'A', 10000, 'JAN'),
-            ... (1, 'B', 400, 'JAN'),
-            ... (2, 'A', 4500, 'JAN'),
-            ... (2, 'A', 35000, 'JAN'),
-            ... (1, 'B', 5000, 'FEB'),
-            ... (1, 'A', 3000, 'FEB'),
-            ... (2, 'B', 200, 'FEB') ''').collect()
-            >>> df = session.table("monthly_sales")
             >>> df.group_by(["empid", "team"]).pivot("month", ['JAN', 'FEB']).sum("amount").sort("empid", "team").show()
             ----------------------------------------
             |"EMPID"  |"TEAM"  |"'JAN'"  |"'FEB'"  |
@@ -451,15 +418,9 @@ class RelationalGroupedDataFrame:
         pc = self._df._convert_cols_to_exprs(
             "RelationalGroupedDataFrame.pivot()", pivot_col
         )
-        if values is None:
-            distinct_values = (
-                self._df.select(pivot_col).distinct()._internal_collect_with_tag()
-            )
-            value_exprs = [Literal(v[0]) for v in distinct_values]
-        else:
-            value_exprs = [
-                v._expression if isinstance(v, Column) else Literal(v) for v in values
-            ]
+        value_exprs = [
+            v._expression if isinstance(v, Column) else Literal(v) for v in values
+        ]
         self._group_type = _PivotType(pc[0], value_exprs)
         return self
 

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -412,7 +412,7 @@ class RelationalGroupedDataFrame:
             <BLANKLINE>
         """
         if not values:
-            raise ValueError("values cannot be None or empty")
+            raise ValueError("values cannot be empty")
         pc = self._df._convert_cols_to_exprs(
             "RelationalGroupedDataFrame.pivot()", pivot_col
         )

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
-from typing import Callable, Dict, Iterable, List, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Self, Tuple, Union
 
 from snowflake.connector.options import pandas
 from snowflake.snowpark import functions
@@ -368,7 +368,7 @@ class RelationalGroupedDataFrame:
 
     def pivot(
         self, pivot_col: ColumnOrName, values: Iterable[LiteralType]
-    ) -> "RelationalGroupedDataFrame":
+    ) -> Self:
         """Rotates this DataFrame by turning unique values from one column in the input
         expression into multiple columns and aggregating results where required on any
         remaining column values.

--- a/tests/integ/scala/test_dataframe_aggregate_suite.py
+++ b/tests/integ/scala/test_dataframe_aggregate_suite.py
@@ -74,16 +74,6 @@ def test_group_by_pivot(session):
 
     Utils.check_answer(
         TestData.monthly_sales_with_team(session)
-        .group_by("empid")
-        .pivot("month")
-        .agg(sum(col("amount")))
-        .sort(col("empid")),
-        [Row(1, 10400, 8000, 11000, 18000), Row(2, 39500, 90700, 12000, 5300)],
-        sort=False,
-    )
-
-    Utils.check_answer(
-        TestData.monthly_sales_with_team(session)
         .group_by(["empid", "team"])
         .pivot("month", ["JAN", "FEB", "MAR", "APR"])
         .agg(sum(col("amount")))

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1958,6 +1958,7 @@ def test_case_insensitive_collect(session):
     assert row["p@$$w0rd"] == "test"
     assert row["P@$$W0RD"] == "test"
 
+
 def test_case_insensitive_local_iterator(session):
     df = session.create_dataframe(
         [["Gordon", 153]], schema=["firstname", "matches_won"]

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -830,6 +830,31 @@ def test_pivot(session):
     assert df.queries["queries"][0].count("SELECT") == 4
 
 
+def test_group_by_pivot(session):
+    df = (
+        TestData.monthly_sales_with_team(session)
+        .group_by("empid")
+        .pivot("month", ["JAN", "FEB", "MAR", "APR"])
+        .agg(sum_(col("amount")))
+        .select("EMPID")
+        .select("EMPID")
+        .select("EMPID")
+    )
+    assert df.queries["queries"][0].count("SELECT") == 5
+    df = (
+        TestData.monthly_sales_with_team(session)
+        .select("EMPID", "team", "month", "amount")
+        .select("EMPID", "team", "month", "amount")
+        .group_by("empid")
+        .pivot("month", ["JAN", "FEB", "MAR", "APR"])
+        .agg(sum_(col("amount")))
+        .select("EMPID")
+        .select("EMPID")
+        .select("EMPID")
+    )
+    assert df.queries["queries"][0].count("SELECT") == 5
+
+
 @pytest.mark.parametrize("func_name", ["cube", "rollup"])
 def test_cube_rollup(session, func_name):
     df = session.create_dataframe(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -800,6 +800,30 @@ class TestData:
         )
 
     @classmethod
+    def monthly_sales_with_team(cls, session: "Session") -> DataFrame:
+        return session.create_dataframe(
+            [
+                (1, "A", 10000, "JAN"),
+                (1, "A", 400, "JAN"),
+                (2, "A", 4500, "JAN"),
+                (2, "B", 35000, "JAN"),
+                (1, "B", 5000, "FEB"),
+                (1, "B", 3000, "FEB"),
+                (2, "A", 200, "FEB"),
+                (2, "A", 90500, "FEB"),
+                (1, "B", 6000, "MAR"),
+                (1, "A", 5000, "MAR"),
+                (2, "B", 2500, "MAR"),
+                (2, "B", 9500, "MAR"),
+                (1, "B", 8000, "APR"),
+                (1, "A", 10000, "APR"),
+                (2, "A", 800, "APR"),
+                (2, "A", 4500, "APR"),
+            ],
+            schema=("empid", "team", "amount", "month"),
+        )
+
+    @classmethod
     def monthly_sales_flat(cls, session: "Session"):
         return session.create_dataframe(
             [


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1093

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Added a`pivot` method in `RelationalGroupedDataFrame` which allows to access `pivot` using `df.group_by().pivot()`
