### PR TITLE
SNOW-1318080: local testing move use object logic into session.py for better sql query isolation

### DIFF
--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -7,7 +7,6 @@ import functools
 import json
 import logging
 import os
-import re
 import sys
 import time
 import uuid
@@ -491,20 +490,11 @@ class MockServerConnection:
         ] = None,  # this argument is currently only used by AsyncJob
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncJob]:
-        use_ddl_pattern = r"^\s*use\s+(warehouse|database|schema|role)\s+(.+)\s*$"
-        if match := re.match(use_ddl_pattern, query):
-            # if the query is "use xxx", then the object name is already verified by the upper stream
-            # we do not validate here
-            object_type = match.group(1)
-            object_name = match.group(2)
-            setattr(self, f"_active_{object_type}", object_name)
-            return {"data": [("Statement executed successfully.",)], "sfqid": None}
-        else:
-            self.log_not_supported_error(
-                external_feature_name="Running SQL queries",
-                internal_feature_name="MockServerConnection.run_query",
-                raise_error=NotImplementedError,
-            )
+        self.log_not_supported_error(
+            external_feature_name="Running SQL queries",
+            internal_feature_name="MockServerConnection.run_query",
+            raise_error=NotImplementedError,
+        )
 
     def _to_data_or_iter(
         self,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2772,7 +2772,7 @@ class Session:
                     # we do not validate here
                     object_type = match.group(1)
                     object_name = match.group(2)
-                    setattr(self, f"_active_{object_type}", object_name)
+                    setattr(self._conn, f"_active_{object_type}", object_name)
                 else:
                     self._run_query(query)
             else:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2761,7 +2761,22 @@ class Session:
     def _use_object(self, object_name: str, object_type: str) -> None:
         if object_name:
             validate_object_name(object_name)
-            self._run_query(f"use {object_type} {object_name}")
+            query = f"use {object_type} {object_name}"
+            if isinstance(self._conn, MockServerConnection):
+                use_ddl_pattern = (
+                    r"^\s*use\s+(warehouse|database|schema|role)\s+(.+)\s*$"
+                )
+
+                if match := re.match(use_ddl_pattern, query):
+                    # if the query is "use xxx", then the object name is already verified by the upper stream
+                    # we do not validate here
+                    object_type = match.group(1)
+                    object_name = match.group(2)
+                    setattr(self, f"_active_{object_type}", object_name)
+                else:
+                    self._run_query(query)
+            else:
+                self._run_query(query)
         else:
             raise ValueError(f"'{object_type}' must not be empty or None.")
 

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -116,11 +116,11 @@ def test_get_schema_database_works_after_use_role(session):
     try:
         db = session.get_current_database()
         schema = session.get_current_schema()
-        session._run_query("use role public")
+        session.use_role("public")
         assert session.get_current_database() == db
         assert session.get_current_schema() == schema
     finally:
-        session._run_query(f"use role {current_role}")
+        session.use_role(current_role)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1318080

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Move "use object_type object" handling parsing logic into session to avoid accidentally causing confusion to users that sql query is supported
