### PR TITLE
SNOW-1349055 CI change: use ubuntu-latest for small tasks

### DIFF
--- a/.github/workflows/daily_modin_precommit.yml
+++ b/.github/workflows/daily_modin_precommit.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint:
     name: Check linting
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -40,7 +40,7 @@ jobs:
   build:
     needs: lint
     name: Build Wheel File
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
   test-unsupported-py38:
     name: Test importing Snowpark pandas with Python 3.8 fails
     needs: build
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
     if: ${{ success() || failure() }}
     name: Combine coverage
     needs: test
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -274,7 +274,7 @@ jobs:
   doc:
     needs: lint
     name: Build Doc
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/daily_precommit.yml
+++ b/.github/workflows/daily_precommit.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   lint:
     name: Check linting
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -40,7 +40,7 @@ jobs:
 
   type_checking:
     name: Type Checking
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -59,7 +59,7 @@ jobs:
   build:
     needs: lint
     name: Build Wheel File
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -453,7 +453,7 @@ jobs:
     if: ${{ success() || failure() }}
     name: Combine coverage
     needs: test
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -501,7 +501,7 @@ jobs:
   doc:
     needs: lint
     name: Build Doc
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint:
     name: Check linting
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -38,7 +38,7 @@ jobs:
 
   type_checking:
     name: Type Checking
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -57,7 +57,7 @@ jobs:
   build:
     needs: lint
     name: Build Wheel File
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -474,7 +474,7 @@ jobs:
     needs:
       - test
       - test-snowpark-pandas
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -522,7 +522,7 @@ jobs:
   doc:
     needs: lint
     name: Build Doc
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1349055 CI change: use ubuntu-latest for small tasks

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

For small tasks, use `ubuntu-latest` instead of 64-core machines.