### PR TITLE
Fixed import from context bug

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -49,7 +49,6 @@ from snowflake.snowpark._internal.utils import (
     unwrap_stage_location_single_quote,
     validate_object_name,
 )
-from snowflake.snowpark.context import _should_continue_registration
 from snowflake.snowpark.types import DataType, StructField, StructType
 from snowflake.snowpark.version import VERSION
 
@@ -1209,7 +1208,7 @@ $$
     )
 
     # As an FYI, _should_continue_registration is a function, and is defined outside the Snowpark context.
-    if _should_continue_registration is None:
+    if snowflake.snowpark.context._should_continue_registration is None:
         continue_registration = True
     else:
         extension_function_properties = ExtensionFunctionProperties(
@@ -1232,8 +1231,10 @@ $$
             native_app_params=native_app_params,
             raw_imports=raw_imports,
         )
-        continue_registration = _should_continue_registration(
-            extension_function_properties
+        continue_registration = (
+            snowflake.snowpark.context._should_continue_registration(
+                extension_function_properties
+            )
         )
 
     # This means the execution environment does not want to continue creating the object in Snowflake
@@ -1331,7 +1332,7 @@ $$
     )
 
     # As an FYI, _should_continue_registration is a function, and is defined outside the Snowpark context.
-    if _should_continue_registration is not None:
+    if snowflake.snowpark.context._should_continue_registration is not None:
         extension_function_properties = ExtensionFunctionProperties(
             anonymous=True,
             object_type=TempObjectType.PROCEDURE,
@@ -1351,7 +1352,9 @@ $$
             func=func,
         )
         # The result of the function call below does not matter because we are not using session object here
-        _should_continue_registration(extension_function_properties)
+        snowflake.snowpark.context._should_continue_registration(
+            extension_function_properties
+        )
 
     sql = f"""
 WITH {object_name} AS PROCEDURE ({sql_func_args})

--- a/tests/unit/test_stored_procedure.py
+++ b/tests/unit/test_stored_procedure.py
@@ -106,7 +106,7 @@ def test_do_register_sproc_sandbox(session_sandbox, cleanup_registration_patch):
         return False
 
     with mock.patch(
-        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        "snowflake.snowpark.context._should_continue_registration",
         new=mock_callback,
     ):
         sproc(

--- a/tests/unit/test_udaf.py
+++ b/tests/unit/test_udaf.py
@@ -112,7 +112,7 @@ def test_do_register_udaf_sandbox(session_sandbox, cleanup_registration_patch):
         return False  # i.e. don't register with Snowflake.
 
     with mock.patch(
-        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        "snowflake.snowpark.context._should_continue_registration",
         new=mock_callback,
     ):
 

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -53,7 +53,7 @@ def test_do_register_udf_sandbox(session_sandbox, cleanup_registration_patch):
         return False  # i.e. don't register with Snowflake.
 
     with mock.patch(
-        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        "snowflake.snowpark.context._should_continue_registration",
         new=mock_callback,
     ):
         udf(

--- a/tests/unit/test_udf_utils.py
+++ b/tests/unit/test_udf_utils.py
@@ -268,7 +268,7 @@ def test_create_python_udf_or_sp_with_none_session():
     mock_callback = mock.MagicMock(return_value=False)
 
     with mock.patch(
-        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        "snowflake.snowpark.context._should_continue_registration",
         new=mock_callback,
     ):
         create_python_udf_or_sp(
@@ -294,7 +294,7 @@ def test_generate_anonymous_python_sp_sql_with_none_session():
     mock_callback = mock.MagicMock(return_value=False)
 
     with mock.patch(
-        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        "snowflake.snowpark.context._should_continue_registration",
         new=mock_callback,
     ):
         generate_anonymous_python_sp_sql(

--- a/tests/unit/test_udtf.py
+++ b/tests/unit/test_udtf.py
@@ -72,7 +72,7 @@ def test_do_register_udtf_sandbox(session_sandbox, cleanup_registration_patch):
         return False  # i.e. don't register with Snowflake.
 
     with mock.patch(
-        "snowflake.snowpark._internal.udf_utils._should_continue_registration",
+        "snowflake.snowpark.context._should_continue_registration",
         new=mock_callback,
     ):
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

There is no open Github issue for this PR as it is initiated internally within Snowflake.

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

A bug was identified in PR #1397 whereby the first time the udf_utils module is loaded, the callback value is read and never updated. This is because of the semantics of `from ... import` in Python (vs `import <module>`). The bug was not detected by the existing tests because they incorrectly mocked the state. The tests have been updated now, and the behaviour was verified manually through an end-to-end example. I verified that the tests fail without the associated code change.
