### PR TITLE
SNOW-1257115: Fix docs for Snowpark pandas DataFrame/Series.isnull/isna

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1337,43 +1337,6 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         Whether elements in `BasePandasDataset` are contained in `values`.
         """
 
-    def isna():
-        """
-        Detect missing values for an array-like object.
-
-        This function takes a scalar or array-like object and indicates whether values are missing (NaN in numeric
-        arrays, None or NaN in object arrays, NaT in datetimelike).
-
-        Parameters
-        ----------
-        obj : scalar or array-like
-                Object to check for null or missing values.
-
-        Returns
-        -------
-        bool or array-like of bool
-            For scalar input, returns a scalar boolean. For array input, returns an array of boolean indicating whether
-            each corresponding element is missing.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
-        >>> df
-             0     1    2
-        0  ant   bee  cat
-        1  dog  None  fly
-        >>> df.isna()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
-        >>> df.isnull()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
-        """
-
-    isnull = isna
-
     @property
     def iloc():
         """

--- a/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
@@ -1750,72 +1750,70 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
     def isna():
         """
-        Detect missing values for an array-like object.
+        Detect missing values.
 
-        This function takes a scalar or array-like object and indicates whether values are missing (NaN in numeric
-        arrays, None or NaN in object arrays, NaT in datetimelike).
-
-        Parameters
-        ----------
-        obj : scalar or array-like
-                Object to check for null or missing values.
+        Return a boolean same-sized object indicating if the values are NA. NA values, such as None
+        or `numpy.NaN`, gets mapped to True values. Everything else gets mapped to False values.
+        Characters such as empty strings `''` or `numpy.inf` are not considered NA values.
 
         Returns
         -------
-        bool or array-like of bool
-            For scalar input, returns a scalar boolean. For array input, returns an array of boolean indicating whether
-            each corresponding element is missing.
+        DataFrame
+            Mask of bool values for each element in DataFrame that indicates whether an element is an NA value.
 
         Examples
         --------
-        >>> df = pd.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
+        >>> df = pd.DataFrame(dict(age=[5, 6, np.nan],
+        ...                   born=[pd.NaT, pd.Timestamp('1939-05-27'),
+        ...                         pd.Timestamp('1940-04-25')],
+        ...                   name=['Alfred', 'Batman', ''],
+        ...                   toy=[None, 'Batmobile', 'Joker']))
         >>> df
-             0     1    2
-        0  ant   bee  cat
-        1  dog  None  fly
+           age       born    name        toy
+        0  5.0        NaT  Alfred       None
+        1  6.0 1939-05-27  Batman  Batmobile
+        2  NaN 1940-04-25              Joker
+
         >>> df.isna()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
-        >>> df.isnull()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
+             age   born   name    toy
+        0  False   True  False   True
+        1  False  False  False  False
+        2   True  False  False  False
         """
 
     def isnull():
         """
-        Detect missing values for an array-like object.
+        `DataFrame.isnull` is an alias for `DataFrame.isna`.
 
-        This function takes a scalar or array-like object and indicates whether values are missing (NaN in numeric
-        arrays, None or NaN in object arrays, NaT in datetimelike).
+        Detect missing values.
 
-        Parameters
-        ----------
-        obj : scalar or array-like
-                Object to check for null or missing values.
+        Return a boolean same-sized object indicating if the values are NA. NA values, such as None
+        or `numpy.NaN`, gets mapped to True values. Everything else gets mapped to False values.
+        Characters such as empty strings `''` or `numpy.inf` are not considered NA values.
 
         Returns
         -------
-        bool or array-like of bool
-            For scalar input, returns a scalar boolean. For array input, returns an array of boolean indicating whether
-            each corresponding element is missing.
+        DataFrame
+            Mask of bool values for each element in DataFrame that indicates whether an element is an NA value.
 
         Examples
         --------
-        >>> df = pd.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
+        >>> df = pd.DataFrame(dict(age=[5, 6, np.nan],
+        ...                   born=[pd.NaT, pd.Timestamp('1939-05-27'),
+        ...                         pd.Timestamp('1940-04-25')],
+        ...                   name=['Alfred', 'Batman', ''],
+        ...                   toy=[None, 'Batmobile', 'Joker']))
         >>> df
-             0     1    2
-        0  ant   bee  cat
-        1  dog  None  fly
+           age       born    name        toy
+        0  5.0        NaT  Alfred       None
+        1  6.0 1939-05-27  Batman  Batmobile
+        2  NaN 1940-04-25              Joker
+
         >>> df.isna()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
-        >>> df.isnull()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
+             age   born   name    toy
+        0  False   True  False   True
+        1  False  False  False  False
+        2   True  False  False  False
         """
 
     def isetitem():

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2898,72 +2898,62 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
 
     def isna():
         """
-        Detect missing values for an array-like object.
+        Detect missing values.
 
-        This function takes a scalar or array-like object and indicates whether values are missing (NaN in numeric
-        arrays, None or NaN in object arrays, NaT in datetimelike).
-
-        Parameters
-        ----------
-        obj : scalar or array-like
-                Object to check for null or missing values.
+        Return a boolean same-sized object indicating if the values are NA. NA values, such as None
+        or `numpy.NaN`, gets mapped to True values. Everything else gets mapped to False values.
+        Characters such as empty strings `''` or `numpy.inf` are not considered NA values.
 
         Returns
         -------
-        bool or array-like of bool
-            For scalar input, returns a scalar boolean. For array input, returns an array of boolean indicating whether
-            each corresponding element is missing.
+        Series
+            Mask of bool values for each element in Series that indicates whether an element is an NA value.
 
         Examples
         --------
-        >>> df = pd.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
-        >>> df
-             0     1    2
-        0  ant   bee  cat
-        1  dog  None  fly
-        >>> df.isna()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
-        >>> df.isnull()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
+        >>> ser = pd.Series([5, 6, np.nan])
+        >>> ser
+        0    5.0
+        1    6.0
+        2    NaN
+        dtype: float64
+
+        >>> ser.isna()
+        0    False
+        1    False
+        2     True
+        dtype: bool
         """
 
     def isnull():
         """
-        Detect missing values for an array-like object.
+        `Series.isnull` is an alias for `Series.isna`.
 
-        This function takes a scalar or array-like object and indicates whether values are missing (NaN in numeric
-        arrays, None or NaN in object arrays, NaT in datetimelike).
+        Detect missing values.
 
-        Parameters
-        ----------
-        obj : scalar or array-like
-                Object to check for null or missing values.
+        Return a boolean same-sized object indicating if the values are NA. NA values, such as None
+        or `numpy.NaN`, gets mapped to True values. Everything else gets mapped to False values.
+        Characters such as empty strings `''` or `numpy.inf` are not considered NA values.
 
         Returns
         -------
-        bool or array-like of bool
-            For scalar input, returns a scalar boolean. For array input, returns an array of boolean indicating whether
-            each corresponding element is missing.
+        Series
+            Mask of bool values for each element in Series that indicates whether an element is an NA value.
 
         Examples
         --------
-        >>> df = pd.DataFrame([['ant', 'bee', 'cat'], ['dog', None, 'fly']])
-        >>> df
-             0     1    2
-        0  ant   bee  cat
-        1  dog  None  fly
-        >>> df.isna()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
-        >>> df.isnull()
-               0      1      2
-        0  False  False  False
-        1  False   True  False
+        >>> ser = pd.Series([5, 6, np.nan])
+        >>> ser
+        0    5.0
+        1    6.0
+        2    NaN
+        dtype: float64
+
+        >>> ser.isna()
+        0    False
+        1    False
+        2     True
+        dtype: bool
         """
 
     @property


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1257115

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

The docstrings for the `isnull` and `isna` methods of `DataFrame`/`Series` previously used the top-level `pd.isna`/`isnull` documentation instead. This PR changes them to use the correct docstring.