### PR TITLE
Fix of to_pandas() when having integer column with null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Added support for an optional `date_part` argument in function `last_day`
 
+## 1.12.1 (TBD)
+
+### New Features
+
+### Bug Fixes
+
+- Fixed a bug in `DataFrame.to_pandas` that caused an error when evaluating on a dataframe with an IntergerType column with null values.
+
 ## 1.12.0 (2024-01-30)
 
 ### New Features

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -702,7 +702,7 @@ def _fix_pandas_df_fixed_type(
                 # we try to strictly use astype("int64") in this scenario. If the values are too large to
                 # fit in int64, an OverflowError is thrown and we rely on to_numeric to choose and appropriate
                 # floating datatype to represent the number.
-                if column_metadata.precision > 10:
+                if column_metadata.precision > 10 and not pd_df[pandas_col_name].hasnans:
                     try:
                         pd_df[pandas_col_name] = pd_df[pandas_col_name].astype("int64")
                     except OverflowError:

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -191,7 +191,7 @@ def test_to_pandas_non_select(session):
     assert df._plan.queries[2].sql.strip().startswith("SELECT")
     isinstance(df.toPandas(), PandasDF)
 
-def test_to_pandas_precision_for_number_38_0(session):
+def test_to_pandas_for_int_column_with_none_values(session):
     # Assert that we try to fit into int64 when possible and keep precision
     data = [
         [0],

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -191,6 +191,22 @@ def test_to_pandas_non_select(session):
     assert df._plan.queries[2].sql.strip().startswith("SELECT")
     isinstance(df.toPandas(), PandasDF)
 
+def test_to_pandas_precision_for_number_38_0(session):
+    # Assert that we try to fit into int64 when possible and keep precision
+    data = [
+        [0],
+        [1],
+        [None]
+        ]
+    schema = ["A"]
+    df = session.create_dataframe(data, schema)
+
+    pdf = df.to_pandas()
+    assert pdf["A"][0] == 0
+    assert pdf["A"][1] == 1
+    assert pd.isna(pdf["A"][2])
+    assert pdf["A"].dtype == "float64"
+
 
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="SNOW-507565: Need localaws for large result"


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-1026241 ](https://github.com/snowflakedb/snowpark-python/issues/1229)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When there is a NaN value in the column, it does not try to cast it to integer but keeps it as float64
