### PR TITLE
SNOW-990777 Use temp table for non-nullable schema when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
   df = copy(df)
   df.select(col("b").alias("c"))  # threw an error. Now it's fixed.
   ```
-- Fixed a bug in `Session.create_dataframe` that the non-nullable field in schema is not respected. Note that this fix requires the user to have the privilege to create a temp table.
+- Fixed a bug in `Session.create_dataframe` that the non-nullable field in schema is not respected for boolean type. Note that this fix requires the user to have the privilege to create a temp table.
 
 ### Behavior Changes (API Compatible)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
   df = copy(df)
   df.select(col("b").alias("c"))  # threw an error. Now it's fixed.
   ```
-- Fixed a bug in `Session.create_dataframe` that the non-nullable field in schema is not respected for boolean type. Note that this fix requires the user to have the privilege to create a temp table.
+- Fixed a bug in `Session.create_dataframe` that the non-nullable field in schema is not respected for boolean type. Note that this fix is only effective when the user to have the privilege to create a temp table.
 
 ### Behavior Changes (API Compatible)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   df = copy(df)
   df.select(col("b").alias("c"))  # threw an error. Now it's fixed.
   ```
+- Fixed a bug in `Session.create_dataframe` that the non-nullable field in schema is not respected. Note that this fix requires the user to have the privilege to create a temp table.
 
 ### Behavior Changes (API Compatible)
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -886,7 +886,11 @@ class Analyzer:
             )
 
         if isinstance(logical_plan, SnowflakeValues):
-            schema_query = schema_query_for_values_statement(logical_plan.output)
+            if logical_plan.schema_query:
+                schema_query = logical_plan.schema_query
+            else:
+                schema_query = schema_query_for_values_statement(logical_plan.output)
+
             if logical_plan.data:
                 if (
                     len(logical_plan.output) * len(logical_plan.data)

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -903,7 +903,10 @@ class Analyzer:
                     )
                 else:
                     return self.plan_builder.large_local_relation_plan(
-                        logical_plan.output, logical_plan.data, logical_plan
+                        logical_plan.output,
+                        logical_plan.data,
+                        logical_plan,
+                        schema_query=schema_query,
                     )
             else:
                 return self.plan_builder.query(

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -422,6 +422,7 @@ class SelectStatement(Selectable):
         limit_: Optional[int] = None,
         offset: Optional[int] = None,
         analyzer: "Analyzer",
+        schema_query: Optional[str] = None,
     ) -> None:
         super().__init__(analyzer)
         self.projection: Optional[List[Expression]] = projection
@@ -433,7 +434,7 @@ class SelectStatement(Selectable):
         self.pre_actions = self.from_.pre_actions
         self.post_actions = self.from_.post_actions
         self._sql_query = None
-        self._schema_query = None
+        self._schema_query = schema_query
         self._projection_in_str = None
         self._query_params = None
         self.expr_to_alias.update(self.from_.expr_to_alias)
@@ -453,11 +454,11 @@ class SelectStatement(Selectable):
             limit_=self.limit_,
             offset=self.offset,
             analyzer=self.analyzer,
+            schema_query=self.schema_query,
         )
         # The following values will change if they're None in the newly copied one so reset their values here
         # to avoid problems.
         new._projection_in_str = None
-        new._schema_query = None
         new._column_states = None
         new._snowflake_plan = None
         new.flatten_disabled = False  # by default a SelectStatement can be flattened.

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -459,6 +459,7 @@ class SelectStatement(Selectable):
         # The following values will change if they're None in the newly copied one so reset their values here
         # to avoid problems.
         new._projection_in_str = None
+        new._schema_query = None
         new._column_states = None
         new._snowflake_plan = None
         new.flatten_disabled = False  # by default a SelectStatement can be flattened.

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -433,6 +433,7 @@ class SnowflakePlanBuilder:
         output: List[Attribute],
         data: List[Row],
         source_plan: Optional[LogicalPlan],
+        schema_query: Optional[str],
     ) -> SnowflakePlan:
         temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
         attributes = [
@@ -451,7 +452,7 @@ class SnowflakePlanBuilder:
         )
         select_stmt = project_statement([], temp_table_name)
         drop_table_stmt = drop_table_if_exists_statement(temp_table_name)
-        schema_query = schema_value_statement(attributes)
+        schema_query = schema_query or schema_value_statement(attributes)
         queries = [
             Query(create_table_stmt, is_ddl_on_temp_object=True),
             BatchInsertQuery(insert_stmt, data),

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -253,7 +253,8 @@ class SnowflakePlan(LogicalPlan):
     @cached_property
     def attributes(self) -> List[Attribute]:
         output = analyze_attributes(self.schema_query, self.session)
-        if not self.schema_query:
+        # No simplifier case relies on this schema_query change to update SHOW TABLES to a nested sql friendly query.
+        if not self.schema_query or not self.session.sql_simplifier_enabled:
             self.schema_query = schema_value_statement(output)
         return output
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -253,7 +253,8 @@ class SnowflakePlan(LogicalPlan):
     @cached_property
     def attributes(self) -> List[Attribute]:
         output = analyze_attributes(self.schema_query, self.session)
-        self.schema_query = schema_value_statement(output)
+        if not self.schema_query:
+            self.schema_query = schema_value_statement(output)
         return output
 
     @cached_property

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -47,10 +47,16 @@ class UnresolvedRelation(LeafNode):
 
 
 class SnowflakeValues(LeafNode):
-    def __init__(self, output: List[Attribute], data: List[Row]) -> None:
+    def __init__(
+        self,
+        output: List[Attribute],
+        data: List[Row],
+        schema_query: Optional[str] = None,
+    ) -> None:
         super().__init__()
         self.output = output
         self.data = data
+        self.schema_query = schema_query
 
 
 class SaveMode(Enum):

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2263,8 +2263,10 @@ class Session:
             new_schema = schema
             # SELECT query has an undefined behavior for nullability, so if the schema requires non-nullable column and
             # all columns are primitive type columns, we use a temp table to lock in the nullabilities.
-            if any([field.nullable is False for field in schema.fields]) and all(
-                [field.datatype.is_primitive() for field in schema.fields]
+            if (
+                not isinstance(self._conn, MockServerConnection)
+                and any([field.nullable is False for field in schema.fields])
+                and all([field.datatype.is_primitive() for field in schema.fields])
             ):
                 temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
                 schema_string = analyzer_utils.attribute_to_schema_string(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -26,6 +26,7 @@ import pkg_resources
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.connector.pandas_tools import write_pandas
+from snowflake.snowpark._internal.analyzer import analyzer_utils
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
 from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql
@@ -2257,8 +2258,24 @@ class Session:
 
         # infer the schema based on the data
         names = None
+        schema_query = None
         if isinstance(schema, StructType):
             new_schema = schema
+            if any([not field.nullable for field in schema.fields]):
+                temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
+                schema_string = analyzer_utils.attribute_to_schema_string(
+                    schema._to_attributes()
+                )
+                try:
+                    self._run_query(
+                        f"CREATE SCOPED TEMP TABLE {temp_table_name} ({schema_string})"
+                    )
+                    schema_query = f"SELECT * FROM {temp_table_name}"
+                except ProgrammingError as e:
+                    logging.debug(
+                        f"Cannot create temp table for specified non-nullable schema, fall back to using schema "
+                        f"string from select query. Exception: {str(e)}"
+                    )
         else:
             if not data:
                 raise ValueError("Cannot infer schema from empty data")
@@ -2430,6 +2447,7 @@ class Session:
                         SnowflakeValues(attrs, converted), analyzer=self._analyzer
                     ),
                     analyzer=self._analyzer,
+                    schema_query=schema_query,
                 ),
             ).select(project_columns)
         else:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2261,7 +2261,11 @@ class Session:
         schema_query = None
         if isinstance(schema, StructType):
             new_schema = schema
-            if any([not field.nullable for field in schema.fields]):
+            # SELECT query has an undefined behavior for nullability, so if the schema requires non-nullable column and
+            # all columns are primitive type columns, we use a temp table to lock in the nullabilities.
+            if any([field.nullable is False for field in schema.fields]) and all(
+                [field.datatype.is_primitive() for field in schema.fields]
+            ):
                 temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
                 schema_string = analyzer_utils.attribute_to_schema_string(
                     schema._to_attributes()
@@ -2270,7 +2274,7 @@ class Session:
                     self._run_query(
                         f"CREATE SCOPED TEMP TABLE {temp_table_name} ({schema_string})"
                     )
-                    schema_query = f"SELECT * FROM {temp_table_name}"
+                    schema_query = f"SELECT * FROM {self.get_current_database()}.{self.get_current_schema()}.{temp_table_name}"
                 except ProgrammingError as e:
                     logging.debug(
                         f"Cannot create temp table for specified non-nullable schema, fall back to using schema "
@@ -2444,16 +2448,16 @@ class Session:
                 self,
                 self._analyzer.create_select_statement(
                     from_=self._analyzer.create_select_snowflake_plan(
-                        SnowflakeValues(attrs, converted), analyzer=self._analyzer
+                        SnowflakeValues(attrs, converted, schema_query=schema_query),
+                        analyzer=self._analyzer,
                     ),
                     analyzer=self._analyzer,
-                    schema_query=schema_query,
                 ),
             ).select(project_columns)
         else:
-            df = DataFrame(self, SnowflakeValues(attrs, converted)).select(
-                project_columns
-            )
+            df = DataFrame(
+                self, SnowflakeValues(attrs, converted, schema_query=schema_query)
+            ).select(project_columns)
         set_api_call_source(df, "Session.create_dataframe[values]")
 
         if (

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2263,6 +2263,7 @@ class Session:
             new_schema = schema
             # SELECT query has an undefined behavior for nullability, so if the schema requires non-nullable column and
             # all columns are primitive type columns, we use a temp table to lock in the nullabilities.
+            # TODO(SNOW-1015527): Support non-primitive type
             if (
                 not isinstance(self._conn, MockServerConnection)
                 and any([field.nullable is False for field in schema.fields])

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -38,6 +38,9 @@ class DataType:
     def __repr__(self):
         return f"{self.__class__.__name__}()"
 
+    def is_primitive(self):
+        return True
+
 
 # Data types
 class NullType(DataType):
@@ -220,6 +223,9 @@ class ArrayType(DataType):
     def __repr__(self) -> str:
         return f"ArrayType({repr(self.element_type) if self.element_type else ''})"
 
+    def is_primitive(self):
+        return False
+
 
 class MapType(DataType):
     """Map data type. This maps to the OBJECT data type in Snowflake."""
@@ -232,6 +238,9 @@ class MapType(DataType):
 
     def __repr__(self) -> str:
         return f"MapType({repr(self.key_type) if self.key_type else ''}, {repr(self.value_type) if self.value_type else ''})"
+
+    def is_primitive(self):
+        return False
 
 
 class VectorType(DataType):
@@ -256,6 +265,9 @@ class VectorType(DataType):
 
     def __repr__(self) -> str:
         return f"VectorType({self.element_type},{self.dimension})"
+
+    def is_primitive(self):
+        return False
 
 
 class ColumnIdentifier:
@@ -424,7 +436,8 @@ class StructType(DataType):
 class VariantType(DataType):
     """Variant data type. This maps to the VARIANT data type in Snowflake."""
 
-    pass
+    def is_primitive(self):
+        return False
 
 
 class GeographyType(DataType):

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2499,8 +2499,6 @@ def test_save_as_table_respects_schema(session, save_mode):
         FloatType(),
         DoubleType(),
         DecimalType(),
-        ArrayType(),
-        MapType(),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 from decimal import Decimal
 from itertools import product
 from typing import Tuple
+from unittest import mock
 
 try:
     import pandas as pd  # noqa: F401
@@ -25,7 +26,7 @@ except ImportError:
 
 import pytest
 
-from snowflake.connector import IntegrityError
+from snowflake.connector import IntegrityError, ProgrammingError
 from snowflake.snowpark import Column, Row, Window
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
 from snowflake.snowpark._internal.analyzer.expression import Attribute, Interval, Star
@@ -59,12 +60,15 @@ from snowflake.snowpark.types import (
     ArrayType,
     BinaryType,
     BooleanType,
+    ByteType,
     DateType,
     DecimalType,
     DoubleType,
+    FloatType,
     IntegerType,
     LongType,
     MapType,
+    ShortType,
     StringType,
     StructField,
     StructType,
@@ -2479,15 +2483,35 @@ def test_save_as_table_respects_schema(session, save_mode):
         Utils.drop_table(session, table_name)
 
 
+# TODO(SNOW-974852): Add VectorType once rolled out
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        BinaryType(),
+        BooleanType(),
+        StringType(),
+        TimestampType(),
+        TimeType(),
+        ByteType(),
+        ShortType(),
+        IntegerType(),
+        LongType(),
+        FloatType(),
+        DoubleType(),
+        DecimalType(),
+        ArrayType(),
+        MapType(),
+    ],
+)
 @pytest.mark.parametrize(
     "save_mode", ["append", "overwrite", "ignore", "errorifexists"]
 )
-def test_save_as_table_nullable_test(session, save_mode):
+def test_save_as_table_nullable_test(session, save_mode, data_type):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     schema = StructType(
         [
-            StructField("A", IntegerType(), False),
-            StructField("B", IntegerType(), True),
+            StructField("A", data_type, False),
+            StructField("B", data_type, True),
         ]
     )
     df = session.create_dataframe([(None, None)], schema=schema)
@@ -2500,6 +2524,38 @@ def test_save_as_table_nullable_test(session, save_mode):
             df.write.save_as_table(table_name, mode=save_mode)
     finally:
         Utils.drop_table(session, table_name)
+
+
+@pytest.mark.parametrize(
+    "save_mode", ["append", "overwrite", "ignore", "errorifexists"]
+)
+def test_nullable_without_create_temp_table_access(session, save_mode):
+    original_run_query = session._run_query
+
+    def mock_run_query(*args, **kwargs):
+        if "CREATE SCOPED TEMP TABLE" in args[0]:
+            raise ProgrammingError("Cannot create temp table in the schema")
+        return original_run_query(*args, **kwargs)
+
+    with mock.patch.object(session, "_run_query") as mocked_run_query:
+        mocked_run_query.side_effect = mock_run_query
+        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        schema = StructType(
+            [
+                StructField("A", IntegerType(), False),
+                StructField("B", IntegerType(), True),
+            ]
+        )
+        df = session.create_dataframe([(None, None)], schema=schema)
+
+        try:
+            with pytest.raises(
+                (IntegrityError, SnowparkSQLException),
+                match="NULL result in a non-nullable column",
+            ):
+                df.write.save_as_table(table_name, mode=save_mode)
+        finally:
+            Utils.drop_table(session, table_name)
 
 
 @pytest.mark.udf

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2483,7 +2483,7 @@ def test_save_as_table_respects_schema(session, save_mode):
         Utils.drop_table(session, table_name)
 
 
-# TODO(SNOW-974852): Add VectorType once rolled out
+@pytest.mark.parametrize("large_data", [True, False])
 @pytest.mark.parametrize(
     "data_type",
     [
@@ -2504,7 +2504,7 @@ def test_save_as_table_respects_schema(session, save_mode):
 @pytest.mark.parametrize(
     "save_mode", ["append", "overwrite", "ignore", "errorifexists"]
 )
-def test_save_as_table_nullable_test(session, save_mode, data_type):
+def test_save_as_table_nullable_test(session, save_mode, data_type, large_data):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     schema = StructType(
         [
@@ -2512,7 +2512,9 @@ def test_save_as_table_nullable_test(session, save_mode, data_type):
             StructField("B", data_type, True),
         ]
     )
-    df = session.create_dataframe([(None, None)], schema=schema)
+    df = session.create_dataframe(
+        [(None, None)] * (5000 if large_data else 1), schema=schema
+    )
 
     try:
         with pytest.raises(


### PR DESCRIPTION
Description

Snowflake has an undefined behavior of nullability for columns in select statement. For example, `select 'string'` returns non-nullable, but `select True` returns nullable.

This means our approach of type mapping between user-specified schema is not working as expected. For example if a user specifies a non-nullable boolean field when invoking create_dataframe, then does a save_as_table, the table will contain a nullable boolean column, which can be surprising.

In this change, we create a temporary table using user's specified schema if there is non-nullable fields, then override the schema query by directly select from the newly created temp table. If user does not have temp table creation privilege, we will fall back to the original select statement approach for schema.

Testing

integ

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-990777

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Snowflake has an undefined behavior of nullability for columns in select statement. For example, `select 'string'` returns non-nullable, but `select True` returns nullable.

This means our approach of type mapping between user-specified schema is not working as expected. For example if a user specifies a non-nullable boolean field when invoking create_dataframe, then does a save_as_table, the table will contain a nullable boolean column, which can be surprising.

In this change, we create a temporary table using user's specified schema if there is non-nullable fields, then override the schema query by directly select from the newly created temp table. If user does not have temp table creation privilege, we will fall back to the original select statement approach for schema.
