### PR TITLE
SNOW-1357695: Fix int64 not serializable errors on apply(axis=1)

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed DataFrame's `__getitem__` with boolean DataFrame key.
 - Fixed incorrect regex used in `DataFrame/Series.replace`.
 - Fixed AssertionError in `Series.sort_values` after repr and indexing operations.
+- Fixed UDTF "int64 is not serializable" errors from new Snowflake release in `apply(axis=1)`
 
 ### Behavior Changes
 - Raise not implemented error instead of fallback to pandas in following APIs:

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -221,7 +221,7 @@ def create_udtf_for_apply_axis_1(
                 raise TypeError(f"Unsupported data type {df} from df.apply")
 
             result["value"] = (
-                result["value"].apply(handle_missing_value_in_variant).astype(object)
+                result["value"].apply(handle_missing_value_in_variant).astype(object).apply(convert_numpy_int_result_to_int)
             )
             return result
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -221,7 +221,10 @@ def create_udtf_for_apply_axis_1(
                 raise TypeError(f"Unsupported data type {df} from df.apply")
 
             result["value"] = (
-                result["value"].apply(handle_missing_value_in_variant).astype(object).apply(convert_numpy_int_result_to_int)
+                result["value"]
+                .apply(handle_missing_value_in_variant)
+                .apply(convert_numpy_int_result_to_int)
+                .astype(object)
             )
             return result
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -222,8 +222,11 @@ def create_udtf_for_apply_axis_1(
 
             result["value"] = (
                 result["value"]
-                .apply(handle_missing_value_in_variant)
-                .apply(convert_numpy_int_result_to_int)
+                .apply(
+                    lambda v: handle_missing_value_in_variant(
+                        convert_numpy_int_result_to_int(v)
+                    )
+                )
                 .astype(object)
             )
             return result

--- a/tests/integ/modin/frame/test_apply.py
+++ b/tests/integ/modin/frame/test_apply.py
@@ -544,7 +544,6 @@ def test_axis_1_multi_index_column_labels_different_levels_negative():
     )
 
 
-# @pytest.mark.skip(reason="SNOW-1358681")
 def test_apply_variant_json_null():
     # series -> scalar
     def f(v):

--- a/tests/integ/modin/frame/test_apply.py
+++ b/tests/integ/modin/frame/test_apply.py
@@ -544,7 +544,7 @@ def test_axis_1_multi_index_column_labels_different_levels_negative():
     )
 
 
-@pytest.mark.skip(reason="SNOW-1358681")
+# @pytest.mark.skip(reason="SNOW-1358681")
 def test_apply_variant_json_null():
     # series -> scalar
     def f(v):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1357695

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   We convert numpy ints to ints explicitly in the UDTF for `groupby.apply` [here](https://github.com/snowflakedb/snowpark-python/blob/31aad1fc33c263e3b2c3403f3dab160712e00f22/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py#L310) and [here](https://github.com/snowflakedb/snowpark-python/blob/31aad1fc33c263e3b2c3403f3dab160712e00f22/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py#L546) but have so far managed to avoid doing so for apply(axis=1). With the new server release, that doesn't work any more, and we need to explicitly convert to ints.
