### PR TITLE
SNOW-1284674: fix timestamp data comparison beyond datetime64[ns] range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Fixed a bug in local testing that null filled columns for constant functions.
 - Fixed a bug causing `snowflake.snowpark.Session.file.get_stream` to fail for quoted stage locations
 - Fixed a bug in local testing implementation of to_object, to_array and to_binary to better handle null inputs.
+- Fixed a bug in local testing implementation that timestamp data comparison can not handle year beyond 2262.
 
 ## 1.14.0 (2024-03-20)
 

--- a/src/snowflake/snowpark/mock/_util.py
+++ b/src/snowflake/snowpark/mock/_util.py
@@ -202,7 +202,7 @@ def fix_drift_between_column_sf_type_and_dtype(col: ColumnEmulator):
     1. python doesn't have built-in datetime nanosecond support:
       https://github.com/python/cpython/blob/3.12/Lib/_pydatetime.py
 
-    2. numpy datetime64 restrictions:
+    2. numpy datetime64 restrictions, https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units:
       datetime64[ns] supports nanoseconds, the year range is limited to [ 1678 AD, 2262 AD]
       datetime64[us] supports milliseconds, the year range is more relaxed [290301 BC, 294241 AD]
 

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -130,6 +130,15 @@ def test_gt_and_lt(session):
     assert test_data1.where(test_data1["NUM"] < 2).collect() == [Row(1, True, "a")]
     assert test_data1.where(test_data1["NUM"] < lit(2)).collect() == [Row(1, True, "a")]
 
+    test_data_datetime = TestData.datetime_primitives2(session)
+    res = datetime.datetime(2000, 5, 6, 0, 0, 0)
+    assert test_data_datetime.where(
+        test_data_datetime["timestamp"] > res
+    ).collect() == [Row(datetime.datetime(9999, 12, 31, 0, 0, 0, 123456))]
+    assert test_data_datetime.where(
+        test_data_datetime["timestamp"] < res
+    ).collect() == [Row(datetime.datetime(1583, 1, 1, 23, 59, 59, 567890))]
+
 
 @pytest.mark.localtest
 def test_leq_and_geq(session):
@@ -754,11 +763,8 @@ def test_in_expression_2_in_with_subquery(session):
     Utils.check_answer(df4, [Row(False), Row(True), Row(True)])
 
 
+@pytest.mark.localtest
 def test_in_expression_3_with_all_types(session, local_testing_mode):
-    # TODO: local testing support to_timestamp_ntz
-    #  stored proc by default uses timestime type according to:
-    #  https://docs.snowflake.com/en/sql-reference/parameters#timestamp-type-mapping
-    #  we keep the test here for future reference
     schema = StructType(
         [
             StructField("id", LongType()),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -816,6 +816,7 @@ class TestData:
         )
         return session.create_dataframe(data, schema)
 
+    @classmethod
     def time_primitives1(cls, session: "Session") -> DataFrame:
         # simple string data
         data = [("01:02:03",), ("22:33:44",)]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -791,6 +791,19 @@ class TestData:
         return session.create_dataframe(data, schema)
 
     @classmethod
+    def datetime_primitives2(cls, session: "Session") -> DataFrame:
+        data = [
+            "9999-12-31 00:00:00.123456",
+            "1583-01-01 23:59:59.56789",
+        ]
+        schema = StructType(
+            [
+                StructField("timestamp", TimestampType(TimestampTimeZone.NTZ)),
+            ]
+        )
+        return session.create_dataframe(data, schema)
+
+    @classmethod
     def variant_datetimes1(cls, session: "Session") -> DataFrame:
         primitives_df = cls.datetime_primitives1(session)
         variant_cols = [


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1284674

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

in local testing, timestamp comparison beyond year 2262 will trigger pandas out of time bound error.

it's a know limitation from numpy https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units:
`ns nanosecond +/- 292 years [ 1678 AD, 2262 AD]`

to handle the issue, we change to use `object` for now -- there is not obvious side effect as tests are passing. ideally we can use datetime64[us] (microsecond) to bypass the issue, however datetime64[us] don't work on Python 3.8 (still trigger out-of-bound error) as pandas on Py 3.8 defaults to nanosecond.

JIRA for tracking timestamtype drift: https://snowflakecomputing.atlassian.net/browse/SNOW-1331839