### PR TITLE
Fix structured types related test failures.

### DIFF
--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -313,9 +313,7 @@ def test_structured_dtypes(session, query, expected_dtypes, expected_schema):
     "query,expected_dtypes,expected_schema",
     [STRUCTURED_TYPES_EXAMPLES[IS_STRUCTURED_TYPES_SUPPORTED]],
 )
-def test_structured_dtypes_select(
-    session, query, expected_dtypes, expected_schema, sql_simplifier_enabled
-):
+def test_structured_dtypes_select(session, query, expected_dtypes, expected_schema):
     df = session.sql(query)
     flattened_df = df.select(
         df.map["k1"].alias("value1"),

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 
 import pytest
 
+from snowflake.connector.options import installed_pandas
 from snowflake.snowpark import Row
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import col, lit, udf
@@ -304,11 +305,17 @@ def test_structured_dtypes(session, query, expected_dtypes, expected_schema):
     assert df.dtypes == expected_dtypes
 
 
+@pytest.mark.skipif(
+    "config.getvalue('disable_sql_simplifier')",
+    reason="without sql_simplifier returned types are all variants",
+)
 @pytest.mark.parametrize(
     "query,expected_dtypes,expected_schema",
     [STRUCTURED_TYPES_EXAMPLES[IS_STRUCTURED_TYPES_SUPPORTED]],
 )
-def test_structured_dtypes_select(session, query, expected_dtypes, expected_schema):
+def test_structured_dtypes_select(
+    session, query, expected_dtypes, expected_schema, sql_simplifier_enabled
+):
     df = session.sql(query)
     flattened_df = df.select(
         df.map["k1"].alias("value1"),
@@ -341,6 +348,7 @@ def test_structured_dtypes_select(session, query, expected_dtypes, expected_sche
     ]
 
 
+@pytest.mark.skipif(not installed_pandas, reason="Pandas required for this test.")
 @pytest.mark.parametrize(
     "query,expected_dtypes,expected_schema",
     [STRUCTURED_TYPES_EXAMPLES[IS_STRUCTURED_TYPES_SUPPORTED]],


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR fixes two test failures in the daily precommit job.

- test_structured_dtypes_pandas was failing when pandas is not available. I've added a skip for when pandas is not installed since it is required for this test.
- test_structured_dtypes_select was failing because it relies on the sql simplifier to resolve type information for queries that extract nested data from structured types. I've added a skip so that the test does not run when the simplifier is enabled. It may be worthwhile show in that test that Variants are expected when the simplifier is disabled.