### PR TITLE
Remove large data values from test_unique.py to resolve flakes

### DIFF
--- a/tests/integ/modin/series/test_unique.py
+++ b/tests/integ/modin/series/test_unique.py
@@ -26,7 +26,7 @@ HOMOGENEOUS_INPUT_DATA_FOR_SERIES = [
     [12.0, 11.999999, 11.999999],
     ["A", "A", "C", "C", "A"],
     [None, "A", None, "B"],
-    native_pd.Series([1, 2, 2**63, 2**63], dtype=np.uint64),
+    native_pd.Series([1, 2, 2**10, 2**10], dtype=np.uint64),
     _make_nan_interleaved_float_series(),
 ]
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

  This PR resolves flakes in `test_unique_homogeneous_data` and `test_unique_post_sort_values` by removing large powers of 2 from the data, which can result in off-by-one flakes due to memory/environment issues (see https://github.com/snowflakedb/snowpark-python/actions/runs/8840722940/job/24276602840).
