### PR TITLE
Fix test_add_requirements_unsupported_with_cache_path merge gate

### DIFF
--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -999,7 +999,7 @@ def test_add_requirements_unsupported_with_cache_path(
 
     # Add a second environment
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
-        session.add_packages(["sktime==0.20.0"])
+        session.add_packages(["sktime==0.25.0"])
 
     package_set = set(session.get_packages().keys())
     assert "numpy" in package_set
@@ -1010,7 +1010,6 @@ def test_add_requirements_unsupported_with_cache_path(
     assert "python-dateutil" in package_set
     assert "scikit-learn" in package_set
     assert "six" in package_set
-    assert "wrapt" in package_set
 
     # Assert that metadata contains two environment signatures
     metadata_path = f"{temporary_stage}/{metadata_file}"


### PR DESCRIPTION
Description

The merge gate failed because installing scikit_fuzzy will bring in numpy 1.26.3, however, sktime==0.20.0 has a version restriction numpy <1.26. Updating to sktime==0.25.0 which allows numpy <1.27 as a temporary patch, but we should think about how to make this future-proof

Testing

integ

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
