### PR TITLE
SNOW-993572 Change source code links to use release tags

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -129,7 +129,7 @@ def linkcode_resolve(domain, info):
             linespec = ""
     return (
         f"https://github.com/snowflakedb/snowpark-python/blob/"
-        f"release-v{release}/{os.path.relpath(fn, start=os.pardir)}{linespec}"
+        f"v{release}/{os.path.relpath(fn, start=os.pardir)}{linespec}"
     )
     
     


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-993572

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We no longer create release branches in the release process. This PR changes the path of source code links in the API reference docs to use release tags.
