### PR TITLE
[Local Testing] SNOW-976759 Fix implementation of mock_avg to compute the correct return type and precision

### DIFF
--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -32,6 +32,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
     VariantType,
+    _FractionalType,
     _IntegralType,
     _NumericType,
 )
@@ -164,6 +165,7 @@ def mock_avg(column: ColumnEmulator) -> ColumnEmulator:
             scale = 12
         res_type = DecimalType(precision, scale)
     else:
+        assert isinstance(column.sf_type.datatype, _FractionalType)
         res_type = FloatType()
 
     notna = column[~column.isna()]

--- a/src/snowflake/snowpark/mock/functions.py
+++ b/src/snowflake/snowpark/mock/functions.py
@@ -24,6 +24,7 @@ from snowflake.snowpark.types import (
     DateType,
     DecimalType,
     DoubleType,
+    FloatType,
     LongType,
     MapType,
     NullType,
@@ -31,6 +32,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
     VariantType,
+    _IntegralType,
     _NumericType,
 )
 
@@ -141,22 +143,34 @@ def mock_sum(column: ColumnEmulator) -> ColumnEmulator:
 
 @patch("avg")
 def mock_avg(column: ColumnEmulator) -> ColumnEmulator:
-    all_item_is_none = True
-    ret = 0
-    cnt = 0
-    for data in column:
-        if data is not None:
-            all_item_is_none = False
-            ret += float(data)
-            cnt += 1
+    if not isinstance(column.sf_type.datatype, (_NumericType, NullType)):
+        raise SnowparkSQLException(
+            f"Cannot compute avg on a column of type {column.sf_type.datatype}"
+        )
 
-    ret = (
-        ColumnEmulator(data=[round((ret / cnt), 5)])
-        if not all_item_is_none
-        else ColumnEmulator(data=[None])
-    )
-    ret.sf_type = column.sf_type
-    return ret
+    if isinstance(column.sf_type.datatype, NullType) or column.isna().all():
+        return ColumnEmulator(data=[None], sf_type=ColumnType(NullType(), True))
+    elif isinstance(column.sf_type.datatype, _IntegralType):
+        res_type = DecimalType(38, 6)
+    elif isinstance(column.sf_type.datatype, DecimalType):
+        precision, scale = (
+            column.sf_type.datatype.precision,
+            column.sf_type.datatype.scale,
+        )
+        precision = max(38, column.sf_type.datatype.precision + 12)
+        if scale <= 6:
+            scale = scale + 6
+        elif scale < 12:
+            scale = 12
+        res_type = DecimalType(precision, scale)
+    else:
+        res_type = FloatType()
+
+    notna = column[~column.isna()]
+    res = notna.mean()
+    if isinstance(res_type, Decimal):
+        res = round(res, scale)
+    return ColumnEmulator(data=[res], sf_type=ColumnType(res_type, False))
 
 
 @patch("count")


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   N/A

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Previously `mock_avg` always return a column of floating point values rounded to 5 digits after the floating point, where the result type is incorrectly set to the type of the incoming column. As a result, average of Integer column will have a return type of Integer. Average of Decimal columns will not have the correct precision and scale. This PR fixes these issues.
