### PR TITLE
Skip `test_update_query_tag` in stored procedure tests

### DIFF
--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -66,6 +66,7 @@ def test_runtime_config(db_parameters):
     session.close()
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot alter session in SP")
 def test_update_query_tag(session):
     store_tag = session.query_tag
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  When setting the query tag, we run `alter session...`, which should be skipped in stored proc tests
