### PR TITLE
SNOW-1018660: Pass down params to fetch_pandas_all & fetch_pandas_batches

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -175,6 +175,26 @@ SCOPED_TEMPORARY_STRING = "SCOPED TEMPORARY"
 
 SUPPORTED_TABLE_TYPES = ["temp", "temporary", "transient"]
 
+# pyarrow.Table.to_pandas kwargs: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
+PYARROW_TABLE_TO_PANDAS_KWARG_KEYS = (
+    "memory_pool",
+    "categories",
+    "strings_to_categorical",
+    "zero_copy_only",
+    "integer_object_nulls",
+    "date_as_object",
+    "timestamp_as_object",
+    "use_threads",
+    "deduplicate_objects",
+    "ignore_metadata",
+    "safe",
+    "split_blocks",
+    "self_destruct",
+    "maps_as_pydicts",
+    "types_mapper",
+    "coerce_temporal_nanoseconds",
+)
+
 
 class TempObjectType(Enum):
     TABLE = "TABLE"
@@ -299,6 +319,18 @@ def get_udf_upload_prefix(udf_name: str) -> str:
 def random_number() -> int:
     """Get a random unsigned integer."""
     return random.randint(0, 2**31)
+
+
+def filter_pyarrow_table_to_pandas_kwargs(
+    all_kwargs: Dict[str, Any]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    to_pandas_kwargs, other_kwargs = {}, {}
+    for kwarg, value in all_kwargs.items():
+        if kwarg in PYARROW_TABLE_TO_PANDAS_KWARG_KEYS:
+            to_pandas_kwargs[kwarg] = value
+        else:
+            other_kwargs[kwarg] = value
+    return to_pandas_kwargs, other_kwargs
 
 
 @contextlib.contextmanager

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -331,19 +331,22 @@ class MockServerConnection:
         results_cursor: SnowflakeCursor,
         to_pandas: bool = False,
         to_iter: bool = False,
+        fetch_pandas_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         if to_pandas:
+            fetch_pandas_kwargs = fetch_pandas_kwargs or {}
             try:
                 data_or_iter = (
                     map(
                         functools.partial(
                             _fix_pandas_df_fixed_type, results_cursor=results_cursor
                         ),
-                        results_cursor.fetch_pandas_batches(),
+                        results_cursor.fetch_pandas_batches(**fetch_pandas_kwargs),
                     )
                     if to_iter
                     else _fix_pandas_df_fixed_type(
-                        results_cursor.fetch_pandas_all(), results_cursor
+                        results_cursor.fetch_pandas_all(**fetch_pandas_kwargs),
+                        results_cursor,
                     )
                 )
             except NotSupportedError:

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -15,6 +15,7 @@ from snowflake.snowpark._internal.utils import (
     calculate_checksum,
     deprecated,
     experimental,
+    filter_pyarrow_table_to_pandas_kwargs,
     get_stage_file_prefix_length,
     get_temp_type_for_object,
     get_udf_upload_prefix,
@@ -131,6 +132,34 @@ def test_calculate_checksum():
             )
             == "83582388fa5d2b2f0a71666bca88a8f11a6c0d40b20096c8aeb2fccf113d3ca6"
         )
+
+
+def test_filter_pyarrow_table_to_pandas_kwargs():
+    to_pandas, other = filter_pyarrow_table_to_pandas_kwargs({})
+    assert len(to_pandas) == len(other) == 0
+
+    to_pandas, other = filter_pyarrow_table_to_pandas_kwargs(
+        {"split_blocks": True, "integer_object_nulls": False}
+    )
+    assert len(to_pandas) == 2
+    assert len(other) == 0
+
+    to_pandas, other = filter_pyarrow_table_to_pandas_kwargs(
+        {"_statement_params": {"RESULT_FORMAT_TYPE": "arrow"}, "other2": False}
+    )
+    assert len(to_pandas) == 0
+    assert len(other) == 2
+
+    to_pandas, other = filter_pyarrow_table_to_pandas_kwargs(
+        {
+            "split_blocks": True,
+            "integer_object_nulls": False,
+            "_statement_params": {"RESULT_FORMAT_TYPE": "arrow"},
+            "other2": False,
+        }
+    )
+    assert len(to_pandas) == 2
+    assert len(other) == 2
 
 
 def test_normalize_stage_location():

--- a/tests/unit/test_df_to_pandas.py
+++ b/tests/unit/test_df_to_pandas.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from unittest import mock
+
+import pytest
+
+try:
+    import pandas
+except ImportError:
+    pytest.skip("Pandas is not available", allow_module_level=True)
+
+
+from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.snowpark import Session
+
+
+def test_df_to_pandas_kwargs_passing(mock_server_connection):
+    # setup
+    fake_session = Session(mock_server_connection)
+    query = "select 1 as A"
+    mock_result_cursor = mock.create_autospec(SnowflakeCursor)
+    mock_result_cursor.query = query
+    mock_result_cursor.sfqid = ""
+    mock_result_cursor.fetch_pandas_all = mock.Mock(
+        return_value=pandas.DataFrame({"A": [1]})
+    )
+    mock_result_cursor.fetch_pandas_batches = mock.Mock(
+        return_value=pandas.DataFrame({"A": [1]})
+    )
+    mock_execute = mock.Mock(return_value=mock_result_cursor)
+    fake_session._conn._conn.cursor().execute = mock_execute
+
+    # test cases
+    fake_session.sql(query).to_pandas()
+    mock_result_cursor.fetch_pandas_all.assert_called_with()
+
+    fake_session.sql(query).to_pandas(statement_params={"SF_PARTNER": "FAKE_PARTNER"})
+    mock_result_cursor.fetch_pandas_all.assert_called_with()
+
+    fake_session.sql(query).to_pandas(deduplicate_objects=True, split_blocks=True)
+    mock_result_cursor.fetch_pandas_all.assert_called_with(
+        deduplicate_objects=True, split_blocks=True
+    )
+
+    fake_session.sql(query).to_pandas(
+        deduplicate_objects=True,
+        split_blocks=True,
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"},
+    )
+    mock_result_cursor.fetch_pandas_all.assert_called_with(
+        deduplicate_objects=True, split_blocks=True
+    )
+
+    fake_session.sql(query).to_pandas_batches()
+    mock_result_cursor.fetch_pandas_batches.assert_called_with()
+
+    fake_session.sql(query).to_pandas_batches(
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"}
+    )
+    mock_result_cursor.fetch_pandas_batches.assert_called_with()
+
+    fake_session.sql(query).to_pandas_batches(
+        deduplicate_objects=True, split_blocks=True
+    )
+    mock_result_cursor.fetch_pandas_batches.assert_called_with(
+        deduplicate_objects=True, split_blocks=True
+    )
+
+    fake_session.sql(query).to_pandas_batches(
+        deduplicate_objects=True,
+        split_blocks=True,
+        statement_params={"SF_PARTNER": "FAKE_PARTNER"},
+    )
+    mock_result_cursor.fetch_pandas_batches.assert_called_with(
+        deduplicate_objects=True, split_blocks=True
+    )

--- a/tests/unit/test_df_to_pandas.py
+++ b/tests/unit/test_df_to_pandas.py
@@ -36,7 +36,7 @@ def test_df_to_pandas_kwargs_passing(mock_server_connection):
     mock_execute = mock.Mock(return_value=mock_result_cursor)
     fake_session._conn._conn.cursor().execute = mock_execute
 
-    # test cases
+    # test cases - to_pandas()
     fake_session.sql(query).to_pandas()
     mock_result_cursor.fetch_pandas_all.assert_called_with()
 
@@ -57,6 +57,7 @@ def test_df_to_pandas_kwargs_passing(mock_server_connection):
         deduplicate_objects=True, split_blocks=True
     )
 
+    # test cases - to_pandas_batches()
     fake_session.sql(query).to_pandas_batches()
     mock_result_cursor.fetch_pandas_batches.assert_called_with()
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1018660

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Adding way to pass on kwargs from `DataFrame.to_pandas` and `DataFrame.to_pandas_batches` to `pyarrow.Table.to_pandas`
