### PR TITLE
SNOW-1239792: disable oob telemetry in stored procedure

### DIFF
--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -242,7 +242,7 @@ class MockServerConnection:
             "disable_local_testing_telemetry", False
         )
         self._oob_telemetry = LocalTestOOBTelemetryService.get_instance()
-        if self._disable_local_testing_telemetry:
+        if self._disable_local_testing_telemetry or is_in_stored_procedure():
             # after disabling, the log will basically be a no-op, not sending any telemetry
             self._oob_telemetry.disable()
         else:

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -83,6 +83,8 @@ class LocalTestOOBTelemetryService(TelemetryService):
         success = True
         response = None
         try:
+            # import here is because stored proc doesn't have vendored request module
+            # have it at the top will cause import error in stored procedure running
             from snowflake.connector.vendored import requests
 
             with requests.Session() as session:

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -13,7 +13,6 @@ from typing import Optional
 from snowflake.connector.compat import OK
 from snowflake.connector.secret_detector import SecretDetector
 from snowflake.connector.telemetry_oob import REQUEST_TIMEOUT, TelemetryService
-from snowflake.connector.vendored import requests
 from snowflake.snowpark._internal.utils import (
     get_os_name,
     get_python_version,
@@ -84,6 +83,8 @@ class LocalTestOOBTelemetryService(TelemetryService):
         success = True
         response = None
         try:
+            from snowflake.connector.vendored import requests
+
             with requests.Session() as session:
                 response = session.post(
                     self._deployment_url,

--- a/tests/mock/test_oob_telemetry.py
+++ b/tests/mock/test_oob_telemetry.py
@@ -19,11 +19,9 @@ from snowflake.snowpark.mock._telemetry import LocalTestOOBTelemetryService
 from snowflake.snowpark.session import Session
 from tests.utils import IS_IN_STORED_PROC
 
-pytestmark = [
-    pytest.mark.skipif(
-        IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
-    )
-]
+pytestmark = pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+)
 
 
 def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):

--- a/tests/mock/test_oob_telemetry.py
+++ b/tests/mock/test_oob_telemetry.py
@@ -17,8 +17,12 @@ from snowflake.snowpark._internal.utils import (
 from snowflake.snowpark.mock._connection import MockServerConnection
 from snowflake.snowpark.mock._telemetry import LocalTestOOBTelemetryService
 from snowflake.snowpark.session import Session
+from tests.utils import IS_IN_STORED_PROC
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+)
 def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
     with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
@@ -66,6 +70,9 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         )
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+)
 def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
     connection_uuid = str(uuid.uuid4())
@@ -158,6 +165,9 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
         assert oob_service.log_not_supported_error()
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+)
 def test_unit_connection(caplog, local_testing_telemetry_setup):
     conn = MockServerConnection()
     # creating a mock connection will send connection telemetry
@@ -179,6 +189,9 @@ def test_unit_connection(caplog, local_testing_telemetry_setup):
     assert conn._oob_telemetry.get_instance().size() == 0
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+)
 def test_unit_connection_disable_telemetry(caplog, local_testing_telemetry_setup):
     disabled_telemetry_conn = MockServerConnection(
         options={"disable_local_testing_telemetry": True}
@@ -199,6 +212,9 @@ def test_unit_connection_disable_telemetry(caplog, local_testing_telemetry_setup
     assert disabled_telemetry_conn._oob_telemetry.get_instance().size() == 0
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+)
 def test_snowpark_telemetry(caplog, local_testing_telemetry_setup):
     session = Session.builder.configs(options={"local_testing": True}).create()
     assert session._conn._oob_telemetry.get_instance().size() == 1

--- a/tests/mock/test_oob_telemetry.py
+++ b/tests/mock/test_oob_telemetry.py
@@ -19,10 +19,13 @@ from snowflake.snowpark.mock._telemetry import LocalTestOOBTelemetryService
 from snowflake.snowpark.session import Session
 from tests.utils import IS_IN_STORED_PROC
 
+pytestmark = [
+    pytest.mark.skipif(
+        IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
+    )
+]
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
-)
+
 def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
     with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
@@ -70,9 +73,6 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         )
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
-)
 def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
     connection_uuid = str(uuid.uuid4())
@@ -165,9 +165,6 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
         assert oob_service.log_not_supported_error()
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
-)
 def test_unit_connection(caplog, local_testing_telemetry_setup):
     conn = MockServerConnection()
     # creating a mock connection will send connection telemetry
@@ -189,9 +186,6 @@ def test_unit_connection(caplog, local_testing_telemetry_setup):
     assert conn._oob_telemetry.get_instance().size() == 0
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
-)
 def test_unit_connection_disable_telemetry(caplog, local_testing_telemetry_setup):
     disabled_telemetry_conn = MockServerConnection(
         options={"disable_local_testing_telemetry": True}
@@ -212,9 +206,6 @@ def test_unit_connection_disable_telemetry(caplog, local_testing_telemetry_setup
     assert disabled_telemetry_conn._oob_telemetry.get_instance().size() == 0
 
 
-@pytest.mark.skipif(
-    IS_IN_STORED_PROC, reason="OOB Telemetry not available in stored procedure"
-)
 def test_snowpark_telemetry(caplog, local_testing_telemetry_setup):
     session = Session.builder.configs(options={"local_testing": True}).create()
     assert session._conn._oob_telemetry.get_instance().size() == 1


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

skip oob telemetry tests as stored proc does not support oob telemetry

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
