### PR TITLE
SNOW-1216530 Fix Local Testing's handling of `VARIANT` columns at `DataFrame.collect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Bug Fixes
 
 - Fixed a bug in Local Testing's implementation of LEFT ANTI and LEFT SEMI joins where rows with null values are dropped.
+- Fixed a bug in Local Testing's implementation where VARIANT columns raise errors at `DataFrame.collect`.
 
 ### Deprecations:
 

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -420,15 +420,15 @@ class MockServerConnection:
                 ):
                     from snowflake.snowpark.mock import CUSTOM_JSON_ENCODER
 
-                    for row in range(len(res[col])):
-                        if res[col][row] is not None:
-                            res.loc[row, col] = json.dumps(
-                                res[col][row], cls=CUSTOM_JSON_ENCODER, indent=2
+                    for idx, row in res.iterrows():
+                        if row[col] is not None:
+                            res.loc[idx, col] = json.dumps(
+                                row[col], cls=CUSTOM_JSON_ENCODER, indent=2
                             )
                         else:
                             # snowflake returns Python None instead of the str 'null' for DataType data
-                            res.loc[row, col] = (
-                                "null" if row in res._null_rows_idxs_map[col] else None
+                            res.loc[idx, col] = (
+                                "null" if idx in res._null_rows_idxs_map[col] else None
                             )
 
             # when setting output rows, snowpark python running against snowflake don't escape double quotes

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1748,6 +1748,7 @@ def test_create_dataframe_with_schema_col_names(session):
         assert Utils.equals_ignore_case(field.name, expected_name)
 
 
+@pytest.mark.localtest
 def test_create_dataframe_with_variant(session):
     data = [
         1,


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1216530, i.e. #1290

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   **Issue**: The current implementation is not iterating over the rows correctly. E.g. A pandas DataFrame can be initialized with 3 rows, after removing the middle row, the dataframe's row index now looks like [0,2]. So `df[col][1]` does not access the second row, the code would fail to find a row indexed with `1`.

    **Solution**: This PR uses `DataFrame.iterrows` to iterrate the rows of a pandas DataFrame instead. 
