### PR TITLE
SNOW-1064328 Use object name if db/schema is missing in stored proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added support for creating vectorized UDTFs with `process` method.
 
+### Deprecations:
+
+- Deprecated `Session.get_fully_qualified_current_schema`. Consider using `Session.get_fully_qualified_name_if_possible` instead.
+
 ## 1.13.0 (2024-02-26)
 
 ### New Features

--- a/docs/source/session.rst
+++ b/docs/source/session.rst
@@ -52,6 +52,7 @@ Snowpark Session
       Session.get_current_user
       Session.get_current_warehouse
       Session.get_fully_qualified_current_schema
+      Session.get_fully_qualified_name_if_possible
       Session.get_imports
       Session.get_packages
       Session.get_session_stage

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -818,7 +818,6 @@ class SnowflakePlanBuilder:
         path: str,
         format: str,
         options: Dict[str, str],
-        fully_qualified_schema: str,
         schema: List[Attribute],
         schema_to_cast: Optional[List[Tuple[str, str]]] = None,
         transformations: Optional[List[str]] = None,
@@ -853,10 +852,8 @@ class SnowflakePlanBuilder:
             post_queries: List[Query] = []
             use_temp_file_format: bool = "FORMAT_NAME" not in options
             if use_temp_file_format:
-                format_name = (
-                    fully_qualified_schema
-                    + "."
-                    + random_name_for_temp_object(TempObjectType.FILE_FORMAT)
+                format_name = self.session.get_fully_qualified_name_if_possible(
+                    random_name_for_temp_object(TempObjectType.FILE_FORMAT)
                 )
                 queries.append(
                     Query(
@@ -928,10 +925,8 @@ class SnowflakePlanBuilder:
                 ]
             )
 
-            temp_table_name = (
-                fully_qualified_schema
-                + "."
-                + random_name_for_temp_object(TempObjectType.TABLE)
+            temp_table_name = self.session.get_fully_qualified_name_if_possible(
+                random_name_for_temp_object(TempObjectType.TABLE)
             )
             queries = [
                 Query(

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -548,9 +548,7 @@ def process_registration_inputs(
     else:
         object_name = random_name_for_temp_object(object_type)
         if not anonymous:
-            object_name = (
-                f"{session.get_fully_qualified_current_schema()}.{object_name}"
-            )
+            object_name = session.get_fully_qualified_name_if_possible(object_name)
     validate_object_name(object_name)
 
     # get return and input types

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3646,7 +3646,9 @@ class DataFrame:
         """
         from snowflake.snowpark.mock._connection import MockServerConnection
 
-        temp_table_name = f'{self._session.get_current_database()}.{self._session.get_current_schema()}."{random_name_for_temp_object(TempObjectType.TABLE)}"'
+        temp_table_name = self._session.get_fully_qualified_name_if_possible(
+            f'"{random_name_for_temp_object(TempObjectType.TABLE)}"'
+        )
 
         if isinstance(self._session._conn, MockServerConnection):
             self.write.save_as_table(temp_table_name, create_temp_table=True)

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -434,7 +434,6 @@ class DataFrameReader:
                             path,
                             self._file_type,
                             self._cur_options,
-                            self._session.get_fully_qualified_current_schema(),
                             schema,
                             schema_to_cast=schema_to_cast,
                             transformations=transformations,
@@ -453,7 +452,6 @@ class DataFrameReader:
                     path,
                     self._file_type,
                     self._cur_options,
-                    self._session.get_fully_qualified_current_schema(),
                     schema,
                     schema_to_cast=schema_to_cast,
                     transformations=transformations,
@@ -576,10 +574,8 @@ class DataFrameReader:
     ) -> Tuple[List, List, List, Exception]:
         format_type_options, _ = get_copy_into_table_options(self._cur_options)
 
-        temp_file_format_name = (
-            self._session.get_fully_qualified_current_schema()
-            + "."
-            + random_name_for_temp_object(TempObjectType.FILE_FORMAT)
+        temp_file_format_name = self._session.get_fully_qualified_name_if_possible(
+            random_name_for_temp_object(TempObjectType.FILE_FORMAT)
         )
         drop_tmp_file_format_if_exists_query: Optional[str] = None
         use_temp_file_format = "FORMAT_NAME" not in self._cur_options
@@ -685,7 +681,6 @@ class DataFrameReader:
                             path,
                             format,
                             self._cur_options,
-                            self._session.get_fully_qualified_current_schema(),
                             schema,
                             schema_to_cast=schema_to_cast,
                             transformations=read_file_transformations,
@@ -704,7 +699,6 @@ class DataFrameReader:
                     path,
                     format,
                     self._cur_options,
-                    self._session.get_fully_qualified_current_schema(),
                     schema,
                     schema_to_cast=schema_to_cast,
                     transformations=read_file_transformations,

--- a/src/snowflake/snowpark/mock/_plan_builder.py
+++ b/src/snowflake/snowpark/mock/_plan_builder.py
@@ -21,7 +21,6 @@ class MockSnowflakePlanBuilder(SnowflakePlanBuilder):
         path: str,
         format: str,
         options: Dict[str, str],
-        fully_qualified_schema: str,
         schema: List[Attribute],
         schema_to_cast: Optional[List[Tuple[str, str]]] = None,
         transformations: Optional[List[str]] = None,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2593,7 +2593,7 @@ class Session:
         """
         return self._conn._get_current_parameter("schema")
 
-    @deprecated(version="1.15.0")
+    @deprecated(version="1.14.0")
     def get_fully_qualified_current_schema(self) -> str:
         """Returns the fully qualified name of the current schema for the session."""
         return self.get_fully_qualified_name_if_possible("")[:-1]

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2593,6 +2593,11 @@ class Session:
         """
         return self._conn._get_current_parameter("schema")
 
+    @deprecated(version="1.15.0")
+    def get_fully_qualified_current_schema(self) -> str:
+        """Returns the fully qualified name of the current schema for the session."""
+        return self.get_fully_qualified_name_if_possible("")[:-1]
+
     def get_fully_qualified_name_if_possible(self, name: str) -> str:
         """
         Returns the fully qualified object name if current database/schema exists, otherwise returns the object name

--- a/tests/integ/scala/test_permanent_udf_suite.py
+++ b/tests/integ/scala/test_permanent_udf_suite.py
@@ -107,8 +107,12 @@ def test_support_fully_qualified_udf_name(session, new_session):
     def add_one(x: int) -> int:
         return x + 1
 
-    temp_func_name = f"{session.get_fully_qualified_current_schema()}.{Utils.random_name_for_temp_object(TempObjectType.FUNCTION)}"
-    perm_func_name = f"{session.get_fully_qualified_current_schema()}.{Utils.random_name_for_temp_object(TempObjectType.FUNCTION)}"
+    temp_func_name = session.get_fully_qualified_name_if_possible(
+        Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
+    )
+    perm_func_name = session.get_fully_qualified_name_if_possible(
+        Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
+    )
     stage_name = Utils.random_stage_name()
     try:
         Utils.create_stage(session, stage_name, is_temporary=False)

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -128,7 +128,7 @@ def test_negative_test_for_missing_required_parameter_schema(
     new_session.sql_simplifier_enabled = sql_simplifier_enabled
     with new_session:
         with pytest.raises(SnowparkMissingDbOrSchemaException) as ex_info:
-            new_session.get_fully_qualified_current_schema()
+            new_session.get_fully_qualified_name_if_possible("table")
         assert "The SCHEMA is not set for the current session." in str(ex_info)
 
 

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -299,7 +299,7 @@ def test_call_udf_api(session):
         df.with_column(
             "c",
             call_udf(
-                f"{session.get_fully_qualified_current_schema()}.{function_name}",
+                session.get_fully_qualified_name_if_possible(function_name),
                 col("a"),
             ),
         ).collect(),

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -222,7 +222,7 @@ def test_list_files_in_stage(session, resources_path, local_testing_mode):
         assert len(files) == 1
         assert os.path.basename(test_files.test_file_avro) in files
 
-        full_name = f"{session.get_fully_qualified_current_schema()}.{stage_name}"
+        full_name = session.get_fully_qualified_name_if_possible(stage_name)
         files2 = session._list_files_in_stage(full_name)
         assert len(files2) == 1
         assert os.path.basename(test_files.test_file_avro) in files2
@@ -241,8 +241,8 @@ def test_list_files_in_stage(session, resources_path, local_testing_mode):
         assert len(files4) == 1
         assert os.path.basename(test_files.test_file_avro) in files4
 
-        full_name_with_prefix = (
-            f"{session.get_fully_qualified_current_schema()}.{quoted_name}"
+        full_name_with_prefix = session.get_fully_qualified_name_if_possible(
+            quoted_name
         )
         files5 = session._list_files_in_stage(full_name_with_prefix)
         assert len(files5) == 1

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -249,12 +249,7 @@ def test_call_named_stored_procedure(session, temp_schema, db_parameters):
         name=sproc_name,
     )
     assert session.call(sproc_name, 13, 19) == 13 * 19
-    assert (
-        session.call(
-            f"{session.get_fully_qualified_current_schema()}.{sproc_name}", 13, 19
-        )
-        == 13 * 19
-    )
+    assert session.call(session.get_session_stage(sproc_name), 13, 19) == 13 * 19
 
     # create a stored procedure when the session doesn't have a schema
     new_session = (

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -249,7 +249,10 @@ def test_call_named_stored_procedure(session, temp_schema, db_parameters):
         name=sproc_name,
     )
     assert session.call(sproc_name, 13, 19) == 13 * 19
-    assert session.call(session.get_session_stage(sproc_name), 13, 19) == 13 * 19
+    assert (
+        session.call(session.get_fully_qualified_name_if_possible(sproc_name), 13, 19)
+        == 13 * 19
+    )
 
     # create a stored procedure when the session doesn't have a schema
     new_session = (

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -192,7 +192,7 @@ def test_call_named_udf(session, temp_schema, db_parameters):
     Utils.check_answer(
         df.select(
             call_udf(
-                f"{session.get_fully_qualified_current_schema()}.{mult_udf_name}",
+                session.get_fully_qualified_name_if_possible(mult_udf_name),
                 6,
                 7,
             )

--- a/tests/unit/test_stored_procedure.py
+++ b/tests/unit/test_stored_procedure.py
@@ -72,7 +72,7 @@ def test_negative_execute_as():
 def test_do_register_sp_negative(cleanup_registration_patch):
     fake_session = mock.create_autospec(Session)
     fake_session._runtime_version_from_requirement = None
-    fake_session.get_fully_qualified_current_schema = mock.Mock(
+    fake_session.get_fully_qualified_name_if_possible = mock.Mock(
         return_value="database.schema"
     )
     fake_session._run_query = mock.Mock(side_effect=ProgrammingError())

--- a/tests/unit/test_udaf.py
+++ b/tests/unit/test_udaf.py
@@ -39,7 +39,7 @@ def test_register_udaf_negative():
 @mock.patch("snowflake.snowpark.udaf.cleanup_failed_permanent_registration")
 def test_do_register_udaf_negative(cleanup_registration_patch):
     fake_session = mock.create_autospec(Session)
-    fake_session.get_fully_qualified_current_schema = mock.Mock(
+    fake_session.get_fully_qualified_name_if_possible = mock.Mock(
         return_value="database.schema"
     )
     fake_session._run_query = mock.Mock(side_effect=ProgrammingError())

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -18,7 +18,7 @@ from snowflake.snowpark.udf import UDFRegistration
 def test_do_register_sp_negative(cleanup_registration_patch):
     fake_session = mock.create_autospec(Session)
     fake_session._runtime_version_from_requirement = None
-    fake_session.get_fully_qualified_current_schema = mock.Mock(
+    fake_session.get_fully_qualified_name_if_possible = mock.Mock(
         return_value="database.schema"
     )
     fake_session._run_query = mock.Mock(side_effect=ProgrammingError())

--- a/tests/unit/test_udtf.py
+++ b/tests/unit/test_udtf.py
@@ -26,7 +26,7 @@ else:
 @mock.patch("snowflake.snowpark.udtf.cleanup_failed_permanent_registration")
 def test_do_register_sp_negative(cleanup_registration_patch):
     fake_session = mock.create_autospec(Session)
-    fake_session.get_fully_qualified_current_schema = mock.Mock(
+    fake_session.get_fully_qualified_name_if_possible = mock.Mock(
         return_value="database.schema"
     )
     fake_session._run_query = mock.Mock(side_effect=ProgrammingError())


### PR DESCRIPTION
Description

In snowpark API, we use fully qualified name for temp objects created implicitly by the API, mainly to support locating the object even if user changes schema of the session.

However, in stored procs, we have use cases like bundle where it is legit to have current_database/current_schema to return NULL. We still want to support object creation in this case.

Thus, our change is to fall back to use the object name if there is no current database/schema and the client is running inside the stored procedure

Testing

Existing tests + bundle integration test

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
