### PR TITLE
[SNOW-1000455]: Fixing return type hints in DataFrameNaFunctions

### DIFF
--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -60,7 +60,7 @@ def _is_value_type_matching_for_na_function(
 class DataFrameNaFunctions:
     """Provides functions for handling missing values in a :class:`DataFrame`."""
 
-    def __init__(self, df: "snowflake.snowpark.dataframe.DataFrame") -> None:
+    def __init__(self, df: "snowflake.snowpark.DataFrame") -> None:
         self._df = df
 
     def drop(
@@ -68,7 +68,7 @@ class DataFrameNaFunctions:
         how: str = "any",
         thresh: Optional[int] = None,
         subset: Optional[Union[str, Iterable[str]]] = None,
-    ) -> "snowflake.snowpark.dataframe.DataFrame":
+    ) -> "snowflake.snowpark.DataFrame":
         """
         Returns a new DataFrame that excludes all rows containing fewer than
         a specified number of non-null and non-NaN values in the specified
@@ -219,7 +219,7 @@ class DataFrameNaFunctions:
         self,
         value: Union[LiteralType, Dict[str, LiteralType]],
         subset: Optional[Union[str, Iterable[str]]] = None,
-    ) -> "snowflake.snowpark.dataframe.DataFrame":
+    ) -> "snowflake.snowpark.DataFrame":
         """
         Returns a new DataFrame that replaces all null and NaN values in the specified
         columns with the values provided.
@@ -400,7 +400,7 @@ class DataFrameNaFunctions:
         ],
         value: Optional[Union[LiteralType, Iterable[LiteralType]]] = None,
         subset: Optional[Iterable[str]] = None,
-    ) -> "snowflake.snowpark.dataframe.DataFrame":
+    ) -> "snowflake.snowpark.DataFrame":
         """
         Returns a new DataFrame that replaces values in the specified columns.
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1000455

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

 The PR corrects the `DataFrame` return type hint import path for all `DataFrameNaFunctions` class methods.
