### PR TITLE
SNOW-1370365: Avoid UNION ALL for 1-column quantile operations

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -47,7 +47,7 @@
 - Given an input of type `Series`, `pd.qcut` always returns a `Series`.
 
 ### Improvements
-- Improved performance for `pd.qcut`, `Series.quantile`, and `Series.describe`.
+- Improved performance for `pd.qcut`, `Series.quantile`, `Series.describe`. Also improved `DataFrame.quantile` and `DataFrame.describe` for one-column `DataFrame`s.
 
 ### New Features
 - Added partial support for `SeriesGroupBy.apply` (where the `SeriesGrouBy` is obtained through `DataFrameGroupBy.__getitem__`).

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -46,6 +46,9 @@
 - Changed the import path of Snowpark pandas package to use Modin 0.28.1 instead. The new recommended import statement is `import modin.pandas as pd; import snowflake.snowpark.modin.plugin`.
 - Given an input of type `Series`, `pd.qcut` always returns a `Series`.
 
+### Improvements
+- Improved performance for `pd.qcut`, `Series.quantile`, and `Series.describe`.
+
 ### New Features
 - Added partial support for `SeriesGroupBy.apply` (where the `SeriesGrouBy` is obtained through `DataFrameGroupBy.__getitem__`).
 

--- a/tests/integ/modin/frame/test_describe.py
+++ b/tests/integ/modin/frame/test_describe.py
@@ -30,7 +30,7 @@ from tests.integ.modin.utils import (
 # In general, 7 UNIONs occur because we concat 8 query compilers together:
 # count, mean, std, min, 0.25, 0.5, 0.75, max
 # However, for 1-column frames, we compute all the quantiles in a single query compiler, lowering the
-# union count to 5 UNIONs for 7 query compilers
+# union count to 5 UNIONs for 6 query compilers
 def test_describe_numeric_only(data):
     with SqlCounter(query_count=1, union_count=5 if len(data) == 1 else 7):
         eval_snowpark_pandas_result(*create_test_dfs(data), lambda df: df.describe())

--- a/tests/integ/modin/frame/test_describe.py
+++ b/tests/integ/modin/frame/test_describe.py
@@ -108,15 +108,16 @@ def test_describe_empty_cols():
         # Since we have K=2 object columns, the result is 9 + (4 * 2 - 1) = 16 UNIONs.
         ([int, object], None, None, 16),
         (np.number, [], None, 7),
-        # Including only datetimes has 1 fewer UNION, since it has 7 statistics
-        # since std is not computed.
-        # (count, mean, min, 0.25, 0.5, 0.75, max)
-        (np.datetime64, [], None, 6),
+        # Including only datetimes has 7 statistics since std is not computed.
+        # Since there is only 1 column, all quantiles are computed in a single QC.
+        # (count, mean, min, [0.25, 0.5, 0.75], max)
+        (np.datetime64, [], None, 4),
         ([int, np.datetime64], [], None, 7),
         # *** Only exclude is specified ***
         (None, [int, object], None, 7),
         # np.datetime64 is not a subtype of np.number, and should still be included
-        (None, [object, "number"], None, 6),
+        # There's only one column, so quantiles are computed together.
+        (None, [object, "number"], None, 4),
         # Error if all columns get excluded
         (None, [object, "number", np.datetime64], ValueError, 0),
         # When include is "all", exclude must be unspecified
@@ -327,8 +328,8 @@ DUP_COL_FAIL_REASON = "SNOW-1019479: describe on frames with mixed object/number
         ),
         (object, None, 5),
         (None, object, 7),
-        (int, float, 7),
-        (float, int, 7),
+        (int, float, 5),
+        (float, int, 5),
     ],
 )
 def test_describe_duplicate_columns(include, exclude, expected_union_count):

--- a/tests/integ/modin/frame/test_quantile.py
+++ b/tests/integ/modin/frame/test_quantile.py
@@ -8,7 +8,6 @@ import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import create_test_dfs, eval_snowpark_pandas_result
 
@@ -133,15 +132,15 @@ def test_quantile_datetime_negative():
 
 
 @pytest.mark.xfail(
-    reason="Bug in quantile emitting large amount of queries except for small data. TODO: SNOW-1229442"
+    reason="Bug in quantile emitting large amount of queries except for small data. TODO: SNOW-1229442",
+    strict=True,
 )
-@pytest.mark.skipif(running_on_public_ci())
 @sql_count_checker(query_count=0)
 def test_quantile_large():
     snow_series = pd.DataFrame({"a": range(1000), "b": range(1000)})
     q = np.linspace(0, 1, 16)
 
     # actual query count for this 81. This seems like a bug.
-    ans = snow_series.quantile(q, "linear").to_pandas()
+    ans = snow_series.quantile(q, interpolation="linear").to_pandas()
 
     assert len(ans) == len(q)

--- a/tests/integ/modin/frame/test_quantile.py
+++ b/tests/integ/modin/frame/test_quantile.py
@@ -50,7 +50,7 @@ def test_quantile_basic(q, interpolation):
 @pytest.mark.parametrize("q", TEST_QUANTILES)
 def test_quantile_single_column(q):
     # When the input frame has only a single column, and q is sorted, no UNION ALLs are performed
-    expected_union_count = len(q) - 1 if sorted(q) != q else 0
+    expected_union_count = 0 if isinstance(q, float) or sorted(q) == q else len(q) - 1
     snow_df, native_df = create_test_dfs({"a": [1, 2, 3, 4]})
     with SqlCounter(query_count=1, union_count=expected_union_count):
         eval_snowpark_pandas_result(snow_df, native_df, lambda df: df.quantile(q))

--- a/tests/integ/modin/frame/test_quantile.py
+++ b/tests/integ/modin/frame/test_quantile.py
@@ -49,16 +49,17 @@ def test_quantile_basic(q, interpolation):
 
 @pytest.mark.parametrize("q", TEST_QUANTILES)
 def test_quantile_single_column(q):
-    # When the input frame has only a single column, no UNION ALLs are performed
+    # When the input frame has only a single column, and q is sorted, no UNION ALLs are performed
+    expected_union_count = len(q) - 1 if sorted(q) != q else 0
     snow_df, native_df = create_test_dfs({"a": [1, 2, 3, 4]})
-    with SqlCounter(query_count=1, union_count=0):
+    with SqlCounter(query_count=1, union_count=expected_union_count):
         eval_snowpark_pandas_result(snow_df, native_df, lambda df: df.quantile(q))
     # This should apply even if the input frame has multiple columns, but numeric_only=True
     # filters it down to only one
     snow_df, native_df = create_test_dfs(
         {"a": [1, 2, 3, 4], "b": ["the", "quick", "brown", "fox"]}
     )
-    with SqlCounter(query_count=1, union_count=0):
+    with SqlCounter(query_count=1, union_count=expected_union_count):
         eval_snowpark_pandas_result(
             snow_df, native_df, lambda df: df.quantile(q, numeric_only=True)
         )

--- a/tests/integ/modin/frame/test_quantile.py
+++ b/tests/integ/modin/frame/test_quantile.py
@@ -8,8 +8,9 @@ import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
+from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
-from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.integ.modin.utils import create_test_dfs, eval_snowpark_pandas_result
 
 TEST_QUANTILE_DATA = {
     "dates": [
@@ -27,7 +28,7 @@ TEST_QUANTILE_DATA = {
 TEST_QUANTILES = [
     0.1,
     [0.1, 0.2, 0.8],
-    [0.2, 0.8, 0.1],  # output will not be sorted by quantile
+    [0.2, 0.9, 0.8, 0.5, 0.1],  # output will not be sorted by quantile
 ]
 
 
@@ -36,13 +37,30 @@ TEST_QUANTILES = [
 def test_quantile_basic(q, interpolation):
     snow_df = pd.DataFrame(TEST_QUANTILE_DATA)
     native_df = native_pd.DataFrame(TEST_QUANTILE_DATA)
-    expected_query_count = 2 if isinstance(q, list) else 0
-
-    with SqlCounter(query_count=1, union_count=expected_query_count):
+    with SqlCounter(
+        query_count=1, union_count=0 if isinstance(q, float) else len(q) - 1
+    ):
         eval_snowpark_pandas_result(
             snow_df,
             native_df,
             lambda df: df.quantile(q, numeric_only=True),
+        )
+
+
+@pytest.mark.parametrize("q", TEST_QUANTILES)
+def test_quantile_single_column(q):
+    # When the input frame has only a single column, no UNION ALLs are performed
+    snow_df, native_df = create_test_dfs({"a": [1, 2, 3, 4]})
+    with SqlCounter(query_count=1, union_count=0):
+        eval_snowpark_pandas_result(snow_df, native_df, lambda df: df.quantile(q))
+    # This should apply even if the input frame has multiple columns, but numeric_only=True
+    # filters it down to only one
+    snow_df, native_df = create_test_dfs(
+        {"a": [1, 2, 3, 4], "b": ["the", "quick", "brown", "fox"]}
+    )
+    with SqlCounter(query_count=1, union_count=0):
+        eval_snowpark_pandas_result(
+            snow_df, native_df, lambda df: df.quantile(q, numeric_only=True)
         )
 
 
@@ -111,3 +129,18 @@ def test_quantile_datetime_negative():
     snow_df = pd.DataFrame(TEST_QUANTILE_DATA)
     with pytest.raises(NotImplementedError):
         snow_df.quantile(numeric_only=False)
+
+
+@pytest.mark.xfail(
+    reason="Bug in quantile emitting large amount of queries except for small data. TODO: SNOW-1229442"
+)
+@pytest.mark.skipif(running_on_public_ci())
+@sql_count_checker(query_count=0)
+def test_quantile_large():
+    snow_series = pd.DataFrame({"a": range(1000), "b": range(1000)})
+    q = np.linspace(0, 1, 16)
+
+    # actual query count for this 81. This seems like a bug.
+    ans = snow_series.quantile(q, "linear").to_pandas()
+
+    assert len(ans) == len(q)

--- a/tests/integ/modin/series/test_quantile.py
+++ b/tests/integ/modin/series/test_quantile.py
@@ -137,16 +137,13 @@ def test_quantile_datetime_negative():
         snow_ser.quantile()
 
 
-@pytest.mark.xfail(
-    reason="Bug in quantile emitting large amount of queries except for small data. TODO: SNOW-1229442"
-)
+@sql_count_checker(query_count=1)
 def test_quantile_large():
     snow_series = pd.Series(range(1000))
     q = np.linspace(0, 1, 16)
 
     # actual query count for this 81. This seems like a bug.
-    with SqlCounter(query_count=1):
-        ans = snow_series.quantile(q, "linear").to_pandas()
+    ans = snow_series.quantile(q, "linear").to_pandas()
 
     assert len(ans) == len(q)
 

--- a/tests/integ/modin/series/test_quantile.py
+++ b/tests/integ/modin/series/test_quantile.py
@@ -11,7 +11,7 @@ from pandas._testing import assert_almost_equal
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
-from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.integ.modin.utils import create_test_series, eval_snowpark_pandas_result
 
 NUMERIC_DATA = [-5, -2, -1, 0, 1, 3, 4, 5]
 DATETIME_DATA = [
@@ -137,15 +137,13 @@ def test_quantile_datetime_negative():
         snow_ser.quantile()
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=6)
 def test_quantile_large():
-    snow_series = pd.Series(range(1000))
     q = np.linspace(0, 1, 16)
-
-    # actual query count for this 81. This seems like a bug.
-    ans = snow_series.quantile(q, "linear").to_pandas()
-
-    assert len(ans) == len(q)
+    eval_snowpark_pandas_result(
+        *create_test_series(range(1000)),
+        lambda df: df.quantile(q, "linear"),
+    )
 
 
 @pytest.mark.parametrize("q", [-10.0, 8.3])

--- a/tests/integ/modin/series/test_quantile.py
+++ b/tests/integ/modin/series/test_quantile.py
@@ -23,21 +23,24 @@ DATETIME_DATA = [
 
 
 @pytest.mark.parametrize(
-    "q",
+    "q, expected_union_count",
     [
-        [0.1, 0.2, 0.8],
-        [0.2, 0.8, 0.1],  # output will not be sorted by quantile
+        ([0.1, 0.2, 0.8], 0),
+        (
+            [0.2, 0.8, 0.1],
+            2,
+        ),  # output will not be sorted by quantile, and thus cannot use the no-union code
     ],
 )
-@sql_count_checker(query_count=1)
-def test_quantile_basic(q):
+def test_quantile_basic(q, expected_union_count):
     snow_ser = pd.Series(NUMERIC_DATA)
     native_ser = native_pd.Series(NUMERIC_DATA)
-    eval_snowpark_pandas_result(
-        snow_ser,
-        native_ser,
-        lambda df: df.quantile(q),
-    )
+    with SqlCounter(query_count=1, union_count=expected_union_count):
+        eval_snowpark_pandas_result(
+            snow_ser,
+            native_ser,
+            lambda df: df.quantile(q),
+        )
 
 
 @sql_count_checker(query_count=1)

--- a/tests/integ/modin/series/test_quantile.py
+++ b/tests/integ/modin/series/test_quantile.py
@@ -29,7 +29,7 @@ DATETIME_DATA = [
         [0.2, 0.8, 0.1],  # output will not be sorted by quantile
     ],
 )
-@sql_count_checker(query_count=1, union_count=2)
+@sql_count_checker(query_count=1)
 def test_quantile_basic(q):
     snow_ser = pd.Series(NUMERIC_DATA)
     native_ser = native_pd.Series(NUMERIC_DATA)
@@ -40,7 +40,7 @@ def test_quantile_basic(q):
     )
 
 
-@sql_count_checker(query_count=1, union_count=4)
+@sql_count_checker(query_count=1)
 def test_quantile_withna():
     # nans in the data do not affect the quantile
     data = [np.nan, 25, 0, 75, 50, 100, np.nan]

--- a/tests/integ/modin/test_qcut.py
+++ b/tests/integ/modin/test_qcut.py
@@ -271,6 +271,7 @@ def test_qcut_invalid_quantiles_negative(q):
 def test_qcut_two_columns():
     # reported by Mats Stewall, applying qcut twice leads to exploding SQL query.
     # attempt finding a remedy
+
     DATA_PATH = "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1"
     spd_order = pd.read_snowflake(f"{DATA_PATH}.ORDERS").drop(
         ["O_ORDERPRIORITY", "O_CLERK", "O_SHIPPRIORITY", "O_COMMENT"], axis=1

--- a/tests/integ/modin/test_qcut.py
+++ b/tests/integ/modin/test_qcut.py
@@ -42,15 +42,19 @@ def test_qcut_non_series(x, q):
     [
         (5, 1, 1),
         (100, 1, 1),
-        (1000, 1, 16),
+        (1000, 1, 11),
         (5, 10, 2),
         (100, 10, 2),
-        (1000, 10, 122),
-        # TODO: With SNOW-1229442, uncomment the following two lines.
-        # These configs do not work, as the current quantile implementation
-        # is buggy and fails within Snowpark for larger len(q).
-        # (5, 47, 1), (100, 47, 1), (1000, 47, 1),
-        # (5, 10000, 1), (100, 10000, 1), (1000, 10000, 1)
+        (1000, 10, 22),
+        (5, 47, 2),
+        (100, 47, 2),
+        (1000, 47, 22),
+        # TODO: SNOW-1229442
+        # qcut was significantly optimized with SNOW-1368640 and SNOW-1370365, but still
+        # cannot compute 10k q values in a reasonable amount of time.
+        # (5, 10000, 1),
+        # (100, 10000, 1),
+        # (1000, 10000, 1),
     ],
 )
 def test_qcut_series(n, q, expected_query_count):
@@ -64,7 +68,7 @@ def test_qcut_series(n, q, expected_query_count):
     with SqlCounter(
         query_count=expected_query_count,
         high_count_expected=True,
-        high_count_reason="Bug in quantile, TODO SNOW-1229442.",
+        high_count_reason="to_pandas() data transfer issues many CREATE SCOPED TEMPORARY TABLE ... / INSERT INTO ... queries",
     ):
         ans = pd.qcut(snow_series, q, labels=False, duplicates="drop")
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(ans, native_ans)
@@ -105,8 +109,9 @@ def test_qcut_series_with_none_labels(n, q, expected_query_count):
     [
         1,
         10,
+        47,
         # TODO: Once SNOW-1229442 is done, uncomment following lin.
-        # 47, 10000
+        # 10000
     ],
 )
 @pytest.mark.parametrize("s", [native_pd.Series([0]), native_pd.Series([1])])
@@ -136,15 +141,16 @@ def test_qcut_series_single_element_negative(q, s):
     [
         1,
         10,
+        47,
         # uncomment this line once quantile is fixed in TODO SNOW-1229442.
-        # 47, 10000
+        # 10000
     ],
 )
 @pytest.mark.parametrize("s", [native_pd.Series([0]), native_pd.Series([1])])
 def test_qcut_series_single_element(q, s):
     native_ans = native_pd.qcut(s, q, duplicates="drop", labels=False)
 
-    with SqlCounter(query_count=1 if q == 1 else 2, join_count=1, union_count=q):
+    with SqlCounter(query_count=1 if q == 1 else 2, join_count=1):
         ans = pd.qcut(pd.Series(s), q, duplicates="drop", labels=False)
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(ans, native_ans)
 
@@ -200,16 +206,16 @@ def test_qcut_increasing_quantiles_negative(q):
 
 @pytest.mark.parametrize("data", [[2014, 2014, 2015, 2016, 2017, 2014]])
 @pytest.mark.parametrize(
-    "q,union_count",
-    [([0, 0.15, 0.35, 0.51, 0.78, 1], 5), ([0, 0.5, 1], 2), ([0.2, 0.8], 1)],
+    "q",
+    [[0, 0.15, 0.35, 0.51, 0.78, 1], [0, 0.5, 1], [0.2, 0.8]],
 )
-def test_qcut_list_of_values(data, q, union_count):
+def test_qcut_list_of_values(data, q):
     native_s = native_pd.Series(data)
     snow_s = pd.Series(data)
 
     native_ans = native_pd.qcut(native_s, q, duplicates="drop", labels=False)
 
-    with SqlCounter(query_count=1, join_count=1, union_count=union_count):
+    with SqlCounter(query_count=1, join_count=1):
         ans = pd.qcut(snow_s, q, duplicates="drop", labels=False)
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(ans, native_ans)
 
@@ -229,7 +235,7 @@ def test_qcut_list_of_values_raise_negative():
     with pytest.raises(ValueError, match=expected_msg):
         native_pd.qcut(native_s, q, duplicates="raise", labels=False)
 
-    with SqlCounter(query_count=3, union_count=10):
+    with SqlCounter(query_count=3):
         with pytest.raises(ValueError, match=expected_msg):
             pd.qcut(snow_s, q, duplicates="raise", labels=False)
 

--- a/tests/integ/modin/test_qcut.py
+++ b/tests/integ/modin/test_qcut.py
@@ -272,7 +272,6 @@ def test_qcut_invalid_quantiles_negative(q):
 def test_qcut_two_columns():
     # reported by Mats Stewall, applying qcut twice leads to exploding SQL query.
     # attempt finding a remedy
-
     DATA_PATH = "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1"
     spd_order = pd.read_snowflake(f"{DATA_PATH}.ORDERS").drop(
         ["O_ORDERPRIORITY", "O_CLERK", "O_SHIPPRIORITY", "O_COMMENT"], axis=1

--- a/tests/integ/modin/test_qcut.py
+++ b/tests/integ/modin/test_qcut.py
@@ -264,8 +264,7 @@ def test_qcut_invalid_quantiles_negative(q):
 
 @sql_count_checker(
     query_count=5,
-    join_count=34,
-    union_count=90,
+    join_count=14,
     high_count_expected=True,
     high_count_reason="data pipeline, to_pandas() data transfer issues many CREATE SCOPED TEMPORARY TABLE ... / INSERT INTO ... queries",
 )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1370365

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR avoids UNION ALL operations for computing quantiles over 1-column datasets. This optimization has significant implications for `pd.qcut`, which frequently computes a large number of quantiles and previously would had extremely high union counts in queries.
In particular, `test_qcut.py::test_qcut_two_columns` goes from 90 unions -> 0 unions, 34 joins -> 14 joins; and `series/test_quantile.py::test_quantile_large' goes from ~80 queries -> 6 queries.