### PR TITLE
Update CHANGELOG.md to reflect the correct release dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Release History
 
-## 1.11.1 (2023-11-07)
+## 1.11.1 (2023-12-07)
 
 ### Bug Fixes
 
 - Fixed a bug that numpy should not be imported at the top level of mock module.
 
-## 1.11.0 (2023-11-05)
+## 1.11.0 (2023-12-05)
 
 ### New Features
 


### PR DESCRIPTION
We mistakenly put 11-xx for the last two release dates happened in December, this PR corrects the dates.