### PR TITLE
SNOW-1054699: Fix single-row Series and DataFrame binary ops

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -458,6 +458,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
 
         from snowflake.snowpark.modin.pandas.dataframe import DataFrame
 
+        # For a Series interacting with a DataFrame, always return a DataFrame
         return (
             DataFrame(query_compiler=new_query_compiler)
             if lhs_series_rhs_dataframe

--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -458,6 +458,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
 
         from snowflake.snowpark.modin.pandas.dataframe import DataFrame
 
+        # Modin Bug: https://github.com/modin-project/modin/issues/7236
         # For a Series interacting with a DataFrame, always return a DataFrame
         return (
             DataFrame(query_compiler=new_query_compiler)

--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -442,14 +442,17 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         # pandas itself will ignore the axis argument when using Series.<op>.
         # Per default, it is set to axis=0. However, for the case of a Series interacting with
         # a DataFrame the behavior is axis=1. Manually check here for this case and adjust the axis.
-        lhs_series_rhs_dataframe = False
-        if isinstance(self, pd.Series) and isinstance(other, pd.DataFrame):
-            lhs_series_rhs_dataframe = True
+
+        is_lhs_series_and_rhs_dataframe = (
+            True
+            if isinstance(self, pd.Series) and isinstance(other, pd.DataFrame)
+            else False
+        )
 
         new_query_compiler = self._query_compiler.binary_op(
             op=op,
             other=other,
-            axis=1 if lhs_series_rhs_dataframe else axis,
+            axis=1 if is_lhs_series_and_rhs_dataframe else axis,
             level=level,
             fill_value=fill_value,
             squeeze_self=squeeze_self,
@@ -462,7 +465,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         # For a Series interacting with a DataFrame, always return a DataFrame
         return (
             DataFrame(query_compiler=new_query_compiler)
-            if lhs_series_rhs_dataframe
+            if is_lhs_series_and_rhs_dataframe
             else self._create_or_update_from_compiler(new_query_compiler)
         )
 

--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -442,19 +442,27 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         # pandas itself will ignore the axis argument when using Series.<op>.
         # Per default, it is set to axis=0. However, for the case of a Series interacting with
         # a DataFrame the behavior is axis=1. Manually check here for this case and adjust the axis.
+        lhs_series_rhs_dataframe = False
         if isinstance(self, pd.Series) and isinstance(other, pd.DataFrame):
-            axis = 1
+            lhs_series_rhs_dataframe = True
 
         new_query_compiler = self._query_compiler.binary_op(
             op=op,
             other=other,
-            axis=axis,
+            axis=1 if lhs_series_rhs_dataframe else axis,
             level=level,
             fill_value=fill_value,
             squeeze_self=squeeze_self,
             **kwargs,
         )
-        return self._create_or_update_from_compiler(new_query_compiler)
+
+        from snowflake.snowpark.modin.pandas.dataframe import DataFrame
+
+        return (
+            DataFrame(query_compiler=new_query_compiler)
+            if lhs_series_rhs_dataframe
+            else self._create_or_update_from_compiler(new_query_compiler)
+        )
 
     def _default_to_pandas(self, op, *args, **kwargs):
         """

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed DataFrame's `__getitem__` with boolean DataFrame key.
 - Fixed incorrect regex used in `DataFrame/Series.replace`.
 - Fixed AssertionError in `Series.sort_values` after repr and indexing operations.
+- Fixed binary operations with one-row DataFrame and Series.
 
 ### Behavior Changes
 - Raise not implemented error instead of fallback to pandas in following APIs:

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed DataFrame's `__getitem__` with boolean DataFrame key.
 - Fixed incorrect regex used in `DataFrame/Series.replace`.
 - Fixed AssertionError in `Series.sort_values` after repr and indexing operations.
-- Fixed binary operations with one-row DataFrame and Series.
+- Fixed binary operations with single-row DataFrame and Series.
 
 ### Behavior Changes
 - Raise not implemented error instead of fallback to pandas in following APIs:

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -11008,11 +11008,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if squeeze_self:
             # self is a Series, other a DataFrame.
             series_self = self.to_pandas()
-            if series_self.size > 1:
-                series = series_self.squeeze()
-            else:
-                # Series.squeeze on one row returns a scalar, so instead use squeeze with axis=0
-                series = series_self.squeeze(axis=0)
+            # Series.squeeze on one row returns a scalar, so instead use squeeze with axis=0
+            series = (
+                series_self.squeeze()
+                if series_self.size > 1
+                else series_self.squeeze(axis=0)
+            )
 
             self_column_labels = list(series.index.values)
             other_column_labels = other._modin_frame.data_column_pandas_labels
@@ -11026,11 +11027,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         else:
             # self is a DataFrame, other a Series.
             series_other = other.to_pandas()
-            if series_other.size > 1:
-                series = series_other.squeeze()
-            else:
-                # Series.squeeze on one row returns a scalar, so instead use squeeze with axis=0
-                series = series_other.squeeze(axis=0)
+            # Series.squeeze on one row returns a scalar, so instead use squeeze with axis=0
+            series = (
+                series_other.squeeze()
+                if series_other.size > 1
+                else series_other.squeeze(axis=0)
+            )
 
             self_column_labels = self._modin_frame.data_column_pandas_labels
             other_column_labels = list(series.index.values)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -11007,7 +11007,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # Inherit the index names from the dataframe.
         if squeeze_self:
             # self is a Series, other a DataFrame.
-            series = self.to_pandas().squeeze()
+            series_self = self.to_pandas()
+            if series_self.size > 1:
+                series = series_self.squeeze()
+            else:
+                series = series_self.squeeze(axis=0)
+
             self_column_labels = list(series.index.values)
             other_column_labels = other._modin_frame.data_column_pandas_labels
             frame = other._modin_frame
@@ -11019,7 +11024,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
         else:
             # self is a DataFrame, other a Series.
-            series = other.to_pandas().squeeze()
+            series_other = other.to_pandas()
+            if series_other.size > 1:
+                series = series_other.squeeze()
+            else:
+                series = series_other.squeeze(axis=0)
+
             self_column_labels = self._modin_frame.data_column_pandas_labels
             other_column_labels = list(series.index.values)
             frame = self._modin_frame

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -11011,6 +11011,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             if series_self.size > 1:
                 series = series_self.squeeze()
             else:
+                # Series.squeeze on one row returns a scalar, so instead use squeeze with axis=0
                 series = series_self.squeeze(axis=0)
 
             self_column_labels = list(series.index.values)
@@ -11028,6 +11029,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             if series_other.size > 1:
                 series = series_other.squeeze()
             else:
+                # Series.squeeze on one row returns a scalar, so instead use squeeze with axis=0
                 series = series_other.squeeze(axis=0)
 
             self_column_labels = self._modin_frame.data_column_pandas_labels

--- a/tests/integ/modin/binary/test_binary_op.py
+++ b/tests/integ/modin/binary/test_binary_op.py
@@ -2045,7 +2045,7 @@ def test_binary_add_dataframe_and_series_axis0(df, s):
 
     # The other direction for axis=0 behaves like axis=1.
     with SqlCounter(
-        query_count=3,
+        query_count=2,
     ):
         snow_ans = snow_s.add(snow_df, axis=0)
         ans = s.add(df, axis=0)

--- a/tests/integ/modin/binary/test_binary_op.py
+++ b/tests/integ/modin/binary/test_binary_op.py
@@ -2517,3 +2517,23 @@ def test_binary_bitwise_op_on_df(df1, df2, func, expected):
 
     snow_ans = func(snow_df1, snow_df2)
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_ans, expected)
+
+
+@sql_count_checker(query_count=2)
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda df: df + df[0],
+        lambda df: df - df[0],
+        lambda df: df[0] + df,
+        lambda df: df[0] - df,
+    ],
+)
+def test_binary_single_row_dataframe_and_series(func):
+    native_df = native_pd.DataFrame([1])
+    snow_df = pd.DataFrame([1])
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        func,
+    )


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   SNOW-1054699

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR fixes single-row Series and DataFrame binary ops which previously returned `AttributeError: 'numpy.int8' object has no attribute 'index'`. 
