### PR TITLE
SNOW-1014048: Set `PARAM_APPLICATIONS` for snowpark ML usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.13.0 (TBD)
 
 ### New Features
+
 - Added support for an optional `date_part` argument in function `last_day`
 - `SessionBuilder.app_name` will set the query_tag after the session is created.
 - Set `"application"` parameter for snowpark ML usage tracking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@
 ## 1.13.0 (TBD)
 
 ### New Features
-- Added support for an optional `date_part` argument in function `last_day`.
-- Added `"other_applications"` parameter for snowpark ML usage tracking.
 - Added support for an optional `date_part` argument in function `last_day`
 - `SessionBuilder.app_name` will set the query_tag after the session is created.
+- Set `"application"` parameter for snowpark ML usage tracking.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 1.13.0 (TBD)
 
 ### New Features
-- Added support for an optional `date_part` argument in function `last_day`
+- Added support for an optional `date_part` argument in function `last_day`.
+- Added `"other_applications"` parameter for snowpark ML usage tracking.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Added support for an optional `date_part` argument in function `last_day`
 - `SessionBuilder.app_name` will set the query_tag after the session is created.
-- Set `"application"` parameter for snowpark ML usage tracking.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -4,6 +4,7 @@
 #
 
 import functools
+import importlib
 import inspect
 import os
 import sys
@@ -177,10 +178,16 @@ class ServerConnection:
                 self._lower_case_parameters[PARAM_APPLICATION] = os.environ[
                     ENV_VAR_PARTNER
                 ]
-            elif "streamlit" in sys.modules:
-                self._lower_case_parameters[PARAM_APPLICATION] = "streamlit"
             else:
-                self._lower_case_parameters[PARAM_APPLICATION] = get_application_name()
+                applications = []
+                if importlib.util.find_spec("streamlit"):
+                    applications.append("streamlit")
+                if importlib.util.find_spec("snowflake.ml"):
+                    applications.append("SnowparkML")
+                self._lower_case_parameters[PARAM_APPLICATION] = (
+                    ":".join(applications) or get_application_name()
+                )
+
         if PARAM_INTERNAL_APPLICATION_NAME not in self._lower_case_parameters:
             self._lower_case_parameters[
                 PARAM_INTERNAL_APPLICATION_NAME
@@ -189,11 +196,6 @@ class ServerConnection:
             self._lower_case_parameters[
                 PARAM_INTERNAL_APPLICATION_VERSION
             ] = get_version()
-        if PARAM_OTHER_APPLICATIONS not in self._lower_case_parameters:
-            other_applications = []
-            if "snowflake-ml-python" in sys.modules:
-                other_applications.append("snowflake-ml-python")
-            self._lower_case_parameters[PARAM_OTHER_APPLICATIONS] = other_applications
 
     def add_query_listener(self, listener: QueryHistory) -> None:
         self._query_listener.add(listener)

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -71,7 +71,6 @@ logger = getLogger(__name__)
 
 # parameters needed for usage tracking
 PARAM_APPLICATION = "application"
-PARAM_OTHER_APPLICATIONS = "other_applications"
 PARAM_INTERNAL_APPLICATION_NAME = "internal_application_name"
 PARAM_INTERNAL_APPLICATION_VERSION = "internal_application_version"
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -70,6 +70,7 @@ logger = getLogger(__name__)
 
 # parameters needed for usage tracking
 PARAM_APPLICATION = "application"
+PARAM_OTHER_APPLICATIONS = "other_applications"
 PARAM_INTERNAL_APPLICATION_NAME = "internal_application_name"
 PARAM_INTERNAL_APPLICATION_VERSION = "internal_application_version"
 
@@ -152,7 +153,7 @@ class ServerConnection:
         conn: Optional[SnowflakeConnection] = None,
     ) -> None:
         self._lower_case_parameters = {k.lower(): v for k, v in options.items()}
-        self._add_application_name()
+        self._add_application_parameters()
         self._conn = conn if conn else connect(**self._lower_case_parameters)
         if "password" in self._lower_case_parameters:
             self._lower_case_parameters["password"] = None
@@ -169,7 +170,7 @@ class ServerConnection:
             "_skip_upload_on_content_match" in signature.parameters
         )
 
-    def _add_application_name(self) -> None:
+    def _add_application_parameters(self) -> None:
         if PARAM_APPLICATION not in self._lower_case_parameters:
             # Mirrored from snowflake-connector-python/src/snowflake/connector/connection.py#L295
             if ENV_VAR_PARTNER in os.environ.keys():
@@ -188,6 +189,11 @@ class ServerConnection:
             self._lower_case_parameters[
                 PARAM_INTERNAL_APPLICATION_VERSION
             ] = get_version()
+        if PARAM_OTHER_APPLICATIONS not in self._lower_case_parameters:
+            other_applications = []
+            if "snowflake-ml-python" in sys.modules:
+                other_applications.append("snowflake-ml-python")
+            self._lower_case_parameters[PARAM_OTHER_APPLICATIONS] = other_applications
 
     def add_query_listener(self, listener: QueryHistory) -> None:
         self._query_listener.add(listener)


### PR DESCRIPTION
This fix enables tracking snowpark ML usage in sprocs, notebooks, and streamlit apps. This is a workaround because statement params telemetry is not received from sprocs.

* set "applications" parameter if snowpark ML is present
* fix helper method name
* Make sure "streamlit" is also set if present

Please answer these questions before submitting your pull requests. Thanks!

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
