### PR TITLE
Fix type hints for src/snowflake/snowpark/_internal/packaging_utils.py, code_generation.py error_message.py server_connection.py

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,18 +1,20 @@
 [mypy]
 follow_imports = silent
 
-[mypy-snowflake.connector.vendored.*]
-ignore_errors = True
-ignore_missing_imports = True
-
 [mypy-test.parameters]
 ignore_errors = True
 
-[mypy-pyarrow.*]
+[mypy-yaml.*]
 ignore_missing_imports = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True
 
 [mypy-cloudpickle.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-pkg_resources.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,8 @@ setup(
             "sphinx==5.0.2",
             "cachetools",  # used in UDF doctest
             "pytest-timeout",
+            "types-PyYAML",
+            "types-setuptools",
         ],
         "localtest": [
             "pandas",

--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -12,8 +12,8 @@ import sys
 import textwrap
 from collections import defaultdict, namedtuple
 from logging import getLogger
-from types import BuiltinFunctionType, Callable, CodeType, FunctionType, ModuleType
-from typing import Any, Dict, List, Set, Tuple, Union
+from types import BuiltinFunctionType, CodeType, FunctionType, ModuleType
+from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 import opcode
 

--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -40,15 +40,17 @@ CODE_HEADER = """\
 from __future__ import annotations
 import pickle
 """
-ImportNameAliasPair = namedtuple("ImportNameAliasPair", "name alias", defaults=[""] * 2)
+ImportNameAliasPair = namedtuple("ImportNameAliasPair", "name alias", defaults=["", ""])
 ClassCodeGeneration = namedtuple(
     "ClassCodeGeneration", "class_object, generate_code", defaults=[None, True]
 )
 
 
-def get_func_references(func: FunctionType, ref_objects: Dict[str, Any]) -> None:
+def get_func_references(
+    func: Union[FunctionType, Callable], ref_objects: Dict[str, Any]
+) -> None:
     """
-    Get the objects references by target func, they could be methods, modules, classes, methods, global variables
+    Get the objects references by target func, they could be methods, modules, classes, global variables
     and its closures.
     This method will update the input ref_objects.
 
@@ -385,6 +387,9 @@ def get_lambda_code_text(code_text: str) -> str:
     # session.udf.register(
     #    lambda x, y:\
     #    x + y, ...)
+    assert (
+        lambda_node.end_lineno is not None
+    ), f"end_lineno is None for lambda function {lambda_node}"
     for line_idx in range(lambda_node.lineno - 1, lambda_node.end_lineno):
         line = lines[line_idx]
         if line_idx == 0:
@@ -450,7 +455,7 @@ def extract_submodule_imports(
 
 
 def find_target_func_objects_references(
-    func: Union[FunctionType, BuiltinFunctionType],
+    func: Union[FunctionType, BuiltinFunctionType, Callable],
     to_import: Set[ImportNameAliasPair],
     ref_objects: Dict[str, Any],
     classes_to_generate: List[type],
@@ -487,7 +492,7 @@ def find_target_func_objects_references(
 
 
 def resolve_target_func_referenced_objects_by_type(
-    func: Union[FunctionType, BuiltinFunctionType],
+    func: Union[FunctionType, BuiltinFunctionType, Callable],
     to_import: Set[ImportNameAliasPair],
     to_import_from_module: Dict[str, Set[ImportNameAliasPair]],
     ref_objects: Dict[str, Any],
@@ -593,7 +598,7 @@ def resolve_target_func_imports(
 
 
 def handle_target_func_self_source_code(
-    func: Union[FunctionType, BuiltinFunctionType],
+    func: Union[FunctionType, BuiltinFunctionType, Callable],
     source_code_without_target_func: str,
     code_as_comment: bool,
 ) -> Tuple[str, str]:

--- a/src/snowflake/snowpark/_internal/code_generation.py
+++ b/src/snowflake/snowpark/_internal/code_generation.py
@@ -12,8 +12,8 @@ import sys
 import textwrap
 from collections import defaultdict, namedtuple
 from logging import getLogger
-from types import BuiltinFunctionType, CodeType, FunctionType, ModuleType
-from typing import Any, Callable, Dict, List, Set, Tuple, Union
+from types import BuiltinFunctionType, Callable, CodeType, FunctionType, ModuleType
+from typing import Any, Dict, List, Set, Tuple, Union
 
 import opcode
 

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -316,13 +316,17 @@ class SnowparkClientExceptionMessages:
     def SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
         pe: ProgrammingError,
     ) -> SnowparkSQLException:
-        return SnowparkSQLException(pe.msg, error_code="1304", conn_error=pe)
+        return SnowparkSQLException(
+            pe.msg or "Unknown Error", error_code="1304", conn_error=pe
+        )
 
     @staticmethod
     def SQL_EXCEPTION_FROM_OPERATIONAL_ERROR(
         oe: OperationalError,
     ) -> SnowparkSQLException:
-        return SnowparkSQLException(oe.msg, error_code="1305", conn_error=oe)
+        return SnowparkSQLException(
+            oe.msg or "Unknown Error", error_code="1305", conn_error=oe
+        )
 
     # Server Error Messages 04XX
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -62,8 +62,8 @@ from snowflake.snowpark.query_history import QueryHistory, QueryRecord
 from snowflake.snowpark.row import Row
 
 if TYPE_CHECKING:
-    if TYPE_CHECKING:
-        import pandas as pd
+    import pandas as pd
+
     try:
         from snowflake.connector.cursor import ResultMetadataV2
     except ImportError:
@@ -465,7 +465,7 @@ class ServerConnection:
         log_on_exception: bool = False,
         case_sensitive: bool = True,
         **kwargs,
-    ) -> Union[List[Row], pd.DataFrame, Iterator[Row], Iterator[pd.DataFrame]]:
+    ) -> Union[List[Row], "pd.DataFrame", Iterator[Row], Iterator["pd.DataFrame"]]:
         if (
             is_in_stored_procedure()
             and not block

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -62,10 +62,14 @@ from snowflake.snowpark.query_history import QueryHistory, QueryRecord
 from snowflake.snowpark.row import Row
 
 if TYPE_CHECKING:
+    if TYPE_CHECKING:
+        import pandas as pd
     try:
         from snowflake.connector.cursor import ResultMetadataV2
     except ImportError:
-        ResultMetadataV2 = ResultMetadata
+        from snowflake.connector.cursor import (  # type: ignore
+            ResultMetadata as ResultMetadataV2,
+        )
 
 logger = getLogger(__name__)
 
@@ -152,7 +156,9 @@ class ServerConnection:
         options: Dict[str, Union[int, str]],
         conn: Optional[SnowflakeConnection] = None,
     ) -> None:
-        self._lower_case_parameters = {k.lower(): v for k, v in options.items()}
+        self._lower_case_parameters: Dict[str, Union[int, str, None]] = {
+            k.lower(): v for k, v in options.items()
+        }
         self._add_application_name()
         self._conn = conn if conn else connect(**self._lower_case_parameters)
         if "password" in self._lower_case_parameters:
@@ -243,9 +249,10 @@ class ServerConnection:
             target_path = _build_target_path(stage_location, dest_prefix)
             try:
                 # upload_stream directly consume stage path, so we don't need to normalize it
-                self._cursor.upload_stream(
+                self._cursor.upload_stream(  # type: ignore
                     open(path, "rb"), f"{target_path}/{file_name}"
                 )
+                return None
             except ProgrammingError as pe:
                 tb = sys.exc_info()[2]
                 ne = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
@@ -292,9 +299,10 @@ class ServerConnection:
                 target_path = _build_target_path(stage_location, dest_prefix)
                 try:
                     # upload_stream directly consume stage path, so we don't need to normalize it
-                    self._cursor.upload_stream(
+                    self._cursor.upload_stream(  # type: ignore
                         input_stream, f"{target_path}/{dest_filename}"
                     )
+                    return None
                 except ProgrammingError as pe:
                     tb = sys.exc_info()[2]
                     ne = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
@@ -396,6 +404,7 @@ class ServerConnection:
                 results_cursor=results_cursor, to_pandas=to_pandas, to_iter=to_iter
             )
         else:
+            assert async_job_plan is not None
             return AsyncJob(
                 results_cursor["queryId"],
                 query,
@@ -456,9 +465,7 @@ class ServerConnection:
         log_on_exception: bool = False,
         case_sensitive: bool = True,
         **kwargs,
-    ) -> Union[
-        List[Row], "pandas.DataFrame", Iterator[Row], Iterator["pandas.DataFrame"]
-    ]:
+    ) -> Union[List[Row], pd.DataFrame, Iterator[Row], Iterator[pd.DataFrame]]:
         if (
             is_in_stored_procedure()
             and not block
@@ -505,23 +512,14 @@ class ServerConnection:
         case_sensitive: bool = True,
         **kwargs,
     ) -> Tuple[
-        Dict[
-            str,
-            Union[
-                List[Any],
-                "pandas.DataFrame",
-                SnowflakeCursor,
-                Iterator["pandas.DataFrame"],
-                str,
-            ],
-        ],
-        Union[List[ResultMetadata], List["ResultMetadataV2"]],
+        Dict[str, Any],
+        Union[List[ResultMetadata], List["ResultMetadataV2"], None],
     ]:
         action_id = plan.session._generate_new_action_id()
 
         result, result_meta = None, None
         try:
-            placeholders = {}
+            placeholders: Dict[str, Any] = {}
             is_batch_insert = False
             for q in plan.queries:
                 if isinstance(q, BatchInsertQuery):
@@ -529,7 +527,7 @@ class ServerConnection:
                     break
             # since batch insert does not support async execution (? in the query), we handle it separately here
             if len(plan.queries) > 1 and not block and not is_batch_insert:
-                params = []
+                params: List[Any] = []
                 final_queries = []
                 last_place_holder = None
                 for q in plan.queries:
@@ -637,16 +635,31 @@ class ServerConnection:
             set_query_tag_cursor = self._cursor.execute(
                 f"alter session set query_tag = {str_to_sql(query_tag)}"
             )
+            assert (
+                set_query_tag_cursor is not None
+                and set_query_tag_cursor.sfqid is not None
+                and set_query_tag_cursor.query is not None
+            )
             self.notify_query_listeners(
                 QueryRecord(set_query_tag_cursor.sfqid, set_query_tag_cursor.query)
             )
         results_cursor = self._cursor.executemany(query, params)
+        assert (
+            results_cursor is not None
+            and results_cursor.sfqid is not None
+            and results_cursor.query is not None
+        )
         self.notify_query_listeners(
             QueryRecord(results_cursor.sfqid, results_cursor.query)
         )
         if query_tag:
             unset_query_tag_cursor = self._cursor.execute(
                 "alter session unset query_tag"
+            )
+            assert (
+                unset_query_tag_cursor is not None
+                and unset_query_tag_cursor.sfqid is not None
+                and unset_query_tag_cursor.query is not None
             )
             self.notify_query_listeners(
                 QueryRecord(unset_query_tag_cursor.sfqid, unset_query_tag_cursor.query)
@@ -665,8 +678,8 @@ class ServerConnection:
 
 
 def _fix_pandas_df_integer(
-    pd_df: "pandas.DataFrame", results_cursor: SnowflakeCursor
-) -> "pandas.DataFrame":
+    pd_df: "pd.DataFrame", results_cursor: SnowflakeCursor
+) -> "pd.DataFrame":
     """The compiler does not make any guarantees about the return types - only that they will be large enough for the result.
     As a result, the ResultMetadata may contain precision=38, scale=0 for result of a column which may only contain single
     digit numbers. Then the returned pandas DataFrame has dtype "object" with a str value for that column instead of int64.

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -314,7 +314,7 @@ def int_size_to_type(size: int) -> Optional[Type[DataType]]:
         return IntegerType
     if size <= 64:
         return LongType
-    raise ValueError(f"Size of {size} is unsupported.")
+    return None
 
 
 # The list of all supported array typecodes, is stored here

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -314,7 +314,7 @@ def int_size_to_type(size: int) -> Optional[Type[DataType]]:
         return IntegerType
     if size <= 64:
         return LongType
-    return None
+    raise ValueError(f"Size of {size} is unsupported.")
 
 
 # The list of all supported array typecodes, is stored here
@@ -669,6 +669,7 @@ def retrieve_func_type_hints_from_source(
         if isinstance(annotation, ast.Subscript):
             return f"{parse_arg_annotation(annotation.value)}[{parse_arg_annotation(annotation.slice)}]"
         if isinstance(annotation, ast.Index):
+            assert hasattr(annotation, "value")
             return parse_arg_annotation(annotation.value)
         if isinstance(annotation, ast.Constant) and annotation.value is None:
             return "NoneType"

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -22,7 +22,7 @@ from typing import (
     get_type_hints,
 )
 
-import cloudpickle
+import cloudpickle  # type: ignore
 
 import snowflake.snowpark
 from snowflake.connector.options import installed_pandas, pandas

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -458,10 +458,10 @@ def create_or_update_statement_params_with_query_tag(
     statement_params: Optional[Dict[str, str]] = None,
     exists_session_query_tag: Optional[str] = None,
     skip_levels: int = 0,
-) -> Dict[str, str]:
+) -> Optional[Dict[str, str]]:
     ret = statement_params or {}
     if exists_session_query_tag or QUERY_TAG_STRING in ret:
-        return ret
+        return statement_params
 
     # as create_statement_query_tag is called by the method, skip_levels needs to +1 to skip the current call
     ret[QUERY_TAG_STRING] = create_statement_query_tag(skip_levels + 1)

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -458,10 +458,10 @@ def create_or_update_statement_params_with_query_tag(
     statement_params: Optional[Dict[str, str]] = None,
     exists_session_query_tag: Optional[str] = None,
     skip_levels: int = 0,
-) -> Optional[Dict[str, str]]:
+) -> Dict[str, str]:
     ret = statement_params or {}
     if exists_session_query_tag or QUERY_TAG_STRING in ret:
-        return statement_params
+        return ret
 
     # as create_statement_query_tag is called by the method, skip_levels needs to +1 to skip the current call
     ret[QUERY_TAG_STRING] = create_statement_query_tag(skip_levels + 1)

--- a/tox.ini
+++ b/tox.ini
@@ -132,7 +132,15 @@ commands = pyright src/snowflake/snowpark/_internal/analyzer
 [testenv:mypy]
 description = static type checking with mypy, configuration aligned with python connector
 deps = mypy
-commands = mypy --config-file mypy.ini src/snowflake/snowpark/_internal/telemetry.py src/snowflake/snowpark/_internal/type_utils.py src/snowflake/snowpark/_internal/udf_utils.py src/snowflake/snowpark/_internal/utils.py
+commands = mypy --config-file mypy.ini \
+                src/snowflake/snowpark/_internal/telemetry.py \
+                src/snowflake/snowpark/_internal/type_utils.py \
+                src/snowflake/snowpark/_internal/udf_utils.py \
+                src/snowflake/snowpark/_internal/utils.py \
+                src/snowflake/snowpark/_internal/code_generation.py \
+                src/snowflake/snowpark/_internal/error_message.py \
+                src/snowflake/snowpark/_internal/packaging_utils.py \
+                src/snowflake/snowpark/_internal/server_connection.py
 
 [testenv:dev]
 description = create dev environment


### PR DESCRIPTION
This PR fix the type hints in 
- src/snowflake/snowpark/_internal/packaging_utils.py
- src/snowflake/snowpark/_internal/code_generation.py 
- src/snowflake/snowpark/_internal/error_message.py
- src/snowflake/snowpark/_internal/server_connection.py

such that

`tox -e mypy` pass with no errors.