### PR TITLE
SNOW-971157: Add additional parameters to Session.add_import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.12.0 (TBD)
 
-### Behavior change
+### New Features
 
 - Added two optional arguments to `Session.add_import`.
   - `chunk_size`: The number of bytes to hash per chunk of the uploaded files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.12.0 (TBD)
+
+### Behavior change
+
+- Added two optional arguments to `Session.add_import`.
+  - `chunk_size`: The number of bytes to hash per chunk of the uploaded files.
+  - `whole_file_hash`: By default only the first chunk of the uploaded import is hashed to save time. When this is set to True each uploaded file is fully hashed instead.
+
 ## 1.11.1 (2023-11-07)
 
 ### Bug Fixes

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -453,7 +453,7 @@ def calculate_checksum(
                 if whole_file_hash:
                     _hash_file(hash_algo, filename, chunk_size, whole_file_hash)
                     current_size += file_size
-                if current_size < chunk_size:
+                elif current_size < chunk_size:
                     read_size = min(file_size, chunk_size - current_size)
                     current_size += read_size
                     _hash_file(hash_algo, filename, read_size, False)

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -73,6 +73,30 @@ def test_calculate_checksum():
         calculate_checksum(test_files.test_file_avro)
         == "3317ed5a935104274f4c7ae12b81fac063ed252570876e3f535cd8e13d8cbbb8"
     )
+
+    # Check that a smaller chunk size returns a different size on a sufficiently larger file
+    # Default Chunk Size
+    assert (
+        calculate_checksum(test_files.test_file_with_special_characters_parquet)
+        == "45128082344751b0e35f3c4d07108a42064d2326029e7fca08a7ceb0053ead9f"
+    )
+    # Smaller Chunk Size
+    assert (
+        calculate_checksum(
+            test_files.test_file_with_special_characters_parquet, chunk_size=1024
+        )
+        == "83c9e09fcadca8637e5c29870d996dc3ef5acfc9f838ae8ae1cd1fdbae86e2dc"
+    )
+    # Read whole file
+    assert (
+        calculate_checksum(
+            test_files.test_file_with_special_characters_parquet,
+            chunk_size=1024,
+            whole_file_hash=True,
+        )
+        == "f7bb6ba7de6d458945831882d34937d9f157ccd3186423a4e70b608292ae1cef"
+    )
+
     assert (
         calculate_checksum(test_files.test_file_avro, algorithm="md5")
         == "85bd7b9363853f1815254b1cbc608c22"
@@ -94,6 +118,18 @@ def test_calculate_checksum():
         assert (
             calculate_checksum(test_files.test_udf_directory, algorithm="md5")
             == "728a79922e1b869dc9578c4f8d51cc73"
+        )
+        # Validate that hashes are different when reading whole dir.
+        # Using a sufficiently small chunk size so that the hashes differ.
+        assert (
+            calculate_checksum(test_files.test_udf_directory, chunk_size=128)
+            == "c79d76b72bbbc2eaa149bd5d0965296e45323125cb71f3c5a4c63c1f732f9f24"
+        )
+        assert (
+            calculate_checksum(
+                test_files.test_udf_directory, chunk_size=128, whole_file_hash=True
+            )
+            == "83582388fa5d2b2f0a71666bca88a8f11a6c0d40b20096c8aeb2fccf113d3ca6"
         )
 
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-971157

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR adds a couple extra parameters to the `Session.add_import` method. These parameters allow the user to specify a specific chunk size when adding an import. A larger chunk_size can be useful when files start to get larger. A second parameter allows the user to specify that the entire file should be hashed. In this case it will be read one chunk at a time with the hashing algorithm updated each time.

I've left the default behavior of the the `calculate_checksum` alone, but it might be worth changing it to hash at least one chunk of each file in a folder instead of stopping after the total amount of file read is the chunk size.