### PR TITLE
SNOW-1296430: fix telemetry endpoint

### DIFF
--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -70,7 +70,7 @@ class LocalTestTelemetryEventType(Enum):
 
 
 class LocalTestOOBTelemetryService(TelemetryService):
-    PROD = "https://client-telemetry.c1.us-west-2.aws.app.snowflake.com/enqueue"
+    PROD = "https://client-telemetry.snowflakecomputing.com/enqueue"
 
     def __init__(self) -> None:
         super().__init__()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ def local_testing_telemetry_setup():
     from snowflake.snowpark.mock._telemetry import LocalTestOOBTelemetryService
 
     LocalTestOOBTelemetryService.get_instance().enable()
+    LocalTestOOBTelemetryService.get_instance()._is_internal_usage = True
     yield
     LocalTestOOBTelemetryService.get_instance().disable()
 

--- a/tests/mock/__init__.py
+++ b/tests/mock/__init__.py
@@ -1,3 +1,0 @@
-#
-# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
-#

--- a/tests/mock/__init__.py
+++ b/tests/mock/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#

--- a/tests/mock_unit/conftest.py
+++ b/tests/mock_unit/conftest.py
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
+#
+import pytest
+
+from snowflake.snowpark import Session
+from snowflake.snowpark.mock._connection import MockServerConnection
+
+
+@pytest.fixture(scope="module")
+def session():
+    with Session(MockServerConnection()) as s:
+        yield s

--- a/tests/mock_unit/conftest.py
+++ b/tests/mock_unit/conftest.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2012-2023 Snowflake Computing Inc. All rights reserved.
 #
+import os
+
 import pytest
 
 from snowflake.snowpark import Session
@@ -11,3 +13,7 @@ from snowflake.snowpark.mock._connection import MockServerConnection
 def session():
     with Session(MockServerConnection()) as s:
         yield s
+
+
+def pytest_sessionstart(session):
+    os.environ["SNOWPARK_LOCAL_TESTING_INTERNAL_TELEMETRY"] = "1"

--- a/tests/mock_unit/test_create_df_from_pandas.py
+++ b/tests/mock_unit/test_create_df_from_pandas.py
@@ -9,8 +9,7 @@ import math
 import pytest
 import pytz
 
-from snowflake.snowpark import Row, Session, Table
-from snowflake.snowpark.mock._connection import MockServerConnection
+from snowflake.snowpark import Row, Table
 from snowflake.snowpark.types import BooleanType, DoubleType, LongType, StringType
 
 try:
@@ -18,11 +17,9 @@ try:
 except ImportError:
     pytest.skip("pandas is not installed, skipping the tests", allow_module_level=True)
 
-session = Session(MockServerConnection())
-
 
 @pytest.mark.localtest
-def test_create_from_pandas_basic_pandas_types():
+def test_create_from_pandas_basic_pandas_types(session):
     now_time = datetime.datetime(
         year=2023, month=10, day=25, hour=13, minute=46, second=12, microsecond=123
     )
@@ -120,7 +117,7 @@ StructField('TIMEDELTA', LongType(), nullable=True)\
 
 
 @pytest.mark.localtest
-def test_create_from_pandas_basic_python_types():
+def test_create_from_pandas_basic_python_types(session):
     date_data = datetime.date(year=2023, month=10, day=26)
     time_data = datetime.time(hour=12, minute=12, second=12)
     byte_data = b"bytedata"
@@ -157,7 +154,7 @@ StructType([StructField('A', DateType(), nullable=True), StructField('B', TimeTy
 
 
 @pytest.mark.localtest
-def test_create_from_pandas_datetime_types():
+def test_create_from_pandas_datetime_types(session):
     now_time = datetime.datetime(
         year=2023,
         month=10,
@@ -213,7 +210,7 @@ def test_create_from_pandas_datetime_types():
 
 
 @pytest.mark.localtest
-def test_create_from_pandas_extension_types():
+def test_create_from_pandas_extension_types(session):
     """
 
     notes:
@@ -329,7 +326,7 @@ StructType([StructField('A', VariantType(), nullable=True), StructField('B', Var
 
 
 @pytest.mark.localtest
-def test_na_and_null_data():
+def test_na_and_null_data(session):
     pandas_df = pd.DataFrame(
         data={
             "A": pd.Series([1, None, 2, math.nan]),

--- a/tests/mock_unit/test_create_df_from_pandas.py
+++ b/tests/mock_unit/test_create_df_from_pandas.py
@@ -283,7 +283,9 @@ def test_create_from_pandas_extension_types(session):
 
     pandas_df = pd.DataFrame(
         {
-            "A": pd.Series([pd.Period("2022-01", freq="M")], dtype=pd.PeriodDtype()),
+            "A": pd.Series(
+                [pd.Period("2022-01", freq="M")], dtype=pd.PeriodDtype(freq="M")
+            ),
         }
     )
     sp_df = session.create_dataframe(data=pandas_df)

--- a/tests/mock_unit/test_filter.py
+++ b/tests/mock_unit/test_filter.py
@@ -6,15 +6,12 @@ import math
 
 import pytest
 
-from snowflake.snowpark import DataFrame, Row, Session
+from snowflake.snowpark import DataFrame, Row
 from snowflake.snowpark.functions import col
-from snowflake.snowpark.mock._connection import MockServerConnection
-
-session = Session(MockServerConnection())
 
 
 @pytest.mark.localtest
-def test_basic_filter():
+def test_basic_filter(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1, 2, "abc"],
@@ -100,7 +97,7 @@ def test_basic_filter():
 
 
 @pytest.mark.localtest
-def test_null_nan_filter():
+def test_null_nan_filter(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [float("nan"), 2, "abc"],
@@ -157,7 +154,7 @@ def test_null_nan_filter():
 
 
 @pytest.mark.localtest
-def test_chain_filter():
+def test_chain_filter(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1, 2, "abc"],
@@ -176,7 +173,7 @@ def test_chain_filter():
 
 
 @pytest.mark.localtest
-def test_like_filter():
+def test_like_filter(session):
     origin_df: DataFrame = session.create_dataframe(
         [["test"], ["tttest"], ["tett"], ["ess"], ["es#!s"], ["es#)s"]], schema=["a"]
     ).select("a")
@@ -204,7 +201,7 @@ def test_like_filter():
 
 
 @pytest.mark.localtest
-def test_regex_filter():
+def test_regex_filter(session):
     origin_df: DataFrame = session.create_dataframe(
         [["test"], ["tttest"], ["tett"], ["ess"], ["es#%s"]], schema=["a"]
     ).select("a")

--- a/tests/mock_unit/test_functions.py
+++ b/tests/mock_unit/test_functions.py
@@ -6,7 +6,7 @@ import math
 
 import pytest
 
-from snowflake.snowpark import DataFrame, Row, Session
+from snowflake.snowpark import DataFrame, Row
 from snowflake.snowpark.functions import (  # count,; is_null,;
     abs,
     asc,
@@ -20,13 +20,10 @@ from snowflake.snowpark.functions import (  # count,; is_null,;
     min,
     to_date,
 )
-from snowflake.snowpark.mock._connection import MockServerConnection
-
-session = Session(MockServerConnection())
 
 
 @pytest.mark.localtest
-def test_col():
+def test_col(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1, "a", True],
@@ -41,7 +38,7 @@ def test_col():
 
 
 @pytest.mark.localtest
-def test_max():
+def test_max(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             ["a", "ddd", 11.0, None, None, True, math.nan],
@@ -62,7 +59,7 @@ def test_max():
 
 
 @pytest.mark.localtest
-def test_min():
+def test_min(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             ["a", "ddd", 11.0, None, None, True, math.nan],
@@ -84,7 +81,7 @@ def test_min():
 
 
 @pytest.mark.localtest
-def test_to_date():
+def test_to_date(session):
     origin_df: DataFrame = session.create_dataframe(
         ["2013-05-17", "31536000000000"],
         schema=["m"],
@@ -97,7 +94,7 @@ def test_to_date():
 
 
 @pytest.mark.localtest
-def test_contains():
+def test_contains(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             ["1", "2"],
@@ -136,7 +133,7 @@ def test_contains():
 
 
 @pytest.mark.localtest
-def test_abs():
+def test_abs(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1, -4],
@@ -149,7 +146,7 @@ def test_abs():
 
 
 @pytest.mark.localtest
-def test_asc_and_desc():
+def test_asc_and_desc(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1],
@@ -168,7 +165,7 @@ def test_asc_and_desc():
 
 
 @pytest.mark.localtest
-def test_count():
+def test_count(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1],
@@ -184,7 +181,7 @@ def test_count():
 
 
 @pytest.mark.localtest
-def test_is_null():
+def test_is_null(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [float("nan"), 2, "abc"],
@@ -205,7 +202,7 @@ def test_is_null():
 
 
 @pytest.mark.localtest
-def test_take_first():
+def test_take_first(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [float("nan"), 2, "abc"],
@@ -247,7 +244,7 @@ def test_take_first():
 
 
 @pytest.mark.localtest
-def test_show():
+def test_show(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [float("nan"), 2, "abc"],

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -60,7 +60,6 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         assert oob_service.size() == 0
         assert not caplog.record_tuples
 
-    with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
         # test sending successfully
         oob_service.log_session_creation()
         oob_service.log_session_creation(connection_uuid=connection_uuid)

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -60,6 +60,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         assert oob_service.size() == 0
         assert not caplog.record_tuples
 
+    with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
         # test sending successfully
         oob_service.log_session_creation()
         oob_service.log_session_creation(connection_uuid=connection_uuid)

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -26,6 +26,8 @@ pytestmark = pytest.mark.skipif(
 
 def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
+    # clean up queue first
+    oob_service.export_queue_to_string()
     with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
         connection_uuid = str(uuid.uuid4())
         oob_service.log_session_creation()
@@ -73,6 +75,8 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
 
 def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
+    # clean up queue first
+    oob_service.export_queue_to_string()
     connection_uuid = str(uuid.uuid4())
     logger = logging.getLogger("LocalTestLogger")
 
@@ -164,6 +168,8 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
 
 
 def test_unit_connection(caplog, local_testing_telemetry_setup):
+    # clean up queue first
+    LocalTestOOBTelemetryService.get_instance().export_queue_to_string()
     conn = MockServerConnection()
     # creating a mock connection will send connection telemetry
     error_message = "Error Message"
@@ -185,6 +191,8 @@ def test_unit_connection(caplog, local_testing_telemetry_setup):
 
 
 def test_unit_connection_disable_telemetry(caplog, local_testing_telemetry_setup):
+    # clean up queue first
+    LocalTestOOBTelemetryService.get_instance().export_queue_to_string()
     disabled_telemetry_conn = MockServerConnection(
         options={"disable_local_testing_telemetry": True}
     )
@@ -205,32 +213,36 @@ def test_unit_connection_disable_telemetry(caplog, local_testing_telemetry_setup
 
 
 def test_snowpark_telemetry(caplog, local_testing_telemetry_setup):
-    session = Session.builder.configs(options={"local_testing": True}).create()
-    assert session._conn._oob_telemetry.get_instance().size() == 1
-    with pytest.raises(
-        NotImplementedError,
-        match=re.escape("[Local Testing] Session.sql is not supported."),
-    ):
-        session.sql("select 1")
-        assert session._conn._oob_telemetry.get_instance().size() == 2
-    payload = session._conn._oob_telemetry.export_queue_to_string()
-    unpacked_payload = json.loads(payload)
-    assert unpacked_payload[0]["Tags"]["Event_type"] == "session"
-    assert unpacked_payload[1]["Tags"]["Event_type"] == "unsupported"
-
-    # test sending successfully
-    with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
-        session = Session.builder.configs(options={"local_testing": True}).create()
+    # clean up queue first
+    LocalTestOOBTelemetryService.get_instance().export_queue_to_string()
+    with Session.builder.configs(options={"local_testing": True}).create() as session:
         assert session._conn._oob_telemetry.get_instance().size() == 1
         with pytest.raises(
             NotImplementedError,
             match=re.escape("[Local Testing] Session.sql is not supported."),
         ):
             session.sql("select 1")
+            assert session._conn._oob_telemetry.get_instance().size() == 2
+        payload = session._conn._oob_telemetry.export_queue_to_string()
+        unpacked_payload = json.loads(payload)
+        assert unpacked_payload[0]["Tags"]["Event_type"] == "session"
+        assert unpacked_payload[1]["Tags"]["Event_type"] == "unsupported"
 
-        session._conn._oob_telemetry.flush()
-        assert session._conn._oob_telemetry.get_instance().size() == 0
-        assert (
-            "telemetry server request success: 200" in caplog.text
-            and "Telemetry request success=True" in caplog.text
-        )
+    # test sending successfully
+    with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
+        with Session.builder.configs(
+            options={"local_testing": True}
+        ).create() as session:
+            assert session._conn._oob_telemetry.get_instance().size() == 1
+            with pytest.raises(
+                NotImplementedError,
+                match=re.escape("[Local Testing] Session.sql is not supported."),
+            ):
+                session.sql("select 1")
+
+            session._conn._oob_telemetry.flush()
+            assert session._conn._oob_telemetry.get_instance().size() == 0
+            assert (
+                "telemetry server request success: 200" in caplog.text
+                and "Telemetry request success=True" in caplog.text
+            )

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -66,7 +66,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         assert oob_service.size() == 2
         oob_service.flush()
         assert oob_service.size() == 0
-        assert len(caplog.record_tuples) == 2
+        assert len(caplog.record_tuples) >= 2
         assert (
             "telemetry server request success: 200" in caplog.text
             and "Telemetry request success=True" in caplog.text

--- a/tests/mock_unit/test_sort.py
+++ b/tests/mock_unit/test_sort.py
@@ -4,16 +4,13 @@
 
 import pytest
 
-from snowflake.snowpark import DataFrame, Row, Session
+from snowflake.snowpark import DataFrame, Row
 from snowflake.snowpark.functions import col
-from snowflake.snowpark.mock._connection import MockServerConnection
 from tests.utils import Utils
-
-session = Session(MockServerConnection())
 
 
 @pytest.mark.localtest
-def test_sort_single_column():
+def test_sort_single_column(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1],
@@ -67,7 +64,7 @@ def test_sort_single_column():
 
 
 @pytest.mark.localtest
-def test_sort_multiple_column():
+def test_sort_multiple_column(session):
     origin_df: DataFrame = session.create_dataframe(
         [
             [1.0, 2.3],

--- a/tests/mock_unit/test_union.py
+++ b/tests/mock_unit/test_union.py
@@ -4,15 +4,12 @@
 
 import pytest
 
-from snowflake.snowpark import DataFrame, Row, Session
-from snowflake.snowpark.mock._connection import MockServerConnection
+from snowflake.snowpark import DataFrame, Row
 from tests.utils import Utils
-
-session = Session(MockServerConnection())
 
 
 @pytest.mark.localtest
-def test_union_basic():
+def test_union_basic(session):
     df1: DataFrame = session.create_dataframe(
         [
             [1, 2],
@@ -83,7 +80,7 @@ def test_union_basic():
 
 
 @pytest.mark.localtest
-def test_union_by_name():
+def test_union_by_name(session):
     df1: DataFrame = session.create_dataframe(
         [
             [1, 2],

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     udf: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} or udf" {posargs:} src/snowflake/snowpark tests
     notdoctest: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} or udf" {posargs:} tests
     notudfdoctest: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and not udf" {posargs:} tests
-    local: {env:SNOWFLAKE_PYTEST_CMD} --local_testing_mode -m "(integ and localtest) or unit" {posargs:} tests
+    local: {env:SNOWFLAKE_PYTEST_CMD} --local_testing_mode -m "(integ and localtest) or unit or mock_unit" {posargs:} tests
 
 [testenv:nopandas]
 allowlist_externals = bash


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1296430

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

- update oob telemetry endpoint to use old endpoint which works, the engineering team is working on getting the previous endpoint to work. after their work complete, both endpoint shall work so the change is safe.
- previously the mock unit test is not picked up because of tox.ini setting, now we update the config to run those unit tests
- some mock unit tests are failing in the dir tests/mock, those will be fixed in separate PRs, check SNOW-930299