### PR TITLE
SNOW-1348886: Bugfix: AssertError in sort_values after indexing

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed incorrect regex used in `Series.str.contains`.
 - Fixed DataFrame's `__getitem__` with boolean DataFrame key.
 - Fixed incorrect regex used in `DataFrame/Series.replace`.
+- Fixed AssertionError in `Series.sort_values` after repr and indexing operations.
 
 ### Behavior Changes
 - Raise not implemented error instead of fallback to pandas in following APIs:

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -599,7 +599,8 @@ class OrderedDataFrame:
         this select has the following restrictions:
         1. To select an existing column, must use column name instead of column expression. For example:
             select(col("a")) is not allowed, but select("a") is allowed. Note: only existing active columns
-            can be selected, includes projected columns, ordering columns and row position column.
+            can be selected, which includes projected columns, ordering columns, row position column and
+            row_count column.
         2. if you want to select a Column object, it must have an alias.
         3. You can't select an aggregated column anymore (e.g., `max("a").as_("a")`).
            To select an aggregated column, use `agg()`.
@@ -793,7 +794,9 @@ class OrderedDataFrame:
             return self
 
         return OrderedDataFrame(
-            self._to_projected_snowpark_dataframe_reference(),
+            self._to_projected_snowpark_dataframe_reference(
+                include_row_count_column=True
+            ),
             projected_column_snowflake_quoted_identifiers=self.projected_column_snowflake_quoted_identifiers,
             ordering_columns=ordering_columns,
             # should reset the row position column since ordering is updated

--- a/tests/integ/modin/test_chained_operations.py
+++ b/tests/integ/modin/test_chained_operations.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+import modin.pandas as pd
+import pandas as native_pd
+
+import snowflake.snowpark.modin.plugin  # noqa: F401
+from tests.integ.modin.sql_counter import sql_count_checker
+from tests.integ.modin.utils import eval_snowpark_pandas_result
+
+
+@sql_count_checker(query_count=2)
+def test_chained_op1():
+    # bug fix SNOW-1348886
+    data = {"X": [1, 2, 3], "Y": [4, 5, 6]}
+    snow_df = pd.DataFrame(data)
+    # Add row_count column
+    snow_df.__repr__()
+
+    native_df = native_pd.DataFrame(data)
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: df["X"].sort_values(ascending=True)
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1348886

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
Following steps result in AssertionError: row count column "__row_count__" not found in ['"__row_position__"', '"PRICE"']
   df = pd.read_snowflake("LINEITEM")
   print(df)
   df["PRICE"].sort_values(ascending=True)

Root cause: in ordered_dataframe.sort method we are passing row_count column to new ordered dataframe but didn't include row_count column in projection.
