### PR TITLE
SNOW-1331246: type hint should not raise attribute error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Added support for dynamic pivot.  This feature is currently in private preview.
 
 ### Improvements
+
 - Improved the generated query performance for both compilation and execution by converting duplicate subqueries to Common Table Expressions (CTEs). It is still an experimental feature, and can be enabled by setting `session.cte_optimization_enabled` to `True`.
 
 ### Bug Fixes
@@ -61,6 +62,7 @@
 - Fixed a bug causing `snowflake.snowpark.Session.file.get_stream` to fail for quoted stage locations
 - Fixed a bug in local testing implementation of to_object, to_array and to_binary to better handle null inputs.
 - Fixed a bug in local testing that `Session.builder.getOrCreate` should return the created mock session.
+- Fixed a bug that an internal type hint in `utils.py` might raise AttributeError in case the underlying module can not be found.
 
 ## 1.14.0 (2024-03-20)
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -395,7 +395,10 @@ def parse_positional_args_to_list(*inputs: Any) -> List:
 
 
 def _hash_file(
-    hash_algo: hashlib._hashlib.HASH, path: str, chunk_size: int, whole_file_hash: bool
+    hash_algo: "hashlib._hashlib.HASH",
+    path: str,
+    chunk_size: int,
+    whole_file_hash: bool,
 ):
     """
     Reads from a file and updates the given hash algorithm with the read text.


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes https://github.com/snowflakedb/snowpark-python/issues/1388

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

type hint in internal module should not raise AttributeError, the `_hashlib` can be unreliable for type hint
 
