### PR TITLE
SCT-7891: Add support for create_map function in snowflake.snowpark.functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `SessionBuilder.getOrCreate` will now attempt to replace the singleton it returns when token expiration has been detected.
 - Added support for new function(s) in `snowflake.snowpark.functions`:
   - `array_except`
+  - `create_map`
   - `sign`/`signum`
 
 ### Bug Fixes

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -105,6 +105,7 @@ Functions
     count_distinct
     covar_pop
     covar_samp
+    create_map
     cume_dist
     current_available_roles
     current_database

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -766,10 +766,31 @@ def create_map(*cols: Union[ColumnOrName, Union[List[ColumnOrName], Tuple[Column
     Example:
         >>> from snowflake.snowpark.functions import create_map
         >>> df = session.create_dataframe([("Paris", "France"), ("Tokyo", "Japan")], ("city", "country"))
-        >>> df.select(create_map("city", "country").alias("map")).collect()
-        [Row(MAP='{"Paris": "France"}'), Row(MAP='{"Tokyo": "Japan"}')]
-        >>> df.select(create_map([df.city, df.country]).alias("map")).collect()
-        [Row(MAP='{"Paris": "France"}'), Row(MAP='{"Tokyo": "Japan"}')]
+        >>> df.select(create_map("city", "country").alias("map")).show()
+        -----------------------
+        |"MAP"                |
+        -----------------------
+        |{                    |
+        |  "Paris": "France"  |
+        |}                    |
+        |{                    |
+        |  "Tokyo": "Japan"   |
+        |}                    |
+        -----------------------
+        <BLANKLINE>
+
+        >>> df.select(create_map([df.city, df.country]).alias("map")).show()
+        -----------------------
+        |"MAP"                |
+        -----------------------
+        |{                    |
+        |  "Paris": "France"  |
+        |}                    |
+        |{                    |
+        |  "Tokyo": "Japan"   |
+        |}                    |
+        -----------------------
+        <BLANKLINE>
     """
     def pairwise(iterable):
         while len(iterable):

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -750,7 +750,7 @@ def covar_samp(column1: ColumnOrName, column2: ColumnOrName) -> Column:
     return builtin("covar_samp")(col1, col2)
 
 
-def create_map(*cols: Union[ColumnOrName, Union[List[ColumnOrName], Tuple[ColumnOrName, ...]]]) -> Column:
+def create_map(*cols: Union[ColumnOrName, Iterable[ColumnOrName]]) -> Column:
     """Transforms multiple column pairs into a single map :class:`~snowflake.snowpark.Column` where each pair of
     columns is treated as a key-value pair in the resulting map.
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SCT-7891](https://snowflakecomputing.atlassian.net/browse/SCT-7891)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It adds support for the function `snowflake.snowpark.functions.create_map` which creates a new column that contains a map of key-value pairs.


[SCT-7891]: https://snowflakecomputing.atlassian.net/browse/SCT-7891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ