### PR TITLE
SNOW-1063758 Fix Local Testing's implementation of Column.regexp to handle Column of strings as `pattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Bug Fixes
 
 - Fixed a bug in local testing implementation of DataFrameReader.csv when the optional parameter `field_optionally_enclosed_by` is specified.
+- Fixed a bug in local testing implementation of Column.regexp where only the first entry is considered when `pattern` is a `Column`.
 
 ## 1.13.0 (2024-02-26)
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1431,14 +1431,25 @@ def calculate_expression(
         lhs = calculate_expression(exp.expr, input_data, analyzer, expr_to_alias)
         raw_pattern = calculate_expression(
             exp.pattern, input_data, analyzer, expr_to_alias
-        )[0]
-        pattern = f"^{raw_pattern}" if not raw_pattern.startswith("^") else raw_pattern
-        pattern = f"{pattern}$" if not pattern.endswith("$") else pattern
-        try:
-            re.compile(pattern)
-        except re.error:
-            raise SnowparkSQLException(f"Invalid regular expression {raw_pattern}")
-        result = lhs.str.match(pattern)
+        )
+        arguments = TableEmulator({"LHS": lhs, "PATTERN": raw_pattern})
+
+        def _match_pattern(row) -> bool:
+            input_str = row["LHS"]
+            raw_pattern = row["PATTERN"]
+            _pattern = (
+                f"^{raw_pattern}" if not raw_pattern.startswith("^") else raw_pattern
+            )
+            _pattern = f"{_pattern}$" if not _pattern.endswith("$") else _pattern
+
+            try:
+                re.compile(_pattern)
+            except re.error:
+                raise SnowparkSQLException(f"Invalid regular expression {raw_pattern}")
+
+            return bool(re.match(_pattern, input_str))
+
+        result = arguments.apply(_match_pattern, axis=1)
         result.sf_type = ColumnType(BooleanType(), True)
         return result
     if isinstance(exp, Like):

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -633,6 +633,21 @@ def test_regexp(session):
         TestData.string4(session).where(col("A").regexp("+*")).collect()
     assert "Invalid regular expression" in str(ex_info)
 
+    # Test when pattern is a column of literal strings
+    df = session.create_dataframe(
+        [
+            ["MATCH", "MATCH"],
+            ["MAT.*", "MATCH"],
+            [".*", "MATCH"],
+            ["NO_MATCH", "MATCH"],
+        ],
+        schema=["pattern", "content"],
+    )
+
+    assert df.select(
+        col("CONTENT").regexp(col("PATTERN")).alias("RESULT")
+    ).collect() == [Row(True), Row(True), Row(True), Row(False)]
+
 
 @pytest.mark.parametrize("spec", ["en_US-trim", "'en_US-trim'"])
 def test_collate(session, spec):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1063758

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Issue**: Previously, if `pattern` is specified as column (e.g. `df.col1.regexp(df.col2)`), Local Testing uses the first entry in the column to match all entries in the left hand side. This is incorrect, the expected behavior is to do a row-wise match so each LHS entry is matched with the corresponding entry from `pattern`.

   **Fix**: This PR implements the expected behavior. 
