### PR TITLE
SNOW-1357700: Remove workaround for native pandas groupby.shift(axis=1)

### DIFF
--- a/tests/integ/modin/frame/test_shift.py
+++ b/tests/integ/modin/frame/test_shift.py
@@ -56,13 +56,7 @@ def test_dataframe_with_values_shift(df, periods, fill_value, axis):
     eval_snowpark_pandas_result(
         snow_df,
         native_df,
-        lambda df: (
-            # pandas df.shift(axis=1) is broken for empty DFs
-            # https://github.com/pandas-dev/pandas/issues/57301
-            native_df
-            if isinstance(df, native_pd.DataFrame) and native_df.empty and axis == 1
-            else df.shift(periods=periods, fill_value=fill_value, axis=axis)
-        ),
+        lambda df: df.shift(periods=periods, fill_value=fill_value, axis=axis),
         check_column_type=False,
     )
 


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1357700

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

pandas bug https://github.com/pandas-dev/pandas/issues/57301 was fixed in 2.2.1, so we should remove the workaround for it.