### PR TITLE
SNOW-940607: use precision value to decide when to use astype(int64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@
 
 ### Bug Fixes
 
-- Fixed a bug in fixing datatype for integers during `to_pandas` to rely on GS precision value and use pandas `astype('int64')` where necessary.
 - Fixed a bug in `DataFrame.na.fill` that caused Boolean values to erroneously override integer values.
 - Fixed sql simplifier for filter with window function columns in select.
+
+### Behavior Changes (API Compatible)
+
+- When parsing datatype during `to_pandas` operation, we rely on GS precision value to fix precision issue for large integer values. This may affect users where a column that was earlier returned as `int8` gets returned as `int64`. Users can fix this by explicitly specifying precision values for their return column.
 
 ## 1.11.1 (2023-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.12.0 (TBD)
+
+### Bug Fixes
+
+- Fixed a bug in fixing datatype for integers during `to_pandas` to rely on GS precision value and use pandas `astype('int64')` where necessary.
+
 ## 1.11.1 (2023-12-07)
 
 ### Bug Fixes

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -681,12 +681,16 @@ def _fix_pandas_df_integer(
         if (
             FIELD_ID_TO_NAME.get(column_metadata.type_code) == "FIXED"
             and column_metadata.precision is not None
-            and column_metadata.precision > 10
             and column_metadata.scale == 0
             and not str(pandas_dtype).startswith("int")
         ):
             try:
-                pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
+                if column_metadata.precision > 10:
+                    pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
+                else:
+                    pd_df[pandas_col_name] = pandas.to_numeric(
+                        pd_df[pandas_col_name], downcast="integer"
+                    )
             except OverflowError:
                 pd_df[pandas_col_name] = pandas.to_numeric(
                     pd_df[pandas_col_name], downcast="integer"

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -685,7 +685,12 @@ def _fix_pandas_df_integer(
             and not str(pandas_dtype).startswith("int")
         ):
             try:
-                if column_metadata.precision > 10:
+                # When scale = 0 and precision values are between 10-20, the integers fit into int64.
+                # If we rely only on pandas.to_numeric, it loses precision value on large integers, therefore
+                # we try to strictly use astype("int64") in this scenario. If the values are too large to
+                # fit in int64, an OverflowError is thrown and we rely on to_numeric to choose and appropriate
+                # floating datatype to represent the number.
+                if column_metadata.precision > 10 and column_metadata.precision < 20:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
                 else:
                     pd_df[pandas_col_name] = pandas.to_numeric(

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -684,19 +684,19 @@ def _fix_pandas_df_integer(
             and column_metadata.scale == 0
             and not str(pandas_dtype).startswith("int")
         ):
-            try:
-                # When scale = 0 and precision values are between 10-20, the integers fit into int64.
-                # If we rely only on pandas.to_numeric, it loses precision value on large integers, therefore
-                # we try to strictly use astype("int64") in this scenario. If the values are too large to
-                # fit in int64, an OverflowError is thrown and we rely on to_numeric to choose and appropriate
-                # floating datatype to represent the number.
-                if column_metadata.precision > 10:
+            # When scale = 0 and precision values are between 10-20, the integers fit into int64.
+            # If we rely only on pandas.to_numeric, it loses precision value on large integers, therefore
+            # we try to strictly use astype("int64") in this scenario. If the values are too large to
+            # fit in int64, an OverflowError is thrown and we rely on to_numeric to choose and appropriate
+            # floating datatype to represent the number.
+            if column_metadata.precision > 10:
+                try:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
-                else:
+                except OverflowError:
                     pd_df[pandas_col_name] = pandas.to_numeric(
                         pd_df[pandas_col_name], downcast="integer"
                     )
-            except OverflowError:
+            else:
                 pd_df[pandas_col_name] = pandas.to_numeric(
                     pd_df[pandas_col_name], downcast="integer"
                 )

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -690,7 +690,7 @@ def _fix_pandas_df_integer(
                 # we try to strictly use astype("int64") in this scenario. If the values are too large to
                 # fit in int64, an OverflowError is thrown and we rely on to_numeric to choose and appropriate
                 # floating datatype to represent the number.
-                if column_metadata.precision > 10 and column_metadata.precision < 20:
+                if column_metadata.precision > 10:
                     pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
                 else:
                     pd_df[pandas_col_name] = pandas.to_numeric(

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -614,9 +614,12 @@ def _fix_pandas_df_integer(table_res: TableEmulator) -> "pandas.DataFrame":
             else:
                 pd_df[pd_df_col_name] = table_res[col_name].astype("int64")
         elif isinstance(col_sf_type.datatype, _IntegralType):
-            pd_df[pd_df_col_name] = pandas.to_numeric(
-                table_res[col_name].tolist(), downcast="integer"
-            )
+            try:
+                pd_df[pd_df_col_name] = table_res[col_name].astype("int64")
+            except OverflowError:
+                pd_df[pd_df_col_name] = pandas.to_numeric(
+                    table_res[col_name].tolist(), downcast="integer"
+                )
         else:
             pd_df[pd_df_col_name] = table_res[col_name].tolist()
 

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -63,7 +63,7 @@ def test_to_pandas_cast_integer(session, to_pandas_api, local_testing_mode):
         col("a").cast(DecimalType(4, 0)),
         col("a").cast(DecimalType(6, 0)),
         col("a").cast(DecimalType(18, 0)),
-        col("a").cast(IntegerType()),
+        col("a").cast(IntegerType()),  # equivalent to NUMBER(38,0)
         col("a"),
         col("b").cast(IntegerType()),
     )
@@ -77,8 +77,8 @@ def test_to_pandas_cast_integer(session, to_pandas_api, local_testing_mode):
     assert str(pandas_df.dtypes[2]) == "int32"
     assert str(pandas_df.dtypes[3]) == "int64"
     assert (
-        str(pandas_df.dtypes[4]) == "int8"
-    )  # When static type can possibly be greater than int64 max, use the actual value to infer the int type.
+        str(pandas_df.dtypes[4]) == "int64"
+    )  # When limits are not explicitly defined, rely on metadata information from GS.
     assert (
         str(pandas_df.dtypes[5]) == "object"
     )  # No cast so it's a string. dtype is "object".

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1775,14 +1775,14 @@ def test_pandas_udf_input_variant(session):
         (
             IntegerType,
             [[4096]],
-            ("<class 'numpy.int16'>", "<class 'int'>"),
-            ("int16", "object"),
+            ("<class 'numpy.int16'>", "<class 'numpy.int64'>", "<class 'int'>"),
+            ("int16", "int64", "object"),
         ),
         (
             IntegerType,
             [[1048576]],
-            ("<class 'numpy.int32'>", "<class 'int'>", "<class 'numpy.intc'>"),
-            ("int32", "object"),
+            ("<class 'numpy.int32'>", "<class 'numpy.int64'>", "<class 'int'>", "<class 'numpy.intc'>"),
+            ("int32", "int64", "object"),
         ),
         (
             IntegerType,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-940607

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In this PR, we update `_fix_pandas_df_integer` to use `astype('int64')` for cases where the precision value sent by GS is greater than 10. This is done to fix the loss of precision when using `pandas.to_numeric` for long numbers.
