### PR TITLE
pin pyright version so it doesn't break the merge gate with a new rel…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,7 @@ commands = pre-commit run
 
 [testenv:pyright]
 description = static type checking with pyright
-deps = pyright
+deps = pyright==1.1.338
 commands = pyright src/snowflake/snowpark/_internal/analyzer
 
 [testenv:dev]


### PR DESCRIPTION
Pin the pyright version so the merge gate won't be broken when a new version of pyright was released.
