### PR TITLE
SNOW-964034 Enable skipped multistmt tests for stored proc

### DIFF
--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -281,10 +281,6 @@ def test_async_copy_into_location(session):
     Utils.check_answer(res, df)
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC,
-    reason="TODO(SNOW-933567): result_scan for child job of multistmt is not supported",
-)
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires stage access")
 @pytest.mark.skipif(not is_pandas_available, reason="to_pandas requires pandas")
 def test_multiple_queries(session, resources_path):
@@ -362,10 +358,6 @@ def test_async_is_running_and_cancel(session):
     assert async_job2.is_done()
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC,
-    reason="TODO(SNOW-933569): large result in multi-stmt is not supported in stored proc",
-)
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 def test_async_place_holder(session):
     exp = session.sql("show functions").where("1=1").collect()


### PR DESCRIPTION
Description

We have to skip these tests before because we don't support result_scan and large result for multistmt queries. Now that these are supported, we could remove the skip

Testing

Regression test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-964034

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
