### PR TITLE
SNOW-1063721: [Local Testing] Add support for current_database and current_session

### DIFF
--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Optional, Tuple, TypeVar, Union
 
 import pytz
 
+import snowflake.snowpark
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.mock._snowflake_data_type import (
     ColumnEmulator,
@@ -1371,4 +1372,20 @@ def mock_convert_timezone(
             TimestampType(return_type), nullable=source_time.sf_type.nullable
         ),
         dtype=object,
+    )
+
+
+@patch("current_session")
+def mock_current_session():
+    session = snowflake.snowpark.session._get_active_session()
+    return ColumnEmulator(
+        data=str(hash(session)), sf_type=ColumnType(StringType(), False)
+    )
+
+
+@patch("current_database")
+def mock_current_database():
+    session = snowflake.snowpark.session._get_active_session()
+    return ColumnEmulator(
+        data=session.get_current_database(), sf_type=ColumnType(StringType(), False)
     )

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -79,6 +79,8 @@ from snowflake.snowpark.functions import (
     covar_pop,
     covar_samp,
     cume_dist,
+    current_database,
+    current_session,
     date_part,
     dateadd,
     datediff,
@@ -1010,6 +1012,30 @@ def test_date_part_date(part, expected, session):
     )
 
     LocalTimezone.set_local_timezone()
+
+
+@pytest.mark.localtest
+def test_current_session(session):
+    df = TestData.integer1(session)
+    rows = df.select(current_session()).collect()
+    assert (
+        len(rows) == 3
+    ), "Three rows should be maintained after call to current_session"
+    assert all(
+        row[0] == rows[0][0] for row in rows
+    ), "All session values should be the same after call to current_session"
+
+
+@pytest.mark.localtest
+def test_current_database(session):
+    df = TestData.integer1(session)
+    rows = df.select(current_database()).collect()
+    assert (
+        len(rows) == 3
+    ), "Three rows should be maintained after call to current_database"
+    assert all(
+        row[0] == rows[0][0] for row in rows
+    ), "All database values should be the same after call to current_database"
 
 
 @pytest.mark.localtest


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1063721

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This change adds local testing mocks for the `current_database` and `current_session` functions. These mocks are depending on the `snowflake.snowpark.session._get_active_session` function which will through an exception if more than one session is running.