### PR TITLE
SNOW-1075566: Refactor local testing to allow constant function returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
     - udf
 - Added the function `DataFrame.write.csv` to unload data from a ``DataFrame`` into one or more CSV files in a stage.
 
+### Bug Fixes
+
+- Fixed a bug in local testing that null filled columns for constant functions.
+
 ## 1.14.0 (2024-03-20)
 
 ### New Features
@@ -90,7 +94,6 @@
 - Fixed a bug in `DataFrame.to_local_iterator` where the iterator could yield wrong results if another query is executed before the iterator finishes due to wrong isolation level. For details, please see #945.
 - Fixed a bug that truncated table names in error messages while running a plan with local testing enabled.
 - Fixed a bug that `Session.range` returns empty result when the range is large.
-- Fixed a bug in local testing that null filled columns for constant functions.
 
 ## 1.12.1 (2024-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Fixed a bug in `DataFrame.to_local_iterator` where the iterator could yield wrong results if another query is executed before the iterator finishes due to wrong isolation level. For details, please see #945.
 - Fixed a bug that truncated table names in error messages while running a plan with local testing enabled.
 - Fixed a bug that `Session.range` returns empty result when the range is large.
+- Fixed a bug in local testing that null filled columns for constant functions.
 
 ## 1.12.1 (2024-02-08)
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -407,7 +407,7 @@ def handle_function_expression(
         )
         and len(result) == 1
     ):
-        resized = result.repeat(len(input_data)).reset_index()[0]
+        resized = result.repeat(len(input_data)).reset_index(drop=True)
         resized.sf_type = result.sf_type
         return resized
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -394,7 +394,24 @@ def handle_function_expression(
             current_row
         )  # the row's 0-base index in the window
         to_pass_args.append(row_idx)
-    return _MOCK_FUNCTION_IMPLEMENTATION_MAP[func_name](*to_pass_args)
+
+    result = _MOCK_FUNCTION_IMPLEMENTATION_MAP[func_name](*to_pass_args)
+
+    # If none of the args are column emulators and the function result only has one item
+    # assume that the single value should be repeated instead of Null filled. This allows
+    # constant expressions like current_date or current_database to fill a column instead
+    # of just the first row.
+    if (
+        not any(
+            isinstance(arg, (ColumnEmulator, TableEmulator)) for arg in to_pass_args
+        )
+        and len(result) == 1
+    ):
+        resized = result.repeat(len(input_data)).reset_index()[0]
+        resized.sf_type = result.sf_type
+        return resized
+
+    return result
 
 
 def handle_udf_expression(

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -2704,7 +2704,6 @@ def test_drop_duplicates(session):
     )
 
     result1 = df.dropDuplicates(["a"])
-    # import pdb; pdb.set_trace()
     assert result1.count() == 1
     row1 = result1.collect()[0]
     # result is non-deterministic.

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -2704,6 +2704,7 @@ def test_drop_duplicates(session):
     )
 
     result1 = df.dropDuplicates(["a"])
+    # import pdb; pdb.set_trace()
     assert result1.count() == 1
     row1 = result1.collect()[0]
     # result is non-deterministic.

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -209,19 +209,31 @@ def test_order(session):
 @pytest.mark.localtest
 def test_current_date_and_time(session):
     max_delta = 1
-    df = session.create_dataframe([1]).select(
-        current_date(), current_time(), current_timestamp()
+    df = (
+        session.create_dataframe([1, 2])
+        .to_df(["a"])
+        .select("a", current_date(), current_time(), current_timestamp())
     )
     rows = df.collect()
 
-    assert len(rows) == 1, "df1 should only contain 1 row"
-    date, time, timestamp = rows[0]
-    time1 = datetime.datetime.combine(date, time).timestamp()
-    time2 = timestamp.timestamp()
+    assert len(rows) == 2, "df should contain 2 rows"
+    for row in rows:
+        assert isinstance(
+            row[1], datetime.date
+        ), f"current_date ({row[1]}) should be datetime.date type"
+        assert isinstance(
+            row[2], datetime.time
+        ), f"current_time ({row[2]}) should be datetime.time type"
+        assert isinstance(
+            row[3], datetime.datetime
+        ), f"current_timestamp ({row[3]}) should be datetime.datetime type"
+        _, date, time, timestamp = row
+        time1 = datetime.datetime.combine(date, time).timestamp()
+        time2 = timestamp.timestamp()
 
-    assert time1 == pytest.approx(
-        time2, max_delta
-    ), f"Times should be within {max_delta} seconds of each other."
+        assert time1 == pytest.approx(
+            time2, max_delta
+        ), f"Times should be within {max_delta} seconds of each other."
 
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1075566

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  This PR adds some pattern matching to function expression handling that detects constant functions and fills the column with the returned value rather than null filling after the first value.

See here for more info: https://github.com/snowflakedb/snowpark-python/issues/1266

An alternative to this PR would be to introduce a new return type to local functions that tells the planner that the result is a constant that should populate a whole column. This would make it more explicit when this behaviour should happen, but would make the user experience of making a local function a little more confusing. @sfc-gh-aling and I agreed that the current approach is better for that reason.
