### PR TITLE
SNOW-1338064 Make tests not rely on implicit ordering

### DIFF
--- a/tests/integ/scala/test_dataframe_aggregate_suite.py
+++ b/tests/integ/scala/test_dataframe_aggregate_suite.py
@@ -551,7 +551,11 @@ def test_rel_grouped_dataframe_median(session):
 
     expected = [Row("a", 2.0, 22.0), Row("b", 4, 44.0)]
     assert (
-        df1.group_by("key").median(col("value1"), col("value2")).sort(col("key")).collect() == expected
+        df1.group_by("key")
+        .median(col("value1"), col("value2"))
+        .sort(col("key"))
+        .collect()
+        == expected
     )
     assert (
         df1.group_by("key")
@@ -561,9 +565,14 @@ def test_rel_grouped_dataframe_median(session):
         == expected
     )
     # same as above, but pass str instead of Column
-    assert df1.group_by("key").median("value1", "value2").sort("key").collect() == expected
     assert (
-        df1.group_by("key").agg([median("value1"), median("value2")]).sort("key").collect()
+        df1.group_by("key").median("value1", "value2").sort("key").collect() == expected
+    )
+    assert (
+        df1.group_by("key")
+        .agg([median("value1"), median("value2")])
+        .sort("key")
+        .collect()
         == expected
     )
 
@@ -1210,7 +1219,9 @@ def test_listagg_within_group(session):
         schema=["v1", "v2", "length", "color", "unused"],
     )
     Utils.check_answer(
-        df.group_by("color").agg(listagg("length", ",").within_group(df.length.asc())).sort("color"),
+        df.group_by("color")
+        .agg(listagg("length", ",").within_group(df.length.asc()))
+        .sort("color"),
         [
             Row("blue", "14"),
             Row("green", "11,77"),

--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -621,14 +621,14 @@ def test_semi_join_with_columns_from_LHS(
         .select("intcol")
         .collect()
     )
-    assert res == [Row(1), Row(2)]
+    assert sorted(res, key=lambda x: x[0]) == [Row(1), Row(2)]
 
     res = (
         rhs.join(lhs, lhs["intcol"] == rhs["intcol"], "leftsemi")
         .select("intcol")
         .collect()
     )
-    assert res == [Row(1), Row(2)]
+    assert sorted(res, key=lambda x: x[0]) == [Row(1), Row(2)]
 
     res = (
         lhs.join(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1338064

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   The tests changed in this PR rely on implicit or ambiguous (with multiple equal values) ordering. This PR adds explicit ordering to these tests by sorting where appropriate.