### PR TITLE
SNOW-1058663  Fix `ServerConnection. _to_data_or_iter` to return the original query id

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -440,9 +440,7 @@ class ServerConnection:
             to_iter and not to_pandas
         ):  # Fix for SNOW-869536, to_pandas doesn't have this issue, SnowflakeCursor.fetch_pandas_batches already handles the isolation.
             new_cursor = results_cursor.connection.cursor()
-            new_cursor.execute(
-                f"SELECT * FROM TABLE(RESULT_SCAN('{results_cursor.sfqid}'))"
-            )
+            new_cursor.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{qid}'))")
             results_cursor = new_cursor
 
         if to_pandas:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1058663

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Context:** Currently t_python_sp::table_procs_on_snowsql.ssql is failing in PythonStoredProcBuildPrecommitTest because of the changes introduced in SNOW-869536 Fix buggy behavior in DataFrame.to_local_iterator  by sfc-gh-stan · Pull Request #1226 · snowflakedb/snowpark-python . This is because the implementation of table sprocs calls `_execute_and_get_query_id`, which calls `ServerConnection._to_data_or_iter` with `to_iter` set to True, therefore is affected by the code change in Snowpark Python API. The error indicates SnowSQL can only retrieve the query result in Arrow, therefore it is likely due to `_execute_and_get_query_id` needs to return the query ID of the original query instead of a result scan.
  
    **Changes in this PR:** Make sure `ServerConnection._to_data_iter` returns the query ID of the original query instead of the result scan when `to_iter` is True and `to_pandas` is False.

    **Successful precommit run**: https://ci-dev-133.int.snowflakecomputing.com/job/RT-Precommit/13976/
