### PR TITLE
SNOW-1324779: Update warnings for Snowpark pandas

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/__init__.py
+++ b/src/snowflake/snowpark/modin/pandas/__init__.py
@@ -25,21 +25,6 @@ from typing import Any
 
 import pandas
 
-__pandas_version__ = "2.2.1"
-
-
-if sys.version_info.major == 3 and sys.version_info.minor == 8:
-    raise RuntimeError(
-        "Snowpark pandas does not support Python 3.8. Please update to Python 3.9 or later, and"
-        + f" update your pandas version to {__pandas_version__}."
-    )  # pragma: no cover
-
-if pandas.__version__ != __pandas_version__:
-    raise RuntimeError(
-        f"The pandas version installed ({pandas.__version__}) does not match the supported pandas version in"
-        + f" Snowpark pandas ({__pandas_version__}). Please update with `pip install pandas=={__pandas_version__}`."
-    )  # pragma: no cover
-
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from pandas import describe_option  # noqa: F401

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -2,20 +2,31 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+import sys
+import warnings
+
 from packaging import version
 
-# We need this import here to prevent circular dependency issues, since snowflake.snowpark.modin.pandas
-# currently imports some internal utilities from snowflake.snowpark.modin.plugin. Test cases will
-# import snowflake.snowpark.modin.plugin before snowflake.snowpark.modin.pandas, so in order to prevent
-# circular dependencies from manifesting, apparently snowflake.snowpark.modin.pandas needs to
-# be imported first.
-from snowflake.snowpark.modin import pandas  # noqa: F401
-from snowflake.snowpark.modin.config import DocModule
-from snowflake.snowpark.modin.plugin import docstrings
+if sys.version_info.major == 3 and sys.version_info.minor == 8:
+    raise RuntimeError(
+        "Snowpark pandas does not support Python 3.8. Please update to Python 3.9 or later."
+    )  # pragma: no cover
 
-DocModule.put(docstrings.__name__)
 
 install_msg = "Run `pip install snowflake-snowpark-python[modin]` to resolve."
+
+# pandas import needs to come before Python version + modin checks,
+# since modin may raise its own warnings/errors on the wrong pandas version
+import pandas  # isort: skip  # noqa: E402
+
+supported_pandas_version = "2.2.1"
+if pandas.__version__ != supported_pandas_version:
+    raise RuntimeError(
+        f"The pandas version installed ({pandas.__version__}) does not match the supported pandas version in"
+        + f" Snowpark pandas ({supported_pandas_version}). "
+        + install_msg
+    )  # pragma: no cover
+
 try:
     import modin
 except ModuleNotFoundError:  # pragma: no cover
@@ -26,5 +37,26 @@ except ModuleNotFoundError:  # pragma: no cover
 supported_modin_version = "0.28.1"
 if version.parse(modin.__version__) != version.parse(supported_modin_version):
     raise ImportError(
-        "Installed Modin version is not supported. " + install_msg
+        f"The Modin version installed ({modin.__version__}) does not match the supported Modin version in"
+        + f" Snowpark pandas ({supported_modin_version}). "
+        + install_msg
     )  # pragma: no cover
+
+
+warnings.warn(
+    "Snowpark pandas is currently in Public Preview."
+    + " See https://docs.snowflake.com/LIMITEDACCESS/snowpark-pandas for details.",
+    stacklevel=1,
+)
+
+# We need this import here to prevent circular dependency issues, since snowflake.snowpark.modin.pandas
+# currently imports some internal utilities from snowflake.snowpark.modin.plugin. Test cases will
+# import snowflake.snowpark.modin.plugin before snowflake.snowpark.modin.pandas, so in order to prevent
+# circular dependencies from manifesting, apparently snowflake.snowpark.modin.pandas needs to
+# be imported first.
+# These imports also all need to occur after modin + pandas dependencies are validated.
+from snowflake.snowpark.modin import pandas  # isort: skip  # noqa: E402,F401
+from snowflake.snowpark.modin.config import DocModule  # isort: skip  # noqa: E402
+from snowflake.snowpark.modin.plugin import docstrings  # isort: skip  # noqa: E402
+
+DocModule.put(docstrings.__name__)

--- a/tests/unit/modin/test_python_version.py
+++ b/tests/unit/modin/test_python_version.py
@@ -18,9 +18,8 @@ def test_error_on_import():
 
         with pytest.raises(RuntimeError):
             # Importing snowpark pandas should error
-            import modin.pandas  # noqa: F401
+            import snowflake.snowpark.modin.plugin  # noqa: F401
     else:
         # Should not error
-        import modin.pandas  # noqa: F401
-
         import snowflake.snowpark  # noqa: F401
+        import snowflake.snowpark.modin.plugin  # noqa: F401


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #1324779

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR modifies Snowpark pandas to error and prompt the user to install Modin if the incorrect pandas or Modin version is encountered. It also adds a warning informing users that the pandas feature is in PuPr.

These error messages were tested manually by manually installing the appropriate dependencies. If so desired, they can also be set up in CI as well, but might be more complicated to run since they require environmental changes.