### PR TITLE
Test don't install python connector from pypi

### DIFF
--- a/scripts/tox_install_cmd.sh
+++ b/scripts/tox_install_cmd.sh
@@ -21,5 +21,5 @@ else
   echo "Python Connector path: ${snowflake_path}"
   ls -al ${snowflake_path}
   python -m pip install ${snowflake_path}/snowflake_connector_python*cp38*.whl
-  python -m pip install -U ${pip_options[@]}
+  # python -m pip install -U ${pip_options[@]}
 fi

--- a/scripts/tox_install_cmd.sh
+++ b/scripts/tox_install_cmd.sh
@@ -21,5 +21,5 @@ else
   echo "Python Connector path: ${snowflake_path}"
   ls -al ${snowflake_path}
   python -m pip install ${snowflake_path}/snowflake_connector_python*cp38*.whl
-  # python -m pip install -U ${pip_options[@]}
+  python -m pip install -U ${pip_options[@]}
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ passenv =
     CLIENT_LOG_DIR_PATH_DOCKER
     PYTEST_ADDOPTS
     SNOWFLAKE_IS_PYTHON_RUNTIME_TEST
+    snowflake_path
 commands =
     notudf: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} and not udf" {posargs:} src/snowflake/snowpark tests
     udf: {env:SNOWFLAKE_PYTEST_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} or udf" {posargs:} src/snowflake/snowpark tests


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #SNOW-1308662

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We set env variable [snowflake_path](https://github.com/snowflakedb/jenkins_utils/blob/2babdc1b74a6058d271dd1fb7aff903dec4211e7/jobs/ci1/jobs/ci-dev-142/SnowparkPythonSnowflakePythonClientRegress.groovy#L104) in the jenkins job but we don't pass this path down to tox environment. This PR fixes the problem.


Testing:
Tested [jenkins job](https://ci-dev-142.int.snowflakecomputing.com/job/SnowparkPythonSnowflakePythonClientRegressRunner/579/console) with this branch and noted that the snowflake path is picked up in pip freeze

```
2024-04-22 15:34:28 notdoctest: freeze> python -m pip freeze --all
2024-04-22 15:34:28 notdoctest: alabaster==0.7.13,asn1crypto==1.5.1,Babel==2.14.0,cachetools==5.3.3,certifi==2024.2.2,cffi==1.16.0,cfgv==3.4.0,charset-normalizer==3.3.2,cloudpickle==2.2.1,coverage==7.4.4,cryptography==42.0.5,Deprecated==1.2.14,distlib==0.3.8,docutils==0.18.1,exceptiongroup==1.2.1,execnet==2.1.1,filelock==3.13.4,identify==2.5.36,idna==3.7,imagesize==1.4.1,importlib-metadata==7.0.0,iniconfig==2.0.0,Jinja2==3.1.3,MarkupSafe==2.1.5,nodeenv==1.8.0,numpy==1.24.4,opentelemetry-api==1.24.0,opentelemetry-sdk==1.24.0,opentelemetry-semantic-conventions==0.45b0,packaging==24.0,pandas==2.0.3,pip==24.0,platformdirs==4.2.0,pluggy==1.5.0,pre-commit==3.5.0,pyarrow==16.0.0,pycparser==2.22,Pygments==2.17.2,PyJWT==2.8.0,pyOpenSSL==24.1.0,pytest==7.4.4,pytest-cov==5.0.0,pytest-timeout==2.3.1,pytest-xdist==3.5.0,python-dateutil==2.9.0.post0,pytz==2024.1,PyYAML==6.0.1,requests==2.31.0,setuptools==69.5.1,six==1.16.0,snowballstemmer==2.2.0,snowflake-connector-python @ file:///home/jenkins/workspace/SnowparkPythonSnowflakePythonClientRegressRunner/snowflake-connector-python/dist/repaired_wheels/snowflake_connector_python-20.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=c30b3af23aa0235488786367d65017d353356ebcc6f9f0e3afc731c5184e85e2,snowflake-snowpark-python @ file:///mnt/jenkins/home/jenkins/workspace/SnowparkPythonSnowflakePythonClientRegressRunner/snowpark-python/.tox/.tmp/package/1/snowflake_snowpark_python-1.14.0.tar.gz#sha256=df8a1b20e98698f8fe2f4866c60f1a3136168da0c7d5f51028ffabe90534e4d0,sortedcontainers==2.4.0,Sphinx==5.0.2,sphinxcontrib-applehelp==1.0.4,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==2.0.1,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.5,tomli==2.0.1,tomlkit==0.12.4,typing_extensions==4.11.0,tzdata==2024.1,urllib3==1.26.18,virtualenv==20.25.3,wheel==0.43.0,wrapt==1.16.0,zipp==3.18.1
```
