### PR TITLE
SNOW-950842 Add support for the vector data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added support for `RelationalGroupedDataframe.pivot()` to access `pivot` in the following pattern `Dataframe.group_by(...).pivot(...)`.
 - Added experimental feature: Local Testing Mode.
 - Added support for `arrays_to_object` new functions in `snowflake.snowpark.functions`.
+- Added support for the vector data type.
 
 ## Dependency Updates
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -205,14 +205,14 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
     if isinstance(data_type, GeometryType):
         return "to_geometry('POINT(-122.35 37.55)')"
     if isinstance(data_type, VectorType):
-        make_float = 0.1 if data_type.element_type == "float" else 0
-        values = [i + 1 + make_float for i in range(data_type.dimension)]
         if data_type.element_type == "int":
-            return f"{values} :: VECTOR({data_type.element_type},{data_type.dimension})"
+            zero = int(0)
         elif data_type.element_type == "float":
-            return f"{values} :: VECTOR({data_type.element_type},{data_type.dimension})"
+            zero = float(0)
         else:
             raise TypeError(f"Invalid vector element type: {data_type.element_type}")
+        values = [i + zero for i in range(data_type.dimension)]
+        return f"{values} :: VECTOR({data_type.element_type},{data_type.dimension})"
     raise Exception(f"Unsupported data type: {data_type.__class__.__name__}")
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/schema_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/schema_utils.py
@@ -16,6 +16,8 @@ from snowflake.snowpark.types import DecimalType, LongType, StringType
 if TYPE_CHECKING:
     import snowflake.snowpark.session
 
+    # Refer to the docstring for ResultMetadataV2 (in cursor.py) for more information about
+    # how it differs from ResultMetadata
     try:
         from snowflake.connector.cursor import ResultMetadataV2
     except ImportError:
@@ -108,10 +110,13 @@ def convert_result_meta_to_attribute(
     return attributes
 
 
-def get_new_description_if_exists(
+def get_new_description(
     cursor: SnowflakeCursor,
 ) -> Union[List[ResultMetadata], List["ResultMetadataV2"]]:  # pyright: ignore
-    """Return the description of a cursor, using the new result metadata format if possible."""
+    """Return the description of a cursor using the new metadata format, if possible.
+
+    If an older connector is in use, this function falls back to the old metadata format.
+    """
 
     # ResultMetadataV2 may not currently be a type, depending on the connector
     # version, so the argument types are pyright ignored
@@ -123,10 +128,13 @@ def get_new_description_if_exists(
         return cursor.description
 
 
-def run_new_describe_if_exists(
+def run_new_describe(
     cursor: SnowflakeCursor, query: str
 ) -> Union[List[ResultMetadata], List["ResultMetadataV2"]]:  # pyright: ignore
-    """Execute a describe() on a cursor, using the new result metadata format if possible."""
+    """Execute describe() on a cursor, returning the new metadata format if possible.
+
+    If an older connector is in use, this function falls back to the old metadata format.
+    """
 
     # ResultMetadataV2 may not currently be a type, depending on the connector
     # version, so the argument types are pyright ignored

--- a/src/snowflake/snowpark/_internal/analyzer/schema_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/schema_utils.py
@@ -2,9 +2,7 @@
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Union
 
 import snowflake.snowpark
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
@@ -24,11 +22,11 @@ if TYPE_CHECKING:
         ResultMetadataV2 = ResultMetadata
 
 
-def command_attributes() -> list[Attribute]:
+def command_attributes() -> List[Attribute]:
     return [Attribute('"status"', StringType())]
 
 
-def list_stage_attributes() -> list[Attribute]:
+def list_stage_attributes() -> List[Attribute]:
     return [
         Attribute('"name"', StringType()),
         Attribute('"size"', LongType()),
@@ -37,11 +35,11 @@ def list_stage_attributes() -> list[Attribute]:
     ]
 
 
-def remove_state_file_attributes() -> list[Attribute]:
+def remove_state_file_attributes() -> List[Attribute]:
     return [Attribute('"name"', StringType()), Attribute('"result"', StringType())]
 
 
-def put_attributes() -> list[Attribute]:
+def put_attributes() -> List[Attribute]:
     return [
         Attribute('"source"', StringType(), nullable=False),
         Attribute('"target"', StringType(), nullable=False),
@@ -55,7 +53,7 @@ def put_attributes() -> list[Attribute]:
     ]
 
 
-def get_attributes() -> list[Attribute]:
+def get_attributes() -> List[Attribute]:
     return [
         Attribute('"file"', StringType(), nullable=False),
         Attribute('"size"', DecimalType(10, 0), nullable=False),
@@ -66,8 +64,8 @@ def get_attributes() -> list[Attribute]:
 
 
 def analyze_attributes(
-    sql: str, session: snowflake.snowpark.session.Session
-) -> list[Attribute]:
+    sql: str, session: "snowflake.snowpark.session.Session"
+) -> List[Attribute]:
     lowercase = sql.strip().lower()
 
     # SQL commands which cannot be prepared
@@ -92,8 +90,8 @@ def analyze_attributes(
 
 
 def convert_result_meta_to_attribute(
-    meta: list[ResultMetadata] | list[ResultMetadataV2],  # pyright: ignore
-) -> list[Attribute]:
+    meta: Union[List[ResultMetadata], List["ResultMetadataV2"]],  # pyright: ignore
+) -> List[Attribute]:
     # ResultMetadataV2 may not currently be a type, depending on the connector
     # version, so the argument types are pyright ignored
 
@@ -112,7 +110,7 @@ def convert_result_meta_to_attribute(
 
 def get_new_description_if_exists(
     cursor: SnowflakeCursor,
-) -> list[ResultMetadata] | list[ResultMetadataV2]:  # pyright: ignore
+) -> Union[List[ResultMetadata], List["ResultMetadataV2"]]:  # pyright: ignore
     """Return the description of a cursor, using the new result metadata format if possible."""
 
     # ResultMetadataV2 may not currently be a type, depending on the connector
@@ -127,7 +125,7 @@ def get_new_description_if_exists(
 
 def run_new_describe_if_exists(
     cursor: SnowflakeCursor, query: str
-) -> list[ResultMetadata] | list[ResultMetadataV2]:  # pyright: ignore
+) -> Union[List[ResultMetadata], List["ResultMetadataV2"]]:  # pyright: ignore
     """Execute a describe() on a cursor, using the new result metadata format if possible."""
 
     # ResultMetadataV2 may not currently be a type, depending on the connector

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -37,8 +37,8 @@ from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql
 from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.analyzer.schema_utils import (
     convert_result_meta_to_attribute,
-    get_new_description_if_exists,
-    run_new_describe_if_exists,
+    get_new_description,
+    run_new_describe,
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan import (
     BatchInsertQuery,
@@ -224,9 +224,7 @@ class ServerConnection:
 
     @SnowflakePlan.Decorator.wrap_exception
     def get_result_attributes(self, query: str) -> List[Attribute]:
-        return convert_result_meta_to_attribute(
-            run_new_describe_if_exists(self._cursor, query)
-        )
+        return convert_result_meta_to_attribute(run_new_describe(self._cursor, query))
 
     @_Decorator.log_msg_and_perf_telemetry("Uploading file to stage")
     def upload_file(
@@ -588,7 +586,7 @@ class ServerConnection:
                         placeholders[query.query_id_place_holder] = (
                             result["sfqid"] if not is_last else result.query_id
                         )
-                        result_meta = get_new_description_if_exists(self._cursor)
+                        result_meta = get_new_description(self._cursor)
                     if action_id < plan.session._last_canceled_id:
                         raise SnowparkClientExceptionMessages.SERVER_QUERY_IS_CANCELLED()
         finally:

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -23,6 +23,7 @@ from json import JSONEncoder
 from random import choice
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -32,6 +33,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    Union,
 )
 
 import snowflake.snowpark
@@ -42,6 +44,12 @@ from snowflake.connector.version import VERSION as connector_version
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.version import VERSION as snowpark_version
+
+if TYPE_CHECKING:
+    try:
+        from snowflake.connector.cursor import ResultMetadataV2
+    except ImportError:
+        ResultMetadataV2 = ResultMetadata
 
 STAGE_PREFIX = "@"
 
@@ -523,7 +531,7 @@ def column_to_bool(col_):
 
 def result_set_to_rows(
     result_set: List[Any],
-    result_meta: Optional[List[ResultMetadata]] = None,
+    result_meta: Optional[Union[List[ResultMetadata], List["ResultMetadataV2"]]] = None,
     case_sensitive: bool = True,
 ) -> List[Row]:
     col_names = [col.name for col in result_meta] if result_meta else None

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -5390,6 +5390,64 @@ def object_pick(obj: ColumnOrName, key1: ColumnOrName, *keys: ColumnOrName) -> C
     return builtin("object_pick")(o, k1, *ks)
 
 
+# The following three vector functions have doctests that are disabled (">>" instead of ">>>")
+# since vectors are not yet rolled out.
+
+
+def vector_cosine_distance(v1: ColumnOrName, v2: ColumnOrName) -> Column:
+    """Returns the cosine distance between two vectors of equal dimension and element type.
+
+    Example::
+        >> from snowflake.snowpark.functions import vector_cosine_distance
+        >> df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
+        >> df.select(vector_cosine_distance(df.a, df.b).as_("dist")).show()
+        ----------------------
+        |"DIST"              |
+        ----------------------
+        |0.9925833339709303  |
+        ----------------------
+    """
+    v1 = _to_col_if_str(v1, "vector_cosine_distance")
+    v2 = _to_col_if_str(v2, "vector_cosine_distance")
+    return builtin("vector_cosine_distance")(v1, v2)
+
+
+def vector_l2_distance(v1: ColumnOrName, v2: ColumnOrName) -> Column:
+    """Returns the cosine distance between two vectors of equal dimension and element type.
+
+    Example::
+        >> from snowflake.snowpark.functions import vector_l2_distance
+        >> df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
+        >> df.select(vector_l2_distance(df.a, df.b).as_("dist")).show()
+        ---------------------
+        |"DIST"              |
+        ----------------------
+        |1.7320508075688772  |
+        ----------------------
+    """
+    v1 = _to_col_if_str(v1, "vector_l2_distance")
+    v2 = _to_col_if_str(v2, "vector_l2_distance")
+    return builtin("vector_l2_distance")(v1, v2)
+
+
+def vector_inner_product(v1: ColumnOrName, v2: ColumnOrName) -> Column:
+    """Returns the inner product between two vectors of equal dimension and element type.
+
+    Example::
+        >> from snowflake.snowpark.functions import vector_inner_product
+        >> df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
+        >> df.select(vector_inner_product(df.a, df.b).as_("dist")).show()
+        ----------
+        |"DIST"  |
+        ----------
+        |20.0    |
+        ----------
+    """
+    v1 = _to_col_if_str(v1, "vector_inner_product")
+    v2 = _to_col_if_str(v2, "vector_inner_product")
+    return builtin("vector_inner_product")(v1, v2)
+
+
 def asc(c: ColumnOrName) -> Column:
     """Returns a Column expression with values sorted in ascending order.
 

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -8,7 +8,7 @@ import datetime
 import re
 import sys
 from enum import Enum
-from typing import Generic, List, Optional, TypeVar, Union
+from typing import Generic, List, Optional, Type, TypeVar, Union
 
 import snowflake.snowpark._internal.analyzer.expression as expression
 from snowflake.connector.options import installed_pandas, pandas
@@ -234,6 +234,30 @@ class MapType(DataType):
         return f"MapType({repr(self.key_type) if self.key_type else ''}, {repr(self.value_type) if self.value_type else ''})"
 
 
+class VectorType(DataType):
+    """Vector data type. This maps to the VECTOR data type in Snowflake."""
+
+    def __init__(
+        self,
+        element_type: Union[Type[int], Type[float], "int", "float"],
+        dimension: int,
+    ) -> None:
+        if isinstance(element_type, str):
+            self.element_type = element_type
+        elif element_type == int:
+            self.element_type = "int"
+        elif element_type == float:
+            self.element_type = "float"
+        else:
+            raise ValueError(
+                f"VectorType does not support element type: {element_type}"
+            )
+        self.dimension = dimension
+
+    def __repr__(self) -> str:
+        return f"VectorType({self.element_type},{self.dimension})"
+
+
 class ColumnIdentifier:
     """Represents a column identifier."""
 
@@ -454,6 +478,11 @@ Geography = TypeVar("Geography")
 
 #: The type hint for annotating Geometry data when registering UDFs.
 Geometry = TypeVar("Geometry")
+
+# TODO(SNOW-969479): Add a type hint that can be used to annotate Vector data. Python does not
+# currently support integer type parameters (which are needed to represent a vector's dimension).
+# typing.Annotate can be used as a temporary bypass once the minimum supported Python version is
+# bumped to 3.9
 
 #: The type hint for annotating TIMESTAMP_NTZ (e.g., ``Timestamp[NTZ]``) data when registering UDFs.
 NTZ = TypeVar("NTZ")

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -1757,92 +1757,100 @@ def test_createDataFrame_with_given_schema_timestamp(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_createDataFrame_with_given_schema_vector(session):
-    schema_int = StructType([StructField("vec", VectorType(int, 3))])
-    data_int = [Row([1, 2, 3]), Row([4, 5, 6]), Row(None)]
-    schema_float = StructType([StructField("vec", VectorType(float, 3))])
-    data_float = [Row([1, 2.2, 3.3]), Row([4.4, 5.5, 6]), Row(None)]
+    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
+    try:
+        schema_int = StructType([StructField("vec", VectorType(int, 3))])
+        data_int = [Row([1, 2, 3]), Row([4, 5, 6]), Row(None)]
+        schema_float = StructType([StructField("vec", VectorType(float, 3))])
+        data_float = [Row([1, 2.2, 3.3]), Row([4.4, 5.5, 6]), Row(None)]
 
-    df = session.create_dataframe(data_int, schema_int)
-    assert df.schema == schema_int
-    Utils.check_answer(df, data_int)
+        df = session.create_dataframe(data_int, schema_int)
+        assert df.schema == schema_int
+        Utils.check_answer(df, data_int)
 
-    df = session.create_dataframe(data_float, schema_float)
-    assert df.schema == schema_float
-    Utils.check_answer(df, data_float)
+        df = session.create_dataframe(data_float, schema_float)
+        assert df.schema == schema_float
+        Utils.check_answer(df, data_float)
+    finally:
+        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
 
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_vector(session):
-    schema_int = StructType([StructField("vec", VectorType(int, 3))])
-    data_int = [Row([1, 2, 3]), Row([4, 5, 6]), Row(None)]
-    schema_float = StructType([StructField("vec", VectorType(float, 3))])
-    data_float = [Row([1, 2.2, 3.3]), Row([4.4, 5.5, 6]), Row(None)]
+    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
+    try:
+        schema_int = StructType([StructField("vec", VectorType(int, 3))])
+        data_int = [Row([1, 2, 3]), Row([4, 5, 6]), Row(None)]
+        schema_float = StructType([StructField("vec", VectorType(float, 3))])
+        data_float = [Row([1, 2.2, 3.3]), Row([4.4, 5.5, 6]), Row(None)]
 
-    df = session.create_dataframe(data_int, schema_int)
-    expected = [Row([4, 5, 6]), Row([1, 2, 3])]
-    df = (
-        df.filter(col("vec").isNotNull())
-        .sort(col("vec"), ascending=False)
-        .select(col("vec").alias("vec2"))
-    )
-    assert df.schema == StructType(
-        [StructField("VEC2", VectorType(int, 3), nullable=True)]
-    )
-    Utils.check_answer(df, expected, sort=False)
+        df = session.create_dataframe(data_int, schema_int)
+        expected = [Row([4, 5, 6]), Row([1, 2, 3])]
+        df = (
+            df.filter(col("vec").isNotNull())
+            .sort(col("vec"), ascending=False)
+            .select(col("vec").alias("vec2"))
+        )
+        assert df.schema == StructType(
+            [StructField("VEC2", VectorType(int, 3), nullable=True)]
+        )
+        Utils.check_answer(df, expected, sort=False)
 
-    df = session.create_dataframe(data_float, schema_float)
-    expected = [Row([4.4, 5.5, 6]), Row([1, 2.2, 3.3])]
-    df = df.filter(col("vec").isNotNull()).sort(col("vec"), ascending=False)
-    Utils.check_answer(df, expected, sort=False)
+        df = session.create_dataframe(data_float, schema_float)
+        expected = [Row([4.4, 5.5, 6]), Row([1, 2.2, 3.3])]
+        df = df.filter(col("vec").isNotNull()).sort(col("vec"), ascending=False)
+        Utils.check_answer(df, expected, sort=False)
 
-    table_name = "vector_test"
-    for data, schema, element_type in [
-        (data_int, schema_int, "int"),
-        (data_float, schema_float, "float"),
-    ]:
-        try:
-            make_float = 0.1 if element_type == "float" else 0
+        table_name = "vector_test"
+        for data, schema, element_type in [
+            (data_int, schema_int, "int"),
+            (data_float, schema_float, "float"),
+        ]:
+            try:
+                make_float = 0.1 if element_type == "float" else 0
 
-            # Test appending values sourced from session.create_dataframe()
-            df = session.create_dataframe(data, schema)
-            df.write.save_as_table(table_name, mode="overwrite")
-            Utils.check_answer(session.table(table_name), data)
-            df.write.save_as_table(table_name, mode="append")
-            Utils.check_answer(session.table(table_name), data + data)
+                # Test appending values sourced from session.create_dataframe()
+                df = session.create_dataframe(data, schema)
+                df.write.save_as_table(table_name, mode="overwrite")
+                Utils.check_answer(session.table(table_name), data)
+                df.write.save_as_table(table_name, mode="append")
+                Utils.check_answer(session.table(table_name), data + data)
 
-            Utils.check_answer(
-                session.table(table_name).filter(
-                    col("vec") == lit(data[0][0]).cast(VectorType(element_type, 3))
-                ),
-                data[:1] * 2,
-            )
+                Utils.check_answer(
+                    session.table(table_name).filter(
+                        col("vec") == lit(data[0][0]).cast(VectorType(element_type, 3))
+                    ),
+                    data[:1] * 2,
+                )
 
-            # Test appending values sourced from session.sql()
-            df = session.sql(
-                f"SELECT [1,{4+make_float},{7+make_float}]::vector({element_type},3) as new_vec"
-            )
-            assert df.schema == StructType(
-                [StructField("NEW_VEC", VectorType(element_type, 3), nullable=True)]
-            )
-            df.write.save_as_table(table_name, mode="append")
-            Utils.check_answer(
-                session.table(table_name),
-                data + data + [Row([1, 4 + make_float, 7 + make_float])],
-            )
+                # Test appending values sourced from session.sql()
+                df = session.sql(
+                    f"SELECT [1,{4+make_float},{7+make_float}]::vector({element_type},3) as new_vec"
+                )
+                assert df.schema == StructType(
+                    [StructField("NEW_VEC", VectorType(element_type, 3), nullable=True)]
+                )
+                df.write.save_as_table(table_name, mode="append")
+                Utils.check_answer(
+                    session.table(table_name),
+                    data + data + [Row([1, 4 + make_float, 7 + make_float])],
+                )
 
-            # Test appending values sourced from session.table()
-            df = session.table(table_name)
-            assert df.schema == StructType(
-                [StructField("VEC", VectorType(element_type, 3), nullable=True)]
-            )
-            df.write.save_as_table(table_name, mode="append")
-            Utils.check_answer(
-                session.table(table_name),
-                (data + data + [Row([1, 4 + make_float, 7 + make_float])]) * 2,
-            )
+                # Test appending values sourced from session.table()
+                df = session.table(table_name)
+                assert df.schema == StructType(
+                    [StructField("VEC", VectorType(element_type, 3), nullable=True)]
+                )
+                df.write.save_as_table(table_name, mode="append")
+                Utils.check_answer(
+                    session.table(table_name),
+                    (data + data + [Row([1, 4 + make_float, 7 + make_float])]) * 2,
+                )
 
-        finally:
-            session.sql(f"drop table if exists {table_name}")
+            finally:
+                session.sql(f"drop table if exists {table_name}")
+    finally:
+        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
 
 
 @pytest.mark.skipif(

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -31,6 +31,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
     VariantType,
+    VectorType,
 )
 from tests.utils import Utils
 
@@ -134,6 +135,33 @@ def test_verify_datatypes_reference2(session):
     )
 
 
+@pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
+def test_verify_datatypes_reference_vector(session):
+    schema = StructType(
+        [
+            StructField("int_vector", VectorType(int, 3)),
+            StructField("float_vector", VectorType(float, 3)),
+        ]
+    )
+    df = session.create_dataframe(
+        [
+            [
+                None,
+                None,
+            ]
+        ],
+        schema,
+    )
+
+    expected_schema = StructType(
+        [
+            StructField("INT_VECTOR", VectorType(int, 3)),
+            StructField("FLOAT_VECTOR", VectorType(float, 3)),
+        ]
+    )
+    Utils.is_schema_same(df.schema, expected_schema)
+
+
 @pytest.mark.xfail(
     condition="config.getvalue('local_testing_mode')",
     raises=NotImplementedError,
@@ -208,4 +236,28 @@ def test_dtypes(session):
         ("DECIMAL", "decimal(10,2)"),
         ("ARRAY", "array<string>"),
         ("MAP", "map<string,string>"),
+    ]
+
+
+@pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
+def test_dtypes_vector(session):
+    schema = StructType(
+        [
+            StructField("int_vector", VectorType(int, 3)),
+            StructField("float_vector", VectorType(float, 3)),
+        ]
+    )
+    df = session.create_dataframe(
+        [
+            [
+                None,
+                None,
+            ]
+        ],
+        schema,
+    )
+
+    assert df.dtypes == [
+        ("INT_VECTOR", "vector<int,3>"),
+        ("FLOAT_VECTOR", "vector<float,3>"),
     ]

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -137,29 +137,33 @@ def test_verify_datatypes_reference2(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_verify_datatypes_reference_vector(session):
-    schema = StructType(
-        [
-            StructField("int_vector", VectorType(int, 3)),
-            StructField("float_vector", VectorType(float, 3)),
-        ]
-    )
-    df = session.create_dataframe(
-        [
+    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
+    try:
+        schema = StructType(
             [
-                None,
-                None,
+                StructField("int_vector", VectorType(int, 3)),
+                StructField("float_vector", VectorType(float, 3)),
             ]
-        ],
-        schema,
-    )
+        )
+        df = session.create_dataframe(
+            [
+                [
+                    None,
+                    None,
+                ]
+            ],
+            schema,
+        )
 
-    expected_schema = StructType(
-        [
-            StructField("INT_VECTOR", VectorType(int, 3)),
-            StructField("FLOAT_VECTOR", VectorType(float, 3)),
-        ]
-    )
-    Utils.is_schema_same(df.schema, expected_schema)
+        expected_schema = StructType(
+            [
+                StructField("INT_VECTOR", VectorType(int, 3)),
+                StructField("FLOAT_VECTOR", VectorType(float, 3)),
+            ]
+        )
+        Utils.is_schema_same(df.schema, expected_schema)
+    finally:
+        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
 
 
 @pytest.mark.xfail(
@@ -241,23 +245,27 @@ def test_dtypes(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_dtypes_vector(session):
-    schema = StructType(
-        [
-            StructField("int_vector", VectorType(int, 3)),
-            StructField("float_vector", VectorType(float, 3)),
-        ]
-    )
-    df = session.create_dataframe(
-        [
+    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
+    try:
+        schema = StructType(
             [
-                None,
-                None,
+                StructField("int_vector", VectorType(int, 3)),
+                StructField("float_vector", VectorType(float, 3)),
             ]
-        ],
-        schema,
-    )
+        )
+        df = session.create_dataframe(
+            [
+                [
+                    None,
+                    None,
+                ]
+            ],
+            schema,
+        )
 
-    assert df.dtypes == [
-        ("INT_VECTOR", "vector<int,3>"),
-        ("FLOAT_VECTOR", "vector<float,3>"),
-    ]
+        assert df.dtypes == [
+            ("INT_VECTOR", "vector<int,3>"),
+            ("FLOAT_VECTOR", "vector<float,3>"),
+        ]
+    finally:
+        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -137,33 +137,29 @@ def test_verify_datatypes_reference2(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_verify_datatypes_reference_vector(session):
-    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
-    try:
-        schema = StructType(
+    schema = StructType(
+        [
+            StructField("int_vector", VectorType(int, 3)),
+            StructField("float_vector", VectorType(float, 3)),
+        ]
+    )
+    df = session.create_dataframe(
+        [
             [
-                StructField("int_vector", VectorType(int, 3)),
-                StructField("float_vector", VectorType(float, 3)),
+                None,
+                None,
             ]
-        )
-        df = session.create_dataframe(
-            [
-                [
-                    None,
-                    None,
-                ]
-            ],
-            schema,
-        )
+        ],
+        schema,
+    )
 
-        expected_schema = StructType(
-            [
-                StructField("INT_VECTOR", VectorType(int, 3)),
-                StructField("FLOAT_VECTOR", VectorType(float, 3)),
-            ]
-        )
-        Utils.is_schema_same(df.schema, expected_schema)
-    finally:
-        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
+    expected_schema = StructType(
+        [
+            StructField("INT_VECTOR", VectorType(int, 3)),
+            StructField("FLOAT_VECTOR", VectorType(float, 3)),
+        ]
+    )
+    Utils.is_schema_same(df.schema, expected_schema)
 
 
 @pytest.mark.xfail(
@@ -245,27 +241,23 @@ def test_dtypes(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_dtypes_vector(session):
-    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
-    try:
-        schema = StructType(
-            [
-                StructField("int_vector", VectorType(int, 3)),
-                StructField("float_vector", VectorType(float, 3)),
-            ]
-        )
-        df = session.create_dataframe(
-            [
-                [
-                    None,
-                    None,
-                ]
-            ],
-            schema,
-        )
-
-        assert df.dtypes == [
-            ("INT_VECTOR", "vector<int,3>"),
-            ("FLOAT_VECTOR", "vector<float,3>"),
+    schema = StructType(
+        [
+            StructField("int_vector", VectorType(int, 3)),
+            StructField("float_vector", VectorType(float, 3)),
         ]
-    finally:
-        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
+    )
+    df = session.create_dataframe(
+        [
+            [
+                None,
+                None,
+            ]
+        ],
+        schema,
+    )
+
+    assert df.dtypes == [
+        ("INT_VECTOR", "vector<int,3>"),
+        ("FLOAT_VECTOR", "vector<float,3>"),
+    ]

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -246,6 +246,7 @@ def test_create_dataframe_for_large_values_array_map_variant(session):
     assert df.sort("id").collect() == expected
 
 
+@pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_create_dataframe_for_large_values_vector(session):
     schema = StructType(
         [

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -248,7 +248,7 @@ def test_create_dataframe_for_large_values_array_map_variant(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_create_dataframe_for_large_values_vector(session):
-    session.sql("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
+    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
     try:
         schema = StructType(
             [
@@ -284,4 +284,4 @@ def test_create_dataframe_for_large_values_vector(session):
             assert row[1] == pytest.approx(expected[i][1])
             assert row[2] == pytest.approx(expected[i][2])
     finally:
-        session.sql("alter session unset ENABLE_VECTOR_DATA_TYPE")
+        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -248,40 +248,36 @@ def test_create_dataframe_for_large_values_array_map_variant(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_create_dataframe_for_large_values_vector(session):
-    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
-    try:
-        schema = StructType(
-            [
-                StructField("id", LongType()),
-                StructField("int_vector", VectorType(int, 5)),
-                StructField("float_vector", VectorType(float, 5)),
-            ]
+    schema = StructType(
+        [
+            StructField("id", LongType()),
+            StructField("int_vector", VectorType(int, 5)),
+            StructField("float_vector", VectorType(float, 5)),
+        ]
+    )
+
+    row_count = 1000
+    large_data = [
+        Row(i, [1, 2, 3, 4, 5], [1.1, 2.2, 3.3, 4.4, 5.5]) for i in range(row_count)
+    ]
+    large_data.append(Row(row_count, None, None))
+    df = session.create_dataframe(large_data, schema)
+    assert [type(field.datatype) for field in df.schema.fields] == [
+        LongType,
+        VectorType,
+        VectorType,
+    ]
+
+    expected = [
+        Row(
+            i,
+            [1, 2, 3, 4, 5],
+            [1.1, 2.2, 3.3, 4.4, 5.5],
         )
-
-        row_count = 1000
-        large_data = [
-            Row(i, [1, 2, 3, 4, 5], [1.1, 2.2, 3.3, 4.4, 5.5]) for i in range(row_count)
-        ]
-        large_data.append(Row(row_count, None, None))
-        df = session.create_dataframe(large_data, schema)
-        assert [type(field.datatype) for field in df.schema.fields] == [
-            LongType,
-            VectorType,
-            VectorType,
-        ]
-
-        expected = [
-            Row(
-                i,
-                [1, 2, 3, 4, 5],
-                [1.1, 2.2, 3.3, 4.4, 5.5],
-            )
-            for i in range(row_count)
-        ]
-        expected.append(Row(row_count, None, None))
-        for i, row in enumerate(df.sort("id").collect()):
-            assert row[0] == expected[i][0]
-            assert row[1] == pytest.approx(expected[i][1])
-            assert row[2] == pytest.approx(expected[i][2])
-    finally:
-        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
+        for i in range(row_count)
+    ]
+    expected.append(Row(row_count, None, None))
+    for i, row in enumerate(df.sort("id").collect()):
+        assert row[0] == expected[i][0]
+        assert row[1] == pytest.approx(expected[i][1])
+        assert row[2] == pytest.approx(expected[i][2])

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -552,75 +552,63 @@ def test_geometry_type(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_vector_type(session):
-    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
-    try:
-        int_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-        Utils.create_table(
-            session, int_table_name, "v vector(int,3)", is_temporary=True
-        )
-        session._run_query(
-            f"insert into {int_table_name} select [1,2,3]::vector(int,3)"
-        )
-        session._run_query(
-            f"insert into {int_table_name} select [4,5,6]::vector(int,3)"
-        )
-        session._run_query(f"insert into {int_table_name} select NULL::vector(int,3)")
+    int_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    Utils.create_table(session, int_table_name, "v vector(int,3)", is_temporary=True)
+    session._run_query(f"insert into {int_table_name} select [1,2,3]::vector(int,3)")
+    session._run_query(f"insert into {int_table_name} select [4,5,6]::vector(int,3)")
+    session._run_query(f"insert into {int_table_name} select NULL::vector(int,3)")
 
-        float_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-        Utils.create_table(
-            session, float_table_name, "v vector(float,3)", is_temporary=True
-        )
-        session._run_query(
-            f"insert into {float_table_name} select [1.1,2.2,3.3]::vector(float,3)"
-        )
-        session._run_query(
-            f"insert into {float_table_name} select [4.4,5.5,6.6]::vector(float,3)"
-        )
-        session._run_query(
-            f"insert into {float_table_name} select NULL::vector(float,3)"
-        )
+    float_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    Utils.create_table(
+        session, float_table_name, "v vector(float,3)", is_temporary=True
+    )
+    session._run_query(
+        f"insert into {float_table_name} select [1.1,2.2,3.3]::vector(float,3)"
+    )
+    session._run_query(
+        f"insert into {float_table_name} select [4.4,5.5,6.6]::vector(float,3)"
+    )
+    session._run_query(f"insert into {float_table_name} select NULL::vector(float,3)")
 
-        def vector_str(v):
-            if not v:
-                return None
-            else:
-                return f"Vector: {list(v)}"
+    def vector_str(v):
+        if not v:
+            return None
+        else:
+            return f"Vector: {list(v)}"
 
-        def vector_add(v):
-            if not v:
-                return None
-            else:
-                return [elem + 1 for elem in v]
+    def vector_add(v):
+        if not v:
+            return None
+        else:
+            return [elem + 1 for elem in v]
 
-        df = session.table(int_table_name)
-        int_vector_udf = udf(
-            vector_str, return_type=StringType(), input_types=[VectorType(int, 3)]
-        )
-        Utils.check_answer(
-            df.select(int_vector_udf(col("v"))),
-            [
-                Row("Vector: [1, 2, 3]"),
-                Row("Vector: [4, 5, 6]"),
-                Row(None),
-            ],
-        )
+    df = session.table(int_table_name)
+    int_vector_udf = udf(
+        vector_str, return_type=StringType(), input_types=[VectorType(int, 3)]
+    )
+    Utils.check_answer(
+        df.select(int_vector_udf(col("v"))),
+        [
+            Row("Vector: [1, 2, 3]"),
+            Row("Vector: [4, 5, 6]"),
+            Row(None),
+        ],
+    )
 
-        df = session.table(float_table_name)
-        float_vector_udf = udf(
-            vector_add,
-            return_type=VectorType(float, 3),
-            input_types=[VectorType(float, 3)],
-        )
-        Utils.check_answer(
-            df.select(float_vector_udf(col("v"))),
-            [
-                Row([2.1, 3.2, 4.3]),
-                Row([5.4, 6.5, 7.6]),
-                Row(None),
-            ],
-        )
-    finally:
-        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
+    df = session.table(float_table_name)
+    float_vector_udf = udf(
+        vector_add,
+        return_type=VectorType(float, 3),
+        input_types=[VectorType(float, 3)],
+    )
+    Utils.check_answer(
+        df.select(float_vector_udf(col("v"))),
+        [
+            Row([2.1, 3.2, 4.3]),
+            Row([5.4, 6.5, 7.6]),
+            Row(None),
+        ],
+    )
 
 
 def test_variant_string_input(session):

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -580,34 +580,42 @@ def test_vector_type(session):
             f"insert into {float_table_name} select NULL::vector(float,3)"
         )
 
-        def vector(v):
+        def vector_str(v):
             if not v:
                 return None
             else:
-                return f"Vector: {v}"
+                return f"Vector: {list(v)}"
+
+        def vector_add(v):
+            if not v:
+                return None
+            else:
+                return [elem + 1 for elem in v]
 
         df = session.table(int_table_name)
         int_vector_udf = udf(
-            vector, return_type=StringType(), input_types=[VectorType(int, 3)]
+            vector_str, return_type=StringType(), input_types=[VectorType(int, 3)]
         )
         Utils.check_answer(
             df.select(int_vector_udf(col("v"))),
             [
-                Row("Vector: [1,2,3]"),
-                Row("Vector: [4,5,6]"),
+                Row("Vector: [1, 2, 3]"),
+                Row("Vector: [4, 5, 6]"),
                 Row(None),
             ],
         )
 
         df = session.table(float_table_name)
         float_vector_udf = udf(
-            vector, return_type=StringType(), input_types=[VectorType(float, 3)]
+            vector_add,
+            return_type=VectorType(float, 3),
+            input_types=[VectorType(float, 3)],
         )
         Utils.check_answer(
             df.select(float_vector_udf(col("v"))),
             [
-                Row("Vector: [1.1,2.2,3.3]"),
-                Row("Vector: [4.4,5.5,6.6]"),
+                Row([2.1, 3.2, 4.3]),
+                Row([5.4, 6.5, 7.6]),
                 Row(None),
             ],
         )

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -550,6 +550,7 @@ def test_geometry_type(session):
     )
 
 
+@pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_vector_type(session):
     int_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(session, int_table_name, "v vector(int,3)", is_temporary=True)

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -1274,52 +1274,46 @@ def test_array_sort(session):
 
 @pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_vector_distances(session):
-    session._run_query("alter session set ENABLE_VECTOR_DATA_TYPE='Enable'")
-    try:
-        df = session.sql(
-            "select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b"
-        )
+    df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
 
-        res = df.select(vector_cosine_distance(df.a, df.b).as_("distance")).collect()
-        Utils.check_answer(
-            res, [Row(DISTANCE=20 / ((1 + 4 + 9) ** 0.5 * (4 + 9 + 16) ** 0.5))]
-        )
+    res = df.select(vector_cosine_distance(df.a, df.b).as_("distance")).collect()
+    Utils.check_answer(
+        res, [Row(DISTANCE=20 / ((1 + 4 + 9) ** 0.5 * (4 + 9 + 16) ** 0.5))]
+    )
 
-        res = df.select(vector_l2_distance(df.a, df.b).as_("distance")).collect()
-        Utils.check_answer(res, [Row(DISTANCE=(1 + 1 + 1) ** 0.5)])
+    res = df.select(vector_l2_distance(df.a, df.b).as_("distance")).collect()
+    Utils.check_answer(res, [Row(DISTANCE=(1 + 1 + 1) ** 0.5)])
 
-        res = df.select(vector_inner_product(df.a, df.b).as_("distance")).collect()
-        Utils.check_answer(res, [Row(DISTANCE=20)])
+    res = df.select(vector_inner_product(df.a, df.b).as_("distance")).collect()
+    Utils.check_answer(res, [Row(DISTANCE=20)])
 
-        df = session.sql(
-            "select [1.1,2.2]::vector(float,2) as a, [2.2,3.3]::vector(float,2) as b"
-        )
-        res = df.select(vector_cosine_distance(df.a, df.b).as_("distance")).collect()
-        inner_product = 1.1 * 2.2 + 2.2 * 3.3
-        Utils.check_answer(
-            res,
-            [
-                Row(
-                    DISTANCE=inner_product
-                    / ((1.1**2 + 2.2**2) ** 0.5 * (2.2**2 + 3.3**2) ** 0.5)
-                )
-            ],
-            float_equality_threshold=0.0005,
-        )
+    df = session.sql(
+        "select [1.1,2.2]::vector(float,2) as a, [2.2,3.3]::vector(float,2) as b"
+    )
+    res = df.select(vector_cosine_distance(df.a, df.b).as_("distance")).collect()
+    inner_product = 1.1 * 2.2 + 2.2 * 3.3
+    Utils.check_answer(
+        res,
+        [
+            Row(
+                DISTANCE=inner_product
+                / ((1.1**2 + 2.2**2) ** 0.5 * (2.2**2 + 3.3**2) ** 0.5)
+            )
+        ],
+        float_equality_threshold=0.0005,
+    )
 
-        res = df.select(vector_l2_distance(df.a, df.b).as_("distance")).collect()
-        Utils.check_answer(
-            res,
-            [Row(DISTANCE=(1.1**2 + 1.1**2) ** 0.5)],
-            float_equality_threshold=0.0005,
-        )
+    res = df.select(vector_l2_distance(df.a, df.b).as_("distance")).collect()
+    Utils.check_answer(
+        res,
+        [Row(DISTANCE=(1.1**2 + 1.1**2) ** 0.5)],
+        float_equality_threshold=0.0005,
+    )
 
-        res = df.select(vector_inner_product(df.a, df.b).as_("distance")).collect()
-        Utils.check_answer(
-            res, [Row(DISTANCE=inner_product)], float_equality_threshold=0.0005
-        )
-    finally:
-        session._run_query("alter session unset ENABLE_VECTOR_DATA_TYPE")
+    res = df.select(vector_inner_product(df.a, df.b).as_("distance")).collect()
+    Utils.check_answer(
+        res, [Row(DISTANCE=inner_product)], float_equality_threshold=0.0005
+    )
 
 
 @pytest.mark.localtest

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -35,6 +35,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
     VariantType,
+    VectorType,
 )
 
 
@@ -143,6 +144,17 @@ def test_to_sql():
         == 'PARSE_JSON(\'{"1": "' + dt.isoformat() + "\"}') :: OBJECT"
     )
 
+    assert to_sql([1, 2, 3.5], VectorType(float, 3)) == "[1, 2, 3.5] :: VECTOR(float,3)"
+    assert (
+        to_sql([1, 2, 3.5, 4.1234567, -3.8], VectorType("float", 5))
+        == "[1, 2, 3.5, 4.1234567, -3.8] :: VECTOR(float,5)"
+    )
+    assert to_sql([1, 2, 3], VectorType(int, 3)) == "[1, 2, 3] :: VECTOR(int,3)"
+    assert (
+        to_sql([1, 2, 31234567, -1928, 0, -3], VectorType(int, 5))
+        == "[1, 2, 31234567, -1928, 0, -3] :: VECTOR(int,5)"
+    )
+
 
 @pytest.mark.parametrize(
     "timezone, expected",
@@ -209,6 +221,8 @@ def test_schema_expression():
     assert schema_expression(TimeType(), True) == "NULL :: TIME"
     assert schema_expression(TimestampType(), True) == "NULL :: TIMESTAMP"
     assert schema_expression(BinaryType(), True) == "NULL :: BINARY"
+    assert schema_expression(VectorType(int, 3), True) == "NULL :: VECTOR(int,3)"
+    assert schema_expression(VectorType(float, 2), True) == "NULL :: VECTOR(float,2)"
 
     assert (
         schema_expression(GeographyType(), False)
@@ -257,3 +271,9 @@ def test_schema_expression():
     )
 
     assert schema_expression(BinaryType(), False) == "'01' :: BINARY"
+
+    assert schema_expression(VectorType(int, 2), False) == "[1, 2] :: VECTOR(int,2)"
+    assert (
+        schema_expression(VectorType(float, 3), False)
+        == "[1.1, 2.1, 3.1] :: VECTOR(float,3)"
+    )

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -272,8 +272,8 @@ def test_schema_expression():
 
     assert schema_expression(BinaryType(), False) == "'01' :: BINARY"
 
-    assert schema_expression(VectorType(int, 2), False) == "[1, 2] :: VECTOR(int,2)"
+    assert schema_expression(VectorType(int, 2), False) == "[0, 1] :: VECTOR(int,2)"
     assert (
         schema_expression(VectorType(float, 3), False)
-        == "[1.1, 2.1, 3.1] :: VECTOR(float,3)"
+        == "[0.0, 1.0, 2.0] :: VECTOR(float,3)"
     )

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -69,6 +69,7 @@ from snowflake.snowpark.types import (
     TimeType,
     Variant,
     VariantType,
+    VectorType,
     _FractionalType,
     _IntegralType,
     _NumericType,
@@ -786,6 +787,10 @@ def test_convert_sp_to_sf_type():
     assert convert_sp_to_sf_type(VariantType()) == "VARIANT"
     assert convert_sp_to_sf_type(GeographyType()) == "GEOGRAPHY"
     assert convert_sp_to_sf_type(GeometryType()) == "GEOMETRY"
+    assert convert_sp_to_sf_type(VectorType(int, 3)) == "VECTOR(int,3)"
+    assert convert_sp_to_sf_type(VectorType("int", 5)) == "VECTOR(int,5)"
+    assert convert_sp_to_sf_type(VectorType(float, 5)) == "VECTOR(float,5)"
+    assert convert_sp_to_sf_type(VectorType("float", 3)) == "VECTOR(float,3)"
     with pytest.raises(TypeError, match="Unsupported data type"):
         convert_sp_to_sf_type(None)
 
@@ -823,6 +828,7 @@ def test_snow_type_to_dtype_str():
     assert snow_type_to_dtype_str(GeographyType()) == "geography"
     assert snow_type_to_dtype_str(GeometryType()) == "geometry"
     assert snow_type_to_dtype_str(VariantType()) == "variant"
+    assert snow_type_to_dtype_str(VectorType("int", 3)) == "vector<int,3>"
     assert snow_type_to_dtype_str(ByteType()) == "tinyint"
     assert snow_type_to_dtype_str(ShortType()) == "smallint"
     assert snow_type_to_dtype_str(IntegerType()) == "int"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,8 @@ import string
 from decimal import Decimal
 from typing import List, NamedTuple, Optional, Union
 
+import pytest
+
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.snowpark import DataFrame, Row, Session
 from snowflake.snowpark._internal import utils
@@ -216,6 +218,17 @@ class Utils:
                     else:
                         assert math.isclose(
                             actual_value, expected_value
+                        ), f"Expected {expected_value}. Actual {actual_value}"
+                elif isinstance(expected_value, list):
+                    if len(expected_value) > 0 and any(
+                        [isinstance(v, float) for v in expected_value]
+                    ):
+                        assert actual_value == pytest.approx(
+                            expected_value
+                        ), f"Expected {expected_value}. Actual {actual_value}"
+                    else:
+                        assert (
+                            actual_value == expected_value
                         ), f"Expected {expected_value}. Actual {actual_value}"
                 else:
                     assert (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -197,7 +197,7 @@ class Utils:
         return f"{session.get_current_database()}.{cls.random_temp_schema()}"
 
     @staticmethod
-    def assert_rows(actual_rows, expected_rows):
+    def assert_rows(actual_rows, expected_rows, float_equality_threshold=0.0):
         assert len(actual_rows) == len(
             expected_rows
         ), f"row count is different. Expected {len(expected_rows)}. Actual {len(actual_rows)}"
@@ -215,6 +215,10 @@ class Utils:
                         assert math.isnan(
                             actual_value
                         ), f"Expected NaN. Actual {actual_value}"
+                    elif float_equality_threshold > 0:
+                        assert actual_value == pytest.approx(
+                            expected_value, abs=float_equality_threshold
+                        )
                     else:
                         assert math.isclose(
                             actual_value, expected_value
@@ -263,6 +267,7 @@ class Utils:
         expected: Union[Row, List[Row], DataFrame],
         sort=True,
         statement_params=None,
+        float_equality_threshold=0.0,
     ) -> None:
         def get_rows(input_data: Union[Row, List[Row], DataFrame]):
             if isinstance(input_data, list):
@@ -282,9 +287,11 @@ class Utils:
         if sort:
             sorted_expected_rows = Utils.get_sorted_rows(expected_rows)
             sorted_actual_rows = Utils.get_sorted_rows(actual_rows)
-            Utils.assert_rows(sorted_actual_rows, sorted_expected_rows)
+            Utils.assert_rows(
+                sorted_actual_rows, sorted_expected_rows, float_equality_threshold
+            )
         else:
-            Utils.assert_rows(actual_rows, expected_rows)
+            Utils.assert_rows(actual_rows, expected_rows, float_equality_threshold)
 
     @staticmethod
     def verify_schema(sql: str, expected_schema: StructType, session: Session) -> None:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-950842

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Added support for the vector data type to snowpark. As with arrays, we temporarily serialize vector inputs as strings and wrap `parse_json` and `cast` calls to construct the right type. Let me know if there are any edge cases that this temporary bypass introduces that I need to handle.

There are many formatting changes that were automatically applied by the repository's precommit because I edited certain files.