### PR TITLE
SNOW-1411340: Revert automatic schema inference change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.17.0 (TBD)
 
-### Improvements
-
-- Improved error message to remind users set `{"infer_schema": True}` when reading csv file without specifying its schema.
-
 ### Local Testing Updates
 
 #### New Features

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -103,7 +103,7 @@ class SnowparkClientExceptionMessages:
     @staticmethod
     def DF_MUST_PROVIDE_SCHEMA_FOR_READING_FILE() -> SnowparkDataframeReaderException:
         return SnowparkDataframeReaderException(
-            'No schema specified in DataFrameReader.schema(). Please specify the schema or set session.read.options({"infer_schema":True})',
+            "You must call DataFrameReader.schema() and specify the schema for the file.",
             error_code="1106",
         )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -393,6 +393,9 @@ class DataFrameReader:
         self._file_path = path
         self._file_type = "CSV"
 
+        # infer schema is set to false by default
+        if "INFER_SCHEMA" not in self._cur_options:
+            self._cur_options["INFER_SCHEMA"] = False
         schema_to_cast, transformations = None, None
 
         if not self._user_schema:
@@ -418,7 +421,6 @@ class DataFrameReader:
                 schema_to_cast = [("$1", "C1")]
                 transformations = []
         else:
-            self._cur_options["INFER_SCHEMA"] = False
             schema = self._user_schema._to_attributes()
 
         metadata_project, metadata_schema = self._get_metadata_project_and_schema()

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -255,6 +255,9 @@ def test_read_csv(session, mode):
     assert len(res[0]) == 3
     assert res == [Row(1, "one", 1.2), Row(2, "two", 2.2)]
 
+    with pytest.raises(SnowparkDataframeReaderException):
+        session.read.csv(test_file_on_stage)
+
     # if users give an incorrect schema with type error
     # the system will throw SnowflakeSQLException during execution
     incorrect_schema = StructType(
@@ -349,26 +352,6 @@ def test_read_csv(session, mode):
     with pytest.raises(SnowparkSQLException) as ex_info:
         df3.collect()
     assert "is out of range" in str(ex_info)
-
-
-def test_read_csv_with_default_infer_schema(session):
-    test_file_on_stage = f"@{tmp_stage_name1}/{test_file_csv}"
-
-    with pytest.raises(SnowparkDataframeReaderException) as exec_info:
-        session.read.options({"infer_schema": False}).csv(test_file_on_stage)
-    assert (
-        'No schema specified in DataFrameReader.schema(). Please specify the schema or set session.read.options({"infer_schema":True})'
-        in str(exec_info)
-    )
-
-    # check infer_schema default as true
-    Utils.check_answer(
-        session.read.csv(test_file_on_stage),
-        [
-            Row(c1=1, c2="one", c3=Decimal("1.2")),
-            Row(c1=2, c2="two", c3=Decimal("2.2")),
-        ],
-    )
 
 
 @pytest.mark.skipif(

--- a/tests/unit/scala/test_error_message.py
+++ b/tests/unit/scala/test_error_message.py
@@ -107,7 +107,7 @@ def test_df_must_provide_schema_for_reading_file():
     assert ex.error_code == "1106"
     assert (
         ex.message
-        == 'No schema specified in DataFrameReader.schema(). Please specify the schema or set session.read.options({"infer_schema":True})'
+        == "You must call DataFrameReader.schema() and specify the schema for the file."
     )
 
 


### PR DESCRIPTION
This reverts commit 75036a4f15a76f391b09ee90630ad96a047d6567.

Snowpark tests have failed on main since we added that commit.

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1411340

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

    Revert "SNOW-1300150:Automatic schema inference for CSV loading option unclear (#1521)"

    This reverts commit 75036a4f15a76f391b09ee90630ad96a047d6567.

    Snowpark tests have failed on main since we added that commit.

