### PR TITLE
Support Python 3.10 union syntax in UDF

### DIFF
--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -12,6 +12,7 @@ import datetime
 import decimal
 import re
 import sys
+from types import UnionType
 import typing  # noqa: F401
 from array import array
 from typing import (  # noqa: F401
@@ -511,7 +512,7 @@ def python_type_to_snow_type(
     # only typing.Optional[X], i.e., typing.Union[X, None] is accepted
     if (
         tp_origin
-        and tp_origin == Union
+        and (tp_origin == Union or tp_origin == UnionType)
         and tp_args
         and len(tp_args) == 2
         and tp_args[1] == NoneType


### PR DESCRIPTION
`str | None` should be equivalent to `Optional[str]`.

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowpark-python/issues/1302

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
