### PR TITLE
SNOW-984111: Fix new test failure related to timezone when executed in stored proc

### DIFF
--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -30,6 +30,7 @@ from snowflake.snowpark.types import (
     StringType,
     StructField,
     StructType,
+    TimestampTimeZone,
     TimestampType,
     TimeType,
 )
@@ -749,8 +750,11 @@ def test_in_expression_2_in_with_subquery(session):
     Utils.check_answer(df4, [Row(False), Row(True), Row(True)])
 
 
-@pytest.mark.localtest
 def test_in_expression_3_with_all_types(session, local_testing_mode):
+    # TODO: local testing support to_timestamp_ntz
+    #  stored proc by default uses timestime type according to:
+    #  https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping
+    #  we keep the test here for future reference
     schema = StructType(
         [
             StructField("id", LongType()),
@@ -762,7 +766,7 @@ def test_in_expression_3_with_all_types(session, local_testing_mode):
             StructField("double", DoubleType()),
             StructField("decimal", DecimalType(10, 3)),
             StructField("boolean", BooleanType()),
-            StructField("timestamp", TimestampType()),
+            StructField("timestamp", TimestampType(TimestampTimeZone.NTZ)),
             StructField("date", DateType()),
             StructField("time", TimeType()),
         ]

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -254,7 +254,8 @@ def test_read_csv(session, mode):
             StructField("i", FloatType()),
             StructField("j", BooleanType()),
             StructField("k", DateType()),
-            StructField("l", TimestampType()),
+            # default timestamp type: https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping
+            StructField("l", TimestampType(TimestampTimeZone.NTZ)),
             StructField("m", TimeType()),
         ]
     )
@@ -309,7 +310,8 @@ def test_read_csv(session, mode):
             StructField("i", FloatType()),
             StructField("j", BooleanType()),
             StructField("k", DateType()),
-            StructField("l", TimestampType()),
+            # default timestamp type: https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping
+            StructField("l", TimestampType(TimestampTimeZone.NTZ)),
             StructField("m", TimeType()),
         ]
     )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-984111

executing inside SP is different than non-SP
the datetime will by default given a timestamp timezone NTZ
to align the behavior, we explicitly set the timestamp type

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
