### PR TITLE
SNOW-1063719: [Local Testing] Add date_trunc support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,27 @@
     - file.put_stream
     - file.get
     - file.get_stream
-  - snowflake.snowpark.functions:
     - add_import
+    - remove_import
+    - get_imports
     - clear_imports
-    - date_trunc
     - udf.register
     - udf.register_from_file
+  - snowflake.snowpark.functions
+    - current_database
+    - current_session
+    - date_trunc
     - udf
 - Added the function `DataFrame.write.csv` to unload data from a ``DataFrame`` into one or more CSV files in a stage.
+- Added distributed tracing using open telemetry apis for action functions in `DataFrame` and `DataFrameWriter`:
+  - snowflake.snowpark.DataFrame:
+    - collect
+    - collect_nowait
+    - to_pandas
+    - count
+    - show
+  - snowflake.snowpark.DataFrameWriter:
+    - save_as_table
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     - file.put_stream
     - file.get
     - file.get_stream
+  - snowflake.snowpark.functions:
+    - date_trunc
 - Added the function `DataFrame.write.csv` to unload data from a ``DataFrame`` into one or more CSV files in a stage.
 
 ## 1.14.0 (2024-03-20)

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -4391,7 +4391,7 @@ def date_from_parts(
     return builtin("date_from_parts")(y_col, m_col, d_col)
 
 
-def date_trunc(part: ColumnOrName, expr: ColumnOrName) -> Column:
+def date_trunc(part: str, expr: ColumnOrName) -> Column:
     """
     Truncates a DATE, TIME, or TIMESTAMP to the specified precision.
 
@@ -4413,9 +4413,10 @@ def date_trunc(part: ColumnOrName, expr: ColumnOrName) -> Column:
         >>> df.select(date_trunc("QUARTER", "a")).collect()
         [Row(DATE_TRUNC("QUARTER", "A")=datetime.datetime(2020, 4, 1, 0, 0))]
     """
-    part_col = _to_col_if_str(part, "date_trunc")
+    if not isinstance(part, str):
+        raise ValueError("part must be a string")
     expr_col = _to_col_if_str(expr, "date_trunc")
-    return builtin("date_trunc")(part_col, expr_col)
+    return builtin("date_trunc")(part, expr_col)
 
 
 def dayname(e: ColumnOrName) -> Column:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -4407,11 +4407,11 @@ def date_trunc(part: str, expr: ColumnOrName) -> Column:
         ...     schema=["a"],
         ... )
         >>> df.select(date_trunc("YEAR", "a"), date_trunc("MONTH", "a"), date_trunc("DAY", "a")).collect()
-        [Row(DATE_TRUNC("YEAR", "A")=datetime.datetime(2020, 1, 1, 0, 0), DATE_TRUNC("MONTH", "A")=datetime.datetime(2020, 5, 1, 0, 0), DATE_TRUNC("DAY", "A")=datetime.datetime(2020, 5, 1, 0, 0))]
+        [Row(DATE_TRUNC('YEAR', "A")=datetime.datetime(2020, 1, 1, 0, 0), DATE_TRUNC('MONTH', "A")=datetime.datetime(2020, 5, 1, 0, 0), DATE_TRUNC('DAY', "A")=datetime.datetime(2020, 5, 1, 0, 0))]
         >>> df.select(date_trunc("HOUR", "a"), date_trunc("MINUTE", "a"), date_trunc("SECOND", "a")).collect()
-        [Row(DATE_TRUNC("HOUR", "A")=datetime.datetime(2020, 5, 1, 13, 0), DATE_TRUNC("MINUTE", "A")=datetime.datetime(2020, 5, 1, 13, 11), DATE_TRUNC("SECOND", "A")=datetime.datetime(2020, 5, 1, 13, 11, 20))]
+        [Row(DATE_TRUNC('HOUR', "A")=datetime.datetime(2020, 5, 1, 13, 0), DATE_TRUNC('MINUTE', "A")=datetime.datetime(2020, 5, 1, 13, 11), DATE_TRUNC('SECOND', "A")=datetime.datetime(2020, 5, 1, 13, 11, 20))]
         >>> df.select(date_trunc("QUARTER", "a")).collect()
-        [Row(DATE_TRUNC("QUARTER", "A")=datetime.datetime(2020, 4, 1, 0, 0))]
+        [Row(DATE_TRUNC('QUARTER', "A")=datetime.datetime(2020, 4, 1, 0, 0))]
     """
     if not isinstance(part, str):
         raise ValueError("part must be a string")

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import math
 import numbers
+import operator
 import string
 from decimal import Decimal
 from functools import partial, reduce
@@ -1226,6 +1227,73 @@ def mock_date_part(part: str, datetime_expr: ColumnEmulator):
             f"{part} is an invalid date part for column of type {datatype.__class__.__name__}"
         )
     return ColumnEmulator(res, sf_type=ColumnType(LongType, nullable=True))
+
+
+@patch("date_trunc")
+def mock_date_trunc(part: str, datetime_expr: ColumnEmulator) -> ColumnEmulator:
+    """
+    SNOW-1183874: Add support for relevant session parameters.
+    https://docs.snowflake.com/en/sql-reference/functions/date_part#usage-notes
+    """
+    import pandas
+
+    # Map snowflake time unit to pandas rounding alias
+    # Not all units have an alias so handle those with a special case
+    SUPPORTED_UNITS = {
+        "day": "D",
+        "hour": "h",
+        "microsecond": "us",
+        "millisecond": "ms",
+        "minute": "min",
+        "month": None,
+        "nanosecond": "ns",
+        "quarter": None,
+        "second": "s",
+        "week": None,
+        "year": None,
+    }
+    time_unit = unalias_datetime_part(part)
+    pandas_unit = SUPPORTED_UNITS.get(time_unit)
+
+    if pandas_unit is not None:
+        truncated = pandas.to_datetime(datetime_expr).dt.floor(pandas_unit)
+    elif time_unit == "month":
+        truncated = datetime_expr.apply(
+            lambda x: datetime.datetime(
+                x.year, x.month, 1, tzinfo=getattr(x, "tzinfo", None)
+            )
+        )
+    elif time_unit == "quarter":
+        # Assuming quarters start in Jan/April/July/Oct
+        quarter_map = {i: (((i - 1) // 3) * 3) + 1 for i in range(1, 13)}
+        truncated = datetime_expr.apply(
+            lambda x: datetime.datetime(
+                x.year, quarter_map[x.month], 1, tzinfo=getattr(x, "tzinfo", None)
+            )
+        )
+    elif time_unit == "week":
+        truncated = pandas.to_datetime(datetime_expr)
+        # Calculate offset from start of week
+        offsets = pandas.to_timedelta(truncated.dt.dayofweek, unit="d")
+        # Subtract off offset
+        truncated = truncated.combine(offsets, operator.sub)
+        # Trim data smaller than a day
+        truncated = truncated.apply(
+            lambda x: datetime.datetime(
+                x.year, x.month, x.day, tzinfo=getattr(x, "tzinfo", None)
+            )
+        )
+    elif time_unit == "year":
+        truncated = datetime_expr.apply(
+            lambda x: datetime.datetime(x.year, 1, 1, tzinfo=getattr(x, "tzinfo", None))
+        )
+    else:
+        raise ValueError(f"{part} is not a supported time unit for date_trunc.")
+
+    if isinstance(datetime_expr.sf_type.datatype, DateType):
+        truncated = truncated.dt.date
+
+    return ColumnEmulator(truncated, sf_type=datetime_expr.sf_type)
 
 
 CompareType = TypeVar("CompareType")

--- a/src/snowflake/snowpark/mock/_util.py
+++ b/src/snowflake/snowpark/mock/_util.py
@@ -267,7 +267,8 @@ DATETIME_ALIASES = set(ALIASES_TO_DATETIME_PART.keys())
 
 
 def unalias_datetime_part(part):
-    if part in DATETIME_ALIASES:
-        return ALIASES_TO_DATETIME_PART[part]
+    lowered_part = part.lower()
+    if lowered_part in DATETIME_ALIASES:
+        return ALIASES_TO_DATETIME_PART[lowered_part]
     else:
         raise ValueError(f"{part} is not a recognized date or time part.")

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -80,6 +80,7 @@ from snowflake.snowpark.functions import (
     covar_samp,
     cume_dist,
     date_part,
+    date_trunc,
     dateadd,
     datediff,
     degrees,
@@ -204,6 +205,7 @@ from snowflake.snowpark.functions import (
 )
 from snowflake.snowpark.mock._functions import LocalTimezone
 from snowflake.snowpark.types import (
+    DateType,
     StructField,
     StructType,
     TimestampTimeZone,
@@ -917,7 +919,7 @@ def test_dateadd_tz(tz_type, tzinfo, part, session):
     )
 
 
-@pytest.mark.local
+@pytest.mark.localtest
 @pytest.mark.parametrize(
     "part,expected",
     [
@@ -981,7 +983,7 @@ def test_date_part_timestamp(part, expected, session):
     LocalTimezone.set_local_timezone()
 
 
-@pytest.mark.local
+@pytest.mark.localtest
 @pytest.mark.parametrize(
     "part,expected",
     [
@@ -1010,6 +1012,194 @@ def test_date_part_date(part, expected, session):
     )
 
     LocalTimezone.set_local_timezone()
+
+
+# p tests/integ/scala/test_function_suite.py::{test_date_trunc_timestamp,test_date_trunc_date,test_date_trunc_negative}
+@pytest.mark.localtest
+@pytest.mark.parametrize(
+    "part,expected",
+    [
+        (
+            "dd",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 0, 0),
+                datetime(2017, 2, 24, 0, 0),
+                datetime(2017, 2, 24, 0, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 2, 24, 0, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "hh",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 12, 0),
+                datetime(2017, 2, 24, 12, 0),
+                datetime(2017, 2, 24, 4, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 2, 24, 14, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "usec",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 12, 0),
+                datetime(2017, 2, 24, 12, 0, 0, 456000),
+                datetime(
+                    2017, 2, 24, 4, 0, 0, 123000, tzinfo=pytz.timezone("Etc/GMT+8")
+                ),
+                datetime(
+                    2017, 2, 24, 14, 0, 0, 789000, tzinfo=pytz.timezone("Etc/GMT-1")
+                ),
+            ],
+        ),
+        (
+            "msec",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 12, 0),
+                datetime(2017, 2, 24, 12, 0, 0, 456000),
+                datetime(
+                    2017, 2, 24, 4, 0, 0, 123000, tzinfo=pytz.timezone("Etc/GMT+8")
+                ),
+                datetime(
+                    2017, 2, 24, 14, 0, 0, 789000, tzinfo=pytz.timezone("Etc/GMT-1")
+                ),
+            ],
+        ),
+        (
+            "min",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 12, 0),
+                datetime(2017, 2, 24, 12, 0),
+                datetime(2017, 2, 24, 4, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 2, 24, 14, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "mm",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 0, 0),
+                datetime(2017, 2, 1, 0, 0),
+                datetime(2017, 2, 1, 0, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 2, 1, 0, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "nsec",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 12, 0),
+                datetime(2017, 2, 24, 12, 0, 0, 456000),
+                datetime(
+                    2017, 2, 24, 4, 0, 0, 123000, tzinfo=pytz.timezone("Etc/GMT+8")
+                ),
+                datetime(
+                    2017, 2, 24, 14, 0, 0, 789000, tzinfo=pytz.timezone("Etc/GMT-1")
+                ),
+            ],
+        ),
+        (
+            "qtr",
+            [
+                date(2024, 1, 1),
+                datetime(2024, 1, 1, 0, 0),
+                datetime(2017, 1, 1, 0, 0),
+                datetime(2017, 1, 1, 0, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 1, 1, 0, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "sec",
+            [
+                date(2024, 2, 1),
+                datetime(2024, 2, 1, 12, 0),
+                datetime(2017, 2, 24, 12, 0),
+                datetime(2017, 2, 24, 4, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 2, 24, 14, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "wk",
+            [
+                date(2024, 1, 29),
+                datetime(2024, 1, 29, 0, 0),
+                datetime(2017, 2, 20, 0, 0),
+                datetime(2017, 2, 20, 0, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 2, 20, 0, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+        (
+            "yyy",
+            [
+                date(2024, 1, 1),
+                datetime(2024, 1, 1, 0, 0),
+                datetime(2017, 1, 1, 0, 0),
+                datetime(2017, 1, 1, 0, 0, tzinfo=pytz.timezone("Etc/GMT+8")),
+                datetime(2017, 1, 1, 0, 0, tzinfo=pytz.timezone("Etc/GMT-1")),
+            ],
+        ),
+    ],
+)
+def test_date_trunc(part, expected, session, local_testing_mode):
+    with parameter_override(
+        session,
+        "timezone",
+        "America/Los_Angeles",
+        not IS_IN_STORED_PROC and not local_testing_mode,
+    ):
+        LocalTimezone.set_local_timezone(pytz.timezone("Etc/GMT+8"))
+
+        df = TestData.datetime_primitives1(session)
+        trunc_df = df.select(
+            *[
+                date_trunc(part, col)
+                for col in [
+                    "date",
+                    "timestamp",
+                    "timestamp_ntz",
+                    "timestamp_ltz",
+                    "timestamp_tz",
+                ]
+            ]
+        )
+        Utils.check_answer(
+            trunc_df,
+            [Row(*expected)],
+            sort=False,
+        )
+        types = [field.datatype for field in trunc_df.schema.fields]
+        assert isinstance(types[0], DateType), "Datetype should remain Datetype"
+        assert all(
+            isinstance(d, TimestampType) for d in types[1:]
+        ), "All timestamp type values should remain timestamps"
+        assert [t.tz for t in types[2:]] == [
+            TimestampTimeZone.NTZ,
+            TimestampTimeZone.LTZ,
+            TimestampTimeZone.TZ,
+        ], "Timestamps with tz type specified should match"
+
+        LocalTimezone.set_local_timezone()
+
+
+@pytest.mark.localtest
+def test_date_trunc_negative(session, local_testing_mode):
+    if local_testing_mode:
+        err = ValueError
+    else:
+        err = SnowparkSQLException
+
+    df = TestData.datetime_primitives1(session)
+
+    # Invalid date part
+    with pytest.raises(err):
+        df.select(date_trunc("foobar", "date")).collect()
+
+    # Unsupported date part
+    with pytest.raises(err):
+        df.select(date_trunc("dow", "date")).collect()
 
 
 @pytest.mark.localtest

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1014,7 +1014,6 @@ def test_date_part_date(part, expected, session):
     LocalTimezone.set_local_timezone()
 
 
-# p tests/integ/scala/test_function_suite.py::{test_date_trunc_timestamp,test_date_trunc_date,test_date_trunc_negative}
 @pytest.mark.localtest
 @pytest.mark.parametrize(
     "part,expected",

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -235,6 +235,10 @@ def test_stored_procedure_with_column_datatype(session):
     assert "not recognized" in str(ex_info)
 
 
+def test_stored_procedure_with_structured_return_type(session):
+    pass
+
+
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Named temporary procedure is not supported in stored proc",

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -235,10 +235,6 @@ def test_stored_procedure_with_column_datatype(session):
     assert "not recognized" in str(ex_info)
 
 
-def test_stored_procedure_with_structured_return_type(session):
-    pass
-
-
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Named temporary procedure is not supported in stored proc",


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1063719

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This change adds support for `date_trunc` to local testing. Most supported cases are handled by a call to pandas.floor, but several time units are not supported by pandas so equivalent logic is provided. I've also added related testing for date_trunc to validate correctness as well as type preservation.
