### PR TITLE
SNOW-990324: Fix inconsistency when calling na.fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.12.0 (TBD)
+
+### Bug Fixes
+- Fixed a bug in `DataFrame.na.fill` that caused Boolean values to erroneously override integer values.
+
+
 ## 1.11.1 (2023-11-07)
 
 ### Bug Fixes

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -236,54 +236,15 @@ class DataFrameNaFunctions:
 
         Examples::
 
-            >>> df = session.create_dataframe([[1.0, 1], [float('nan'), 2], [None, 3], [4.0, None], [float('nan'), None]]).to_df("a", "b")
-            >>> # fill null and NaN values in all columns
-            >>> df.na.fill(3.14).show()
+            >>> df2 = session.create_dataframe([[1.0, True], [2.0, False], [None, None]]).to_df("a", "b")
+            >>> df2.na.fill(lit(True)).show()
             ---------------
             |"A"   |"B"   |
             ---------------
-            |1.0   |1     |
-            |3.14  |2     |
-            |3.14  |3     |
-            |4.0   |NULL  |
-            |3.14  |NULL  |
+            |1.0   |True  |
+            |2.0   |False |
+            |None  |True  |
             ---------------
-            <BLANKLINE>
-            >>> # fill null and NaN values in column "a"
-            >>> df.na.fill(3.14, subset="a").show()
-            ---------------
-            |"A"   |"B"   |
-            ---------------
-            |1.0   |1     |
-            |3.14  |2     |
-            |3.14  |3     |
-            |4.0   |NULL  |
-            |3.14  |NULL  |
-            ---------------
-            <BLANKLINE>
-            >>> # fill null and NaN values in column "a"
-            >>> df.na.fill({"a": 3.14}).show()
-            ---------------
-            |"A"   |"B"   |
-            ---------------
-            |1.0   |1     |
-            |3.14  |2     |
-            |3.14  |3     |
-            |4.0   |NULL  |
-            |3.14  |NULL  |
-            ---------------
-            <BLANKLINE>
-            >>> # fill null and NaN values in column "a" and "b"
-            >>> df.na.fill({"a": 3.14, "b": 15}).show()
-            --------------
-            |"A"   |"B"  |
-            --------------
-            |1.0   |1    |
-            |3.14  |2    |
-            |3.14  |3    |
-            |4.0   |15   |
-            |3.14  |15   |
-            --------------
             <BLANKLINE>
 
         Note:
@@ -353,6 +314,7 @@ class DataFrameNaFunctions:
             if col_name in normalized_value_dict:
                 value = normalized_value_dict[col_name]
                 if _is_value_type_matching_for_na_function(value, datatype):
+                    raise ValueError(locals())
                     if isinstance(datatype, (FloatType, DoubleType)):
                         # iff(col = 'NaN' or col is null, value, col)
                         res_columns.append(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-990324

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  Added an example to na.fill that breaks under current logic. With that example I traced execution and found that `_is_value_type_matching_for_na_function` was incorrectly including `bool` as a valid numeric type. Python counts [bool](https://docs.python.org/3/c-api/bool.html)s as integers, but we don't want it to count as a numeric type so I've added an additional clause to the condition that checks if the datatype is numeric.