### PR TITLE
SNOW-967725 Support array_except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@
   - `whole_file_hash`: By default only the first chunk of the uploaded import is hashed to save time. When this is set to True each uploaded file is fully hashed instead.
 - Added parameters `external_access_integrations` and `secrets` when creating a UDAF from Snowpark Python to allow integration with external access.
 - `SessionBuilder.getOrCreate` will now attempt to replace the singleton it returns when token expiration has been detected.
-- Added support for these new functions in `snowflake.snowpark.functions`:
+- Added support for new function(s) in `snowflake.snowpark.functions`:
   - `array_except`
-  - `array_except_dedup`
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - `whole_file_hash`: By default only the first chunk of the uploaded import is hashed to save time. When this is set to True each uploaded file is fully hashed instead.
 - Added parameters `external_access_integrations` and `secrets` when creating a UDAF from Snowpark Python to allow integration with external access.
 - `SessionBuilder.getOrCreate` will now attempt to replace the singleton it returns when token expiration has been detected.
+- Added support for these new functions in `snowflake.snowpark.functions`:
+  - `array_except`
+  - `array_except_dedup`
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3516,8 +3516,8 @@ def array_except(
 
     Example::
         >>> from snowflake.snowpark import Row
-        >>> df = session.create_dataframe([Row(["A", "B"], ["B", "C"])], schema=["a", "b"])
-        >>> df.select(array_except("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", "B"], ["B", "C"])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3526,8 +3526,8 @@ def array_except(
         |]         |
         ------------
         <BLANKLINE>
-        >>> df = session.create_dataframe([Row(["A", "B", "B", "B", "C"], ["B"])], schema=["a", "b"])
-        >>> df.select(array_except("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", "B", "B", "B", "C"], ["B"])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3539,8 +3539,8 @@ def array_except(
         |]         |
         ------------
         <BLANKLINE>
-        >>> df = session.create_dataframe([Row(["A", None, None], ["B", None])], schema=["a", "b"])
-        >>> df.select(array_except("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", None, None], ["B", None])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3550,8 +3550,8 @@ def array_except(
         |]         |
         ------------
         <BLANKLINE>
-        >>> df = session.create_dataframe([Row([{'a': 1, 'b': 2}, 1], [{'a': 1, 'b': 2}, 3])], schema=["a", "b"])
-        >>> df.select(array_except("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row([{'a': 1, 'b': 2}, 1], [{'a': 1, 'b': 2}, 3])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3560,8 +3560,8 @@ def array_except(
         |]         |
         ------------
         <BLANKLINE>
-        >>> df = session.create_dataframe([Row(["A", "B"], None)], schema=["a", "b"])
-        >>> df.select(array_except("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", "B"], None)], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3578,7 +3578,7 @@ def array_except_dedup(
     source_array: ColumnOrName, array_of_elements_to_exclude: ColumnOrName
 ) -> Column:
     """Returns a new ARRAY that contains the elements from one input ARRAY that are not in another input ARRAY, without
-    deplicate.
+    duplicates.
 
     The function is NULL-safe, meaning it treats NULLs as known values for comparing equality.
 
@@ -3588,10 +3588,14 @@ def array_except_dedup(
     For example, if source_array contains 5 elements with the value 'A' and array_of_elements_to_exclude contains 2
     elements with the value 'A', the returned array is empty.
 
+    Args:
+        source_array: An array that contains elements to be included in the new ARRAY.
+        array_of_elements_to_exclude: An array that contains elements to be excluded from the new ARRAY.
+
     Example::
         >>> from snowflake.snowpark import Row
-        >>> df = session.create_dataframe([Row(["A", "B"], ["B", "C"])], schema=["a", "b"])
-        >>> df.select(array_except_dedup("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", "B"], ["B", "C"])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except_dedup("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3600,8 +3604,8 @@ def array_except_dedup(
         |]         |
         ------------
         <BLANKLINE>
-        >>> df = session.create_dataframe([Row(["A", "B", "B", "B", "C"], ["B"])], schema=["a", "b"])
-        >>> df.select(array_except_dedup("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", "B", "B", "B", "C"], ["B"])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except_dedup("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------
@@ -3611,8 +3615,8 @@ def array_except_dedup(
         |]         |
         ------------
         <BLANKLINE>
-        >>> df = session.create_dataframe([Row(["A", None, None], ["B", None])], schema=["a", "b"])
-        >>> df.select(array_except_dedup("a", "b").alias("result")).show()
+        >>> df = session.create_dataframe([Row(["A", None, None], ["B", None])], schema=["source_array", "array_of_elements_to_exclude"])
+        >>> df.select(array_except_dedup("source_array", "array_of_elements_to_exclude").alias("result")).show()
         ------------
         |"RESULT"  |
         ------------

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3496,6 +3496,139 @@ def array_intersection(array1: ColumnOrName, array2: ColumnOrName) -> Column:
     return builtin("array_intersection")(a1, a2)
 
 
+def array_except(
+    source_array: ColumnOrName, array_of_elements_to_exclude: ColumnOrName
+) -> Column:
+    """Returns a new ARRAY that contains the elements from one input ARRAY that are not in another input ARRAY.
+
+    The function is NULL-safe, meaning it treats NULLs as known values for comparing equality.
+
+    ARRAY_EXCEPT compares arrays by using multi-set semantics (sometimes called “bag semantics”). If source_array
+    includes multiple copies of a value, the function only removes the number of copies of that value that are specified
+    in array_of_elements_to_exclude.
+
+    For example, if source_array contains 5 elements with the value 'A' and array_of_elements_to_exclude contains 2
+    elements with the value 'A', the returned array contains 3 elements with the value 'A'.
+
+    Args:
+        source_array: An array that contains elements to be included in the new ARRAY.
+        array_of_elements_to_exclude: An array that contains elements to be excluded from the new ARRAY.
+
+    Example::
+        >>> from snowflake.snowpark import Row
+        >>> df = session.create_dataframe([Row(["A", "B"], ["B", "C"])], schema=["a", "b"])
+        >>> df.select(array_except("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  "A"     |
+        |]         |
+        ------------
+        <BLANKLINE>
+        >>> df = session.create_dataframe([Row(["A", "B", "B", "B", "C"], ["B"])], schema=["a", "b"])
+        >>> df.select(array_except("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  "A",    |
+        |  "B",    |
+        |  "B",    |
+        |  "C"     |
+        |]         |
+        ------------
+        <BLANKLINE>
+        >>> df = session.create_dataframe([Row(["A", None, None], ["B", None])], schema=["a", "b"])
+        >>> df.select(array_except("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  "A",    |
+        |  null    |
+        |]         |
+        ------------
+        <BLANKLINE>
+        >>> df = session.create_dataframe([Row([{'a': 1, 'b': 2}, 1], [{'a': 1, 'b': 2}, 3])], schema=["a", "b"])
+        >>> df.select(array_except("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  1       |
+        |]         |
+        ------------
+        <BLANKLINE>
+        >>> df = session.create_dataframe([Row(["A", "B"], None)], schema=["a", "b"])
+        >>> df.select(array_except("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |NULL      |
+        ------------
+        <BLANKLINE>
+    """
+    array1 = _to_col_if_str(source_array, "array_except")
+    array2 = _to_col_if_str(array_of_elements_to_exclude, "array_except")
+    return builtin("array_except")(array1, array2)
+
+
+def array_except_dedup(
+    source_array: ColumnOrName, array_of_elements_to_exclude: ColumnOrName
+) -> Column:
+    """Returns a new ARRAY that contains the elements from one input ARRAY that are not in another input ARRAY, without
+    deplicate.
+
+    The function is NULL-safe, meaning it treats NULLs as known values for comparing equality.
+
+    ARRAY_EXCEPT_DEDUP compares arrays by using set semantics. Specifically, it will first do an element deduplication
+    for both arrays, and then compute the array_except result.
+
+    For example, if source_array contains 5 elements with the value 'A' and array_of_elements_to_exclude contains 2
+    elements with the value 'A', the returned array is empty.
+
+    Example::
+        >>> from snowflake.snowpark import Row
+        >>> df = session.create_dataframe([Row(["A", "B"], ["B", "C"])], schema=["a", "b"])
+        >>> df.select(array_except_dedup("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  "A"     |
+        |]         |
+        ------------
+        <BLANKLINE>
+        >>> df = session.create_dataframe([Row(["A", "B", "B", "B", "C"], ["B"])], schema=["a", "b"])
+        >>> df.select(array_except_dedup("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  "A",    |
+        |  "C"     |
+        |]         |
+        ------------
+        <BLANKLINE>
+        >>> df = session.create_dataframe([Row(["A", None, None], ["B", None])], schema=["a", "b"])
+        >>> df.select(array_except_dedup("a", "b").alias("result")).show()
+        ------------
+        |"RESULT"  |
+        ------------
+        |[         |
+        |  "A"     |
+        |]         |
+        ------------
+        <BLANKLINE>
+    """
+    array1 = _to_col_if_str(source_array, "array_except")
+    array2 = _to_col_if_str(array_of_elements_to_exclude, "array_except")
+    return builtin("array_except")(
+        builtin("array_distinct")(array1), builtin("array_distinct")(array2)
+    )
+
+
 def array_min(array: ColumnOrName) -> Column:
     """Returns smallest defined non-NULL element in the input array. If the input
     array is empty, or there is no defined element in the input array, then the


### PR DESCRIPTION
Description

Add support for array_except that by default follows the semantic of Snowflake. We also introduced a flag `allow_duplicates` to control the behavior.

Testing

doc test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-967725

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  
Add support for array_except that by default follows the semantic of Snowflake. We also introduced a flag `allow_duplicates` to control the behavior.