### PR TITLE
SNOW-1359484 Allow write Snowpark pandas DataFrame and Series in sess…

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -9,6 +9,7 @@ import datetime
 import decimal
 import functools
 import hashlib
+import importlib
 import io
 import logging
 import os
@@ -41,7 +42,11 @@ from typing import (
 import snowflake.snowpark
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.description import OPERATING_SYSTEM, PLATFORM
-from snowflake.connector.options import pandas
+from snowflake.connector.options import (
+    MissingOptionalDependency,
+    ModuleLikeObject,
+    pandas,
+)
 from snowflake.connector.version import VERSION as connector_version
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark.row import Row
@@ -950,3 +955,21 @@ def prepare_pivot_arguments(
         )
 
     return df, pc, pivot_values, default_on_null
+
+
+class MissingModin(MissingOptionalDependency):
+    """The class is specifically for modin optional dependency."""
+
+    _dep_name = "modin"
+
+
+def import_or_missing_modin_pandas() -> tuple[ModuleLikeObject, bool]:
+    """This function tries importing the following packages: modin.pandas
+
+    If available it returns modin package with a flag of whether it was imported.
+    """
+    try:
+        modin = importlib.import_module("modin.pandas")
+        return modin, True
+    except ImportError:
+        return MissingModin(), False

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -963,7 +963,7 @@ class MissingModin(MissingOptionalDependency):
     _dep_name = "modin"
 
 
-def import_or_missing_modin_pandas() -> tuple[ModuleLikeObject, bool]:
+def import_or_missing_modin_pandas() -> Tuple[ModuleLikeObject, bool]:
     """This function tries importing the following packages: modin.pandas
 
     If available it returns modin package with a flag of whether it was imported.

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Improvements
 - Improved performance of `pd.qcut` by removing joins in generated sql query.
 
+### Improvements
+- Allow `session.write_pandas` to write Snowpark pandas DataFrame or Series to a table.
+
 ## 1.15.0a1 (2024-07-05)
 
 ### Bug Fixes

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -7,8 +7,6 @@
 
 ### Improvements
 - Improved performance of `pd.qcut` by removing joins in generated sql query.
-
-### Improvements
 - Allow `session.write_pandas` to write Snowpark pandas DataFrame or Series to a table.
 
 ## 1.15.0a1 (2024-07-05)

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2172,7 +2172,8 @@ class Session:
 
         if not auto_create_table and not self._table_exists(name):
             raise SnowparkClientException(
-                f"Cannot write Snowpark pandas DataFrame to table {location} because it does not exist. Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame"
+                f"Cannot write Snowpark pandas DataFrame or Series to table {location} because it does not exist. Use "
+                f"auto_create_table = True to create table before writing a Snowpark pandas DataFrame or Series"
             )
         if_exists = "replace" if overwrite else "append"
         df.to_snowflake(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2277,10 +2277,11 @@ class Session:
             your pandas DataFrame cannot be written to the specified table, an
             exception will be raised.
 
-            If the dataframe is :class:`~snowflake.snowpark.modin.pandas.DataFrame` or :class:`~snowflake.snowpark.modin.pandas.Series`,
-            it will call :func:`snowflake.snowpark.modin.pandas.DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>` or
-             :func:`snowflake.snowpark.modin.pandas.Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>` internally
-            to write a Snowpark pandas DataFrame into a Snowflake table.
+            If the dataframe is Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+            or :class:`~snowflake.snowpark.modin.pandas.Series`, it will call
+            :func:`modin.pandas.DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>`
+            or :func:`modin.pandas.Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>`
+            internally to write a Snowpark pandas DataFrame into a Snowflake table.
         """
         if create_temp_table:
             warning(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2112,9 +2112,84 @@ class Session:
             self._stage_created = True
         return f"{STAGE_PREFIX}{stage_name}"
 
+    def _write_modin_pandas_helper(
+        self,
+        df: Union[
+            "snowflake.snowpark.modin.pandas.DataFrame",  # noqa: F821
+            "snowflake.snowpark.modin.pandas.Series",  # noqa: F821
+        ],
+        table_name: str,
+        location: str,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        quote_identifiers: bool = True,
+        auto_create_table: bool = False,
+        overwrite: bool = False,
+        index: bool = False,
+        index_label: Optional["IndexLabel"] = None,  # noqa: F821
+        table_type: Literal["", "temp", "temporary", "transient"] = "",
+    ) -> None:
+        """A helper method used by `write_pandas` to write Snowpark pandas DataFrame or Series to a table by using
+        :func:`snowflake.snowpark.modin.pandas.DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>` or
+        :func:`snowflake.snowpark.modin.pandas.Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>` internally
+
+        Args:
+            df: The Snowpark pandas DataFrame or Series we'd like to write back.
+            table_name: Name of the table we want to insert into.
+            location: the location of the table in string.
+            database: Database that the table is in. If not provided, the default one will be used.
+            schema: Schema that the table is in. If not provided, the default one will be used.
+            quote_identifiers: By default, identifiers, specifically database, schema, table and column names
+                (from :attr:`DataFrame.columns`) will be quoted. If set to ``False``, identifiers
+                are passed on to Snowflake without quoting, i.e. identifiers will be coerced to uppercase by Snowflake.
+            auto_create_table: When true, automatically creates a table to store the passed in pandas DataFrame using the
+                passed in ``database``, ``schema``, and ``table_name``. Note: there are usually multiple table configurations that
+                would allow you to upload a particular pandas DataFrame successfully. If you don't like the auto created
+                table, you can always create your own table before calling this function. For example, auto-created
+                tables will store :class:`list`, :class:`tuple` and :class:`dict` as strings in a VARCHAR column.
+            overwrite: Default value is ``False`` and the pandas DataFrame data is appended to the existing table. If set to ``True`` and if auto_create_table is also set to ``True``,
+                then it drops the table. If set to ``True`` and if auto_create_table is set to ``False``,
+                then it truncates the table. Note that in both cases (when overwrite is set to ``True``) it will replace the existing
+                contents of the table with that of the passed in pandas DataFrame.
+            index: default True
+                If true, save DataFrame index columns as table columns.
+            index_label:
+                Column label for index column(s). If None is given (default) and index is True,
+                then the index names are used. A sequence should be given if the DataFrame uses MultiIndex.
+            table_type: The table type of table to be created. The supported values are: ``temp``, ``temporary``,
+                and ``transient``. An empty string means to create a permanent table. Learn more about table types
+                `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
+        """
+
+        def quote_id(id: str) -> str:
+            return '"' + id + '"' if quote_identifiers else id
+
+        name = [table_name]
+        if schema:
+            name = [quote_id(schema)] + name
+        if database:
+            name = [quote_id(database)] + name
+
+        if not auto_create_table and not self._table_exists(name):
+            raise SnowparkClientException(
+                f"Cannot write Snowpark pandas DataFrame to table {location} because it does not exist. Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame"
+            )
+        if_exists = "replace" if overwrite else "append"
+        df.to_snowflake(
+            name=name,
+            if_exists=if_exists,
+            index=index,
+            index_label=index_label,
+            table_type=table_type,
+        )
+
     def write_pandas(
         self,
-        df: "pandas.DataFrame",
+        df: Union[
+            "pandas.DataFrame",
+            "snowflake.snowpark.modin.pandas.DataFrame",  # noqa: F821
+            "snowflake.snowpark.modin.pandas.Series",  # noqa: F821
+        ],
         table_name: str,
         *,
         database: Optional[str] = None,
@@ -2135,7 +2210,7 @@ class Session:
         pandas DataFrame was written to.
 
         Args:
-            df: The pandas DataFrame we'd like to write back.
+            df: The pandas DataFrame or Snowpark pandas DataFrame or Series we'd like to write back.
             table_name: Name of the table we want to insert into.
             database: Database that the table is in. If not provided, the default one will be used.
             schema: Schema that the table is in. If not provided, the default one will be used.
@@ -2200,6 +2275,11 @@ class Session:
             Snowflake that the passed in pandas DataFrame can be written to. If
             your pandas DataFrame cannot be written to the specified table, an
             exception will be raised.
+
+            If the dataframe is :class:`~snowflake.snowpark.modin.pandas.DataFrame` or :class:`~snowflake.snowpark.modin.pandas.Series`,
+            it will call :func:`snowflake.snowpark.modin.pandas.DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>` or
+             :func:`snowflake.snowpark.modin.pandas.Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>` internally
+            to write a Snowpark pandas DataFrame into a Snowflake table.
         """
         if create_temp_table:
             warning(
@@ -2241,22 +2321,37 @@ class Session:
                         "snowflake-connector-python to 3.4.0 or above.",
                         stacklevel=1,
                     )
-            success, nchunks, nrows, ci_output = write_pandas(
-                self._conn._conn,
-                df,
-                table_name,
-                database=database,
-                schema=schema,
-                chunk_size=chunk_size,
-                compression=compression,
-                on_error=on_error,
-                parallel=parallel,
-                quote_identifiers=quote_identifiers,
-                auto_create_table=auto_create_table,
-                overwrite=overwrite,
-                table_type=table_type,
-                **kwargs,
-            )
+            if "modin" in str(type(df)):
+                self._write_modin_pandas_helper(
+                    df,
+                    table_name,
+                    location,
+                    database=database,
+                    schema=schema,
+                    quote_identifiers=quote_identifiers,
+                    auto_create_table=auto_create_table,
+                    overwrite=overwrite,
+                    table_type=table_type,
+                    **kwargs,
+                )
+                success, ci_output = True, ""
+            else:
+                success, _, _, ci_output = write_pandas(
+                    self._conn._conn,
+                    df,
+                    table_name,
+                    database=database,
+                    schema=schema,
+                    chunk_size=chunk_size,
+                    compression=compression,
+                    on_error=on_error,
+                    parallel=parallel,
+                    quote_identifiers=quote_identifiers,
+                    auto_create_table=auto_create_table,
+                    overwrite=overwrite,
+                    table_type=table_type,
+                    **kwargs,
+                )
         except ProgrammingError as pe:
             if pe.msg.endswith("does not exist"):
                 raise SnowparkClientExceptionMessages.DF_PANDAS_TABLE_DOES_NOT_EXIST_EXCEPTION(

--- a/tests/integ/modin/test_session_write_pandas.py
+++ b/tests/integ/modin/test_session_write_pandas.py
@@ -240,3 +240,19 @@ def test_write_to_different_schema(session):
             )
     finally:
         Utils.drop_schema(session, test_schema_name)
+
+
+def test_write_series(session):
+    s = pd.Series([1, 2, 3], name="s")
+    try:
+        table_name = random_name_for_temp_object(TempObjectType.TABLE)
+        with SqlCounter(query_count=5):
+            table = session.write_pandas(
+                s,
+                table_name,
+                quote_identifiers=False,
+                auto_create_table=True,
+            )
+            assert_frame_equal(s.to_frame(), table.to_pandas(), check_dtype=False)
+    finally:
+        Utils.drop_table(session, table_name)

--- a/tests/integ/modin/test_session_write_pandas.py
+++ b/tests/integ/modin/test_session_write_pandas.py
@@ -272,13 +272,14 @@ def test_write_pandas_with_quote_identifiers(
             pd1 = pd1.to_pandas()
 
         if is_modin_dataframe and not quote_identifiers:
-            with pytest.raises(NotImplementedError):
-                table1 = session.write_pandas(
-                    pd1,
-                    table_name,
-                    quote_identifiers=quote_identifiers,
-                    auto_create_table=True,
-                )
+            with SqlCounter(query_count=0):
+                with pytest.raises(NotImplementedError):
+                    session.write_pandas(
+                        pd1,
+                        table_name,
+                        quote_identifiers=quote_identifiers,
+                        auto_create_table=True,
+                    )
         else:
             with SqlCounter(query_count=3 if is_modin_dataframe else 0):
                 # Create initial table and insert 3 rows

--- a/tests/integ/modin/test_session_write_pandas.py
+++ b/tests/integ/modin/test_session_write_pandas.py
@@ -1,0 +1,228 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+import modin.pandas as pd
+import pytest
+
+from snowflake.snowpark import Row
+from snowflake.snowpark._internal.utils import (
+    TempObjectType,
+    is_in_stored_procedure,
+    random_name_for_temp_object,
+)
+from snowflake.snowpark.exceptions import SnowparkClientException, SnowparkSQLException
+from snowflake.snowpark.types import (
+    FloatType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
+from tests.integ.modin.utils import assert_frame_equal
+from tests.utils import Utils
+
+
+@pytest.mark.parametrize("quote_identifiers", [True, False])
+@pytest.mark.parametrize("auto_create_table", [True, False])
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_write_pandas_with_overwrite(
+    session,
+    quote_identifiers: bool,
+    auto_create_table: bool,
+    overwrite: bool,
+):
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    try:
+        pd1 = pd.DataFrame(
+            [
+                (1, 4.5, "Nike"),
+                (2, 7.5, "Adidas"),
+                (3, 10.5, "Puma"),
+            ],
+            columns=["id".upper(), "foot_size".upper(), "shoe_make".upper()],
+        )
+
+        pd2 = pd.DataFrame(
+            [(1, 8.0, "Dia Dora")],
+            columns=["id".upper(), "foot_size".upper(), "shoe_make".upper()],
+        )
+
+        pd3 = pd.DataFrame(
+            [(1, "dash", 1000, 32)],
+            columns=["id".upper(), "name".upper(), "points".upper(), "age".upper()],
+        )
+
+        # Create initial table and insert 3 rows
+        table1 = session.write_pandas(
+            pd1, table_name, quote_identifiers=quote_identifiers, auto_create_table=True
+        )
+
+        assert_frame_equal(pd1, table1.to_pandas(), check_dtype=False)
+
+        # Insert 1 row
+        table2 = session.write_pandas(
+            pd2,
+            table_name,
+            quote_identifiers=quote_identifiers,
+            overwrite=overwrite,
+            auto_create_table=auto_create_table,
+        )
+        results = table2.to_pandas()
+        if overwrite:
+            # Results should match pd2
+            assert_frame_equal(results, pd2, check_dtype=False)
+        else:
+            # Results count should match pd1 + pd2
+            assert results.shape[0] == 4
+
+        if overwrite:
+            # In this case, the table is first dropped and since there's a new schema, the results should now match pd3
+            table3 = session.write_pandas(
+                pd3,
+                table_name,
+                quote_identifiers=quote_identifiers,
+                overwrite=overwrite,
+                auto_create_table=auto_create_table,
+            )
+            results = table3.to_pandas()
+            assert_frame_equal(results, pd3, check_dtype=False)
+        else:
+            # In this case, the table is truncated but since there's a new schema, it should fail
+            with pytest.raises(SnowparkSQLException) as ex_info:
+                session.write_pandas(
+                    pd3,
+                    table_name,
+                    quote_identifiers=quote_identifiers,
+                    overwrite=overwrite,
+                    auto_create_table=auto_create_table,
+                )
+            assert "Insert value list does not match column list" in str(ex_info)
+
+        with pytest.raises(SnowparkClientException) as ex_info:
+            session.write_pandas(pd1, "tmp_table")
+        assert (
+            'Cannot write Snowpark pandas DataFrame to table "tmp_table" because it does not exist. '
+            "Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame"
+            in str(ex_info)
+        )
+    finally:
+        Utils.drop_table(session, table_name)
+        Utils.drop_table(session, "tmp_table")
+
+
+@pytest.fixture(scope="module")
+def tmp_table_basic(session):
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    df = session.create_dataframe(
+        data=[],
+        schema=StructType(
+            [
+                StructField("id", IntegerType()),
+                StructField("foot_size", FloatType()),
+                StructField("shoe_model", StringType()),
+            ]
+        ),
+    )
+    df.write.save_as_table(table_name)
+    try:
+        yield table_name
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_write_pandas(session, tmp_table_basic):
+    df = pd.DataFrame(
+        [
+            (1, 4.5, "t1"),
+            (2, 7.5, "t2"),
+            (3, 10.5, "t3"),
+        ],
+        columns=["id".upper(), "foot_size".upper(), "shoe_model".upper()],
+    )
+
+    table = session.write_pandas(df, tmp_table_basic, overwrite=True)
+    results = table.to_pandas()
+    assert_frame_equal(results, df, check_dtype=False)
+
+    # Auto create a new table
+    session._run_query(f'drop table if exists "{tmp_table_basic}"')
+    table = session.write_pandas(df, tmp_table_basic, auto_create_table=True)
+    table_info = session.sql(f"show tables like '{tmp_table_basic}'").collect()
+    assert table_info[0]["kind"] == "TABLE"
+    results = table.to_pandas()
+    assert_frame_equal(results, df, check_dtype=False)
+
+    nonexistent_table = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    with pytest.raises(SnowparkClientException) as ex_info:
+        session.write_pandas(df, nonexistent_table, auto_create_table=False)
+        assert (
+            f'Cannot write Snowpark pandas DataFrame to table "{nonexistent_table}" because it does not exist. '
+            "Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame"
+            in str(ex_info)
+        )
+
+    # Drop tables that were created for this test
+    session._run_query(f'drop table if exists "{tmp_table_basic}"')
+
+
+@pytest.mark.parametrize("table_type", ["", "temp", "temporary", "transient"])
+def test_write_pandas_with_table_type(session, table_type: str):
+    df = pd.DataFrame(
+        [
+            (1, 4.5, "t1"),
+            (2, 7.5, "t2"),
+            (3, 10.5, "t3"),
+        ],
+        columns=["id".upper(), "foot_size".upper(), "shoe_model".upper()],
+    )
+
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    try:
+        table = session.write_pandas(
+            df,
+            table_name,
+            table_type=table_type,
+            auto_create_table=True,
+        )
+        results = table.to_pandas()
+        assert_frame_equal(results, df, check_dtype=False)
+        Utils.assert_table_type(session, table_name, table_type)
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_write_to_different_schema(session, local_testing_mode):
+    pd_df = pd.DataFrame(
+        [
+            (1, 4.5, "Nike"),
+            (2, 7.5, "Adidas"),
+            (3, 10.5, "Puma"),
+        ],
+        columns=["id".upper(), "foot_size".upper(), "shoe_make".upper()],
+    )
+    original_schema_name = session.get_current_schema()
+    test_schema_name = Utils.random_temp_schema()
+
+    try:
+        if not local_testing_mode:
+            Utils.create_schema(session, test_schema_name)
+        # For owner's rights stored proc test, current schema does not change after creating a new schema
+        if not is_in_stored_procedure():
+            session.use_schema(original_schema_name)
+        assert session.get_current_schema() == original_schema_name
+        table_name = random_name_for_temp_object(TempObjectType.TABLE)
+        session.write_pandas(
+            pd_df,
+            table_name,
+            quote_identifiers=False,
+            schema=test_schema_name,
+            auto_create_table=True,
+        )
+        Utils.check_answer(
+            session.table(f"{test_schema_name}.{table_name}").sort("id"),
+            [Row(1, 4.5, "Nike"), Row(2, 7.5, "Adidas"), Row(3, 10.5, "Puma")],
+        )
+    finally:
+        if not local_testing_mode:
+            Utils.drop_schema(session, test_schema_name)

--- a/tests/integ/modin/test_session_write_pandas.py
+++ b/tests/integ/modin/test_session_write_pandas.py
@@ -111,8 +111,8 @@ def test_write_pandas_with_overwrite(
             with pytest.raises(SnowparkClientException) as ex_info:
                 session.write_pandas(pd1, "tmp_table")
             assert (
-                'Cannot write Snowpark pandas DataFrame to table "tmp_table" because it does not exist. '
-                "Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame"
+                'Cannot write Snowpark pandas DataFrame or Series to table "tmp_table" because it does not exist. '
+                "Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame or Series"
                 in str(ex_info)
             )
     finally:
@@ -171,8 +171,8 @@ def test_write_pandas(session, tmp_table_basic):
             with pytest.raises(SnowparkClientException) as ex_info:
                 session.write_pandas(df, nonexistent_table, auto_create_table=False)
                 assert (
-                    f'Cannot write Snowpark pandas DataFrame to table "{nonexistent_table}" because it does not exist. '
-                    "Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame"
+                    f'Cannot write Snowpark pandas DataFrame or Series to table "{nonexistent_table}" because it does not exist. '
+                    "Use auto_create_table = True to create table before writing a Snowpark pandas DataFrame or Series "
                     in str(ex_info)
                 )
     finally:


### PR DESCRIPTION
…ion.write_pandas

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1359484

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Allow user to use `session.write_pandas` to write Snowpark pandas objects:

- It reuse and does not change the interface of `write_pandas`
- it reuse `to_snowflake` to implement the write logic
- copied main tests from `test_pandas_to_df.py` and use them to test writing Snowpark pandas DataFrame.