### PR TITLE
[SNOW-1338078]: Do not fail in deduplication if ordering columns not renamed

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1008,7 +1008,10 @@ class OrderedDataFrame:
         # get the ordering columns for the right frame after rename
         new_ordering_columns = [
             OrderingColumn(
-                column_identifiers_rename_map[order_col.snowflake_quoted_identifier],
+                column_identifiers_rename_map.get(
+                    order_col.snowflake_quoted_identifier,
+                    order_col.snowflake_quoted_identifier,
+                ),
                 order_col.ascending,
                 order_col.na_last,
             )
@@ -1016,7 +1019,10 @@ class OrderedDataFrame:
         ]
 
         new_row_position_snowflake_quoted_identifier = (
-            column_identifiers_rename_map[self.row_position_snowflake_quoted_identifier]
+            column_identifiers_rename_map.get(
+                self.row_position_snowflake_quoted_identifier,
+                self.row_position_snowflake_quoted_identifier,
+            )
             if self.row_position_snowflake_quoted_identifier
             else None
         )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -7585,6 +7585,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     ]
                 }
         else:
+            frame = frame.ensure_row_position_column()
+            cond_frame = cond_frame.ensure_row_position_column()
             joined_frame, result_column_mapper = join_utils.join(
                 frame,
                 cond_frame,

--- a/tests/integ/modin/frame/test_where.py
+++ b/tests/integ/modin/frame/test_where.py
@@ -991,3 +991,14 @@ def test_where_series_other_axis_1(index, data):
         native_df,
         perform_where,
     )
+
+
+@sql_count_checker(query_count=1, join_count=1)
+def test_where_series_cond_after_join():
+    snow_df1 = pd.DataFrame({"A": [1, 2]})
+    snow_df = snow_df1.join(snow_df1, lsuffix="_l", rsuffix="_r")
+    snow_df = snow_df.where(snow_df["A_l"] != snow_df["A_r"])
+    native_df1 = native_pd.DataFrame({"A": [1, 2]})
+    native_df = native_df1.join(native_df1, lsuffix="_l", rsuffix="_r")
+    native_df = native_df.where(native_df["A_l"] != native_df["A_r"])
+    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, native_df)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1338078

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR makes sure that deduplication of columns before a join does not fail if metadata columns are not renamed. It also adds a test for this, which uncovered a bug where the `where` API does not ensure the row position column before doing a positional join, which was also fixed.