### PR TITLE
[SNOW-1297195] Add tox to daily jenkins job, fix tox.ini.

### DIFF
--- a/scripts/jenkins_regress_snowpandas.sh
+++ b/scripts/jenkins_regress_snowpandas.sh
@@ -11,7 +11,7 @@ set -euxo pipefail
 # decrypt profile
 gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output "tests/parameters.py" $@
 
-# Install tox, not part of modin-development.
+# Install tox, which is by default not present in the environment.
 python -m pip install tox
 
 # Run snowpandas tests

--- a/scripts/jenkins_regress_snowpandas.sh
+++ b/scripts/jenkins_regress_snowpandas.sh
@@ -11,5 +11,8 @@ set -euxo pipefail
 # decrypt profile
 gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output "tests/parameters.py" $@
 
+# Install tox, not part of modin-development.
+python -m pip install tox
+
 # Run snowpandas tests
 python -m tox -c $WORKING_DIR -e snowparkpandasjenkins-modin

--- a/scripts/tox_install_cmd.sh
+++ b/scripts/tox_install_cmd.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-set -euxo pipefail
 
 # The options are passed to us with spaces and we need to get rid
 # of those spaces when we pump it into pip install

--- a/scripts/tox_install_cmd.sh
+++ b/scripts/tox_install_cmd.sh
@@ -1,6 +1,7 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
+set -euxo pipefail
 
 # The options are passed to us with spaces and we need to get rid
 # of those spaces when we pump it into pip install
@@ -12,6 +13,9 @@ for val in "${input_options[@]}"; do
 done
 
 echo "${pip_options[*]}"
+
+# Default to empty, to ensure snowflake_path variable is defined.
+snowflake_path=${snowflake_path:-""}
 
 if [[ -z "${snowflake_path}" ]]; then
   echo "Using Python Connector from PyPI"

--- a/src/snowflake/snowpark/modin/config/envvars.py
+++ b/src/snowflake/snowpark/modin/config/envvars.py
@@ -884,7 +884,7 @@ def _check_vars() -> None:  # pragma: no cover
         and issubclass(obj, EnvironmentVariable)
         and not obj.is_abstract
     }
-    valid_names.update(["MODIN_PYTEST_CMD", "MODIN_PYTEST_DAILY_CMD"])
+    valid_names.update(["MODIN_PYTEST_CMD", "MODIN_PYTEST_DAILY_CMD", "MODIN_PYTEST_NO_COV_CMD"])
     found_names = {name for name in os.environ if name.startswith("MODIN_")}
     unknown = found_names - valid_names
     deprecated: dict[str, DeprecationDescriptor] = {

--- a/src/snowflake/snowpark/modin/config/envvars.py
+++ b/src/snowflake/snowpark/modin/config/envvars.py
@@ -884,7 +884,9 @@ def _check_vars() -> None:  # pragma: no cover
         and issubclass(obj, EnvironmentVariable)
         and not obj.is_abstract
     }
-    valid_names.update(["MODIN_PYTEST_CMD", "MODIN_PYTEST_DAILY_CMD", "MODIN_PYTEST_NO_COV_CMD"])
+    valid_names.update(
+        ["MODIN_PYTEST_CMD", "MODIN_PYTEST_DAILY_CMD", "MODIN_PYTEST_NO_COV_CMD"]
+    )
     found_names = {name for name in os.environ if name.startswith("MODIN_")}
     unknown = found_names - valid_names
     deprecated: dict[str, DeprecationDescriptor] = {

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ setenv =
     SNOW_1314507_WORKAROUND_RERUN_FLAGS = --reruns 2 --only-rerun "Insufficient resource during interleaved execution."
     MODIN_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources
     MODIN_PYTEST_DAILY_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_DAILY_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources
+    MODIN_PYTEST_NO_COV_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} --ignore=tests/resources
 
 passenv =
     AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-1297195

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   There were a few issues which prevent the daily snowpark pandas API jenkins job to run successfully:
      - tox.ini had `MODIN_PYTEST_NO_COV_CMD` missing
      - the jenkins invocation script requires tox to be installed
      - the tox_install_cmd.sh was using sh, but should be bash and variables were not defined.
   this PR addresses these issues.
