### PR TITLE
SNOW-1023214: Support date_part argument in last_day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - When parsing datatype during `to_pandas` operation, we rely on GS precision value to fix precision issue for large integer values. This may affect users where a column that was earlier returned as `int8` gets returned as `int64`. Users can fix this by explicitly specifying precision values for their return column.
 - Aligned behavior for `Session.call` in case of table stored procedures where running `Session.call` would not trigger stored procedure unless a `collect()` operation was performed.
+- Support for optional `date_part` argument in Snowpark function `last_day`
 
 ## 1.11.1 (2023-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.13.0 (TBD)
+
+### Behavior Changes (API Compatible)
+
+- Added support for an optional `date_part` argument in function `last_day`
+
 ## 1.12.0 (2024-01-29)
 
 ### New Features
@@ -50,7 +56,6 @@
 - When parsing data types during a `to_pandas` operation, we rely on GS precision value to fix precision issues for large integer values. This may affect users where a column that was earlier returned as `int8` gets returned as `int64`. Users can fix this by explicitly specifying precision values for their return column.
 - Aligned behavior for `Session.call` in case of table stored procedures where running `Session.call` would not trigger stored procedure unless a `collect()` operation was performed.
 - `StoredProcedureRegistration` will now automatically add `snowflake-snowpark-python` as a package dependency. The added dependency will be on the client's local version of the library and an error is thrown if the server cannot support that version.
-- Added support for an optional `date_part` argument in function `last_day`
 
 ## 1.11.1 (2023-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - When parsing data types during a `to_pandas` operation, we rely on GS precision value to fix precision issues for large integer values. This may affect users where a column that was earlier returned as `int8` gets returned as `int64`. Users can fix this by explicitly specifying precision values for their return column.
 - Aligned behavior for `Session.call` in case of table stored procedures where running `Session.call` would not trigger stored procedure unless a `collect()` operation was performed.
 - `StoredProcedureRegistration` will now automatically add `snowflake-snowpark-python` as a package dependency. The added dependency will be on the client's local version of the library and an error is thrown if the server cannot support that version.
-- Support for optional `date_part` argument in Snowpark function `last_day`
+- Added support for an optional `date_part` argument in function `last_day`
 
 ## 1.11.1 (2023-12-07)
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3249,6 +3249,11 @@ def last_day(expr: ColumnOrName, part: Optional[ColumnOrName] = "MONTH") -> Colu
     Returns the last day of the specified date part for a date or timestamp.
     Commonly used to return the last day of the month for a date or timestamp.
 
+    Args:
+        expr: The array column
+        part: The date part used to compute the last day of the given array column, default is "MONTH".
+            Valid values are "YEAR", "MONTH", "QUARTER", "WEEK" or any of their supported variations.
+
     Example::
 
         >>> import datetime

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3259,7 +3259,7 @@ def last_day(expr: ColumnOrName, part: Optional[ColumnOrName] = "MONTH") -> Colu
         >>> df.select(last_day("a")).collect()
         [Row(LAST_DAY("A", "MONTH")=datetime.date(2020, 5, 31)), Row(LAST_DAY("A", "MONTH")=datetime.date(2020, 8, 31))]
         >>> df.select(last_day("a", "YEAR")).collect()
-        [Row(LAST_DAY("A")=datetime.date(2020, 12, 31)), Row(LAST_DAY("A")=datetime.date(2020, 12, 31))]
+        [Row(LAST_DAY("A", "YEAR")=datetime.date(2020, 12, 31)), Row(LAST_DAY("A", "YEAR")=datetime.date(2020, 12, 31))]
     """
     part_col = _to_col_if_str(part, "last_day")
     expr_col = _to_col_if_str(expr, "last_day")

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3257,7 +3257,7 @@ def last_day(expr: ColumnOrName, part: Optional[ColumnOrName] = "MONTH") -> Colu
         ...     datetime.datetime.strptime("2020-08-21 01:30:05.000", "%Y-%m-%d %H:%M:%S.%f")
         ... ], schema=["a"])
         >>> df.select(last_day("a")).collect()
-        [Row(LAST_DAY("A")=datetime.date(2020, 5, 31)), Row(LAST_DAY("A")=datetime.date(2020, 8, 31))]
+        [Row(LAST_DAY("A", "MONTH")=datetime.date(2020, 5, 31)), Row(LAST_DAY("A", "MONTH")=datetime.date(2020, 8, 31))]
         >>> df.select(last_day("a", "YEAR")).collect()
         [Row(LAST_DAY("A")=datetime.date(2020, 12, 31)), Row(LAST_DAY("A")=datetime.date(2020, 12, 31))]
     """

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3166,7 +3166,7 @@ def hour(e: ColumnOrName) -> Column:
     return builtin("hour")(c)
 
 
-def last_day(e: ColumnOrName) -> Column:
+def last_day(expr: ColumnOrName, part: Optional[ColumnOrName] = "MONTH") -> Column:
     """
     Returns the last day of the specified date part for a date or timestamp.
     Commonly used to return the last day of the month for a date or timestamp.
@@ -3180,9 +3180,12 @@ def last_day(e: ColumnOrName) -> Column:
         ... ], schema=["a"])
         >>> df.select(last_day("a")).collect()
         [Row(LAST_DAY("A")=datetime.date(2020, 5, 31)), Row(LAST_DAY("A")=datetime.date(2020, 8, 31))]
+        >>> df.select(last_day("a", "YEAR")).collect()
+        [Row(LAST_DAY("A")=datetime.date(2020, 12, 31)), Row(LAST_DAY("A")=datetime.date(2020, 12, 31))]
     """
-    c = _to_col_if_str(e, "last_day")
-    return builtin("last_day")(c)
+    part_col = _to_col_if_str(part, "last_day")
+    expr_col = _to_col_if_str(expr, "last_day")
+    return builtin("last_day")(expr_col, part_col)
 
 
 def minute(e: ColumnOrName) -> Column:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-1023214

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR adds support for the optional `date_part` argument for the Snowflake function `last_day`. See the SQL documentation here: https://docs.snowflake.com/en/sql-reference/functions/last_day
