### PR TITLE
SNOW-949781: Add Snowpark Package automatically for sprocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 - When parsing datatype during `to_pandas` operation, we rely on GS precision value to fix precision issue for large integer values. This may affect users where a column that was earlier returned as `int8` gets returned as `int64`. Users can fix this by explicitly specifying precision values for their return column.
 - Aligned behavior for `Session.call` in case of table stored procedures where running `Session.call` would not trigger stored procedure unless a `collect()` operation was performed.
-- `StoredProcedureRegistration` will now automatically add `snowflake-snowpark-python` as a package dependency. By default the lower of either the local version or the server version is used.
+- `StoredProcedureRegistration` will now automatically add `snowflake-snowpark-python` as a package dependency. The added dependency will be on the clients local version of the library and an error is thrown if the server cannot support that version.
 
 ## 1.11.1 (2023-12-07)
 
@@ -38,11 +38,7 @@
   - `from_utc_timestamp`
   - `to_utc_timestamp`
 
-<<<<<<< HEAD
 ## 1.11.0 (2023-12-05)
-=======
-## 1.11.0 (2023-11-05)
->>>>>>> bf110ad5 (Update CHANGELOG)
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@
   - `from_utc_timestamp`
   - `to_utc_timestamp`
 
+<<<<<<< HEAD
 ## 1.11.0 (2023-12-05)
+=======
+## 1.11.0 (2023-11-05)
+>>>>>>> bf110ad5 (Update CHANGELOG)
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - When parsing datatype during `to_pandas` operation, we rely on GS precision value to fix precision issue for large integer values. This may affect users where a column that was earlier returned as `int8` gets returned as `int64`. Users can fix this by explicitly specifying precision values for their return column.
 - Aligned behavior for `Session.call` in case of table stored procedures where running `Session.call` would not trigger stored procedure unless a `collect()` operation was performed.
+- `StoredProcedureRegistration` will now automatically add `snowflake-snowpark-python` as a package dependency. By default the lower of either the local version or the server version is used.
 
 ## 1.11.1 (2023-12-07)
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1217,8 +1217,10 @@ class Session:
                 current_packages[package_name] = package
 
         # Raise all exceptions at once so users know all issues in a single invocation.
-        if len(errors) > 0:
-            raise Exception(errors)
+        if len(errors) == 1:
+            raise errors[0]
+        elif len(errors) > 0:
+            raise RuntimeError(errors)
 
         dependency_packages: List[pkg_resources.Requirement] = []
         if len(unsupported_packages) != 0:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1114,14 +1114,13 @@ class Session:
             package_dict[package] = (package_name, use_local_version, package_req)
         return package_dict
 
-    def _get_dependcy_packages(
+    def _get_dependency_packages(
         self,
         package_dict: Dict[str, Tuple[str, bool, pkg_resources.Requirement]],
         validate_package: bool,
         package_table: str,
         current_packages: Dict[str, str],
     ) -> (List[Exception], Any):
-
         # Keep track of any package errors
         errors = []
 
@@ -1295,7 +1294,7 @@ class Session:
         )
 
         # Retrieve list of dependencies that need to be added
-        dependency_packages = self._get_dependcy_packages(
+        dependency_packages = self._get_dependency_packages(
             package_dict, validate_package, package_table, result_dict
         )
 
@@ -2738,8 +2737,6 @@ class Session:
 
             >>> import snowflake.snowpark
             >>> from snowflake.snowpark.functions import sproc
-            >>>
-            >>> session.add_packages('snowflake-snowpark-python')
             >>>
             >>> @sproc(name="my_copy_sp", replace=True)
             ... def my_copy(session: snowflake.snowpark.Session, from_table: str, to_table: str, count: int) -> str:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2740,6 +2740,8 @@ class Session:
             >>> import snowflake.snowpark
             >>> from snowflake.snowpark.functions import sproc
             >>>
+            >>> session.add_packages('snowflake-snowpark-python')
+            >>>
             >>> @sproc(name="my_copy_sp", replace=True)
             ... def my_copy(session: snowflake.snowpark.Session, from_table: str, to_table: str, count: int) -> str:
             ...     session.table(from_table).limit(count).write.save_as_table(to_table)

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -321,13 +321,21 @@ def test_add_packages_negative(session, caplog):
         with pytest.raises(RuntimeError, match="Cannot add package dateutil"):
             session.add_packages("dateutil")
 
+    # Verify multiple errors can be raised at once
+    with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: False):
+        with pytest.raises(
+            RuntimeError,
+            match="Cannot add package dateutil.*Cannot add package functools",
+        ):
+            session.add_packages("dateutil", "functools")
+
     with pytest.raises(ValueError, match="is already added"):
         with caplog.at_level(logging.WARNING):
             # using numpy version 1.16.6 here because using any other version raises a
             # ValueError for "non-existent python version in Snowflake" instead of
             # "package is already added".
             # In case this test fails in the future, choose a version of numpy which
-            # is supportezd by Snowflake using query:
+            # is supported by Snowflake using query:
             #     select package_name, array_agg(version)
             #     from information_schema.packages
             #     where language='python' and package_name like 'numpy'

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -109,7 +109,7 @@ def test_add_packages_failures(packages, should_fail, db_parameters):
                 return_type=StringType(),
                 packages=packages,
             )
-            assert return1_sproc == "1"
+            assert return1_sproc(session=new_session) == "1"
 
 
 @patch(

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -103,12 +103,13 @@ def test_add_packages_failures(packages, should_fail, db_parameters):
                     packages=packages,
                 )
         else:
-            sproc(
+            return1_sproc = sproc(
                 return1,
                 session=new_session,
                 return_type=StringType(),
                 packages=packages,
             )
+            assert return1_sproc == "1"
 
 
 @patch(

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -47,7 +47,6 @@ from snowflake.snowpark.types import (
     StructField,
     StructType,
 )
-from snowflake.snowpark.version import VERSION
 from tests.utils import (
     IS_IN_STORED_PROC,
     IS_NOT_ON_GITHUB,
@@ -74,6 +73,7 @@ def setup(session, resources_path, local_testing_mode):
     )
 
 
+@patch("snowflake.snowpark.stored_procedure.VERSION", (999, 9, 9))
 def test_add_packages_failures(session):
     # Save off a list of packages other tests may need
     stored_packages = list(session.get_packages().values())
@@ -118,11 +118,12 @@ def test_add_packages_failures(session):
     "snowflake.snowpark.stored_procedure.resolve_imports_and_packages",
     wraps=resolve_imports_and_packages,
 )
+@patch("snowflake.snowpark.stored_procedure.VERSION", (999, 9, 9))
 def test__do_register_sp_submits_correct_packages(patched_resolve, session):
     # Save off a list of packages other tests may need
     stored_packages = list(session.get_packages().values())
 
-    major, minor, patch = VERSION
+    major, minor, patch = (999, 9, 9)
     this_package = f"snowflake-snowpark-python=={major}.{minor}.{patch}"
 
     def return1(session_):

--- a/tests/unit/test_stored_procedure.py
+++ b/tests/unit/test_stored_procedure.py
@@ -34,6 +34,7 @@ def test_stored_procedure_execute_as(execute_as):
     fake_session._plan_builder = SnowflakePlanBuilder(fake_session)
     fake_session._analyzer = Analyzer(fake_session)
     fake_session._runtime_version_from_requirement = None
+    fake_session._packages = {}
 
     def return1(_):
         return 1
@@ -76,6 +77,7 @@ def test_do_register_sp_negative(cleanup_registration_patch):
     )
     fake_session._run_query = mock.Mock(side_effect=ProgrammingError())
     fake_session.sproc = StoredProcedureRegistration(fake_session)
+    fake_session._packages = {}
     with pytest.raises(SnowparkSQLException) as ex_info:
         sproc(lambda: 1, session=fake_session, return_type=IntegerType(), packages=[])
     assert ex_info.value.error_code == "1304"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-949781

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

As part of this change I had to understand `Session._resolve_packages`. This method was overly long so as part of this commit I broke it up into smaller chunks to make it a little more understandable. I also modified the exception logic for that function so that errors are gathered for all packages rather than failing on the first erroneous package. If this sort of refactor is better pulled into a separate commit I can remove it from this one.

After understanding that method it seemed easier to modify the sproc method that registers functions instead of adding another parameter to the resolve packages function. I've removed all sproc references to `session.add_packages('snowflake-snowpark-python')` which causes those tests to fail before this change.