### PR TITLE
SNOW-1248609: fix newly introduced test failure related to timezone in sproc

### DIFF
--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -618,7 +618,7 @@ def test_read_csv_with_special_chars_in_format_type_options(session, mode):
             StructField("d", DoubleType()),
             StructField("e", StringType()),
             StructField("f", BooleanType()),
-            StructField("g", TimestampType()),
+            StructField("g", TimestampType(TimestampTimeZone.NTZ)),
             StructField("h", TimeType()),
         ]
     )
@@ -1307,9 +1307,18 @@ def test_filepath_not_exist_or_empty(session):
     not_exist_file_path = f"@{tmp_stage_name1}/{not_exist_file}"
 
     with pytest.raises(FileNotFoundError) as ex_info:
-        session.read.option("PARSE_HEADER", True).option("INFER_SCHEMA", True).csv(empty_file_path)
-    assert f"Given path: '{empty_file_path}' could not be found or is empty." in str(ex_info)
+        session.read.option("PARSE_HEADER", True).option("INFER_SCHEMA", True).csv(
+            empty_file_path
+        )
+    assert f"Given path: '{empty_file_path}' could not be found or is empty." in str(
+        ex_info
+    )
 
     with pytest.raises(FileNotFoundError) as ex_info:
-        session.read.option("PARSE_HEADER", True).option("INFER_SCHEMA", True).csv(not_exist_file_path)
-    assert f"Given path: '{not_exist_file_path}' could not be found or is empty." in str(ex_info)
+        session.read.option("PARSE_HEADER", True).option("INFER_SCHEMA", True).csv(
+            not_exist_file_path
+        )
+    assert (
+        f"Given path: '{not_exist_file_path}' could not be found or is empty."
+        in str(ex_info)
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

PR similar to https://github.com/snowflakedb/snowpark-python/pull/1165.

in sproc + our current test setting, the timezone information is wanted:
```python
G=datetime.datetime(2024, 3, 1, 9, 10, 11, tzinfo=&lt;UTC&gt;)
```

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
