### PR TITLE
SNOW-1057861 Bug - loc set with scalar column key and DataFrame item

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fixed incorrect regex used in `Series.str.contains`.
 - Fixed DataFrame's `__getitem__` with boolean DataFrame key.
 
+### Behavior Changes
+- As a part of the transition to pandas 2.2.1, pandas `df.loc` and `__setitem__` have buggy behavior when a column key is used to assign a DataFrame item to a DataFrame (a scalar column key and DataFrame item are used for assignment (https://github.com/pandas-dev/pandas/issues/58482)). Snowpark pandas deviates from this behavior and will maintain the same behavior as pandas from versions 1.5.x.
+
 ## 1.14.0a2 (2024-04-18)
 
 ### Behavior Changes

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -1791,7 +1791,7 @@ def _set_2d_labels_helper_for_frame_item(
 
     Args:
         internal_frame: the internal frame for the main dataframe/series
-        index: the internal frame for the index. Note that index can be None and we can save one join for this case.
+        index: the internal frame for the index. Note that index can be None, and we can save one join for this case.
         item: the internal frame for the item
         matching_item_columns_by_label: whether matching item columns by labels or positions
         matching_item_rows_by_label: whether matching item rows by labels or positions
@@ -1799,7 +1799,7 @@ def _set_2d_labels_helper_for_frame_item(
         index_is_bool_indexer: if True, the index is a boolean indexer
 
     Returns:
-        the frame joined with internal frame, index, and, item
+        the frame joined with internal frame, index, and item
     """
     if not matching_item_columns_by_label:
         expected_num_cols_item = len(col_info.column_pandas_labels)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1057861

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Investigated deviating behavior in pandas `df.loc` and `__setitem__` when a scalar column key is used to assign a single value DataFrame item. This issue is present in pandas 2.x.x, pandas 1.5.x has the correct behavior. I modified the xfail'd test to correctly test Snowpark pandas behavior and included the pandas GitHub issue for the bug: https://github.com/pandas-dev/pandas/issues/58482