### PR TITLE
[SNOW-1036413] Fix stored proc register failure when packages are given as modules.

### DIFF
--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -771,7 +771,8 @@ class StoredProcedureRegistration:
             if package_name not in self._session._packages:
                 packages = list(self._session._packages.values()) + [this_package]
         else:
-            if not any(package_name in p for p in packages):
+            package_names = [p if isinstance(p, str) else p.__name__ for p in packages]
+            if not any(p.startswith(package_name) for p in package_names):
                 packages.append(this_package)
 
         (

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1508,7 +1508,7 @@ def test_stored_proc_register_with_module(session):
 
     # use pandas module here
     packages = list(session.get_packages().values())
-    assert "pandas" "pandas" not in packages
+    assert "pandas" not in packages
     packages = [pandas] + packages
 
     def proc_function(session: Session) -> str:

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1497,3 +1497,28 @@ def test_force_inline_code(session):
             f, packages=["snowflake-snowpark-python"], force_inline_code=True
         )
     assert any("AS $$" in query.sql_text for query in query_history.queries)
+
+
+@pytest.mark.skipif(
+    not is_pandas_available, reason="test module dependency with pandas dependency"
+)
+def test_stored_proc_register_with_module(session):
+
+    import pandas
+
+    # use pandas module here
+    packages = list(session.get_packages().values())
+    assert "pandas" "pandas" not in packages
+    packages = [pandas] + packages
+
+    def proc_function(session: Session) -> str:
+        import pandas
+
+        return f"test response: {pandas.__version__}"
+
+    session.sproc.register(
+        proc_function,
+        name="test_proc",
+        source_code_display=False,
+        packages=packages,
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-1036413

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   SNOW-949781 introduced changes to stored proc register, which results in failure when giving packages as modules to the stored proc register function. Fix here.
