### PR TITLE
SNOW-1043119: Add upper/lower/length/initcap support to local testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added support for an optional `date_part` argument in function `last_day`
 - `SessionBuilder.app_name` will set the query_tag after the session is created.
+- Added support for the following local testing functions:
+  - upper
+  - lower
+  - length
+  - initcap
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -6,6 +6,7 @@ import binascii
 import datetime
 import json
 import math
+import string
 from decimal import Decimal
 from functools import partial
 from numbers import Real
@@ -843,13 +844,6 @@ def mock_row_number(window: TableEmulator, row_idx: int):
     return ColumnEmulator(data=[row_idx + 1], sf_type=ColumnType(LongType(), False))
 
 
-@patch("upper")
-def mock_upper(expr: ColumnEmulator):
-    res = expr.apply(lambda x: x.upper())
-    res.sf_type = ColumnType(StringType(), expr.sf_type.nullable)
-    return res
-
-
 @patch("parse_json")
 def mock_parse_json(expr: ColumnEmulator):
     from snowflake.snowpark.mock import CUSTOM_JSON_DECODER
@@ -929,3 +923,48 @@ def mock_to_variant(expr: ColumnEmulator):
     res = expr.copy()
     res.sf_type = ColumnType(VariantType(), expr.sf_type.nullable)
     return res
+
+
+@patch("upper")
+def mock_upper(expr: ColumnEmulator):
+    return expr.str.upper()
+
+
+@patch("lower")
+def mock_lower(expr: ColumnEmulator):
+    return expr.str.lower()
+
+
+@patch("length")
+def mock_length(expr: ColumnEmulator):
+    result = expr.str.len()
+    result.sf_type = ColumnType(LongType(), nullable=expr.sf_type.nullable)
+    return result
+
+
+# See https://docs.snowflake.com/en/sql-reference/functions/initcap for list of delimiters
+DEFAULT_INITCAP_DELIMITERS = set('!?@"^#$&~_,.:;+-*%/|\\[](){}<>' + string.whitespace)
+
+
+def _initcap(value: Optional[str], delimiters: Optional[str]) -> str:
+    if value is None:
+        return None
+
+    delims = DEFAULT_INITCAP_DELIMITERS if delimiters is None else set(delimiters)
+
+    result = ""
+    cap = True
+    for char in value:
+        if cap:
+            result += char.upper()
+        else:
+            result += char.lower()
+        cap = char in delims
+    return result
+
+
+@patch("initcap")
+def mock_initcap(values: ColumnEmulator, delimiters: ColumnEmulator):
+    result = values.combine(delimiters, _initcap)
+    result.sf_type = values.sf_type
+    return result

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -586,6 +586,22 @@ class TestData:
         return session.create_dataframe([["str", 1], [None, 2]], schema=["a", "b"])
 
     @classmethod
+    def string8(cls, session: "Session") -> DataFrame:
+        return session.create_dataframe(
+            [
+                (
+                    "foo-bar;baz",
+                    "qwer,dvor>azer",
+                    "lower",
+                    "UPPER",
+                    "Chief Variable Officer",
+                    "Lorem ipsum dolor sit amet",
+                )
+            ],
+            schema=["delim1", "delim2", "lower", "upper", "title", "sentence"],
+        )
+
+    @classmethod
     def array1(cls, session: "Session") -> DataFrame:
         return session.sql(
             "select array_construct(a,b,c) as arr1, array_construct(d,e,f) as arr2 "


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1043119

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR adds support for string operations upper, lower, length, and initcap to local testing. I also added additional testing examples to check a few more cases that I wanted.