### PR TITLE
SNOW-1357844: fix flaky test caused by oob telemetry datetime comparsion

### DIFF
--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -48,7 +48,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
             assert event["UUID"]
             assert datetime.strptime(
                 event["Created_on"], "%Y-%m-%d %H:%M:%S"
-            ).timestamp() == pytest.approx(now_time.timestamp(), abs=1)
+            ).timestamp() == pytest.approx(now_time.timestamp(), abs=3)
             assert event["Message"]["Connection_UUID"] == (
                 None if idx == 0 else connection_uuid
             )
@@ -127,7 +127,7 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
         assert event["UUID"]
         assert datetime.strptime(
             event["Created_on"], "%Y-%m-%d %H:%M:%S"
-        ).timestamp() == pytest.approx(now_time.timestamp(), abs=1)
+        ).timestamp() == pytest.approx(now_time.timestamp(), abs=3)
         assert event["Message"]["Connection_UUID"] == (
             None if idx == 0 else connection_uuid
         )

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 
@@ -48,7 +48,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
             assert event["UUID"]
             assert datetime.strptime(
                 event["Created_on"], "%Y-%m-%d %H:%M:%S"
-            ) == pytest.approx(now_time, abs=timedelta(seconds=1))
+            ).timestamp() == pytest.approx(now_time.timestamp(), abs=1)
             assert event["Message"]["Connection_UUID"] == (
                 None if idx == 0 else connection_uuid
             )
@@ -127,7 +127,7 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
         assert event["UUID"]
         assert datetime.strptime(
             event["Created_on"], "%Y-%m-%d %H:%M:%S"
-        ) == pytest.approx(now_time, abs=timedelta(seconds=1))
+        ).timestamp() == pytest.approx(now_time.timestamp(), abs=1)
         assert event["Message"]["Connection_UUID"] == (
             None if idx == 0 else connection_uuid
         )

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -26,15 +26,15 @@ pytestmark = pytest.mark.skipif(
 
 
 def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
+    mock_date_value = datetime(2024, 5, 3, 1, 2, 3)
     oob_service = LocalTestOOBTelemetryService.get_instance()
     # clean up queue first
     oob_service.export_queue_to_string()
-    mock_date_value = datetime(2024, 5, 3, 1, 2, 3)
+    connection_uuid = str(uuid.uuid4())
     with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
         with mock.patch("snowflake.snowpark.mock._telemetry.datetime") as mock_datetime:
-            # mock datetime due to flakiness to time comparison
+            # mock datetime due to flakiness in time comparison
             mock_datetime.now.return_value = mock_date_value
-            connection_uuid = str(uuid.uuid4())
             oob_service.log_session_creation()
             assert oob_service.size() == 1
             oob_service.log_session_creation(connection_uuid=connection_uuid)
@@ -94,7 +94,7 @@ def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setu
     logger = logging.getLogger("LocalTestLogger")
 
     with mock.patch("snowflake.snowpark.mock._telemetry.datetime") as mock_datetime:
-        # mock datetime due to flakiness to time comparison
+        # mock datetime due to flakiness in time comparison
         mock_datetime.now.return_value = mock_date_value
         unraise_feature_name = "Test Feature No Raise Error"
         with caplog.at_level(logging.WARNING, logger="LocalTestLogger"):

--- a/tests/mock_unit/test_oob_telemetry.py
+++ b/tests/mock_unit/test_oob_telemetry.py
@@ -6,6 +6,7 @@ import logging
 import re
 import uuid
 from datetime import datetime
+from unittest import mock
 
 import pytest
 
@@ -28,7 +29,10 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
     oob_service = LocalTestOOBTelemetryService.get_instance()
     # clean up queue first
     oob_service.export_queue_to_string()
-    with caplog.at_level(logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"):
+    with caplog.at_level(
+        logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"
+    ), mock.patch("snowflake.snowpark.mock._telemetry.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 5, 3, 1, 2, 3)
         connection_uuid = str(uuid.uuid4())
         oob_service.log_session_creation()
         assert oob_service.size() == 1
@@ -36,7 +40,7 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
         assert oob_service.size() == 2
         payload = oob_service.export_queue_to_string()
         unpacked_payload = json.loads(payload)
-        now_time = datetime.now().replace(microsecond=0)
+        now_time = datetime(2024, 5, 3, 1, 2, 3)
 
         # test generated payload
         for idx, event in enumerate(unpacked_payload):
@@ -46,9 +50,9 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
             assert len(event["Tags"]) == 4
             assert event["Type"] == event["properties"]["type"] == "Snowpark Python"
             assert event["UUID"]
-            assert datetime.strptime(
-                event["Created_on"], "%Y-%m-%d %H:%M:%S"
-            ).timestamp() == pytest.approx(now_time.timestamp(), abs=3)
+            assert (
+                datetime.strptime(event["Created_on"], "%Y-%m-%d %H:%M:%S") == now_time
+            )
             assert event["Message"]["Connection_UUID"] == (
                 None if idx == 0 else connection_uuid
             )
@@ -81,107 +85,111 @@ def test_unit_oob_connection_telemetry(caplog, local_testing_telemetry_setup):
 
 
 def test_unit_oob_log_not_implemented_error(caplog, local_testing_telemetry_setup):
-    oob_service = LocalTestOOBTelemetryService.get_instance()
-    # clean up queue first
-    oob_service.export_queue_to_string()
-    connection_uuid = str(uuid.uuid4())
-    logger = logging.getLogger("LocalTestLogger")
 
-    unraise_feature_name = "Test Feature No Raise Error"
-    with caplog.at_level(logging.WARNING, logger="LocalTestLogger"):
-        # test basic case + warning
-        oob_service.log_not_supported_error(
-            external_feature_name=unraise_feature_name,
-            warning_logger=logger,
-        )
-        assert (
-            f"[Local Testing] {unraise_feature_name} is not supported." in caplog.text
-        )
-    assert oob_service.size() == 1
+    with mock.patch("snowflake.snowpark.mock._telemetry.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2024, 5, 3, 1, 2, 3)
+        oob_service = LocalTestOOBTelemetryService.get_instance()
+        # clean up queue first
+        oob_service.export_queue_to_string()
+        connection_uuid = str(uuid.uuid4())
+        logger = logging.getLogger("LocalTestLogger")
 
-    # test raising error
-    raise_feature_name = "Test Feature With Raise Error"
-    with pytest.raises(
-        NotImplementedError,
-        match=re.escape(f"[Local Testing] {raise_feature_name} is not supported."),
-    ):
-        oob_service.log_not_supported_error(
-            external_feature_name=raise_feature_name,
-            internal_feature_name="module_a.function_b",
-            parameters_info={"param_c": "value_d"},
-            connection_uuid=connection_uuid,
-            raise_error=NotImplementedError,
-        )
-    assert oob_service.size() == 2
-    payload = oob_service.export_queue_to_string()
-    unpacked_payload = json.loads(payload)
-    now_time = datetime.now().replace(microsecond=0)
+        unraise_feature_name = "Test Feature No Raise Error"
+        with caplog.at_level(logging.WARNING, logger="LocalTestLogger"):
+            # test basic case + warning
+            oob_service.log_not_supported_error(
+                external_feature_name=unraise_feature_name,
+                warning_logger=logger,
+            )
+            assert (
+                f"[Local Testing] {unraise_feature_name} is not supported."
+                in caplog.text
+            )
+        assert oob_service.size() == 1
 
-    # test generated payload
-    for idx, event in enumerate(unpacked_payload):
-        assert len(event) == 6
-        assert len(event["properties"]) == 1
-        assert len(event["Message"]) == 4
-        assert len(event["Tags"]) == 4
-        assert event["Type"] == event["properties"]["type"] == "Snowpark Python"
-        assert event["UUID"]
-        assert datetime.strptime(
-            event["Created_on"], "%Y-%m-%d %H:%M:%S"
-        ).timestamp() == pytest.approx(now_time.timestamp(), abs=3)
-        assert event["Message"]["Connection_UUID"] == (
-            None if idx == 0 else connection_uuid
-        )
-        assert event["Message"]["is_internal"] == 1
-        assert event["Message"]["feature_name"] == (
-            unraise_feature_name if idx == 0 else "module_a.function_b"
-        )
-        assert event["Message"]["parameters_info"] == (
-            None if idx == 0 else {"param_c": "value_d"}
-        )
-        assert event["Tags"]["Snowpark_Version"] == get_version()
-        assert event["Tags"]["OS_Version"] == get_os_name()
-        assert event["Tags"]["Python_Version"] == get_python_version()
-        assert event["Tags"]["Event_type"] == "unsupported"
-    assert oob_service.size() == 0
+        # test raising error
+        raise_feature_name = "Test Feature With Raise Error"
+        with pytest.raises(
+            NotImplementedError,
+            match=re.escape(f"[Local Testing] {raise_feature_name} is not supported."),
+        ):
+            oob_service.log_not_supported_error(
+                external_feature_name=raise_feature_name,
+                internal_feature_name="module_a.function_b",
+                parameters_info={"param_c": "value_d"},
+                connection_uuid=connection_uuid,
+                raise_error=NotImplementedError,
+            )
+        assert oob_service.size() == 2
+        payload = oob_service.export_queue_to_string()
+        unpacked_payload = json.loads(payload)
+        now_time = datetime(2024, 5, 3, 1, 2, 3)
 
-    # test sending successfully
-    caplog.clear()
+        # test generated payload
+        for idx, event in enumerate(unpacked_payload):
+            assert len(event) == 6
+            assert len(event["properties"]) == 1
+            assert len(event["Message"]) == 4
+            assert len(event["Tags"]) == 4
+            assert event["Type"] == event["properties"]["type"] == "Snowpark Python"
+            assert event["UUID"]
+            assert (
+                datetime.strptime(event["Created_on"], "%Y-%m-%d %H:%M:%S") == now_time
+            )
+            assert event["Message"]["Connection_UUID"] == (
+                None if idx == 0 else connection_uuid
+            )
+            assert event["Message"]["is_internal"] == 1
+            assert event["Message"]["feature_name"] == (
+                unraise_feature_name if idx == 0 else "module_a.function_b"
+            )
+            assert event["Message"]["parameters_info"] == (
+                None if idx == 0 else {"param_c": "value_d"}
+            )
+            assert event["Tags"]["Snowpark_Version"] == get_version()
+            assert event["Tags"]["OS_Version"] == get_os_name()
+            assert event["Tags"]["Python_Version"] == get_python_version()
+            assert event["Tags"]["Event_type"] == "unsupported"
+        assert oob_service.size() == 0
 
-    max_retry = 10
-    for i in range(max_retry):
-        try:
-            with caplog.at_level(
-                logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"
-            ):
-                oob_service.log_not_supported_error(
-                    external_feature_name=unraise_feature_name,
-                )
-                try:
+        # test sending successfully
+        caplog.clear()
+
+        max_retry = 10
+        for i in range(max_retry):
+            try:
+                with caplog.at_level(
+                    logging.DEBUG, logger="snowflake.snowpark.mock._telemetry"
+                ):
                     oob_service.log_not_supported_error(
-                        external_feature_name=raise_feature_name,
-                        internal_feature_name="module_a.function_b",
-                        parameters_info={"param_c": "value_d"},
-                        connection_uuid=connection_uuid,
-                        raise_error=NotImplementedError,
+                        external_feature_name=unraise_feature_name,
                     )
-                except Exception:
-                    pass
-                assert oob_service.size() == 2
-                oob_service.flush()
-                assert oob_service.size() == 0
-                assert (
-                    "telemetry server request success: 200" in caplog.text
-                    and "Telemetry request success=True" in caplog.text
-                )
-            break
-        except AssertionError:
-            caplog.clear()
-            if i == max_retry - 1:
-                raise
+                    try:
+                        oob_service.log_not_supported_error(
+                            external_feature_name=raise_feature_name,
+                            internal_feature_name="module_a.function_b",
+                            parameters_info={"param_c": "value_d"},
+                            connection_uuid=connection_uuid,
+                            raise_error=NotImplementedError,
+                        )
+                    except Exception:
+                        pass
+                    assert oob_service.size() == 2
+                    oob_service.flush()
+                    assert oob_service.size() == 0
+                    assert (
+                        "telemetry server request success: 200" in caplog.text
+                        and "Telemetry request success=True" in caplog.text
+                    )
+                break
+            except AssertionError:
+                caplog.clear()
+                if i == max_retry - 1:
+                    raise
 
-    # test sending empty raise error
-    with pytest.raises(ValueError):
-        assert oob_service.log_not_supported_error()
+        # test sending empty raise error
+        with pytest.raises(ValueError):
+            assert oob_service.log_not_supported_error()
 
 
 def test_unit_connection(caplog, local_testing_telemetry_setup):


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1357844

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

pytest.approx only supports number, datetime is not supported, so previously implementation doesn't work at all.
change to use timestamp to the approx equal
