### PR TITLE
SNOW-1284684 Remove private_preview tag for udaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   - snowflake.snowpark.DataFrameWriter:
     - save_as_table
 - Added support for snow:// URLs to `snowflake.snowpark.Session.file.get` and `snowflake.snowpark.Session.file.get_stream`
+- UDAF client support is ready for public preview. Please stay tuned for the Snowflake announcement of UDAF public preview.
 
 ### Bug Fixes
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ information, see the `Snowpark Developer Guide for Python <https://docs.snowflak
    async_job
    stored_procedures
    udf
+   udaf
    udtf
    observability
    files

--- a/docs/source/udaf.rst
+++ b/docs/source/udaf.rst
@@ -1,0 +1,41 @@
+
+
+=====================================
+User-Defined Aggregate Functions
+=====================================
+
+.. automodule:: snowflake.snowpark.udaf
+   :noindex:
+
+.. currentmodule:: snowflake.snowpark.udaf
+
+
+
+.. rubric:: Classes
+
+.. autosummary::
+    :toctree: api/
+
+    UserDefinedAggregateFunction
+    UDAFRegistration
+
+
+
+.. rubric:: Methods
+
+.. autosummary::
+    :toctree: api/
+
+    ~UDAFRegistration.describe
+    ~UDAFRegistration.register
+    ~UDAFRegistration.register_from_file
+
+
+
+.. rubric:: Attributes
+
+.. autosummary::
+    :toctree: api/
+
+    ~UserDefinedAggregateFunction.handler
+    ~UserDefinedAggregateFunction.name

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -190,7 +190,6 @@ from snowflake.snowpark._internal.type_utils import (
 )
 from snowflake.snowpark._internal.utils import (
     parse_positional_args_to_list,
-    private_preview,
     validate_object_name,
 )
 from snowflake.snowpark.column import (
@@ -7458,7 +7457,6 @@ def udtf(
         )
 
 
-@private_preview(version="1.6.0")
 def udaf(
     handler: Optional[typing.Type] = None,
     *,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -94,7 +94,6 @@ from snowflake.snowpark._internal.utils import (
     normalize_local_file,
     normalize_remote_file_or_dir,
     parse_positional_args_to_list,
-    private_preview,
     quote_name,
     random_name_for_temp_object,
     strip_double_quotes_in_like_statement_in_table_name,
@@ -2793,7 +2792,6 @@ class Session:
         return self._udtf_registration
 
     @property
-    @private_preview(version="1.6.0")
     def udaf(self) -> UDAFRegistration:
         """
         Returns a :class:`udaf.UDAFRegistration` object that you can use to register UDAFs.


### PR DESCRIPTION
Description

We are shooting for public preview at the end of April, so we want to remove the private preview decorator in the April client release.

Testing

N/A

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1284684

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
