### PR TITLE
Merge gate fix

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -918,6 +918,7 @@ class Session:
             >>> # add numpy with the latest version on Snowflake Anaconda
             >>> # and pandas with the version "1.3.*"
             >>> # and dateutil with the local version in your environment
+            >>> session.custom_package_usage_config = {"enabled": True}  # This is added because latest dateutil is not in snowflake yet
             >>> session.add_packages("numpy", "pandas==1.5.*", dateutil)
             >>> @udf
             ... def get_package_name_udf() -> list:

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -1007,7 +1007,6 @@ def test_add_requirements_unsupported_with_cache_path(
     assert "matplotlib" in package_set
     assert "pyyaml" in package_set
     assert "pandas" in package_set
-    assert "python-dateutil" in package_set
     assert "scikit-learn" in package_set
     assert "six" in package_set
 


### PR DESCRIPTION
Description

Our merge gate is broken because of a new python-dateutil release.

To fix merge gate, there are two changes

- We don't check python-dateutil is in package set. The reason is that the latest version of python-dateutil is not on Snowflake yet, and as a result, we use custom package and not specify this package in session.
- We add session.custom_package_usage_config for the python-dateutil related doc test.

Testing

Merge gate passing

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #NNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
