### PR TITLE
SNOW-1054965  Fix Local Testing's implementation of left anti/semi join by removing unnecessary dropnas 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added support for creating vectorized UDTFs with `process` method.
 
+### Bug Fixes
+
+- Fixed a bug in Local Testing's implementation of LEFT ANTI and LEFT SEMI joins where rows with null values are dropped.
+
 ### Deprecations:
 
 - Deprecated `Session.get_fully_qualified_current_schema`. Consider using `Session.get_fully_qualified_name_if_possible` instead.

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -854,9 +854,9 @@ def execute_mock_plan(
             )
             sf_types = result_df.sf_types
             if "SEMI" in source_plan.join_type.sql:  # left semi
-                result_df = left[outer_join(left)].dropna()
+                result_df = left[outer_join(left)]
             elif "ANTI" in source_plan.join_type.sql:  # left anti
-                result_df = left[~outer_join(left)].dropna()
+                result_df = left[~outer_join(left)]
             elif "LEFT" in source_plan.join_type.sql:  # left outer join
                 # rows from LEFT that did not get matched
                 unmatched_left = left[~outer_join(left)]

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1193,6 +1193,12 @@ def test_join_left_anti(session):
     expected = [Row(3, 3), Row(4, 4)]
     assert sorted(res, key=lambda r: r[0]) == expected
 
+    df3 = session.create_dataframe(
+        [[i if i & 2 else None] for i in range(3, 8)], schema=["id"]
+    )
+    res = df3.join(df1, "id", "leftanti").collect()
+    assert res == [Row(ID=None), Row(ID=None)]
+
 
 @pytest.mark.localtest
 def test_join_left_outer(session):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1054965

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Issue:**  The current implementation drops all rows containing null values from the result of a LEFT ANTI JOIN or LEFT SEMI JOIN. This is incorrect and unnecessary.

    **Fix**: This PR removes the `dropna` and adds a test for when there are null values in the result. 
