### PR TITLE
SNOW-1184278 [Local Testing] Support registering UDF from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - Session.use_role
   - Session.file.put
   - Session.file.put_stream
+  - udf
 
 ### Bug Fixes
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3108,7 +3108,7 @@ def date_format(c: ColumnOrName, fmt: ColumnOrLiteralStr) -> Column:
     return to_char(try_cast(c, TimestampType()), fmt)
 
 
-def to_time(e: ColumnOrName, fmt: Optional["Column"] = None) -> Column:
+def to_time(e: ColumnOrName, fmt: Optional[ColumnOrLiteralStr] = None) -> Column:
     """Converts an input expression into the corresponding time.
 
     Example::

--- a/src/snowflake/snowpark/mock/__init__.py
+++ b/src/snowflake/snowpark/mock/__init__.py
@@ -1,11 +1,31 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
+from json import JSONEncoder
+
 from ._functions import patch
 from ._snowflake_data_type import ColumnEmulator, ColumnType, TableEmulator
 
-CUSTOM_JSON_ENCODER = None
+
+class NumpyEncoder(JSONEncoder):
+    def default(self, obj):
+        import numpy
+
+        if isinstance(obj, numpy.integer):
+            return int(obj)
+        if isinstance(obj, numpy.floating):
+            return float(obj)
+        if isinstance(obj, numpy.ndarray):
+            return obj.tolist()
+        if isinstance(obj, numpy.bool_):
+            return bool(obj)
+
+        return super().default(obj)
+
+
+CUSTOM_JSON_ENCODER = NumpyEncoder
 CUSTOM_JSON_DECODER = None
+
 
 __all__ = [
     "patch",

--- a/src/snowflake/snowpark/mock/_analyzer.py
+++ b/src/snowflake/snowpark/mock/_analyzer.py
@@ -510,7 +510,7 @@ class MockAnalyzer:
             expr_str = self.analyze(expr.child, expr_to_alias, parse_local_name)
             if parse_local_name:
                 expr_str = expr_str.upper()
-            return expr_str
+            return quote_name(expr_str.strip())
         elif isinstance(expr, Cast):
             return cast_expression(
                 self.analyze(expr.child, expr_to_alias, parse_local_name),

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -464,13 +464,18 @@ def mock_to_time(
     """
     res = []
 
-    auto_detect = bool(not fmt)
+    if not isinstance(fmt, ColumnEmulator):
+        fmt = [fmt] * len(column)
 
-    time_fmt, hour_delta, fractional_seconds = convert_snowflake_datetime_format(
-        fmt, default_format="%H:%M:%S"
-    )
-    for data in column:
+    for data, _fmt in zip(column, fmt):
         try:
+            auto_detect = _fmt is None
+
+            (
+                time_fmt,
+                hour_delta,
+                fractional_seconds,
+            ) = convert_snowflake_datetime_format(_fmt, default_format="%H:%M:%S")
             if data is None:
                 res.append(None)
                 continue

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -84,6 +84,7 @@ from snowflake.snowpark._internal.analyzer.expression import (
     MultipleExpression,
     RegExp,
     ScalarSubquery,
+    SnowflakeUDF,
     Star,
     SubfieldInt,
     SubfieldString,
@@ -319,6 +320,14 @@ def handle_function_expression(
     else:
         func_name = exp.name.lower()
 
+    udf_name = exp.name.split(".")[-1]
+    # If udf name in the registry then this is a udf, not an actual function
+    if udf_name in analyzer.session.udf._registry:
+        exp.udf_name = udf_name
+        return handle_udf_expression(
+            exp, input_data, analyzer, expr_to_alias, current_row
+        )
+
     try:
         original_func = getattr(
             importlib.import_module("snowflake.snowpark.functions"), func_name
@@ -386,6 +395,32 @@ def handle_function_expression(
         )  # the row's 0-base index in the window
         to_pass_args.append(row_idx)
     return _MOCK_FUNCTION_IMPLEMENTATION_MAP[func_name](*to_pass_args)
+
+
+def handle_udf_expression(
+    exp: FunctionExpression,
+    input_data: Union[TableEmulator, ColumnEmulator],
+    analyzer: "MockAnalyzer",
+    expr_to_alias: Optional[Dict[str, str]],
+    current_row=None,
+):
+    udf = analyzer.session.udf._registry.get(exp.udf_name)
+
+    if udf is None:
+        raise SnowparkSQLException(
+            f"[Local Testing] udf {exp.udf_name} does not exist."
+        )
+
+    to_pass_args = [
+        calculate_expression(child, input_data, analyzer, expr_to_alias).name
+        for child in exp.children
+    ]
+
+    res = input_data.apply(lambda row: udf(*[row[col] for col in to_pass_args]), axis=1)
+    res.sf_type = ColumnType(exp.datatype, exp.nullable)
+    res.name = quote_name(f"{exp.udf_name}({', '.join(to_pass_args)})".upper())
+
+    return res
 
 
 def execute_mock_plan(
@@ -462,6 +497,7 @@ def execute_mock_plan(
                 column_series = calculate_expression(
                     exp, from_df, analyzer, expr_to_alias
                 )
+
                 result_df[column_name] = column_series
 
                 if isinstance(exp, (Alias)):
@@ -1271,7 +1307,7 @@ def describe(plan: MockExecutionPlan) -> List[Attribute]:
 
             ret.append(
                 Attribute(
-                    quote_name(result[c].name.strip()),
+                    result[c].name,
                     data_type,
                     result[c].sf_type.nullable,
                 )
@@ -1946,7 +1982,8 @@ def calculate_expression(
         res = col.apply(lambda x: None if x is None else x[exp.field])
         res.set_sf_type(ColumnType(VariantType(), col.sf_type.nullable))
         return res
-
+    elif isinstance(exp, SnowflakeUDF):
+        return handle_udf_expression(exp, input_data, analyzer, expr_to_alias)
     analyzer.session._conn.log_not_supported_error(
         external_feature_name=f"Mocking Expression {type(exp).__name__}",
         internal_feature_name=type(exp).__name__,

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -320,19 +320,19 @@ def handle_function_expression(
     else:
         func_name = exp.name.lower()
 
-    udf_name = exp.name.split(".")[-1]
-    # If udf name in the registry then this is a udf, not an actual function
-    if udf_name in analyzer.session.udf._registry:
-        exp.udf_name = udf_name
-        return handle_udf_expression(
-            exp, input_data, analyzer, expr_to_alias, current_row
-        )
-
     try:
         original_func = getattr(
             importlib.import_module("snowflake.snowpark.functions"), func_name
         )
     except AttributeError:
+        udf_name = exp.name.split(".")[-1]
+        # If udf name in the registry then this is a udf, not an actual function
+        if udf_name in analyzer.session.udf._registry:
+            exp.udf_name = udf_name
+            return handle_udf_expression(
+                exp, input_data, analyzer, expr_to_alias, current_row
+            )
+
         # this is missing function in snowpark-python, need support for both live and local test
         analyzer.session._conn.log_not_supported_error(
             external_feature_name=func_name,

--- a/src/snowflake/snowpark/mock/_udf.py
+++ b/src/snowflake/snowpark/mock/_udf.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+from types import ModuleType
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+from snowflake.snowpark._internal.udf_utils import (
+    check_python_runtime_version,
+    process_registration_inputs,
+)
+from snowflake.snowpark._internal.utils import TempObjectType
+from snowflake.snowpark.exceptions import SnowparkSQLException
+from snowflake.snowpark.types import DataType
+from snowflake.snowpark.udf import UDFRegistration, UserDefinedFunction
+
+
+class MockUDFRegistration(UDFRegistration):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._registry: Dict[str, Callable] = dict()
+
+    def register_from_file(self, *_, **__) -> UserDefinedFunction:
+        raise NotImplementedError(
+            "[Local Testing] Registering UDF from file is not currently supported."
+        )
+
+    def _do_register_udf(
+        self,
+        func: Union[Callable, Tuple[str, str]],
+        return_type: Optional[DataType],
+        input_types: Optional[List[DataType]],
+        name: Optional[str],
+        stage_location: Optional[str] = None,
+        imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
+        packages: Optional[List[Union[str, ModuleType]]] = None,
+        replace: bool = False,
+        if_not_exists: bool = False,
+        parallel: int = 4,
+        max_batch_size: Optional[int] = None,
+        from_pandas_udf_function: bool = False,
+        strict: bool = False,
+        secure: bool = False,
+        external_access_integrations: Optional[List[str]] = None,
+        secrets: Optional[Dict[str, str]] = None,
+        immutable: bool = False,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        source_code_display: bool = True,
+        api_call_source: str,
+        skip_upload_on_content_match: bool = False,
+        is_permanent: bool = False,
+    ) -> UserDefinedFunction:
+        if is_permanent:
+            raise NotImplementedError(
+                "[Local Testing] Registering permanent UDF is not currently supported."
+            )
+
+        # get the udf name, return and input types
+        (
+            udf_name,
+            is_pandas_udf,
+            is_dataframe_input,
+            return_type,
+            input_types,
+        ) = process_registration_inputs(
+            self._session, TempObjectType.FUNCTION, func, return_type, input_types, name
+        )
+
+        # allow registering pandas UDF from udf(),
+        # but not allow registering non-pandas UDF from pandas_udf()
+        if from_pandas_udf_function and not is_pandas_udf:
+            raise ValueError(
+                "You cannot create a non-vectorized UDF using pandas_udf(). "
+                "Use udf() instead."
+            )
+
+        if packages or imports:
+            raise NotImplementedError(
+                "[Local Testing] Uploading imports and packages not currently supported."
+            )
+
+        custom_python_runtime_version_allowed = False
+
+        if not custom_python_runtime_version_allowed:
+            check_python_runtime_version(
+                self._session._runtime_version_from_requirement
+            )
+
+        if udf_name in self._registry:
+            raise SnowparkSQLException(
+                f"002002 (42710): SQL compilation error: \nObject '{udf_name}' already exists.",
+                error_code="1304",
+            )
+
+        self._registry[udf_name] = func
+
+        return UserDefinedFunction(func, return_type, input_types, udf_name)

--- a/src/snowflake/snowpark/mock/_udf.py
+++ b/src/snowflake/snowpark/mock/_udf.py
@@ -20,8 +20,10 @@ class MockUDFRegistration(UDFRegistration):
         self._registry: Dict[str, Callable] = dict()
 
     def register_from_file(self, *_, **__) -> UserDefinedFunction:
-        raise NotImplementedError(
-            "[Local Testing] Registering UDF from file is not currently supported."
+        self._session._conn.log_not_supported_error(
+            external_feature_name="udf",
+            error_message="Registering UDF from file is not currently supported.",
+            raise_error=NotImplementedError,
         )
 
     def _do_register_udf(
@@ -51,8 +53,10 @@ class MockUDFRegistration(UDFRegistration):
         is_permanent: bool = False,
     ) -> UserDefinedFunction:
         if is_permanent:
-            raise NotImplementedError(
-                "[Local Testing] Registering permanent UDF is not currently supported."
+            self._session._conn.log_not_supported_error(
+                external_feature_name="udf",
+                error_message="Registering permanent UDF is not currently supported.",
+                raise_error=NotImplementedError,
             )
 
         # get the udf name, return and input types
@@ -75,8 +79,10 @@ class MockUDFRegistration(UDFRegistration):
             )
 
         if packages or imports:
-            raise NotImplementedError(
-                "[Local Testing] Uploading imports and packages not currently supported."
+            self._session._conn.log_not_supported_error(
+                external_feature_name="udf",
+                error_message="Uploading imports and packages not currently supported.",
+                raise_error=NotImplementedError,
             )
 
         custom_python_runtime_version_allowed = False
@@ -86,7 +92,7 @@ class MockUDFRegistration(UDFRegistration):
                 self._session._runtime_version_from_requirement
             )
 
-        if udf_name in self._registry:
+        if udf_name in self._registry and not replace:
             raise SnowparkSQLException(
                 f"002002 (42710): SQL compilation error: \nObject '{udf_name}' already exists.",
                 error_code="1304",

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -113,7 +113,6 @@ from snowflake.snowpark.exceptions import SnowparkClientException
 from snowflake.snowpark.file_operation import FileOperation
 from snowflake.snowpark.functions import (
     array_agg,
-    builtin,
     col,
     column,
     lit,
@@ -138,6 +137,7 @@ from snowflake.snowpark.mock._pandas_util import (
     _extract_schema_and_data_from_pandas_df,
 )
 from snowflake.snowpark.mock._plan_builder import MockSnowflakePlanBuilder
+from snowflake.snowpark.mock._udf import MockUDFRegistration
 from snowflake.snowpark.query_history import QueryHistory
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.stored_procedure import StoredProcedureRegistration
@@ -437,7 +437,12 @@ class Session:
 """
         self._session_stage = random_name_for_temp_object(TempObjectType.STAGE)
         self._stage_created = False
-        self._udf_registration = UDFRegistration(self)
+
+        if options is not None and options.get("local_testing", False):
+            self._udf_registration = MockUDFRegistration(self)
+        else:
+            self._udf_registration = UDFRegistration(self)
+
         self._udtf_registration = UDTFRegistration(self)
         self._udaf_registration = UDAFRegistration(self)
         self._sp_registration = StoredProcedureRegistration(self)
@@ -2738,10 +2743,6 @@ class Session:
         Returns a :class:`udf.UDFRegistration` object that you can use to register UDFs.
         See details of how to use this object in :class:`udf.UDFRegistration`.
         """
-        if isinstance(self._conn, MockServerConnection):
-            self._conn.log_not_supported_error(
-                external_feature_name="Session.udf", raise_error=NotImplementedError
-            )
         return self._udf_registration
 
     @property

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -50,27 +50,34 @@ view2 = f'"{Utils.random_name_for_temp_object(TempObjectType.VIEW)}"'
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup(session, resources_path):
-    test_files = TestFiles(resources_path)
+def setup(session, resources_path, local_testing_mode):
+    if not local_testing_mode:
+        # Stages not supported in local testing yet
+        test_files = TestFiles(resources_path)
 
-    Utils.create_stage(session, tmp_stage_name, is_temporary=True)
-    Utils.upload_to_stage(
-        session, tmp_stage_name, test_files.test_file_parquet, compress=False
-    )
-    Utils.create_table(session, table1, "a int")
-    session._run_query(f"insert into {table1} values(1),(2),(3)")
-    Utils.create_table(session, table2, "a int, b int")
-    session._run_query(f"insert into {table2} values(1, 2),(2, 3),(3, 4)")
+        Utils.create_stage(session, tmp_stage_name, is_temporary=True)
+        Utils.upload_to_stage(
+            session, tmp_stage_name, test_files.test_file_parquet, compress=False
+        )
+
+    session.create_dataframe([[1], [2], [3]], schema=["a"]).write.save_as_table(table1)
+    session.create_dataframe(
+        [[1, 2], [2, 3], [3, 4]], schema=["a", "b"]
+    ).write.save_as_table(table2)
     yield
+
     Utils.drop_table(session, tmp_table_name)
     Utils.drop_table(session, table1)
     Utils.drop_table(session, table2)
     Utils.drop_table(session, semi_structured_table)
-    Utils.drop_view(session, view1)
-    Utils.drop_view(session, view2)
-    Utils.drop_stage(session, tmp_stage_name)
+    if not local_testing_mode:
+        # Views not supported in local testing yet.
+        Utils.drop_view(session, view1)
+        Utils.drop_view(session, view2)
+        Utils.drop_stage(session, tmp_stage_name)
 
 
+@pytest.mark.localtest
 def test_basic_udf_function(session):
     df = session.table(table1)
     double_udf = udf(
@@ -238,6 +245,7 @@ def test_view_with_udf(session):
     )
 
 
+@pytest.mark.localtest
 def test_string_return_type(session):
     df = session.table(table1)
     prefix = "Hello"
@@ -256,6 +264,7 @@ def test_string_return_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_large_closure(session):
     df = session.table(table1)
     factor = 64
@@ -269,6 +278,7 @@ def test_large_closure(session):
     assert rows[1][0].startswith(long_string)
 
 
+@pytest.mark.localtest
 def test_udf_function_with_multiple_columns(session):
     df = session.table(table2)
     sum_udf = udf(
@@ -286,6 +296,7 @@ def test_udf_function_with_multiple_columns(session):
     )
 
 
+@pytest.mark.localtest
 def test_call_udf_api(session):
     df = session.table(table1)
     function_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
@@ -307,6 +318,7 @@ def test_call_udf_api(session):
     )
 
 
+@pytest.mark.localtest
 def test_long_type(session):
     df = session.create_dataframe([1, 2, 3]).to_df("a")
     long_udf = udf(lambda x: x + x, return_type=LongType(), input_types=[LongType()])
@@ -320,6 +332,7 @@ def test_long_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_short_type(session):
     df = session.create_dataframe([1, 2, 3]).to_df("a")
     short_udf = udf(lambda x: x + x, return_type=ShortType(), input_types=[ShortType()])
@@ -333,6 +346,7 @@ def test_short_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_float_type(session):
     df = session.create_dataframe([1.1, 2.2, 3.3]).to_df("a")
     float_udf = udf(lambda x: x + x, return_type=FloatType(), input_types=[FloatType()])
@@ -346,6 +360,7 @@ def test_float_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_double_type(session):
     df = session.create_dataframe([1.01, 2.01, 3.01]).to_df("a")
     double_udf = udf(
@@ -361,6 +376,7 @@ def test_double_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_boolean_type(session):
     df = session.create_dataframe([[1, 1], [2, 2], [3, 4]]).to_df("a", "b")
     boolean_udf = udf(
@@ -378,6 +394,7 @@ def test_boolean_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_binary_type(session):
     data = ["Hello", "World"]
     bytes_data = [bytes(s, "utf8") for s in data]
@@ -608,6 +625,7 @@ def test_vector_type(session):
     )
 
 
+@pytest.mark.localtest
 def test_variant_string_input(session):
     @udf(return_type=StringType(), input_types=[VariantType()])
     def variant_string_input_udf(v):
@@ -634,6 +652,7 @@ def test_variant_binary_input(session):
     )
 
 
+@pytest.mark.localtest
 def test_variant_boolean_input(session):
     @udf(return_type=BooleanType(), input_types=[VariantType()])
     def variant_boolean_input_udf(v):
@@ -645,6 +664,7 @@ def test_variant_boolean_input(session):
     )
 
 
+@pytest.mark.localtest
 def test_variant_number_input(session):
     @udf(return_type=IntegerType(), input_types=[VariantType()])
     def variant_number_input_udf(v):
@@ -721,7 +741,10 @@ def test_variant_null(session):
         return None
 
     Utils.check_answer(
-        session.sql("select 1 as a").select(variant_null_output_udf("a")).collect(),
+        session.create_dataframe([[1]])
+        .to_df(["a"])
+        .select(variant_null_output_udf("a"))
+        .collect(),
         [Row(None)],
     )
 
@@ -731,7 +754,10 @@ def test_variant_null(session):
         return None
 
     Utils.check_answer(
-        session.sql("select 1 as a").select(variant_null_output_udf1("a")).collect(),
+        session.create_dataframe([[1]])
+        .to_df(["a"])
+        .select(variant_null_output_udf1("a"))
+        .collect(),
         [Row(None)],
     )
 
@@ -740,7 +766,10 @@ def test_variant_null(session):
         return None
 
     Utils.check_answer(
-        session.sql("select 1 as a").select(variant_null_output_udf2("a")).collect(),
+        session.create_dataframe([[1]])
+        .to_df(["a"])
+        .select(variant_null_output_udf2("a"))
+        .collect(),
         [Row("null")],
     )
 
@@ -755,6 +784,7 @@ def test_variant_null(session):
     )
 
 
+@pytest.mark.localtest
 def test_variant_string_output(session):
     @udf(return_type=VariantType(), input_types=[VariantType()])
     def variant_string_output_udf(_):
@@ -768,6 +798,7 @@ def test_variant_string_output(session):
 
 # The behavior of Variant("null") in Python UDF is different from the one in Java UDF
 # Given a string "null", Python UDF will just a string "null", instead of NULL value
+@pytest.mark.localtest
 def test_variant_null_string_output(session):
     @udf(return_type=VariantType(), input_types=[VariantType()])
     def variant_null_string_output_udf(_):
@@ -781,6 +812,7 @@ def test_variant_null_string_output(session):
     )
 
 
+@pytest.mark.localtest
 def test_variant_number_output(session):
     @udf(return_type=VariantType(), input_types=[VariantType()])
     def variant_int_output_udf(_):
@@ -815,6 +847,7 @@ def test_variant_number_output(session):
     # ).collect() == [Row("1.1")]
 
 
+@pytest.mark.localtest
 def test_variant_boolean_output(session):
     @udf(return_type=VariantType(), input_types=[VariantType()])
     def variant_boolean_output_udf(_):
@@ -910,6 +943,7 @@ def test_variant_date_output(session):
     )
 
 
+@pytest.mark.localtest
 def test_array_variant(session):
     @udf(return_type=ArrayType(VariantType()), input_types=[ArrayType(VariantType())])
     def variant_udf(v):
@@ -939,6 +973,7 @@ def test_array_variant(session):
     )
 
 
+@pytest.mark.localtest
 def test_map_variant(session):
     @udf(
         return_type=MapType(StringType(), VariantType()),
@@ -977,6 +1012,7 @@ def test_map_variant(session):
     )
 
 
+@pytest.mark.localtest
 def test_negative_test_to_input_invalid_func_name(session):
     func_name = "negative test invalid name"
     with pytest.raises(SnowparkClientException) as ex_info:

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -86,6 +86,14 @@ def test_basic_udf_function(session):
     Utils.check_answer(df.select(double_udf("a")).collect(), [Row(2), Row(4), Row(6)])
 
 
+@pytest.mark.localtest
+def test_child_expression(session):
+    df = session.table(table1)
+    rows = df.select(col("A") + col("A")).collect()
+    assert len(rows) == 3, "The number of rows should remain the same."
+    assert rows == [Row(2), Row(4), Row(6)]
+
+
 def test_udf_with_arrays(session):
     Utils.create_table(session, semi_structured_table, "a1 array")
     session._run_query(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,22 @@ from snowflake.snowpark._internal.utils import (
     is_in_stored_procedure,
     quote_name,
 )
-from snowflake.snowpark.functions import col, parse_json, to_variant
+from snowflake.snowpark.functions import (
+    col,
+    lit,
+    parse_json,
+    to_array,
+    to_binary,
+    to_date,
+    to_decimal,
+    to_double,
+    to_object,
+    to_time,
+    to_timestamp_ltz,
+    to_timestamp_ntz,
+    to_timestamp_tz,
+    to_variant,
+)
 from snowflake.snowpark.mock._connection import MockServerConnection
 from snowflake.snowpark.types import (
     ArrayType,
@@ -661,21 +676,30 @@ class TestData:
 
     @classmethod
     def variant1(cls, session: "Session") -> DataFrame:
-        return session.sql(
-            "select to_variant(to_array('Example')) as arr1,"
-            + ' to_variant(to_object(parse_json(\'{"Tree": "Pine"}\'))) as obj1, '
-            + " to_variant(to_binary('snow', 'utf-8')) as bin1,"
-            + " to_variant(true) as bool1,"
-            + " to_variant('X') as str1, "
-            + " to_variant(to_date('2017-02-24')) as date1, "
-            + " to_variant(to_time('20:57:01.123456789+07:00')) as time1, "
-            + " to_variant(to_timestamp_ntz('2017-02-24 12:00:00.456')) as timestamp_ntz1, "
-            + " to_variant(to_timestamp_ltz('2017-02-24 13:00:00.123 +01:00')) as timestamp_ltz1, "
-            + " to_variant(to_timestamp_tz('2017-02-24 13:00:00.123 +01:00')) as timestamp_tz1, "
-            + " to_variant(1.23::decimal(6, 3)) as decimal1, "
-            + " to_variant(3.21::double) as double1, "
-            + " to_variant(15) as num1 "
+        df = session.create_dataframe([1]).select(
+            to_variant(to_array(lit("Example"))).alias("arr1"),
+            to_variant(to_object(parse_json(lit('{"Tree": "Pine"}')))).alias("obj1"),
+            to_variant(to_binary(lit("snow"), "utf-8")).alias("bin1"),
+            to_variant(lit(True)).alias("bool1"),
+            to_variant(lit("X")).alias("str1"),
+            to_variant(to_date(lit("2017-02-24"))).alias("date1"),
+            to_variant(
+                to_time(lit("20:57:01.123456+0700"), "HH24:MI:SS.FFTZHTZM")
+            ).alias("time1"),
+            to_variant(to_timestamp_ntz(lit("2017-02-24 12:00:00.456"))).alias(
+                "timestamp_ntz1"
+            ),
+            to_variant(to_timestamp_ltz(lit("2017-02-24 13:00:00.123 +01:00"))).alias(
+                "timestamp_ltz1"
+            ),
+            to_variant(to_timestamp_tz(lit("2017-02-24 13:00:00.123 +01:00"))).alias(
+                "timestamp_tz1"
+            ),
+            to_variant(to_decimal(lit(1.23), 6, 3)).alias("decimal1"),
+            to_variant(to_double(lit(3.21))).alias("double1"),
+            to_variant(lit(15)).alias("num1"),
         )
+        return df
 
     @classmethod
     def variant2(cls, session: "Session") -> DataFrame:


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1184278

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Based on `jrose_snow_1183317_support_registering_udf_2` (#1316) and `SNOW-1064309-feature-session-support-file-operation-get-session-file`(#1309). This PR implements the registering UDF from a local/remote Python file/a directory of Python files representing a Python module.
  
