### PR TITLE
SNOW-1016748 Fixed a bug that Session.range returns empty result when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug in `DataFrame.to_pandas` that caused an error when evaluating on a dataframe with an IntergerType column with null values.
 - Fixed a bug in `DataFrame.to_local_iterator` where the iterator could yield wrong results if another query is executed before the iterator finishes due to wrong isolation level. For details, please see #945.
 - Fixed a bug that truncated table names in error messages while running a plan with local testing enabled.
+- Fixed a bug that `Session.range` returns empty result when the range is large.
 
 ## 1.12.0 (2024-01-30)
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -448,7 +448,7 @@ def sort_statement(order: List[str], child: str) -> str:
 def range_statement(start: int, end: int, step: int, column_name: str) -> str:
     range = end - start
 
-    if range * step < 0:
+    if (range > 0 > step) or (range < 0 < step):
         count = 0
     else:
         count = math.ceil(range / step)

--- a/tests/integ/scala/test_dataframe_range_suite.py
+++ b/tests/integ/scala/test_dataframe_range_suite.py
@@ -108,3 +108,15 @@ def test_range_with_max_and_min(session):
     end = MIN_VALUE + 2
     assert session.range(start, end, 1).collect() == []
     assert session.range(start, start, 1).collect() == []
+
+
+@pytest.mark.localtest
+def test_range_with_large_range_and_step(session):
+    try:
+        import numpy as np
+
+        ints = np.array([691200000000000], dtype="int64")
+        # Use a numpy int64 range with a python int step
+        assert session.range(0, ints[0], 86400000000000).collect() != []
+    except ImportError:
+        pytest.skip("numpy is not installed, skipping the tests")

--- a/tests/integ/scala/test_dataframe_range_suite.py
+++ b/tests/integ/scala/test_dataframe_range_suite.py
@@ -10,6 +10,7 @@ import pytest
 
 from snowflake.snowpark import Row
 from snowflake.snowpark.functions import col, count, sum as sum_
+from tests.integ.test_packaging import is_pandas_and_numpy_available
 
 
 @pytest.mark.localtest
@@ -110,13 +111,11 @@ def test_range_with_max_and_min(session):
     assert session.range(start, start, 1).collect() == []
 
 
+@pytest.mark.skipif(not is_pandas_and_numpy_available, reason="requires numpy")
 @pytest.mark.localtest
 def test_range_with_large_range_and_step(session):
-    try:
-        import numpy as np
+    import numpy as np
 
-        ints = np.array([691200000000000], dtype="int64")
-        # Use a numpy int64 range with a python int step
-        assert session.range(0, ints[0], 86400000000000).collect() != []
-    except ImportError:
-        pytest.skip("numpy is not installed, skipping the tests")
+    ints = np.array([691200000000000], dtype="int64")
+    # Use a numpy int64 range with a python int step
+    assert session.range(0, ints[0], 86400000000000).collect() != []


### PR DESCRIPTION
… the range is large

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1016748 Fixed a bug that Session.range returns empty result when the range is large

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Fix a bug that is triggered by overflow when a numpy int multiply with a python int. 