### PR TITLE
Fix query count for `test_binary_op_between_dataframe_and_series_axis0` and add back to merge gate

### DIFF
--- a/tests/integ/modin/binary/test_binary_op.py
+++ b/tests/integ/modin/binary/test_binary_op.py
@@ -2098,7 +2098,6 @@ def test_binary_add_dataframe_and_series_axis0(df, s):
         ),
     ],
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="exhaustive and slow operation test")
 def test_binary_op_between_dataframe_and_series_axis0(opname, df, s):
     snow_df = pd.DataFrame(df)
     snow_s = pd.Series(s)
@@ -2119,7 +2118,7 @@ def test_binary_op_between_dataframe_and_series_axis0(opname, df, s):
     #   - One query to retrieve the result as a native pandas object.
     # Series <op> DataFrame
     with SqlCounter(
-        query_count=3,
+        query_count=2,
     ):
         snow_ans = getattr(snow_s, opname)(snow_df, axis=0)
         ans = getattr(s, opname)(df, axis=0)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR fixes the query count for `test_binary_op_between_dataframe_and_series_axis0`(related to this PR: https://github.com/snowflakedb/snowpark-python/pull/1505) and adds them back to the merge gate.
