### PR TITLE
[Local Testing] SNOW-904981 Support Column bitwise operations and unary minus expression #1115

### DIFF
--- a/src/snowflake/snowpark/mock/util.py
+++ b/src/snowflake/snowpark/mock/util.py
@@ -6,7 +6,30 @@ import math
 from functools import cmp_to_key, partial
 from typing import Any, Tuple
 
+import numpy
+
 from snowflake.connector.options import pandas as pd
+from snowflake.snowpark.mock.snowflake_data_type import ColumnEmulator
+from snowflake.snowpark.types import (
+    ArrayType,
+    BinaryType,
+    BooleanType,
+    ByteType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    MapType,
+    NullType,
+    ShortType,
+    StringType,
+    TimestampType,
+    TimeType,
+    VariantType,
+    _NumericType,
+)
 
 # placeholder map helps convert wildcard to reg. In practice, we convert wildcard to a middle string first,
 # and then convert middle string to regex. See the following example:
@@ -164,3 +187,33 @@ def process_string_time_with_fractional_seconds(time: str, fractional_seconds) -
         seconds_part = seconds_part[: min(idx, fractional_seconds)] + seconds_part[idx:]
         ret = f"{time_parts[0]}.{seconds_part}"
     return ret
+
+
+def fix_drift_between_column_sf_type_and_dtype(col: ColumnEmulator):
+    if (
+        isinstance(col.sf_type.datatype, _NumericType)
+        and col.apply(lambda x: x is None).any()
+    ):  # non-object dtype converts None to NaN for numeric columns
+        return col
+    sf_type_to_dtype = {
+        ArrayType: object,
+        BinaryType: object,
+        BooleanType: bool,
+        ByteType: numpy.int8 if not col.sf_type.nullable else "Int8",
+        DateType: object,
+        DecimalType: numpy.int64 if not col.sf_type.nullable else "Int64",
+        DoubleType: numpy.float64,
+        FloatType: numpy.float64,
+        IntegerType: numpy.int64 if not col.sf_type.nullable else "Int64",
+        LongType: numpy.int64 if not col.sf_type.nullable else "Int64",
+        NullType: object,
+        ShortType: numpy.int8 if not col.sf_type.nullable else "Int8",
+        StringType: object,
+        TimestampType: "datetime64[ns]",
+        TimeType: object,
+        VariantType: object,
+        MapType: object,
+    }
+    fixed_type = sf_type_to_dtype.get(type(col.sf_type.datatype), object)
+    col = col.astype(fixed_type)
+    return col

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -66,11 +66,7 @@ def test_column_alias_and_case_sensitive_name(session):
     assert df.select(df["a"].name('"b"')).schema.fields[0].name == '"b"'
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
+@pytest.mark.localtest
 def test_unary_operator(session):
     test_data1 = TestData.test_data1(session)
     # unary minus
@@ -193,10 +189,7 @@ def test_and_or(session):
     ]
 
 
-@pytest.mark.xfail(
-    reason="Divide is expected to return decimal instead of float",
-    raises=AttributeError,
-)
+@pytest.mark.localtest
 def test_add_subtract_multiply_divide_mod_pow(session):
     df = session.create_dataframe([[11, 13]], schema=["a", "b"])
     assert df.select(df["A"] + df["B"]).collect() == [Row(24)]
@@ -278,11 +271,7 @@ def test_order(session):
     ]
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
-)
+@pytest.mark.localtest
 def test_bitwise_operator(session):
     df = session.create_dataframe([[1, 2]], schema=["a", "b"])
     assert df.select(df["A"].bitand(df["B"])).collect() == [Row(0)]
@@ -425,10 +414,8 @@ def test_drop_columns_by_column(session):
     assert df.drop(df2["one"]).schema.fields[0].name == '"One"'
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="sql use is not supported"
 )
 def test_fully_qualified_column_name(session):
     random_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -518,10 +505,8 @@ def test_column_constructors_select(session):
     assert "invalid identifier" in str(ex_info)
 
 
-@pytest.mark.xfail(
-    condition="config.getvalue('local_testing_mode')",
-    raises=NotImplementedError,
-    strict=True,
+@pytest.mark.skipif(
+    condition="config.getvalue('local_testing_mode')", reason="sql use is not supported"
 )
 def test_sql_expr_column(session):
     df = session.create_dataframe([[1, 2, 3]]).to_df("col", '"col"', "col .")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   N/A

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR includes changes to support Column bitwise operations (Column.bitor, bitand, bitxor) and UnaryMinus (-col("a")) in Local Testing and enables 4 tests to run in local testing mode. In addition, it skips the tests `test_fully_qualified_column_name` and 
`test_sql_expr_column` for local testing mode with a better reason message.