### PR TITLE
SNOW-1374343: Use 48 pytest processes.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
     ci: SNOWFLAKE_PYTEST_VERBOSITY = -vvv
     # Do not run doctests in parallel so coverage works
-    # Snowpark uses 24 workers to accelerate testing in merge gate
-    !doctest: SNOWFLAKE_PYTEST_PARALLELISM = -n 24
+    # Snowpark uses 48 workers to accelerate testing in merge gate
+    !doctest: SNOWFLAKE_PYTEST_PARALLELISM = -n 48
     # Snowpark uses 4 workers for daily testing since some of its test jobs use weak MacOS instances.
     !doctest: SNOWFLAKE_PYTEST_DAILY_PARALLELISM = -n 4
     # Set test type, either notset, unit, integ, or both


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1374343

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    CI  times for this PR:
     - [GCP](https://github.com/snowflakedb/snowpark-python/actions/runs/9025175335/job/24800489292?pr=1553): 25 minutes
     - [AWS](https://github.com/snowflakedb/snowpark-python/actions/runs/9025175335/job/24800489826?pr=1553): 20 minutes
     - [Azure](https://github.com/snowflakedb/snowpark-python/actions/runs/9025175335/job/24800490421?pr=1553): 22 minutes

These are a bit better than the usual times, but it's hard to tell because CI time is so variable (probably dependent on how many different jobs are running at the same time-- see SNOW-1347210). 

Let's make this commit and see whether the warehouses can handle the extra load without too much queueing. We have set `MAX_CONCURRENCY_LEVEL` on the warehouse for each cloud provider.