### PR TITLE
SNOW-1324573: local testing fix flaky oob telemetry test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "localtest": [
             "pandas",
             "pyarrow",
+            "requests",
         ],
         "opentelemetry": [
             "opentelemetry-api>=1.0.0, <2.0.0",

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -10,8 +10,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-import requests
-
 from snowflake.connector.compat import OK
 from snowflake.connector.secret_detector import SecretDetector
 from snowflake.connector.telemetry_oob import TelemetryService
@@ -20,6 +18,13 @@ from snowflake.snowpark._internal.utils import (
     get_python_version,
     get_version,
 )
+
+REQUESTS_AVAILABLE = True
+try:
+    # by default in stored procedure requests is not imported
+    import requests
+except ImportError:
+    REQUESTS_AVAILABLE = False
 
 # 3 seconds setting in the connector oob could be too short that the oob service is unable to handle the request,
 # 5 seconds is more tolerant
@@ -86,6 +91,11 @@ class LocalTestOOBTelemetryService(TelemetryService):
         self._deployment_url = self.PROD
 
     def _upload_payload(self, payload) -> None:
+        if not REQUESTS_AVAILABLE:
+            logger.debug(
+                "request module is not available",
+            )
+            return
         success = True
         response = None
         try:

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
+import requests
+
 from snowflake.connector.compat import OK
 from snowflake.connector.secret_detector import SecretDetector
 from snowflake.connector.telemetry_oob import TelemetryService
@@ -87,9 +89,6 @@ class LocalTestOOBTelemetryService(TelemetryService):
         success = True
         response = None
         try:
-            # import here is because stored proc doesn't have requests as requirement
-            import requests
-
             with requests.Session() as session:
                 response = session.post(
                     self._deployment_url,

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -87,8 +87,7 @@ class LocalTestOOBTelemetryService(TelemetryService):
         success = True
         response = None
         try:
-            # import here is because stored proc doesn't have vendored request module
-            # have it at the top will cause import error in stored procedure running
+            # import here is because stored proc doesn't have requests as requirement
             import requests
 
             with requests.Session() as session:

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -89,7 +89,7 @@ class LocalTestOOBTelemetryService(TelemetryService):
         try:
             # import here is because stored proc doesn't have vendored request module
             # have it at the top will cause import error in stored procedure running
-            from snowflake.connector.vendored import requests
+            import requests
 
             with requests.Session() as session:
                 response = session.post(

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -12,12 +12,16 @@ from typing import Optional
 
 from snowflake.connector.compat import OK
 from snowflake.connector.secret_detector import SecretDetector
-from snowflake.connector.telemetry_oob import REQUEST_TIMEOUT, TelemetryService
+from snowflake.connector.telemetry_oob import TelemetryService
 from snowflake.snowpark._internal.utils import (
     get_os_name,
     get_python_version,
     get_version,
 )
+
+# 3 seconds setting in the connector oob could be too short that the oob service is unable to handle the request,
+# 5 seconds is more tolerant
+REQUEST_TIMEOUT = 5
 
 logger = logging.getLogger(__name__)
 

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -60,17 +60,24 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         assert oob_service.size() == 0
         assert not caplog.record_tuples
 
-        # test sending successfully
-        oob_service.log_session_creation()
-        oob_service.log_session_creation(connection_uuid=connection_uuid)
-        assert oob_service.size() == 2
-        oob_service.flush()
-        assert oob_service.size() == 0
-        assert len(caplog.record_tuples) >= 2
-        assert (
-            "telemetry server request success: 200" in caplog.text
-            and "Telemetry request success=True" in caplog.text
-        )
+        max_retry = 3
+        for i in range(max_retry):
+            # test sending successfully
+            oob_service.log_session_creation()
+            oob_service.log_session_creation(connection_uuid=connection_uuid)
+            assert oob_service.size() == 2
+            oob_service.flush()
+            assert oob_service.size() == 0
+            assert len(caplog.record_tuples) >= 2
+            try:
+                assert (
+                    "telemetry server request success: 200" in caplog.text
+                    and "Telemetry request success=True" in caplog.text
+                )
+                break
+            except AssertionError:
+                if i == max_retry - 1:
+                    raise
 
 
 def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setup):

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -76,6 +76,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
                 )
                 break
             except AssertionError:
+                caplog.clear()
                 if i == max_retry - 1:
                     raise
 
@@ -176,6 +177,7 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
                 )
             break
         except AssertionError:
+            caplog.clear()
             if i == max_retry - 1:
                 raise
 

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -60,7 +60,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         assert oob_service.size() == 0
         assert not caplog.record_tuples
 
-        max_retry = 3
+        max_retry = 10
         for i in range(max_retry):
             # test sending successfully
             oob_service.log_session_creation()
@@ -68,7 +68,6 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
             assert oob_service.size() == 2
             oob_service.flush()
             assert oob_service.size() == 0
-            assert len(caplog.record_tuples) >= 2
             try:
                 assert (
                     "telemetry server request success: 200" in caplog.text
@@ -148,7 +147,7 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
     # test sending successfully
     caplog.clear()
 
-    max_retry = 3
+    max_retry = 10
     for i in range(max_retry):
         try:
             with caplog.at_level(
@@ -170,7 +169,6 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
                 assert oob_service.size() == 2
                 oob_service.flush()
                 assert oob_service.size() == 0
-                assert len(caplog.record_tuples) == 2
                 assert (
                     "telemetry server request success: 200" in caplog.text
                     and "Telemetry request success=True" in caplog.text


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1324573

the local testing oob telemetry is flaky because the service takes longer to process or throttled.
do the following to improve:
- increate the default wait time, this barely add overhead to customer as we are doing batch sending underneath
- add retry in our test
- remove duplicate and unreliable exact record tuple assertion, checking caplog text should be enough

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
