### PR TITLE
SNOW-1235486: local testing add more type support for to_char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Release History
 
 ## 1.17.0 (TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Release History
 
 ## 1.17.0 (TBD)
@@ -7,6 +8,10 @@
 #### New Features
 
 - Added support for NumericType and VariantType data conversion in the mocked function `to_timestamp_ltz`, `to_timestamp_ntz`, `to_timestamp_tz` and `to_timestamp`.
+- Added support for DecimalType, BinaryType, ArrayType, MapType, TimestampType, DateType and TimeType data conversion in the mocked function `to_char`.
+- Added support for the following APIs:
+  - snowflake.snowpark.functions:
+    - to_varchar
 
 #### Bug Fixes
 
@@ -16,6 +21,7 @@
 - Fixed a bug that stage operation can not handle directories.
 - Fixed a bug that `DataFrame.to_pandas` should take Snowflake numeric types with precision 38 as `int64`.
 - Fixed a bug that stored proc and udf should not remove imports already in the sys.path during the clean-up step.
+- Fixed a bug that when processing datetime format, fractional second part is not handled properly.
 
 ## 1.16.0 (TBD)
 

--- a/src/snowflake/snowpark/mock/_util.py
+++ b/src/snowflake/snowpark/mock/_util.py
@@ -119,33 +119,33 @@ def array_custom_comparator(ascend: bool, null_first: bool, a: Any, b: Any):
     return ret if ascend else -1 * ret
 
 
-def convert_snowflake_datetime_format(format, default_format) -> Tuple[str, int, int]:
+def convert_snowflake_datetime_format(format, default_format) -> Tuple[str, int]:
     """
     unified processing of the time format
     converting snowflake date/time/timestamp format into python datetime format
     """
 
-    # if this is a PM time in 12-hour format, +12 hour
-    hour_delta = 12 if format is not None and "HH12" in format and "PM" in format else 0
-    time_fmt = format.upper() if format else default_format
+    format_to_use = format or default_format
+    time_fmt = format_to_use.upper()
     time_fmt = time_fmt.replace("YYYY", "%Y")
     time_fmt = time_fmt.replace("MM", "%m")
     time_fmt = time_fmt.replace("MON", "%b")
     time_fmt = time_fmt.replace("DD", "%d")
     time_fmt = time_fmt.replace("HH24", "%H")
-    time_fmt = time_fmt.replace("HH12", "%H")
+    time_fmt = time_fmt.replace("HH12", "%I")
+    time_fmt = time_fmt.replace("AM", "%p")
+    time_fmt = time_fmt.replace("PM", "%p")
     time_fmt = time_fmt.replace("MI", "%M")
-    time_fmt = time_fmt.replace("SS", "%S")
     time_fmt = time_fmt.replace("SS", "%S")
     time_fmt = time_fmt.replace("TZHTZM", "%z")
     time_fmt = time_fmt.replace("TZH", "%z")
     fractional_seconds = 9
-    if format is not None and "FF" in format:
+    if "FF" in format_to_use:
         try:
             ff_index = str(time_fmt).index("FF")
             # handle precision string 'FF[0-9]' which could be like FF0, FF1, ..., FF9
-            if str(format[ff_index + 2 : ff_index + 3]).isdigit():
-                fractional_seconds = int(format[ff_index + 2 : ff_index + 3])
+            if str(time_fmt[ff_index + 2 : ff_index + 3]).isdigit():
+                fractional_seconds = int(time_fmt[ff_index + 2 : ff_index + 3])
                 # replace FF[0-9] with %f
                 time_fmt = time_fmt[:ff_index] + "%f" + time_fmt[ff_index + 3 :]
             else:
@@ -154,7 +154,7 @@ def convert_snowflake_datetime_format(format, default_format) -> Tuple[str, int,
             # 'FF' is not in the fmt
             pass
 
-    return time_fmt, hour_delta, fractional_seconds
+    return time_fmt, fractional_seconds
 
 
 def convert_numeric_string_value_to_float_seconds(time: str) -> float:

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -140,6 +140,7 @@ from snowflake.snowpark.functions import (
     to_double,
     to_json,
     to_object,
+    to_varchar,
     to_variant,
     to_xml,
     translate,
@@ -315,20 +316,90 @@ def test_concat_edge_cases(session):
     ["a", col("a")],
 )
 @pytest.mark.parametrize(
-    "data, expected",
-    [(1, "1"), (True, "true")],
+    "data, fmt, expected",
+    [
+        (1, None, "1"),  # IntegerType
+        (12345.6789, None, "12345.6789"),  # FloatType
+        (
+            decimal.Decimal("12345.6789"),
+            None,
+            "12345.678900000000000000",
+        ),  # DecimalType
+        ("abc", None, "abc"),  # StringType
+        (True, None, "true"),  # BooleanType
+        (None, None, None),  # NullType
+        (b"123", None, "313233"),  # BinaryType + default hex encoding
+        (b"123", "hex", "313233"),  # BinaryType + hex encoding
+        (b"123", "base64", "MTIz"),  # BinaryType + base64 encoding
+        (b"123", "utf-8", "123"),  # BinaryType + utf-8 encoding
+    ],
 )
-def test_to_char(session, col_a, data, expected):
+@pytest.mark.parametrize("convert_func", [to_char, to_varchar])
+def test_primitive_to_char(session, col_a, data, fmt, expected, convert_func):
     df = session.create_dataframe([[data]], schema=["a"])
-    res = df.select(to_char(col_a)).collect()
+    res = df.select(convert_func(col_a, fmt)).collect()
     assert res[0][0] == expected
 
 
 @pytest.mark.localtest
-def test_date_to_char(session):
-    df = session.create_dataframe([[datetime.date(2021, 12, 21)]], schema=["a"])
-    res = df.select(to_char(col("a"), "mm-dd-yyyy")).collect()
-    assert res[0][0] == "12-21-2021"
+@pytest.mark.parametrize("convert_func", [to_char, to_varchar])
+def test_date_or_time_to_char(session, convert_func):
+    # DateType
+    df = session.create_dataframe(
+        [datetime.date(2021, 12, 21), datetime.date(1969, 12, 31)], schema=["a"]
+    )
+    assert df.select(convert_func(col("a"), "mm-dd-yyyy")).collect() == [
+        Row("12-21-2021"),
+        Row("12-31-1969"),
+    ]
+    assert df.select(convert_func(col("a"))).collect() == [
+        Row("2021-12-21"),
+        Row("1969-12-31"),
+    ]
+
+    # TimeType
+    df = session.create_dataframe(
+        [datetime.time(9, 12, 56), datetime.time(22, 33, 44)], schema=["a"]
+    )
+    assert df.select(convert_func(col("a"), "mi:hh24:ss")).collect() == [
+        Row("12:09:56"),
+        Row("33:22:44"),
+    ]
+    assert df.select(convert_func(col("a"), "mi:hh12:ss AM")).collect() == [
+        Row("12:09:56 AM"),
+        Row("33:10:44 PM"),
+    ]
+    assert df.select(convert_func(col("a"))).collect() == [
+        Row("09:12:56"),
+        Row("22:33:44"),
+    ]
+
+    # TimestampType
+    df = session.create_dataframe(
+        [
+            datetime.datetime(2021, 12, 21, 9, 12, 56),
+            datetime.datetime(1969, 1, 1, 1, 1, 1),
+        ],
+        schema=["a"],
+    )
+    assert df.select(convert_func(col("a"), "mm-dd-yyyy mi:ss:hh24")).collect() == [
+        Row("12-21-2021 12:56:09"),
+        Row("01-01-1969 01:01:01"),
+    ]
+    assert df.select(convert_func(col("a"))).collect() == [
+        Row("2021-12-21 09:12:56.000"),
+        Row("1969-01-01 01:01:01.000"),
+    ]
+
+
+@pytest.mark.localtest
+@pytest.mark.parametrize("convert_func", [to_char, to_varchar])
+def test_semi_structure_to_char(session, convert_func):
+    assert session.create_dataframe([1]).select(
+        convert_func(to_array(lit("Example"))),  # ArrayType
+        convert_func(to_variant(lit("Example"))),  # VariantType
+        convert_func(to_object(parse_json(lit('{"Tree": "Pine"}')))),  # MapType
+    ).collect() == [Row('["Example"]', "Example", '{"Tree":"Pine"}')]
 
 
 def test_format_number(session):

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -398,8 +398,10 @@ def test_semi_structure_to_char(session, convert_func):
     assert session.create_dataframe([1]).select(
         convert_func(to_array(lit("Example"))),  # ArrayType
         convert_func(to_variant(lit("Example"))),  # VariantType
+        convert_func(to_variant(lit(123))),  # VariantType
+        convert_func(to_variant(lit("123"))),  # VariantType
         convert_func(to_object(parse_json(lit('{"Tree": "Pine"}')))),  # MapType
-    ).collect() == [Row('["Example"]', "Example", '{"Tree":"Pine"}')]
+    ).collect() == [Row('["Example"]', "Example", "123", "123", '{"Tree":"Pine"}')]
 
 
 def test_format_number(session):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1235486

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

this PR does the following things:

1. added more types support to to_char mock function including DecimalType, BinaryType, ArrayType, MapType, TimestampType, DateType and TimeType.
2. added to_varchar support which is an alias of to_char
3. refactor convert_snowflake_datetime_format to use native python mechanism to handle AM/PM
4. fixed a bug in convert_snowflake_datetime_format to handle fractional second part
5. raise notimplementederror for unsupported cases