### PR TITLE
Allow Session-less Decorators for Extension Functions

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1323,26 +1323,27 @@ $$
     )
 
     # As an FYI, _should_continue_registration is a function, and is defined outside the Snowpark context.
-    extension_function_properties = ExtensionFunctionProperties(
-        anonymous=True,
-        object_type=TempObjectType.PROCEDURE,
-        object_name=object_name,
-        input_args=input_args,
-        input_sql_types=input_sql_types,
-        return_sql=return_sql,
-        runtime_version=runtime_version,
-        all_imports=all_imports,
-        all_packages=all_packages,
-        external_access_integrations=external_access_integrations,
-        secrets=secrets,
-        handler=handler,
-        inline_python_code=inline_python_code,
-        native_app_params=native_app_params,
-        import_paths=import_paths,
-        func=func,
-    )
-    # The result of the function call below does not matter because we are not using session object here
-    _should_continue_registration(extension_function_properties)
+    if _should_continue_registration is not None:
+        extension_function_properties = ExtensionFunctionProperties(
+            anonymous=True,
+            object_type=TempObjectType.PROCEDURE,
+            object_name=object_name,
+            input_args=input_args,
+            input_sql_types=input_sql_types,
+            return_sql=return_sql,
+            runtime_version=runtime_version,
+            all_imports=all_imports,
+            all_packages=all_packages,
+            external_access_integrations=external_access_integrations,
+            secrets=secrets,
+            handler=handler,
+            inline_python_code=inline_python_code,
+            native_app_params=native_app_params,
+            import_paths=import_paths,
+            func=func,
+        )
+        # The result of the function call below does not matter because we are not using session object here
+        _should_continue_registration(extension_function_properties)
 
     sql = f"""
 WITH {object_name} AS PROCEDURE ({sql_func_args})

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -8,6 +8,7 @@ import pickle
 import sys
 import typing
 import zipfile
+from copy import deepcopy
 from logging import getLogger
 from types import ModuleType
 from typing import (
@@ -48,6 +49,11 @@ from snowflake.snowpark._internal.utils import (
     unwrap_stage_location_single_quote,
     validate_object_name,
 )
+from snowflake.snowpark.context import (
+    _is_execution_environment_sandboxed,
+    _should_continue_registration,
+)
+from snowflake.snowpark.session import Session
 from snowflake.snowpark.types import DataType, StructField, StructType
 
 if installed_pandas:
@@ -91,6 +97,59 @@ EXECUTE_AS_WHITELIST = frozenset(["owner", "caller"])
 class UDFColumn(NamedTuple):
     datatype: DataType
     name: str
+
+
+class CallableProperties:
+    """
+    This is a data class to hold all information, resolved or otherwise, about a UDF/UDTF/UDAF/Sproc object
+    that we want to create in a user's Snowflake account.
+    One of the use cases of this class is to be able to pass on information to a callback that may be installed
+    in the execution environment, such as for testing.
+    """
+
+    def __init__(
+        self,
+        replace: bool,
+        object_type: TempObjectType,
+        if_not_exists: bool,
+        object_name: str,
+        input_args: List[UDFColumn],
+        input_sql_types: List[str],
+        return_sql: str,
+        runtime_version: str,
+        all_imports: Optional[str],
+        all_packages: str,
+        handler: Optional[str],
+        external_access_integrations: Optional[List[str]],
+        secrets: Optional[Dict[str, str]],
+        inline_python_code: Optional[str],
+        native_app_params: Optional[Dict[str, Any]],
+        import_paths: Optional[Dict[str, Tuple[Optional[str], Optional[str]]]],
+        func: Union[Callable, Tuple[str, str]],
+        execute_as: Optional[typing.Literal["caller", "owner"]] = None,
+        is_execution_environment_sandboxed: bool = False,
+        anonymous: bool = False,
+    ) -> None:
+        self.func = func
+        self.replace = replace
+        self.object_type = object_type
+        self.if_not_exists = if_not_exists
+        self.object_name = object_name
+        self.input_args = deepcopy(input_args)
+        self.input_sql_types = input_sql_types
+        self.return_sql = return_sql
+        self.runtime_version = runtime_version
+        self.all_imports = all_imports
+        self.all_packages = all_packages
+        self.external_access_integrations = deepcopy(external_access_integrations)
+        self.secrets = deepcopy(secrets)
+        self.handler = handler
+        self.execute_as = execute_as
+        self.inline_python_code = inline_python_code
+        self.native_app_params = deepcopy(native_app_params)
+        self.import_paths = deepcopy(import_paths)
+        self.is_execution_environment_sandboxed = is_execution_environment_sandboxed
+        self.anonymous = anonymous
 
 
 def is_local_python_file(file_path: str) -> bool:
@@ -548,7 +607,8 @@ def process_registration_inputs(
     else:
         object_name = random_name_for_temp_object(object_type)
         if not anonymous:
-            object_name = session.get_fully_qualified_name_if_possible(object_name)
+            if session is not None:
+                object_name = session.get_fully_qualified_name_if_possible(object_name)
     validate_object_name(object_name)
 
     # get return and input types
@@ -806,8 +866,42 @@ import pandas
 """.strip()
 
 
+def resolve_packages_in_sandbox(
+    packages: Optional[List[Union[str, ModuleType]]],
+) -> List[str]:
+    """
+    Special function invoked only when executing Snowpark code in a sandbox environment.
+    """
+    resolved_packages: List[str] = []
+    if packages is not None:
+        parsed_packages = Session._parse_packages(packages)
+        # Similar to local testing we don't resolve the packages, we just return what is added
+        errors = []
+        resolved_packages_dict: Dict[str, str] = {}
+
+        for pkg_name, _, pkg_req in parsed_packages.values():
+            if (
+                pkg_name in resolved_packages_dict
+                and str(pkg_req) != resolved_packages_dict[pkg_name]
+            ):
+                errors.append(
+                    ValueError(
+                        f"Cannot add package '{str(pkg_req)}' because {resolved_packages_dict[pkg_name]} "
+                        "is already added."
+                    )
+                )
+            else:
+                resolved_packages_dict[pkg_name] = str(pkg_req)
+        if len(errors) == 1:
+            raise errors[0]
+        elif len(errors) > 0:
+            raise RuntimeError(errors)
+        resolved_packages = list(resolved_packages_dict.values())
+    return resolved_packages
+
+
 def resolve_imports_and_packages(
-    session: "snowflake.snowpark.Session",
+    session: Optional["snowflake.snowpark.Session"],
     object_type: TempObjectType,
     func: Union[Callable, Tuple[str, str]],
     arg_names: List[str],
@@ -825,43 +919,64 @@ def resolve_imports_and_packages(
     skip_upload_on_content_match: bool = False,
     is_permanent: bool = False,
     force_inline_code: bool = False,
-) -> Tuple[str, str, str, str, str, bool]:
-    import_only_stage = (
-        unwrap_stage_location_single_quote(stage_location)
-        if stage_location
-        else session.get_session_stage(statement_params=statement_params)
-    )
-
-    upload_and_import_stage = (
-        import_only_stage
-        if is_permanent
-        else session.get_session_stage(statement_params=statement_params)
-    )
+) -> Tuple[
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[Dict[str, Tuple[Optional[str], Optional[str]]]],
+    Optional[str],
+    bool,
+]:
 
     # resolve packages
-    resolved_packages = (
-        session._resolve_packages(
-            packages, include_pandas=is_pandas_udf, statement_params=statement_params
+    if session is None:  # In case of sandbox
+        resolved_packages = resolve_packages_in_sandbox(packages=packages)
+    else:  # In any other scenario
+        resolved_packages = (
+            session._resolve_packages(
+                packages,
+                include_pandas=is_pandas_udf,
+                statement_params=statement_params,
+            )
+            if packages is not None
+            else session._resolve_packages(
+                [],
+                session._packages,
+                validate_package=False,
+                include_pandas=is_pandas_udf,
+                statement_params=statement_params,
+            )
         )
-        if packages is not None
-        else session._resolve_packages(
-            [],
-            session._packages,
-            validate_package=False,
-            include_pandas=is_pandas_udf,
-            statement_params=statement_params,
+
+    if session is not None:
+        import_only_stage = (
+            unwrap_stage_location_single_quote(stage_location)
+            if stage_location
+            else session.get_session_stage(statement_params=statement_params)
         )
-    )
+
+        upload_and_import_stage = (
+            import_only_stage
+            if is_permanent
+            else session.get_session_stage(statement_params=statement_params)
+        )
 
     # resolve imports
+    udf_level_imports = {}
     if imports:
-        udf_level_imports = {}
         for udf_import in imports:
             if isinstance(udf_import, str):
-                resolved_import_tuple = session._resolve_import_path(udf_import)
+                resolved_import_tuple = (
+                    session._resolve_import_path(udf_import)
+                    if session
+                    else Session._resolve_import_path(udf_import)
+                )
             elif isinstance(udf_import, tuple) and len(udf_import) == 2:
-                resolved_import_tuple = session._resolve_import_path(
-                    udf_import[0], udf_import[1]
+                resolved_import_tuple = (
+                    session._resolve_import_path(udf_import[0], udf_import[1])
+                    if session
+                    else Session._resolve_import_path(udf_import[0], udf_import[1])
                 )
             else:
                 raise TypeError(
@@ -869,17 +984,25 @@ def resolve_imports_and_packages(
                     "or a tuple of the file path (str) and the import path (str)."
                 )
             udf_level_imports[resolved_import_tuple[0]] = resolved_import_tuple[1:]
-        all_urls = session._resolve_imports(
-            import_only_stage,
-            upload_and_import_stage,
-            udf_level_imports,
-            statement_params=statement_params,
+        all_urls = (
+            session._resolve_imports(
+                import_only_stage,
+                upload_and_import_stage,
+                udf_level_imports,
+                statement_params=statement_params,
+            )
+            if session
+            else []
         )
     elif imports is None:
-        all_urls = session._resolve_imports(
-            import_only_stage,
-            upload_and_import_stage,
-            statement_params=statement_params,
+        all_urls = (
+            session._resolve_imports(
+                import_only_stage,
+                upload_and_import_stage,
+                statement_params=statement_params,
+            )
+            if session
+            else []
         )
     else:
         all_urls = []
@@ -887,80 +1010,87 @@ def resolve_imports_and_packages(
     dest_prefix = get_udf_upload_prefix(udf_name)
 
     # Upload closure to stage if it is beyond inline closure size limit
-    if isinstance(func, Callable):
-        custom_python_runtime_version_allowed = (
-            False  # As cloudpickle is being used, we cannot allow a custom runtime
-        )
-
-        # generate a random name for udf py file
-        # and we compress it first then upload it
-        udf_file_name_base = f"udf_py_{random_number()}"
-        udf_file_name = f"{udf_file_name_base}.zip"
-        code = generate_python_code(
-            func,
-            arg_names,
-            object_type,
-            is_pandas_udf,
-            is_dataframe_input,
-            max_batch_size,
-            source_code_display=source_code_display,
-        )
-        if not force_inline_code and len(code) > _MAX_INLINE_CLOSURE_SIZE_BYTES:
-            dest_prefix = get_udf_upload_prefix(udf_name)
-            upload_file_stage_location = normalize_remote_file_or_dir(
-                f"{upload_and_import_stage}/{dest_prefix}/{udf_file_name}"
+    handler = inline_code = upload_file_stage_location = None
+    if session is not None:
+        if isinstance(func, Callable):
+            custom_python_runtime_version_allowed = (
+                False  # As cloudpickle is being used, we cannot allow a custom runtime
             )
-            udf_file_name_base = os.path.splitext(udf_file_name)[0]
-            with io.BytesIO() as input_stream:
-                with zipfile.ZipFile(
-                    input_stream, mode="w", compression=zipfile.ZIP_DEFLATED
-                ) as zf:
-                    zf.writestr(f"{udf_file_name_base}.py", code)
-                session._conn.upload_stream(
-                    input_stream=input_stream,
+
+            # generate a random name for udf py file
+            # and we compress it first then upload it
+            udf_file_name_base = f"udf_py_{random_number()}"
+            udf_file_name = f"{udf_file_name_base}.zip"
+            code = generate_python_code(
+                func,
+                arg_names,
+                object_type,
+                is_pandas_udf,
+                is_dataframe_input,
+                max_batch_size,
+                source_code_display=source_code_display,
+            )
+            if not force_inline_code and len(code) > _MAX_INLINE_CLOSURE_SIZE_BYTES:
+                dest_prefix = get_udf_upload_prefix(udf_name)
+                upload_file_stage_location = normalize_remote_file_or_dir(
+                    f"{upload_and_import_stage}/{dest_prefix}/{udf_file_name}"
+                )
+                udf_file_name_base = os.path.splitext(udf_file_name)[0]
+                with io.BytesIO() as input_stream:
+                    with zipfile.ZipFile(
+                        input_stream, mode="w", compression=zipfile.ZIP_DEFLATED
+                    ) as zf:
+                        zf.writestr(f"{udf_file_name_base}.py", code)
+                    session._conn.upload_stream(
+                        input_stream=input_stream,
+                        stage_location=upload_and_import_stage,
+                        dest_filename=udf_file_name,
+                        dest_prefix=dest_prefix,
+                        parallel=parallel,
+                        source_compression="DEFLATE",
+                        compress_data=False,
+                        overwrite=True,
+                        is_in_udf=True,
+                        skip_upload_on_content_match=skip_upload_on_content_match,
+                    )
+                all_urls.append(upload_file_stage_location)
+                inline_code = None
+                handler = f"{udf_file_name_base}.{_DEFAULT_HANDLER_NAME}"
+            else:
+                inline_code = code
+                upload_file_stage_location = None
+                handler = _DEFAULT_HANDLER_NAME
+        else:
+            custom_python_runtime_version_allowed = True
+            udf_file_name = os.path.basename(func[0])
+            # for a compressed file, it might have multiple extensions
+            # and we should remove all extensions
+            udf_file_name_base = udf_file_name.split(".")[0]
+            inline_code = None
+            handler = f"{udf_file_name_base}.{func[1]}"
+
+            if func[0].startswith(STAGE_PREFIX):
+                upload_file_stage_location = None
+                all_urls.append(func[0])
+            else:
+                upload_file_stage_location = normalize_remote_file_or_dir(
+                    f"{upload_and_import_stage}/{dest_prefix}/{udf_file_name}"
+                )
+                session._conn.upload_file(
+                    path=func[0],
                     stage_location=upload_and_import_stage,
-                    dest_filename=udf_file_name,
                     dest_prefix=dest_prefix,
                     parallel=parallel,
-                    source_compression="DEFLATE",
                     compress_data=False,
                     overwrite=True,
-                    is_in_udf=True,
                     skip_upload_on_content_match=skip_upload_on_content_match,
                 )
-            all_urls.append(upload_file_stage_location)
-            inline_code = None
-            handler = f"{udf_file_name_base}.{_DEFAULT_HANDLER_NAME}"
-        else:
-            inline_code = code
-            upload_file_stage_location = None
-            handler = _DEFAULT_HANDLER_NAME
+                all_urls.append(upload_file_stage_location)
     else:
-        custom_python_runtime_version_allowed = True
-        udf_file_name = os.path.basename(func[0])
-        # for a compressed file, it might have multiple extensions
-        # and we should remove all extensions
-        udf_file_name_base = udf_file_name.split(".")[0]
-        inline_code = None
-        handler = f"{udf_file_name_base}.{func[1]}"
-
-        if func[0].startswith(STAGE_PREFIX):
-            upload_file_stage_location = None
-            all_urls.append(func[0])
+        if isinstance(func, Callable):
+            custom_python_runtime_version_allowed = False
         else:
-            upload_file_stage_location = normalize_remote_file_or_dir(
-                f"{upload_and_import_stage}/{dest_prefix}/{udf_file_name}"
-            )
-            session._conn.upload_file(
-                path=func[0],
-                stage_location=upload_and_import_stage,
-                dest_prefix=dest_prefix,
-                parallel=parallel,
-                compress_data=False,
-                overwrite=True,
-                skip_upload_on_content_match=skip_upload_on_content_match,
-            )
-            all_urls.append(upload_file_stage_location)
+            custom_python_runtime_version_allowed = True
 
     # build imports and packages string
     all_imports = ",".join(
@@ -972,6 +1102,7 @@ def resolve_imports_and_packages(
         inline_code,
         all_imports,
         all_packages,
+        udf_level_imports,
         upload_file_stage_location,
         custom_python_runtime_version_allowed,
     )
@@ -979,16 +1110,18 @@ def resolve_imports_and_packages(
 
 def create_python_udf_or_sp(
     session: "snowflake.snowpark.Session",
+    func: Union[Callable, Tuple[str, str]],
     return_type: DataType,
     input_args: List[UDFColumn],
-    handler: str,
+    handler: Optional[str],
     object_type: TempObjectType,
     object_name: str,
-    all_imports: str,
+    all_imports: Optional[str],
     all_packages: str,
     is_permanent: bool,
     replace: bool,
     if_not_exists: bool,
+    import_paths: Optional[Dict[str, Tuple[Optional[str], Optional[str]]]] = None,
     inline_python_code: Optional[str] = None,
     execute_as: Optional[typing.Literal["caller", "owner"]] = None,
     api_call_source: Optional[str] = None,
@@ -998,12 +1131,17 @@ def create_python_udf_or_sp(
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
     statement_params: Optional[Dict[str, str]] = None,
+    native_app_params: Optional[Dict[str, Any]] = None,
 ) -> None:
-    runtime_version = (
-        f"{sys.version_info[0]}.{sys.version_info[1]}"
-        if not session._runtime_version_from_requirement
-        else session._runtime_version_from_requirement
-    )
+    if session is not None:
+        runtime_version = (
+            f"{sys.version_info[0]}.{sys.version_info[1]}"
+            if not session._runtime_version_from_requirement
+            else session._runtime_version_from_requirement
+        )
+    else:
+        runtime_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
+
     if replace and if_not_exists:
         raise ValueError("options replace and if_not_exists are incompatible")
     if isinstance(return_type, StructType):
@@ -1050,6 +1188,37 @@ $$
         if secrets
         else ""
     )
+
+    # As an FYI, _should_continue_registration is a function, and is defined outside the Snowpark context.
+    if _should_continue_registration is None:
+        continue_registration = True
+    else:
+        callable_properties = CallableProperties(
+            func=func,
+            replace=replace,
+            object_type=object_type,
+            if_not_exists=if_not_exists,
+            object_name=object_name,
+            input_args=input_args,
+            input_sql_types=input_sql_types,
+            return_sql=return_sql,
+            runtime_version=runtime_version,
+            all_imports=all_imports,
+            all_packages=all_packages,
+            external_access_integrations=external_access_integrations,
+            secrets=secrets,
+            handler=handler,
+            execute_as=execute_as,
+            inline_python_code=inline_python_code,
+            native_app_params=native_app_params,
+            import_paths=import_paths,
+            is_execution_environment_sandboxed=_is_execution_environment_sandboxed,
+        )
+        continue_registration = _should_continue_registration(callable_properties)
+
+    # This means the execution environment does not want to continue creating the object in Snowflake
+    if not bool(continue_registration):
+        return
 
     create_query = f"""
 CREATE{" OR REPLACE " if replace else ""}

--- a/src/snowflake/snowpark/context.py
+++ b/src/snowflake/snowpark/context.py
@@ -11,12 +11,11 @@ import snowflake.snowpark
 _use_scoped_temp_objects = True
 
 # This is an internal-only global flag, used to determine whether to execute code in a client's local sandbox or connect to a Snowflake account.
-# If this is True, then all sessions created using Session.builder will be created using MockServerConnection which mocks connection to Snowflake, instead of creating a real connection
-# which allows interacting with Snowflake.
+# If this is True, then the session instance is forcibly set to None to avoid any interaction with a Snowflake account.
 _is_execution_environment_sandboxed: bool = False
 
-# This callback, assigned by the caller environment outside Snowpark, can be used to share information about the UDxF/Sproc object to be registered.
-# It should also return a decision on whether to proceed with registring the UDxF/SPROC object with the Snowflake account.
+# This callback, assigned by the caller environment outside Snowpark, can be used to share information about the extension function to be registered.
+# It should also return a decision on whether to proceed with registring the extension function with the Snowflake account.
 # If _should_continue_registration is None, i.e. a caller environment never assigned it an alternate callable, then we want to continue registration as part of the regular Snowpark workflow.
 # If _should_continue_registration is not None, i.e. a caller environment has assigned it an alternate callable, then the callback is responsible for determining the rest of the Snowpark workflow.
 _should_continue_registration: Optional[Callable] = None

--- a/src/snowflake/snowpark/context.py
+++ b/src/snowflake/snowpark/context.py
@@ -4,9 +4,22 @@
 #
 
 """Context module for Snowpark."""
+from typing import Callable, Optional
+
 import snowflake.snowpark
 
 _use_scoped_temp_objects = True
+
+# This is an internal-only global flag, used to determine whether to execute code in a client's local sandbox or connect to a Snowflake account.
+# If this is True, then all sessions created using Session.builder will be created using MockServerConnection which mocks connection to Snowflake, instead of creating a real connection
+# which allows interacting with Snowflake.
+_is_execution_environment_sandboxed: bool = False
+
+# This callback, assigned by the caller environment outside Snowpark, can be used to share information about the UDxF/Sproc object to be registered.
+# It should also return a decision on whether to proceed with registring the UDxF/SPROC object with the Snowflake account.
+# If _should_continue_registration is None, i.e. a caller environment never assigned it an alternate callable, then we want to continue registration as part of the regular Snowpark workflow.
+# If _should_continue_registration is not None, i.e. a caller environment has assigned it an alternate callable, then the callback is responsible for determining the rest of the Snowpark workflow.
+_should_continue_registration: Optional[Callable] = None
 
 
 def get_active_session() -> "snowflake.snowpark.Session":

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -162,7 +162,7 @@ import sys
 import typing
 from random import randint
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, overload
+from typing import Callable, Dict, List, Optional, Tuple, Union, overload
 
 import snowflake.snowpark
 import snowflake.snowpark.table_function
@@ -7050,7 +7050,7 @@ def udf(
     external_access_integrations: Optional[List[str]] = None,
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
-    native_app_params: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> Union[UserDefinedFunction, functools.partial]:
     """Registers a Python function as a Snowflake Python UDF and returns the UDF.
 
@@ -7059,9 +7059,6 @@ def udf(
     explicitly specify the ``session`` parameter of this function. If you have a function and would
     like to register it to multiple databases, use ``session.udf.register`` instead. See examples
     in :class:`~snowflake.snowpark.udf.UDFRegistration`.
-
-    This can also be used to create an extension function in a `Snowflake Native App Framework
-    setup script <https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script>`_.
 
     Args:
         func: A Python function used for creating the UDF.
@@ -7138,11 +7135,6 @@ def udf(
             also be specified in the external access integration and the keys are strings used to
             retrieve the secrets using secret API.
         immutable: Whether the UDF result is deterministic or not for the same input.
-        native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-            as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-            such as schema and application roles.
-            A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-            This parameter is ignored if you are not developing a Snowflake Native App.
 
     Returns:
         A UDF function that can be called with :class:`~snowflake.snowpark.Column` expressions.
@@ -7240,7 +7232,7 @@ def udf(
             external_access_integrations=external_access_integrations,
             secrets=secrets,
             immutable=immutable,
-            native_app_params=native_app_params,
+            kwargs=kwargs,
         )
     else:
         return udf_registration_method(
@@ -7263,7 +7255,7 @@ def udf(
             external_access_integrations=external_access_integrations,
             secrets=secrets,
             immutable=immutable,
-            native_app_params=native_app_params,
+            kwargs=kwargs,
         )
 
 
@@ -7287,7 +7279,7 @@ def udtf(
     external_access_integrations: Optional[List[str]] = None,
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
-    native_app_params: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> Union[UserDefinedTableFunction, functools.partial]:
     """Registers a Python class as a Snowflake Python UDTF and returns the UDTF.
 
@@ -7296,9 +7288,6 @@ def udtf(
     explicitly specify the ``session`` parameter of this function. If you have a function and would
     like to register it to multiple databases, use ``session.udtf.register`` instead. See examples
     in :class:`~snowflake.snowpark.udtf.UDTFRegistration`.
-
-    This can also be used to create an extension function in a `Snowflake Native App Framework
-    setup script <https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script>`_.
 
     Args:
         handler: A Python class used for creating the UDTF.
@@ -7361,11 +7350,6 @@ def udtf(
             also be specified in the external access integration and the keys are strings used to
             retrieve the secrets using secret API.
         immutable: Whether the UDTF result is deterministic or not for the same input.
-        native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-            as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-            such as schema and application roles.
-            A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-            This parameter is ignored if you are not developing a Snowflake Native App.
 
     Returns:
         A UDTF function that can be called with :class:`~snowflake.snowpark.Column` expressions.
@@ -7473,7 +7457,7 @@ def udtf(
             external_access_integrations=external_access_integrations,
             secrets=secrets,
             immutable=immutable,
-            native_app_params=native_app_params,
+            kwargs=kwargs,
         )
     else:
         return udtf_registration_method(
@@ -7494,7 +7478,7 @@ def udtf(
             external_access_integrations=external_access_integrations,
             secrets=secrets,
             immutable=immutable,
-            native_app_params=native_app_params,
+            kwargs=kwargs,
         )
 
 
@@ -7516,7 +7500,7 @@ def udaf(
     immutable: bool = False,
     external_access_integrations: Optional[List[str]] = None,
     secrets: Optional[Dict[str, str]] = None,
-    native_app_params: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> Union[UserDefinedAggregateFunction, functools.partial]:
     """Registers a Python class as a Snowflake Python UDAF and returns the UDAF.
 
@@ -7525,9 +7509,6 @@ def udaf(
     explicitly specify the ``session`` parameter of this function. If you have a function and would
     like to register it to multiple databases, use ``session.udaf.register`` instead. See examples
     in :class:`~snowflake.snowpark.udaf.UDAFRegistration`.
-
-    This can also be used to create an extension function in a `Snowflake Native App Framework
-    setup script <https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script>`_.
 
     Args:
         handler: A Python class used for creating the UDAF.
@@ -7590,11 +7571,6 @@ def udaf(
             The secrets can be accessed from handler code. The secrets specified as values must
             also be specified in the external access integration and the keys are strings used to
             retrieve the secrets using secret API.
-        native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-            as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-            such as schema and application roles.
-            A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-            This parameter is ignored if you are not developing a Snowflake Native App.
 
     Returns:
         A UDAF function that can be called with :class:`~snowflake.snowpark.Column` expressions.
@@ -7707,7 +7683,7 @@ def udaf(
             immutable=immutable,
             external_access_integrations=external_access_integrations,
             secrets=secrets,
-            native_app_params=native_app_params,
+            kwargs=kwargs,
         )
     else:
         return udaf_registration_method(
@@ -7726,7 +7702,7 @@ def udaf(
             immutable=immutable,
             external_access_integrations=external_access_integrations,
             secrets=secrets,
-            native_app_params=native_app_params,
+            kwargs=kwargs,
         )
 
 
@@ -7752,6 +7728,7 @@ def pandas_udf(
     external_access_integrations: Optional[List[str]] = None,
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
+    **kwargs,
 ) -> Union[UserDefinedFunction, functools.partial]:
     """
     Registers a Python function as a vectorized UDF and returns the UDF.
@@ -7803,10 +7780,17 @@ def pandas_udf(
         ------------
         <BLANKLINE>
     """
-    session = session or snowflake.snowpark.session._get_active_session()
+    session = snowflake.snowpark.session._get_sandbox_conditional_active_session(
+        session
+    )
+    if session is None:
+        udf_registration_method = UDFRegistration(session=session).register
+    else:
+        udf_registration_method = session.udf.register
+
     if func is None:
         return functools.partial(
-            session.udf.register,
+            udf_registration_method,
             return_type=return_type,
             input_types=input_types,
             name=name,
@@ -7826,9 +7810,10 @@ def pandas_udf(
             external_access_integrations=external_access_integrations,
             secrets=secrets,
             immutable=immutable,
+            kwargs=kwargs,
         )
     else:
-        return session.udf.register(
+        return udf_registration_method(
             func,
             return_type=return_type,
             input_types=input_types,
@@ -7849,6 +7834,7 @@ def pandas_udf(
             external_access_integrations=external_access_integrations,
             secrets=secrets,
             immutable=immutable,
+            kwargs=kwargs,
         )
 
 
@@ -7874,6 +7860,7 @@ def pandas_udtf(
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
     max_batch_size: Optional[int] = None,
+    **kwargs,
 ) -> Union[UserDefinedTableFunction, functools.partial]:
     """Registers a Python class as a vectorized Python UDTF and returns the UDTF.
 
@@ -7957,10 +7944,18 @@ def pandas_udtf(
         -----------------------------
         <BLANKLINE>
     """
-    session = session or snowflake.snowpark.session._get_active_session()
+
+    session = snowflake.snowpark.session._get_sandbox_conditional_active_session(
+        session
+    )
+    if session is None:
+        udtf_registration_method = UDTFRegistration(session=session).register
+    else:
+        udtf_registration_method = session.udtf.register
+
     if handler is None:
         return functools.partial(
-            session.udtf.register,
+            udtf_registration_method,
             output_schema=output_schema,
             input_types=input_types,
             input_names=input_names,
@@ -7979,9 +7974,10 @@ def pandas_udtf(
             secrets=secrets,
             immutable=immutable,
             max_batch_size=max_batch_size,
+            kwargs=kwargs,
         )
     else:
-        return session.udtf.register(
+        return udtf_registration_method(
             handler,
             output_schema=output_schema,
             input_types=input_types,
@@ -8001,6 +7997,7 @@ def pandas_udtf(
             secrets=secrets,
             immutable=immutable,
             max_batch_size=max_batch_size,
+            kwargs=kwargs,
         )
 
 
@@ -8170,7 +8167,6 @@ def sproc(
     source_code_display: bool = True,
     external_access_integrations: Optional[List[str]] = None,
     secrets: Optional[Dict[str, str]] = None,
-    native_app_params: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> Union[StoredProcedure, functools.partial]:
     """Registers a Python function as a Snowflake Python stored procedure and returns the stored procedure.
@@ -8180,9 +8176,6 @@ def sproc(
     explicitly specify the ``session`` parameter of this function. If you have a function and would
     like to register it to multiple databases, use ``session.sproc.register`` instead. See examples
     in :class:`~snowflake.snowpark.stored_procedure.StoredProcedureRegistration`.
-
-    This can also be used to create an extension function in a `Snowflake Native App Framework
-    setup script <https://docs.snowflake.com/en/developer-guide/native-apps/creating-setup-script>`_.
 
     Note that the first parameter of your function should be a snowpark Session. Also, you need to add
     `snowflake-snowpark-python` package (version >= 0.4.0) to your session before trying to create a
@@ -8252,11 +8245,6 @@ def sproc(
             The secrets can be accessed from handler code. The secrets specified as values must
             also be specified in the external access integration and the keys are strings used to
             retrieve the secrets using secret API.
-        native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-            as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-            such as schema and application roles.
-            A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-            This parameter is ignored if you are not developing a Snowflake Native App.
 
     Returns:
         A stored procedure function that can be called with python value.
@@ -8341,7 +8329,6 @@ def sproc(
             source_code_display=source_code_display,
             external_access_integrations=external_access_integrations,
             secrets=secrets,
-            native_app_params=native_app_params,
             **kwargs,
         )
     else:
@@ -8363,7 +8350,6 @@ def sproc(
             source_code_display=source_code_display,
             external_access_integrations=external_access_integrations,
             secrets=secrets,
-            native_app_params=native_app_params,
             **kwargs,
         )
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -729,6 +729,7 @@ class Session:
             self.udf._clear_session_imports()
         self._import_paths.clear()
 
+    @staticmethod
     def _resolve_import_path(
         self,
         path: str,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -105,7 +105,10 @@ from snowflake.snowpark._internal.utils import (
 )
 from snowflake.snowpark.async_job import AsyncJob
 from snowflake.snowpark.column import Column
-from snowflake.snowpark.context import _use_scoped_temp_objects
+from snowflake.snowpark.context import (
+    _is_execution_environment_sandboxed,
+    _use_scoped_temp_objects,
+)
 from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.dataframe_reader import DataFrameReader
 from snowflake.snowpark.exceptions import SnowparkClientException
@@ -211,6 +214,15 @@ def _get_active_sessions() -> Set["Session"]:
 def _add_session(session: "Session") -> None:
     with _session_management_lock:
         _active_sessions.add(session)
+
+
+def _get_sandbox_conditional_active_session(session: "Session") -> "Session":
+    # Precedence to checking sandbox to avoid any side effects
+    if _is_execution_environment_sandboxed:
+        session = None
+    else:
+        session = session or _get_active_session()
+    return session
 
 
 def _close_session_atexit():
@@ -731,7 +743,6 @@ class Session:
 
     @staticmethod
     def _resolve_import_path(
-        self,
         path: str,
         import_path: Optional[str] = None,
         chunk_size: int = 8192,

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -17,6 +17,7 @@ from snowflake.snowpark._internal.telemetry import TelemetryField
 from snowflake.snowpark._internal.type_utils import convert_sp_to_sf_type
 from snowflake.snowpark._internal.udf_utils import (
     UDFColumn,
+    add_snowpark_package_to_sproc_packages,
     check_execute_as_arg,
     check_python_runtime_version,
     check_register_args,
@@ -30,7 +31,6 @@ from snowflake.snowpark._internal.udf_utils import (
 )
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.types import DataType, StructType
-from snowflake.snowpark.version import VERSION
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
@@ -775,23 +775,10 @@ class StoredProcedureRegistration:
         ]
 
         # Add in snowflake-snowpark-python if it is not already in the package list.
-        major, minor, patch = VERSION
-        package_name = "snowflake-snowpark-python"
-        # Use == to ensure that the remote version matches the local version
-        this_package = f"{package_name}=={major}.{minor}.{patch}"
-
-        # When resolve_imports_and_packages is called below it will use the provided packages or
-        # default to the packages in the current session. If snowflake-snowpark-python is not
-        # included by either of those two mechanisms then create package list does include it and
-        # any other relevant packages.
-        if packages is None:
-            if self._session is None:
-                packages = [this_package]
-            elif package_name not in self._session._packages:
-                packages = list(self._session._packages.values()) + [this_package]
-        else:
-            if not any(package_name in p for p in packages):
-                packages.append(this_package)
+        packages = add_snowpark_package_to_sproc_packages(
+            session=self._session,
+            packages=packages,
+        )
 
         (
             handler,

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -464,7 +464,6 @@ class StoredProcedureRegistration:
         *,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
-        native_app_params: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> StoredProcedure:
         """
@@ -535,11 +534,6 @@ class StoredProcedureRegistration:
                 The secrets can be accessed from handler code. The secrets specified as values must
                 also be specified in the external access integration and the keys are strings used to
                 retrieve the secrets using secret API.
-            native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-                as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-                such as schema and application roles.
-                A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-                This parameter is ignored if you are not developing a Snowflake Native App.
 
         See Also:
             - :func:`~snowflake.snowpark.functions.sproc`
@@ -555,6 +549,7 @@ class StoredProcedureRegistration:
         check_register_args(
             TempObjectType.PROCEDURE, name, is_permanent, stage_location, parallel
         )
+        native_app_params = kwargs.get("native_app_params", None)
 
         # register stored procedure
         return self._do_register_sp(

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -326,7 +326,6 @@ class UDAFRegistration:
         external_access_integrations: Optional[List[str]] = None,
         secrets: Optional[Dict[str, str]] = None,
         *,
-        native_app_params: Optional[Dict[str, Any]] = None,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
         immutable: bool = False,
@@ -403,11 +402,6 @@ class UDAFRegistration:
                 The secrets can be accessed from handler code. The secrets specified as values must
                 also be specified in the external access integration and the keys are strings used to
                 retrieve the secrets using secret API.
-            native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-                as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-                such as schema and application roles.
-                A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-                This parameter is ignored if you are not developing a Snowflake Native App.
 
         See Also:
             - :func:`~snowflake.snowpark.functions.udaf`
@@ -425,6 +419,8 @@ class UDAFRegistration:
             stage_location,
             parallel,
         )
+
+        native_app_params = kwargs.get("native_app_params", None)
 
         # register udaf
         return self._do_register_udaf(

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -584,7 +584,13 @@ class UDFRegistration:
                 also be specified in the external access integration and the keys are strings used to
                 retrieve the secrets using secret API.
             immutable: Whether the UDF result is deterministic or not for the same input.
-        See Also:
+            native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
+                as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
+                such as schema and application roles.
+                A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
+                This parameter is ignored if you are not developing a Snowflake Native App.
+
+            See Also:
             - :func:`~snowflake.snowpark.functions.udf`
             - :meth:`register_from_file`
         """
@@ -862,6 +868,7 @@ class UDFRegistration:
         try:
             create_python_udf_or_sp(
                 session=self._session,
+                func=func,
                 return_type=return_type,
                 input_args=input_args,
                 handler=handler,

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -16,7 +16,7 @@ Refer to :class:`~snowflake.snowpark.udf.UDFRegistration` for sample code on how
 """
 import sys
 from types import ModuleType
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.connector import ProgrammingError
@@ -460,7 +460,7 @@ class UDFRegistration:
         - :meth:`~snowflake.snowpark.Session.add_packages`
     """
 
-    def __init__(self, session: "snowflake.snowpark.session.Session") -> None:
+    def __init__(self, session: Optional["snowflake.snowpark.session.Session"]) -> None:
         self._session = session
 
     def describe(
@@ -498,6 +498,7 @@ class UDFRegistration:
         secrets: Optional[Dict[str, str]] = None,
         immutable: bool = False,
         *,
+        native_app_params: Optional[Dict[str, Any]] = None,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
         **kwargs,
@@ -623,6 +624,7 @@ class UDFRegistration:
             api_call_source="UDFRegistration.register"
             + ("[pandas_udf]" if _from_pandas else ""),
             is_permanent=is_permanent,
+            native_app_params=native_app_params,
         )
 
     def register_from_file(
@@ -793,6 +795,7 @@ class UDFRegistration:
         secrets: Optional[Dict[str, str]] = None,
         immutable: bool = False,
         *,
+        native_app_params: Optional[Dict[str, Any]] = None,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
         api_call_source: str,
@@ -828,6 +831,7 @@ class UDFRegistration:
             code,
             all_imports,
             all_packages,
+            import_paths,
             upload_file_stage_location,
             custom_python_runtime_version_allowed,
         ) = resolve_imports_and_packages(
@@ -849,7 +853,7 @@ class UDFRegistration:
             is_permanent=is_permanent,
         )
 
-        if not custom_python_runtime_version_allowed:
+        if (not custom_python_runtime_version_allowed) and (self._session is not None):
             check_python_runtime_version(
                 self._session._runtime_version_from_requirement
             )
@@ -865,6 +869,7 @@ class UDFRegistration:
                 object_name=udf_name,
                 all_imports=all_imports,
                 all_packages=all_packages,
+                import_paths=import_paths,
                 is_permanent=is_permanent,
                 replace=replace,
                 if_not_exists=if_not_exists,
@@ -875,6 +880,7 @@ class UDFRegistration:
                 external_access_integrations=external_access_integrations,
                 secrets=secrets,
                 immutable=immutable,
+                native_app_params=native_app_params,
             )
         # an exception might happen during registering a udf
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -498,7 +498,6 @@ class UDFRegistration:
         secrets: Optional[Dict[str, str]] = None,
         immutable: bool = False,
         *,
-        native_app_params: Optional[Dict[str, Any]] = None,
         statement_params: Optional[Dict[str, str]] = None,
         source_code_display: bool = True,
         **kwargs,
@@ -584,11 +583,6 @@ class UDFRegistration:
                 also be specified in the external access integration and the keys are strings used to
                 retrieve the secrets using secret API.
             immutable: Whether the UDF result is deterministic or not for the same input.
-            native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-                as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-                such as schema and application roles.
-                A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-                This parameter is ignored if you are not developing a Snowflake Native App.
 
         See Also:
         - :func:`~snowflake.snowpark.functions.udf`
@@ -606,6 +600,7 @@ class UDFRegistration:
         )
 
         _from_pandas = kwargs.get("_from_pandas_udf_function", False)
+        native_app_params = kwargs.get("native_app_params", None)
 
         # register udf
         return self._do_register_udf(

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -590,10 +590,11 @@ class UDFRegistration:
                 A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
                 This parameter is ignored if you are not developing a Snowflake Native App.
 
-            See Also:
-            - :func:`~snowflake.snowpark.functions.udf`
-            - :meth:`register_from_file`
+        See Also:
+        - :func:`~snowflake.snowpark.functions.udf`
+        - :meth:`register_from_file`
         """
+
         if not callable(func):
             raise TypeError(
                 "Invalid function: not a function or callable "

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -906,7 +906,7 @@ class UDTFRegistration:
             is_permanent=is_permanent,
         )
 
-        if not custom_python_runtime_version_allowed:
+        if (not custom_python_runtime_version_allowed) and (self._session is not None):
             check_python_runtime_version(
                 self._session._runtime_version_from_requirement
             )

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -547,8 +547,8 @@ class UDTFRegistration:
         immutable: bool = False,
         max_batch_size: Optional[int] = None,
         *,
-        native_app_params: Optional[Dict[str, Any]] = None,
         statement_params: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> UserDefinedTableFunction:
         """
         Registers a Python class as a Snowflake Python UDTF and returns the UDTF.
@@ -625,12 +625,6 @@ class UDTFRegistration:
                 every batch by setting a smaller batch size. Note that setting a larger value does not
                 guarantee that Snowflake will encode batches with the specified number of rows. It will
                 be ignored when registering a non-vectorized UDTF.
-            native_app_params: This is a special parameter, that is relevant when using this function to create UDFs
-                as a Snowflake Native App developer. It is a dictionary of parameters that are relevant in Snowflake Native Apps,
-                such as schema and application roles.
-                A typical dictionary could look like: {"schema": "some_schema", "application_roles": ["app_public", "app_admin"]}
-                This parameter is ignored if you are not developing a Snowflake Native App.
-
 
         See Also:
             - :func:`~snowflake.snowpark.functions.udtf`
@@ -645,6 +639,8 @@ class UDTFRegistration:
         check_register_args(
             TempObjectType.TABLE_FUNCTION, name, is_permanent, stage_location, parallel
         )
+
+        native_app_params = kwargs.get("native_app_params", None)
 
         # register udtf
         return self._do_register_udtf(

--- a/tests/mock/test_session.py
+++ b/tests/mock/test_session.py
@@ -14,6 +14,28 @@ from snowflake.snowpark.mock._constants import (
 )
 from snowflake.snowpark.session import Session
 
+# @mock.patch(
+#     "snowflake.snowpark.session._is_execution_environment_sandboxed"
+# )
+# @pytest.mark.parametrize("is_sandboxed", [False, True])
+# def test_get_current_session(sandbox_patch, is_sandboxed):
+#     sandbox_patch.return_value = is_sandboxed
+#     test_parameter = {
+#         "account": "test_account",
+#         "user": "test_user",
+#         "schema": "test_schema",
+#         "database": "test_database",
+#         "warehouse": "test_warehouse",
+#         "role": "test_role",
+#         "local_testing": True,
+#     }
+#     session = Session.builder.configs(options=test_parameter).create()
+#     session = snowflake.snowpark.session._get_sandbox_conditional_active_session(session)
+#     if is_sandboxed:
+#         assert session is None
+#     else:
+#         assert session is not None
+
 
 def test_connection_get_current_parameter():
     # test no option
@@ -91,6 +113,8 @@ def test_session_get_current_info(monkeypatch):
     assert session.get_current_database() == f'"{test_parameter["database"].upper()}"'
     assert session.get_current_role() == f'"{test_parameter["role"].upper()}"'
 
+    session.close()
+
 
 def test_session_use_object():
     session = Session.builder.configs(options={"local_testing": True}).create()
@@ -106,3 +130,5 @@ def test_session_use_object():
     assert session.get_current_schema() == '"TEST_SCHEMA"'
     assert session.get_current_database() == '"TEST_DATABASE"'
     assert session.get_current_role() == '"TEST_ROLE"'
+
+    session.close()

--- a/tests/mock/test_session.py
+++ b/tests/mock/test_session.py
@@ -14,28 +14,6 @@ from snowflake.snowpark.mock._constants import (
 )
 from snowflake.snowpark.session import Session
 
-# @mock.patch(
-#     "snowflake.snowpark.session._is_execution_environment_sandboxed"
-# )
-# @pytest.mark.parametrize("is_sandboxed", [False, True])
-# def test_get_current_session(sandbox_patch, is_sandboxed):
-#     sandbox_patch.return_value = is_sandboxed
-#     test_parameter = {
-#         "account": "test_account",
-#         "user": "test_user",
-#         "schema": "test_schema",
-#         "database": "test_database",
-#         "warehouse": "test_warehouse",
-#         "role": "test_role",
-#         "local_testing": True,
-#     }
-#     session = Session.builder.configs(options=test_parameter).create()
-#     session = snowflake.snowpark.session._get_sandbox_conditional_active_session(session)
-#     if is_sandboxed:
-#         assert session is None
-#     else:
-#         assert session is not None
-
 
 def test_connection_get_current_parameter():
     # test no option
@@ -113,8 +91,6 @@ def test_session_get_current_info(monkeypatch):
     assert session.get_current_database() == f'"{test_parameter["database"].upper()}"'
     assert session.get_current_role() == f'"{test_parameter["role"].upper()}"'
 
-    session.close()
-
 
 def test_session_use_object():
     session = Session.builder.configs(options={"local_testing": True}).create()
@@ -130,5 +106,3 @@ def test_session_use_object():
     assert session.get_current_schema() == '"TEST_SCHEMA"'
     assert session.get_current_database() == '"TEST_DATABASE"'
     assert session.get_current_role() == '"TEST_ROLE"'
-
-    session.close()

--- a/tests/unit/test_stored_procedure.py
+++ b/tests/unit/test_stored_procedure.py
@@ -12,6 +12,7 @@ from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlanBuilder
 from snowflake.snowpark._internal.server_connection import ServerConnection
 from snowflake.snowpark._internal.telemetry import TelemetryClient
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import sproc
 from snowflake.snowpark.stored_procedure import StoredProcedureRegistration
@@ -88,3 +89,54 @@ def test_do_register_sp_negative(cleanup_registration_patch):
     with pytest.raises(BaseException):
         sproc(lambda: 1, session=fake_session, return_type=IntegerType(), packages=[])
     cleanup_registration_patch.assert_called()
+
+
+@mock.patch("snowflake.snowpark.udf.cleanup_failed_permanent_registration")
+@mock.patch(
+    "snowflake.snowpark.session._is_execution_environment_sandboxed", return_value=True
+)
+def test_do_register_sproc_sandbox(session_sandbox, cleanup_registration_patch):
+
+    callback_side_effect_list = []
+
+    def mock_callback(extension_function_properties):
+        callback_side_effect_list.append(extension_function_properties)
+        return False
+
+    with mock.patch(
+        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        new=mock_callback,
+    ):
+        sproc(
+            lambda: 1,
+            return_type=IntegerType(),
+            packages=[],
+            native_app_params={
+                "schema": "some_schema",
+                "application_roles": ["app_viewer"],
+            },
+        )
+        cleanup_registration_patch.assert_not_called()
+
+        assert len(callback_side_effect_list) == 1
+        callableProperties = callback_side_effect_list[0]
+        assert not callableProperties.replace
+        assert callableProperties.object_type == TempObjectType.PROCEDURE
+        assert not callableProperties.if_not_exists
+        assert callableProperties.object_name != ""
+        assert len(callableProperties.input_args) == 0
+        assert len(callableProperties.input_sql_types) == 0
+        assert callableProperties.return_sql == "RETURNS INT"
+        assert callableProperties.runtime_version == "3.8"
+        assert callableProperties.all_imports == ""
+        assert callableProperties.all_packages == "'snowflake-snowpark-python==1.14.0'"
+        assert callableProperties.external_access_integrations is None
+        assert callableProperties.secrets is None
+        assert callableProperties.handler is None
+        assert callableProperties.execute_as == "owner"
+        assert callableProperties.inline_python_code is None
+        assert callableProperties.native_app_params == {
+            "schema": "some_schema",
+            "application_roles": ["app_viewer"],
+        }
+        assert callableProperties.import_paths == {}

--- a/tests/unit/test_udaf.py
+++ b/tests/unit/test_udaf.py
@@ -8,6 +8,7 @@ import pytest
 
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark import Session
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import udaf
 from snowflake.snowpark.types import IntegerType
@@ -94,3 +95,70 @@ def test_do_register_udaf_negative(cleanup_registration_patch):
                 return self._sum
 
     cleanup_registration_patch.assert_called()
+
+
+@mock.patch("snowflake.snowpark.udf.cleanup_failed_permanent_registration")
+@mock.patch(
+    "snowflake.snowpark.session._is_execution_environment_sandboxed", return_value=True
+)
+def test_do_register_udaf_sandbox(session_sandbox, cleanup_registration_patch):
+
+    callback_side_effect_list = []
+
+    def mock_callback(extension_function_properties):
+        callback_side_effect_list.append(extension_function_properties)
+        return False  # i.e. don't register with Snowflake.
+
+    with mock.patch(
+        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        new=mock_callback,
+    ):
+
+        class PythonSumUDAF:
+            def __init__(self) -> None:
+                self._sum = 0
+
+            @property
+            def aggregate_state(self):
+                return self._sum
+
+            def accumulate(self, input_value):
+                self._sum += input_value
+
+            def merge(self, other_sum):
+                self._sum += other_sum
+
+            def finish(self):
+                return self._sum
+
+        udaf(
+            PythonSumUDAF,
+            name="sum_int",
+            replace=True,
+            return_type=IntegerType(),
+            input_types=[IntegerType()],
+        )
+
+    cleanup_registration_patch.assert_not_called()
+
+    assert len(callback_side_effect_list) == 1
+    extension_function_properties = callback_side_effect_list[0]
+    assert extension_function_properties.replace
+    assert (
+        extension_function_properties.object_type == TempObjectType.AGGREGATE_FUNCTION
+    )
+    assert not extension_function_properties.if_not_exists
+    assert extension_function_properties.object_name != ""
+    assert len(extension_function_properties.input_args) == 1
+    assert len(extension_function_properties.input_sql_types) == 1
+    assert extension_function_properties.return_sql == "RETURNS INT"
+    assert extension_function_properties.runtime_version == "3.8"
+    assert extension_function_properties.all_imports == ""
+    assert extension_function_properties.all_packages == ""
+    assert extension_function_properties.external_access_integrations is None
+    assert extension_function_properties.secrets is None
+    assert extension_function_properties.handler is None
+    assert extension_function_properties.execute_as is None
+    assert extension_function_properties.inline_python_code is None
+    assert extension_function_properties.import_paths == {}
+    assert extension_function_properties.native_app_params is None

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -8,6 +8,7 @@ import pytest
 
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark import Session
+from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import udf
 from snowflake.snowpark.types import IntegerType
@@ -35,3 +36,55 @@ def test_do_register_sp_negative(cleanup_registration_patch):
     with pytest.raises(BaseException, match="Test BaseException code path"):
         udf(lambda: 1, session=fake_session, return_type=IntegerType(), packages=[])
     cleanup_registration_patch.assert_called()
+
+
+@mock.patch("snowflake.snowpark.udf.cleanup_failed_permanent_registration")
+@mock.patch(
+    "snowflake.snowpark.session._is_execution_environment_sandboxed", return_value=True
+)
+def test_do_register_udf_sandbox(session_sandbox, cleanup_registration_patch):
+
+    callback_side_effect_list = []
+
+    def mock_callback(extension_function_properties):
+        callback_side_effect_list.append(extension_function_properties)
+        return False  # i.e. don't register with Snowflake.
+
+    with mock.patch(
+        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        new=mock_callback,
+    ):
+        udf(
+            lambda: 1,
+            return_type=IntegerType(),
+            packages=[],
+            native_app_params={
+                "schema": "some_schema",
+                "application_roles": ["app_viewer"],
+            },
+        )
+
+    cleanup_registration_patch.assert_not_called()
+
+    assert len(callback_side_effect_list) == 1
+    extension_function_properties = callback_side_effect_list[0]
+    assert not extension_function_properties.replace
+    assert extension_function_properties.object_type == TempObjectType.FUNCTION
+    assert not extension_function_properties.if_not_exists
+    assert extension_function_properties.object_name != ""
+    assert len(extension_function_properties.input_args) == 0
+    assert len(extension_function_properties.input_sql_types) == 0
+    assert extension_function_properties.return_sql == "RETURNS INT"
+    assert extension_function_properties.runtime_version == "3.8"
+    assert extension_function_properties.all_imports == ""
+    assert extension_function_properties.all_packages == ""
+    assert extension_function_properties.external_access_integrations is None
+    assert extension_function_properties.secrets is None
+    assert extension_function_properties.handler is None
+    assert extension_function_properties.execute_as is None
+    assert extension_function_properties.inline_python_code is None
+    assert extension_function_properties.import_paths == {}
+    assert extension_function_properties.native_app_params == {
+        "schema": "some_schema",
+        "application_roles": ["app_viewer"],
+    }

--- a/tests/unit/test_udf_utils.py
+++ b/tests/unit/test_udf_utils.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+import os
 import pickle
 from unittest import mock
 
@@ -10,12 +11,19 @@ import pytest
 
 from snowflake.snowpark import Session
 from snowflake.snowpark._internal.udf_utils import (
+    add_snowpark_package_to_sproc_packages,
     cleanup_failed_permanent_registration,
+    create_python_udf_or_sp,
+    generate_anonymous_python_sp_sql,
     generate_python_code,
     get_error_message_abbr,
     pickle_function,
+    resolve_imports_and_packages,
+    resolve_packages_in_sandbox,
 )
 from snowflake.snowpark._internal.utils import TempObjectType
+from snowflake.snowpark.types import StringType
+from snowflake.snowpark.version import VERSION
 
 
 def test_get_error_message_abbr_exception():
@@ -65,3 +73,262 @@ def test_generate_python_code_exception():
             source_code_display=True,
         )
         assert "Source code comment could not be generated" in generated_code
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [
+        ["random_package_one", "random_package_two"],
+        ["random_package_one", "random_package_two", "random_package_two"],
+        [
+            "random_package_one",
+            "random_package_one",
+            "random_package_two",
+            "random_package_two",
+        ],
+    ],
+)
+def test_resolve_packages_in_sandbox(packages):
+    result = resolve_packages_in_sandbox(packages)
+    assert len(result) == 2
+    assert result[0] == "random_package_one"
+    assert result[1] == "random_package_two"
+
+
+@pytest.mark.parametrize(
+    "packages, error_cls",
+    [
+        [
+            [
+                "random_package_one",
+                "random_package_two==1.1",
+                "random_package_two==1.4",
+            ],
+            ValueError,
+        ],
+        [
+            [
+                "random_package_one",
+                "random_package_two==1.1",
+                "random_package_two==1.2",
+                "random_package_two==1.3",
+            ],
+            RuntimeError,
+        ],
+    ],
+)
+def test_resolve_packages_in_sandbox_with_value_error(packages, error_cls):
+    with pytest.raises(error_cls):
+        resolve_packages_in_sandbox(packages)
+
+
+def test_resolve_imports_and_packages_in_sandbox():
+    packages = ["random_package_one", "random_package_two"]
+    (
+        handler,
+        inline_code,
+        all_imports,
+        all_packages,
+        udf_level_imports,
+        upload_file_stage_location,
+        custom_python_runtime_version_allowed,
+    ) = resolve_imports_and_packages(
+        session=None,
+        object_type=TempObjectType.FUNCTION,
+        func=lambda: None,
+        arg_names=["dummy_args"],
+        udf_name="dummy_name",
+        stage_location=None,
+        imports=None,
+        packages=packages,
+    )
+
+    assert handler is None
+    assert inline_code is None
+    assert all_imports == ""
+    assert all_packages == ",".join([f"'{package}'" for package in packages])
+    assert udf_level_imports == {}
+    assert upload_file_stage_location is None
+    assert not custom_python_runtime_version_allowed
+
+
+def test_resolve_imports_and_packages_imports_as_str(tmp_path_factory):
+
+    tmp_path = tmp_path_factory.mktemp("session_test")
+    a_temp_file = tmp_path / "file.py"
+    a_temp_file.write_text("any text is good")
+
+    try:
+        (
+            handler,
+            inline_code,
+            all_imports,
+            all_packages,
+            udf_level_imports,
+            upload_file_stage_location,
+            custom_python_runtime_version_allowed,
+        ) = resolve_imports_and_packages(
+            session=None,
+            object_type=TempObjectType.FUNCTION,
+            func=lambda: None,
+            arg_names=["dummy_args"],
+            udf_name="dummy_name",
+            stage_location=None,
+            imports=[str(a_temp_file)],
+            packages=None,
+        )
+
+        assert handler is None
+        assert inline_code is None
+        assert all_imports == ""
+        assert all_packages == ""
+        assert str(a_temp_file) in udf_level_imports
+        assert upload_file_stage_location is None
+        assert not custom_python_runtime_version_allowed
+
+        packages = ["random_package_one", "random_package_two"]
+        (
+            handler,
+            inline_code,
+            all_imports,
+            all_packages,
+            udf_level_imports,
+            upload_file_stage_location,
+            custom_python_runtime_version_allowed,
+        ) = resolve_imports_and_packages(
+            session=None,
+            object_type=TempObjectType.FUNCTION,
+            func=lambda: None,
+            arg_names=["dummy_args"],
+            udf_name="dummy_name",
+            stage_location=None,
+            imports=[(str(a_temp_file), "file")],
+            packages=packages,
+        )
+
+        assert handler is None
+        assert inline_code is None
+        assert all_imports == ""
+        assert all_packages == ",".join([f"'{package}'" for package in packages])
+        assert str(a_temp_file) in udf_level_imports
+        assert upload_file_stage_location is None
+        assert not custom_python_runtime_version_allowed
+
+        with pytest.raises(TypeError):
+            (
+                handler,
+                inline_code,
+                all_imports,
+                all_packages,
+                udf_level_imports,
+                upload_file_stage_location,
+                custom_python_runtime_version_allowed,
+            ) = resolve_imports_and_packages(
+                session=None,
+                object_type=TempObjectType.FUNCTION,
+                func=lambda: None,
+                arg_names=["dummy_args"],
+                udf_name="dummy_name",
+                stage_location=None,
+                imports=[{}],
+                packages=None,
+            )
+    finally:
+        os.remove(a_temp_file)
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [
+        None,
+        ["random_package_one", "random_package_two"],
+    ],
+)
+def test_add_snowpark_package_to_sproc_packages_add_package(packages):
+    old_packages_length = len(packages) if packages else 0
+    result = add_snowpark_package_to_sproc_packages(session=None, packages=packages)
+
+    major, minor, patch = VERSION
+    package_name = "snowflake-snowpark-python"
+    final_name = f"{package_name}=={major}.{minor}.{patch}"
+
+    assert len(result) == old_packages_length + 1
+    assert final_name in result
+
+
+def test_add_snowpark_package_to_sproc_packages_does_not_replace_package():
+    packages = [
+        "random_package_one",
+        "random_package_two",
+        "snowflake-snowpark-python==1.12.0",
+    ]
+    result = add_snowpark_package_to_sproc_packages(session=None, packages=packages)
+
+    assert len(result) == len(packages)
+    assert "snowflake-snowpark-python==1.12.0" in result
+
+
+def test_add_snowpark_package_to_sproc_packages_to_session():
+    fake_session = mock.create_autospec(Session)
+    fake_session._packages = {
+        "random_package_one": "random_package_one",
+        "random_package_two": "random_package_two",
+    }
+    result = add_snowpark_package_to_sproc_packages(session=fake_session, packages=None)
+
+    major, minor, patch = VERSION
+    package_name = "snowflake-snowpark-python"
+    final_name = f"{package_name}=={major}.{minor}.{patch}"
+    assert len(result) == 3
+    assert final_name in result
+
+    fake_session._packages[
+        "snowflake-snowpark-python"
+    ] = "snowflake-snowpark-python==1.12.0"
+    result = add_snowpark_package_to_sproc_packages(session=fake_session, packages=None)
+    assert result is None
+
+
+def test_create_python_udf_or_sp_with_none_session():
+    mock_callback = mock.MagicMock(return_value=False)
+
+    with mock.patch(
+        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        new=mock_callback,
+    ):
+        create_python_udf_or_sp(
+            session=None,
+            func=lambda: None,
+            return_type=StringType(),
+            input_args=[],
+            handler="",
+            object_type=TempObjectType.FUNCTION,
+            object_name="",
+            all_imports="",
+            all_packages="",
+            is_permanent=True,
+            replace=False,
+            if_not_exists=False,
+        )
+
+    mock_callback.assert_called_once()
+
+
+def test_generate_anonymous_python_sp_sql_with_none_session():
+    mock_callback = mock.MagicMock(return_value=False)
+
+    with mock.patch(
+        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        new=mock_callback,
+    ):
+        generate_anonymous_python_sp_sql(
+            func=lambda: None,
+            return_type=StringType(),
+            input_args=[],
+            handler="",
+            object_name="",
+            all_imports="",
+            all_packages="",
+        )
+
+    mock_callback.assert_called_once()


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   There is no open Github issue for this PR as it is initiated internally within Snowflake.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

### Background
When a user wants to create an extension function (UDF/UDTF/UDAF/Sproc), they are able to use the corresponding decorator and provide certain parameters that help in the creation of the said object in their Snowflake account. As it is, the current code takes in those parameters, performs some validation and transformation on them, pulls in some relevant session information, and then creates a SQL query that is sent to be run in the Snowflake account.

### Ask
As Snowpark is a critical component of developing a Snowflake Native App, we would like to leverage this existing code so that a user does not have to duplicate their effort in writing Snowpark-only code and Snowpark-related code for their Snowflake Native App. We want to capture any user code in python files that use the above decorators, and be able to use that information outside the Snowpark environment without talking to Snowflake. 

### Design
1. In the previously-discussed consensus, Snowflake Native App, or really any user who wants to inspect the information before creating the object in Snowflake, will install a callback into the Snowpark execution, and it is through this callback that the information will be sent back to the user for inspection before creating the object. 
2. Further, Snowflake Native App (or a user that just wants to run code in a local sandbox instead of connecting to Snowflake) logic needs to execute in a sandbox because we do not wish to actually create the extension functions in Snowflake, and avoid any side effects through other session calls. Snowflake Native App wants to be able to use the resolved properties to create our own SQL to be run as part of our application code, and this workflow should not happen in the account that the user is developing for. 
3. Additionally, because we want to give control to the caller environment (an external user/client) to decide whether they should allow creation of the object in Snowflake. If they choose to not proceed with the creation, then the code should be able to receive that decision and short circuit before it can interact with Snowflake.


