### PR TITLE
SNOW-1063738 Rewrite `tests/integ/test_column_names.py::test_binary_expression` to apply to Local Testing

### DIFF
--- a/tests/integ/test_column_names.py
+++ b/tests/integ/test_column_names.py
@@ -553,19 +553,21 @@ def test_list_agg_within_group_sort_order(session):
 
 def test_binary_expression(session):
     """=, !=, >, <, >=, <=, EQUAL_NULL, AND, OR, +, -, *, /, %, POWER, BITAND, BITOR, BITXOR"""
-    df1 = session.sql("select 1 as \" a\", 'x' as \" b\", 1 as a, 'x' as b")
+    df1 = session.create_dataframe(
+        [[1, "x", 1, "x"]], schema=['" a"', '" b"', "a", "b"]
+    )
     df2 = df1.select(
-        df1[" a"] == "x",
-        df1[" a"] != "x",
-        df1[" a"] > "x",
-        df1[" a"] <= "x",
+        df1[" b"] == "x",
+        df1[" b"] != "x",
+        df1[" b"] > "x",
+        df1[" b"] <= "x",
         df1[" a"].equal_null(df1[" b"]),
         (df1[" b"] == "x") & (df1[" a"] == 1),
         (df1[" b"] == "x") | (df1[" a"] == 1),
-        df1[" b"].bitand(lit(1)),
-        df1[" b"].bitor(lit(1)),
-        df1[" b"].bitxor(lit(1)),
-        pow(df1[" b"], 2),
+        df1[" a"].bitand(lit(1)),
+        df1[" a"].bitor(lit(1)),
+        df1[" a"].bitxor(lit(1)),
+        pow(df1[" a"], 2),
         df1[" a"] + df1[" a"],
         df1[" a"] - df1[" a"],
         df1[" a"] * df1[" a"],
@@ -577,17 +579,17 @@ def test_binary_expression(session):
         == df2.columns
         == get_metadata_names(session, df2)
         == [
-            '"("" A"" = \'X\')"',
-            '"("" A"" != \'X\')"',
-            '"("" A"" > \'X\')"',
-            '"("" A"" <= \'X\')"',
+            '"("" B"" = \'X\')"',
+            '"("" B"" != \'X\')"',
+            '"("" B"" > \'X\')"',
+            '"("" B"" <= \'X\')"',
             '"EQUAL_NULL("" A"", "" B"")"',
             '"(("" B"" = \'X\') AND ("" A"" = 1 :: INT))"',
             '"(("" B"" = \'X\') OR ("" A"" = 1 :: INT))"',
-            '"BITAND(1 :: INT, "" B"")"',
-            '"BITOR(1 :: INT, "" B"")"',
-            '"BITXOR(1 :: INT, "" B"")"',
-            '"POWER("" B"", 2 :: INT)"',
+            '"BITAND(1 :: INT, "" A"")"',
+            '"BITOR(1 :: INT, "" A"")"',
+            '"BITXOR(1 :: INT, "" A"")"',
+            '"POWER("" A"", 2 :: INT)"',
             '"("" A"" + "" A"")"',
             '"("" A"" - "" A"")"',
             '"("" A"" * "" A"")"',
@@ -596,17 +598,17 @@ def test_binary_expression(session):
         ]
     )
     df3 = df1.select(
-        df1["a"] == "x",
-        df1["a"] != "x",
-        df1["a"] > "x",
-        df1["a"] <= "x",
+        df1["b"] == "x",
+        df1["b"] != "x",
+        df1["b"] > "x",
+        df1["b"] <= "x",
         df1["a"].equal_null(df1["b"]),
         (df1["b"] == "x") & (df1["a"] == 1),
         (df1["b"] == "x") | (df1["a"] == 1),
-        df1["b"].bitand(lit(1)),
-        df1["b"].bitor(lit(1)),
-        df1["b"].bitxor(lit(1)),
-        pow(df1["b"], 2),
+        df1["a"].bitand(lit(1)),
+        df1["a"].bitor(lit(1)),
+        df1["a"].bitxor(lit(1)),
+        pow(df1["a"], 2),
         df1["a"] + df1["a"],
         df1["a"] - df1["a"],
         df1["a"] * df1["a"],
@@ -617,17 +619,17 @@ def test_binary_expression(session):
         [x.name for x in df3._output]
         == df3.columns
         == [
-            '"(""A"" = \'X\')"',
-            '"(""A"" != \'X\')"',
-            '"(""A"" > \'X\')"',
-            '"(""A"" <= \'X\')"',
+            '"(""B"" = \'X\')"',
+            '"(""B"" != \'X\')"',
+            '"(""B"" > \'X\')"',
+            '"(""B"" <= \'X\')"',
             '"EQUAL_NULL(""A"", ""B"")"',
             '"((""B"" = \'X\') AND (""A"" = 1 :: INT))"',
             '"((""B"" = \'X\') OR (""A"" = 1 :: INT))"',
-            '"BITAND(1 :: INT, ""B"")"',
-            '"BITOR(1 :: INT, ""B"")"',
-            '"BITXOR(1 :: INT, ""B"")"',
-            '"POWER(""B"", 2 :: INT)"',
+            '"BITAND(1 :: INT, ""A"")"',
+            '"BITOR(1 :: INT, ""A"")"',
+            '"BITXOR(1 :: INT, ""A"")"',
+            '"POWER(""A"", 2 :: INT)"',
             '"(""A"" + ""A"")"',
             '"(""A"" - ""A"")"',
             '"(""A"" * ""A"")"',


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1063738

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR rewrites the test `tests/integ/test_column_names.py::test_binary_expression` to get rid of comparison between incompatible data types (i.e. str and int), so it could run against Local Testing. The original test **relies on live connection behavior where getting schema name does not actually run the query**, where the generated query would fail to execute in a live connection. Local Testing needs to evaluate the transformation to obtain the schema name, so this PR essentially rewrites the test to generate executable query.
