### PR TITLE
Alter closing sessions inside a stored procedure to write a warning instead of throwing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Improvements
 
 - Added cleanup logic at interpreter shutdown to close all active sessions.
+- Closing sessions within stored procedures now is a no-op logging a warning instead of raising an error.
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -423,13 +423,6 @@ class SnowparkClientExceptionMessages:
             error_code="1410",
         )
 
-    @staticmethod
-    def DONT_CLOSE_SESSION_IN_SP() -> SnowparkSessionException:
-        return SnowparkSessionException(
-            "In a stored procedure, you shouldn't close a session. The stored procedure manages the lifecycle of the provided session.",
-            error_code="1411",
-        )
-
     # General Error codes 15XX
 
     @staticmethod

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -492,7 +492,7 @@ class Session:
     def close(self) -> None:
         """Close this session."""
         if is_in_stored_procedure():
-            raise SnowparkClientExceptionMessages.DONT_CLOSE_SESSION_IN_SP()
+            _logger.warning("Closing a session in a stored procedure is a no-op.")
         try:
             if self._conn.is_closed():
                 _logger.debug(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -23,7 +23,6 @@ from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Uni
 
 import cloudpickle
 import pkg_resources
-
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.connector.pandas_tools import write_pandas
@@ -493,6 +492,7 @@ class Session:
         """Close this session."""
         if is_in_stored_procedure():
             _logger.warning("Closing a session in a stored procedure is a no-op.")
+            return
         try:
             if self._conn.is_closed():
                 _logger.debug(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -215,6 +215,8 @@ def _close_session_atexit():
     This is the helper function to close all active sessions at interpreter shutdown. For example, when a jupyter
     notebook is shutting down, this will also close all active sessions and make sure send all telemetry to the server.
     """
+    if is_in_stored_procedure():
+        return
     with _session_management_lock:
         for session in _active_sessions.copy():
             try:
@@ -476,6 +478,8 @@ class Session:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if not is_in_stored_procedure():
+            self.close()
         self.close()
 
     def __str__(self):

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -480,7 +480,6 @@ class Session:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if not is_in_stored_procedure():
             self.close()
-        self.close()
 
     def __str__(self):
         return (

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Uni
 
 import cloudpickle
 import pkg_resources
+
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.connector.pandas_tools import write_pandas

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -569,7 +569,6 @@ def test_use_secondary_roles(session):
     session.use_secondary_roles(current_role[1:-1])
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC, reason="Can't create a session in SP")
 def test_close_session_twice(db_parameters):
     new_session = Session.builder.configs(db_parameters).create()
     new_session.close()

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -7,7 +7,6 @@ import os
 from functools import partial
 
 import pytest
-
 import snowflake.connector
 from snowflake.connector.errors import ProgrammingError
 from snowflake.snowpark import Row, Session
@@ -23,6 +22,7 @@ from snowflake.snowpark.session import (
     _get_active_session,
     _get_active_sessions,
 )
+
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 
@@ -199,9 +199,8 @@ def test_close_session_in_sp(session):
     original_platform = internal_utils.PLATFORM
     internal_utils.PLATFORM = "XP"
     try:
-        with pytest.raises(SnowparkSessionException) as exec_info:
-            session.close()
-        assert exec_info.value.error_code == "1411"
+        session.close()
+        assert not session.connection.is_closed()
     finally:
         internal_utils.PLATFORM = original_platform
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -570,7 +570,6 @@ def test_use_secondary_roles(session):
     session.use_secondary_roles(current_role[1:-1])
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC, reason="SP doesn't allow to close a session.")
 def test_close_session_twice(db_parameters):
     new_session = Session.builder.configs(db_parameters).create()
     new_session.close()

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -569,6 +569,7 @@ def test_use_secondary_roles(session):
     session.use_secondary_roles(current_role[1:-1])
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="Can't create a session in SP")
 def test_close_session_twice(db_parameters):
     new_session = Session.builder.configs(db_parameters).create()
     new_session.close()

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -7,6 +7,7 @@ import os
 from functools import partial
 
 import pytest
+
 import snowflake.connector
 from snowflake.connector.errors import ProgrammingError
 from snowflake.snowpark import Row, Session
@@ -22,7 +23,6 @@ from snowflake.snowpark.session import (
     _get_active_session,
     _get_active_sessions,
 )
-
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -570,6 +570,7 @@ def test_use_secondary_roles(session):
     session.use_secondary_roles(current_role[1:-1])
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="Can't create a session in SP")
 def test_close_session_twice(db_parameters):
     new_session = Session.builder.configs(db_parameters).create()
     new_session.close()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -123,7 +123,7 @@ def test_close_exception():
         session.close()
 
 
-def test_close_exception_in_stored_procedure_log_level_warning(caplog):
+def test_close_session_in_stored_procedure_log_level_warning(caplog):
     caplog.set_level(logging.WARNING)
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()
@@ -137,7 +137,7 @@ def test_close_exception_in_stored_procedure_log_level_warning(caplog):
     assert "Closing a session in a stored procedure is a no-op." in caplog.text
 
 
-def test_close_exception_in_stored_procedure_log_level_info(caplog):
+def test_close_session_in_stored_procedure_log_level_info(caplog):
     caplog.set_level(logging.WARNING)
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()
@@ -151,7 +151,7 @@ def test_close_exception_in_stored_procedure_log_level_info(caplog):
     assert "Closing a session in a stored procedure is a no-op." in caplog.text
 
 
-def test_close_exception_in_stored_procedure_log_level_error(caplog):
+def test_close_session_in_stored_procedure_log_level_error(caplog):
     caplog.set_level(logging.ERROR)
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -9,6 +9,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+
 import snowflake.snowpark.session
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 
@@ -241,7 +242,9 @@ def test_resolve_package_terms_not_accepted():
     def get_information_schema_packages(table_name: str):
         if table_name == "information_schema.packages":
             result = MagicMock()
-            result.filter().group_by().agg()._internal_collect_with_tag.return_value = []
+            result.filter().group_by().agg()._internal_collect_with_tag.return_value = (
+                []
+            )
             return result
 
     def run_query(sql: str):


### PR DESCRIPTION
1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1259 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Instead of throwing an error message when attempting to close a session a warning is written informing that closing a session inside a stored procedure is a no-op.
Afterwards the functionality to close sessions is ignored by returning from the function directly after writing a warning.
