### PR TITLE
SNOW-1361200 Fix ambiguous row label error

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -2,12 +2,7 @@
 
 ### Bug Fixes
 - Fixed bug when creating a DataFrame with a dict of Series objects.
-- Fixed incorrect return type in `qcut` when given `Series` input and improved error checking logic.
 - Fixed bug when performing multiple DataFrameGroupBy apply/transform operations on the same DataFrame.
-
-### Behavior Changes
-- Given an input of type `Series`, `pd.qcut` always returns a `Series`.
-- `pd.qcut` produces `NotImplementedError` whenever `labels is not False` instead of falling back to pandas itself.
 
 ## 1.15.0a1 (2024-07-05)
 
@@ -20,6 +15,7 @@
 - Fixed AssertionError in `Series.sort_values` after repr and indexing operations.
 - Fixed UDTF "int64 is not serializable" errors from new Snowflake release in `apply(axis=1)`
 - Fixed binary operations with single-row DataFrame and Series.
+- Fixed incorrect return type in `qcut` when given `Series` input and improved error checking logic.
 
 ### Behavior Changes
 - Raise not implemented error instead of fallback to pandas in the following APIs:
@@ -53,6 +49,8 @@
   - A new row and column are used in the row and column keys (https://github.com/pandas-dev/pandas/issues/58316).
   Snowpark pandas deviates from this behavior and will maintain the same behavior as pandas from versions 1.5.x.
 - Changed the import path of Snowpark pandas package to use Modin 0.28.1 instead. The new recommended import statement is `import modin.pandas as pd; import snowflake.snowpark.modin.plugin`.
+- Given an input of type `Series`, `pd.qcut` always returns a `Series`.
+- `pd.qcut` produces `NotImplementedError` whenever `labels is not False` instead of falling back to pandas itself.
 
 ### Improvements
 - Improved performance for `pd.qcut`, `Series.quantile`, `Series.describe`. Also improved `DataFrame.quantile` and `DataFrame.describe` for one-column `DataFrame`s.

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 - Fixed bug when creating a DataFrame with a dict of Series objects.
+- Fixed bug when performing multiple DataFrameGroupBy apply/transform operations on the same DataFrame.
 
 ## 1.15.0a1 (2024-07-05)
 

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Bug Fixes
 - Fixed bug when creating a DataFrame with a dict of Series objects.
+- Fixed incorrect return type in `qcut` when given `Series` input and improved error checking logic.
 - Fixed bug when performing multiple DataFrameGroupBy apply/transform operations on the same DataFrame.
+
+### Behavior Changes
+- Given an input of type `Series`, `pd.qcut` always returns a `Series`.
 
 ## 1.15.0a1 (2024-07-05)
 
@@ -15,7 +19,6 @@
 - Fixed AssertionError in `Series.sort_values` after repr and indexing operations.
 - Fixed UDTF "int64 is not serializable" errors from new Snowflake release in `apply(axis=1)`
 - Fixed binary operations with single-row DataFrame and Series.
-- Fixed incorrect return type in `qcut` when given `Series` input and improved error checking logic.
 
 ### Behavior Changes
 - Raise not implemented error instead of fallback to pandas in the following APIs:
@@ -49,7 +52,6 @@
   - A new row and column are used in the row and column keys (https://github.com/pandas-dev/pandas/issues/58316).
   Snowpark pandas deviates from this behavior and will maintain the same behavior as pandas from versions 1.5.x.
 - Changed the import path of Snowpark pandas package to use Modin 0.28.1 instead. The new recommended import statement is `import modin.pandas as pd; import snowflake.snowpark.modin.plugin`.
-- Given an input of type `Series`, `pd.qcut` always returns a `Series`.
 
 ### Improvements
 - Improved performance for `pd.qcut`, `Series.quantile`, `Series.describe`. Also improved `DataFrame.quantile` and `DataFrame.describe` for one-column `DataFrame`s.

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -47,8 +47,6 @@ from snowflake.snowpark.window import Window
 
 APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER = '"LABEL"'
 APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER = '"VALUE"'
-APPLY_ORIGINAL_ROW_POSITION_COLUMN_QUOTED_IDENTIFIER = '"ORIGINAL_ROW_POSITION"'
-APPLY_ROW_POSITION_WITHIN_GROUP_COLUMN_QUOTED_IDENTIFIER = '"ROW_POSITION_WITHIN_GROUP"'
 APPLY_FIRST_GROUP_KEY_OCCURRENCE_POSITION_QUOTED_IDENTIFIER = (
     '"FIRST_GROUP_KEY_OCCURRENCE_POSITION"'
 )
@@ -614,15 +612,19 @@ def create_udtf_for_groupby_apply(
         # ...then the data columns for the input dataframe or series.
         *input_data_column_types,
     ]
+    # Random number generator to create a number to append to column names for UDTF.
+    # Need to generate this since a collision with "ROW_POSITION_WITHIN_GROUP" and "ORIGINAL_ROW_POSITON"
+    # occurs when two groupby transform/apply operations are performed on the same DataFrame.
+    rng = np.random.default_rng()
     return udtf(
         ApplyFunc,
         output_schema=PandasDataFrameType(
             [StringType(), IntegerType(), VariantType(), IntegerType(), IntegerType()],
             [
                 APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER,
-                APPLY_ROW_POSITION_WITHIN_GROUP_COLUMN_QUOTED_IDENTIFIER,
+                f'"ROW_POSITION_WITHIN_GROUP_{str(rng.random(size=1))}"',
                 APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER,
-                APPLY_ORIGINAL_ROW_POSITION_COLUMN_QUOTED_IDENTIFIER,
+                f'"ORIGINAL_ROW_POSITION_{str(rng.random(size=1))}"',
                 APPLY_FIRST_GROUP_KEY_OCCURRENCE_POSITION_QUOTED_IDENTIFIER,
             ],
         ),

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -25,6 +25,7 @@ from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
 )
 from snowflake.snowpark.modin.plugin._internal.utils import (
     TempObjectType,
+    generate_snowflake_quoted_identifiers_helper,
     parse_object_construct_snowflake_quoted_identifier_and_extract_pandas_label,
     parse_snowflake_object_construct_identifier_to_map,
 )
@@ -47,9 +48,6 @@ from snowflake.snowpark.window import Window
 
 APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER = '"LABEL"'
 APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER = '"VALUE"'
-APPLY_FIRST_GROUP_KEY_OCCURRENCE_POSITION_QUOTED_IDENTIFIER = (
-    '"FIRST_GROUP_KEY_OCCURRENCE_POSITION"'
-)
 
 # Default partition size to use when applying a UDTF. A higher value results in less parallelism, less contention and higher batching.
 DEFAULT_UDTF_PARTITION_SIZE = 1000
@@ -385,6 +383,7 @@ def create_udtf_for_groupby_apply(
     session: Session,
     series_groupby: bool,
     by_types: list[DataType],
+    existing_identifiers: list[str],
 ) -> UserDefinedTableFunction:
     """
     Create a UDTF from the Python function for groupby.apply.
@@ -473,14 +472,15 @@ def create_udtf_for_groupby_apply(
     input_index_column_types: Types of the input dataframe's index columns
     series_groupby: Whether we are performing a SeriesGroupBy.apply() instead of DataFrameGroupBy.apply()
     by_types: The snowflake types of the by columns.
+    existing_identifiers: List of existing column identifiers; these are omitted when creating new column identifiers.
 
     Returns
     -------
     A UDTF that will apply the provided function to a group and return a
-    dataframe representing all of the data and metadata of the result.
+    dataframe representing all the data and metadata of the result.
     """
 
-    # Get the length of this list outside of the vUDTF function because the vUDTF
+    # Get the length of this list outside the vUDTF function because the vUDTF
     # doesn't have access to the Snowpark module, which defines these types.
     num_by = len(by_types)
 
@@ -500,7 +500,7 @@ def create_udtf_for_groupby_apply(
             """
             current_column_position = 0
 
-            # First column is row position. Save it for later.
+            # The first column is row position. Save it for later.
             row_position_column_number = 0
             row_positions = df.iloc[:, row_position_column_number]
             current_column_position = row_position_column_number + 1
@@ -612,21 +612,26 @@ def create_udtf_for_groupby_apply(
         # ...then the data columns for the input dataframe or series.
         *input_data_column_types,
     ]
-    # Random number generator to create a number to append to column names for UDTF.
-    # Need to generate this since a collision with "ROW_POSITION_WITHIN_GROUP" and "ORIGINAL_ROW_POSITON"
-    # occurs when two groupby transform/apply operations are performed on the same DataFrame.
-    rng = np.random.default_rng()
+
+    col_labels = [
+        "LABEL",
+        "ROW_POSITION_WITHIN_GROUP",
+        "VALUE",
+        "ORIGINAL_ROW_POSITION",
+        "APPLY_FIRST_GROUP_KEY_OCCURRENCE_POSITION",
+    ]
+    # Generate new column identifiers for all required UDTF columns with the helper below to prevent collisions in
+    # column identifiers.
+    col_names = generate_snowflake_quoted_identifiers_helper(
+        pandas_labels=col_labels,
+        excluded=existing_identifiers,
+        wrap_double_underscore=False,
+    )
     return udtf(
         ApplyFunc,
         output_schema=PandasDataFrameType(
             [StringType(), IntegerType(), VariantType(), IntegerType(), IntegerType()],
-            [
-                APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER,
-                f'"ROW_POSITION_WITHIN_GROUP_{str(rng.random(size=1))}"',
-                APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER,
-                f'"ORIGINAL_ROW_POSITION_{str(rng.random(size=1))}"',
-                APPLY_FIRST_GROUP_KEY_OCCURRENCE_POSITION_QUOTED_IDENTIFIER,
-            ],
+            col_names,
         ),
         input_types=[PandasDataFrameType(col_types=input_types)],
         # We have to specify the local pandas package so that the UDF's pandas

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -2838,6 +2838,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 snowflake_type_map[quoted_identifier]
                 for quoted_identifier in by_snowflake_quoted_identifiers_list
             ],
+            existing_identifiers=self._modin_frame.ordered_dataframe._dataframe_ref.snowflake_quoted_identifiers,
         )
 
         new_internal_df = self._modin_frame.ensure_row_position_column()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1361200

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
- The bug here is caused due to the implementation of `create_udtf_for_groupby_apply`. Groupby apply/transform use this method to create a UDTF. 
- When multiple groupby apply/transform operations are performed on the same DataFrame, this method is called multiple times. However, it uses a fixed name for the column labels used to create the OrderedDataFrame used with the UDTF. This is what causes the issue - "ambiguous column name 'ROW_POSITION_WITHIN_GROUP'".
- "'ROW_POSITION_WITHIN_GROUP'" is a column label created and used by `create_udtf_for_groupby_apply`.
- Similarly, this issue occurs with the "'ORIGINAL_ROW_POSITION'"column label.
- To solve this issue, I appended a random number at the end of these column labels to prevent the collision and eradicate the error.