### PR TITLE
SNOW-869536 Fix buggy behavior in DataFrame.to_local_iterator 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Behavior Changes (API Compatible)
 
 - Added support for an optional `date_part` argument in function `last_day`
+### Bug Fixes
+
+- Fixed a bug in `DataFrame.to_local_iterator` and `DataFrame.to_pandas_batches` where the iterator could yield wrong results if another query is executed before the iterator finishes due to wrong isolation level. For details, please see #945.
 
 ## 1.12.0 (2024-01-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added support for an optional `date_part` argument in function `last_day`
 ### Bug Fixes
 
-- Fixed a bug in `DataFrame.to_local_iterator` and `DataFrame.to_pandas_batches` where the iterator could yield wrong results if another query is executed before the iterator finishes due to wrong isolation level. For details, please see #945.
+- Fixed a bug in `DataFrame.to_local_iterator` where the iterator could yield wrong results if another query is executed before the iterator finishes due to wrong isolation level. For details, please see #945.
 
 ## 1.12.0 (2024-01-30)
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -435,7 +435,7 @@ class ServerConnection:
         to_pandas: bool = False,
         to_iter: bool = False,
     ) -> Dict[str, Any]:
-        if to_iter:  # Fix for SNOW-869536
+        if to_iter and not to_pandas:  # Fix for SNOW-869536
             new_cursor = results_cursor.connection.cursor()
             new_cursor.execute(
                 f"SELECT * FROM TABLE(RESULT_SCAN('{results_cursor.sfqid}'))"

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -434,8 +434,14 @@ class ServerConnection:
         results_cursor: SnowflakeCursor,
         to_pandas: bool = False,
         to_iter: bool = False,
-        num_statements: Optional[int] = None,
     ) -> Dict[str, Any]:
+        if to_iter:  # Fix for SNOW-869536
+            new_cursor = results_cursor.connection.cursor()
+            new_cursor.execute(
+                f"SELECT * FROM TABLE(RESULT_SCAN('{results_cursor.sfqid}'))"
+            )
+            results_cursor = new_cursor
+
         if to_pandas:
             try:
                 data_or_iter = (

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -435,7 +435,9 @@ class ServerConnection:
         to_pandas: bool = False,
         to_iter: bool = False,
     ) -> Dict[str, Any]:
-        if to_iter and not to_pandas:  # Fix for SNOW-869536
+        if (
+            to_iter and not to_pandas
+        ):  # Fix for SNOW-869536, to_pandas doesn't have this issue, SnowflakeCursor.fetch_pandas_batches already handles the isolation.
             new_cursor = results_cursor.connection.cursor()
             new_cursor.execute(
                 f"SELECT * FROM TABLE(RESULT_SCAN('{results_cursor.sfqid}'))"

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -107,6 +107,7 @@ def test_async_to_pandas_common(session):
     )
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
 def test_async_to_pandas_batches(session):
     df = session.range(100000).cache_result()
@@ -120,7 +121,6 @@ def test_async_to_pandas_batches(session):
         break
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
 def test_async_to_pandas_empty_result(session):
     df = session.create_dataframe(

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -110,10 +110,14 @@ def test_async_to_pandas_common(session):
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
 def test_async_to_pandas_batches(session):
-    df = session.range(100000).sort("id").cache_result()
+    df = session.range(100000).cache_result()
     async_job = df.to_pandas_batches(block=False)
-    res = pd.concat(async_job.result(), ignore_index=True)
-    expected_res = pd.concat(df.to_pandas_batches(), ignore_index=True)
+    res = pd.concat(async_job.result(), ignore_index=True).sort_values(
+        "ID", ignore_index=True
+    )
+    expected_res = pd.concat(df.to_pandas_batches(), ignore_index=True).sort_values(
+        "ID", ignore_index=True
+    )
     if expected_res["ID"].dtype == "int32":
         expected_res["ID"] = expected_res["ID"].astype("int64")
     assert res.shape == expected_res.shape == (100000, 1)

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -110,15 +110,14 @@ def test_async_to_pandas_common(session):
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
 def test_async_to_pandas_batches(session):
-    df = session.range(100000).cache_result()
+    df = session.range(100000).sort("id").cache_result()
     async_job = df.to_pandas_batches(block=False)
-    res = list(async_job.result())
-    expected_res = list(df.to_pandas_batches())
-    assert len(res) > 0
-    assert len(expected_res) > 0
-    for r, er in zip(res, expected_res):
-        assert_frame_equal(r, er)
-        break
+    res = pd.concat(async_job.result(), ignore_index=True)
+    expected_res = pd.concat(df.to_pandas_batches(), ignore_index=True)
+    if expected_res["ID"].dtype == "int32":
+        expected_res["ID"] = expected_res["ID"].astype("int64")
+    assert res.shape == expected_res.shape == (100000, 1)
+    assert_frame_equal(res, expected_res)
 
 
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -107,21 +107,17 @@ def test_async_to_pandas_common(session):
     )
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
 def test_async_to_pandas_batches(session):
     df = session.range(100000).cache_result()
     async_job = df.to_pandas_batches(block=False)
-    res = pd.concat(async_job.result(), ignore_index=True).sort_values(
-        "ID", ignore_index=True
-    )
-    expected_res = pd.concat(df.to_pandas_batches(), ignore_index=True).sort_values(
-        "ID", ignore_index=True
-    )
-    if expected_res["ID"].dtype == "int32":
-        expected_res["ID"] = expected_res["ID"].astype("int64")
-    assert res.shape == expected_res.shape == (100000, 1)
-    assert_frame_equal(res, expected_res)
+    res = list(async_job.result())
+    expected_res = list(df.to_pandas_batches())
+    assert len(res) > 0
+    assert len(expected_res) > 0
+    for r, er in zip(res, expected_res):
+        assert_frame_equal(r, er)
+        break
 
 
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -120,6 +120,7 @@ def test_async_to_pandas_batches(session):
         break
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
 @pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
 def test_async_to_pandas_empty_result(session):
     df = session.create_dataframe(

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -3690,21 +3690,3 @@ def test_dataframe_to_local_iterator_isolation(session):
     assert (
         row_counter == ROW_NUMBER
     ), f"Expect {ROW_NUMBER} rows, Got {row_counter} instead"
-
-
-@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
-@pytest.mark.skipif(not is_pandas_available, reason="Pandas is not available")
-def test_dataframe_to_pandas_batches_isolation(session):
-    ROW_NUMBER = 100000
-    df = session.range(100000).cache_result()
-
-    my_iter = df.to_pandas_batches()
-    row_counter = 0
-    for batch in my_iter:
-        len(df.schema.fields)  # this executes a schema query internally
-        row_counter += batch.shape[0]
-
-    # my_iter should be iterating on df.collect()'s query's results, not the schema query (1 row)
-    assert (
-        row_counter == ROW_NUMBER
-    ), f"Expect {ROW_NUMBER} rows, Got {row_counter} instead"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #945 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Issue**: All queries issued from a Snowpark `Session` object are executed using the same SnowflakeCursor instance, this causes unexpected, wrong behavior when we fetch results from an iterator but have code that executes a different query half way, e.g.
   ```
    df = session.create_dataframe([[1,2,3],[4,5,6]], schema=["a", "b", "c"]) 
    my_iter = df.to_local_iterator()
    row_counter
    for row in my_iter:
       len(df.schema.fields)  # this executes a schema query, which overwrites properties of the cursor object
       row_counter += 1
    print(counter)  # this prints 1 since schema query only returns 1 row, but should be 2
   ```
   
   **Fix**: This PR changes `src/snowflake/snowpark/_internal/server_connection.py` create a new cursor object locally to read data from the last executed query and continues to use this cursor object in the iterator to achieve isolation between the iterator and the following queries executed within the session.
