### PR TITLE
SNOW-1304211: Pylance throws errors when using copy_options with copy_into_location method

### DIFF
--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -3,7 +3,7 @@
 #
 
 import sys
-from typing import Dict, List, Literal, Optional, Union, overload
+from typing import Any, Dict, List, Literal, Optional, Union, overload
 
 import snowflake.snowpark  # for forward references of type hints
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -240,7 +240,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        **copy_options: Optional[str],
+        **copy_options: Optional[Dict[str, Any]],
     ) -> List[Row]:
         ...  # pragma: no cover
 
@@ -256,7 +256,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = False,
-        **copy_options: Optional[str],
+        **copy_options: Optional[Dict[str, Any]],
     ) -> AsyncJob:
         ...  # pragma: no cover
 
@@ -271,7 +271,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        **copy_options: Optional[str],
+        **copy_options: Optional[Dict[str, Any]],
     ) -> Union[List[Row], AsyncJob]:
         """Executes a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into one or more files in a stage or external stage.
 

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -239,7 +239,7 @@ class DataFrameWriter:
         format_type_options: Optional[Dict[str, str]] = None,
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
-        block: bool = True,
+        block: Literal[True] = True,
         **copy_options: Optional[Dict[str, Any]],
     ) -> List[Row]:
         ...  # pragma: no cover
@@ -255,7 +255,7 @@ class DataFrameWriter:
         format_type_options: Optional[Dict[str, str]] = None,
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
-        block: bool = False,
+        block: Literal[False] = False,
         **copy_options: Optional[Dict[str, Any]],
     ) -> AsyncJob:
         ...  # pragma: no cover


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowpark-python/issues/1363

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

* [`src/snowflake/snowpark/dataframe_writer.py`](diffhunk://#diff-30e3ff47797748b9e4b3bf0e50aede5c2a609f6624f51ef83ac2c04802cf17e9L243-R243): The `copy_into_location` method was updated in three instances. The `copy_options` parameter was changed from `Optional[str]` to `Optional[Dict[str, Any]]`. This change allows for a wider range of types to be accepted as copy options, providing more flexibility when calling the method. [[1]](diffhunk://#diff-30e3ff47797748b9e4b3bf0e50aede5c2a609f6624f51ef83ac2c04802cf17e9L243-R243) [[2]](diffhunk://#diff-30e3ff47797748b9e4b3bf0e50aede5c2a609f6624f51ef83ac2c04802cf17e9L259-R259) [[3]](diffhunk://#diff-30e3ff47797748b9e4b3bf0e50aede5c2a609f6624f51ef83ac2c04802cf17e9L274-R274)
