### PR TITLE
SNOW-1411856: fix getvalue usage in tests

### DIFF
--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -39,7 +39,7 @@ tmp_stage_name1 = Utils.random_stage_name()
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Async Job is a SQL feature",
         run=False,
     )

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -425,7 +425,7 @@ def test_drop_columns_by_column(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="this tests fully qualified column name which is not supported by col() function",
     run=False,
 )
@@ -518,7 +518,7 @@ def test_column_constructors_select(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL expr feature not supported",
     run=False,
 )
@@ -669,7 +669,7 @@ def test_regexp(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1346957 collate feature not supported",
 )
 @pytest.mark.parametrize("spec", ["en_US-trim", "'en_US-trim'"])
@@ -1002,7 +1002,7 @@ def test_in_expression_with_multiple_queries(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370114 pivot should raise not implemented error but get AttributeError: DataFrame object has no attribute queries",
 )
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="pivot does not work in stored proc")

--- a/tests/integ/scala/test_dataframe_aggregate_suite.py
+++ b/tests/integ/scala/test_dataframe_aggregate_suite.py
@@ -49,7 +49,7 @@ from tests.utils import IS_IN_STORED_PROC, TestData, Utils
 
 @pytest.mark.localtest
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: pivot not supported",
 )
 def test_pivot(session):
@@ -160,7 +160,7 @@ def test_pivot_agg_functions(session, func, expected):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: pivot not supported",
 )
 def test_group_by_pivot(session):
@@ -234,7 +234,7 @@ def test_group_by_pivot_dynamic_any(session, caplog):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370114 pivot should raise not implemented error but get AttributeError: DataFrame object has no attribute queries",
 )
 def test_group_by_pivot_dynamic_subquery(session):
@@ -263,7 +263,7 @@ def test_group_by_pivot_dynamic_subquery(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="TODO: Join fails with error 'snowflake.snowpark.exceptions.SnowparkColumnException: (1105): The DataFrame does not contain the column named JAN.'",
     run=False,
 )
@@ -310,7 +310,7 @@ def test_pivot_on_join(session):
 # pivot will materialize the data before executing pivot, otherwise would fail with not finding the
 # data when doing a later schema call.
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370114 pivot should raise not implemented error but get AttributeError: DataFrame object has no attribute queries",
 )
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="pivot does not work in stored proc")
@@ -349,7 +349,7 @@ def test_pivot_dynamic_any(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370114 pivot should raise not implemented error but get AttributeError: DataFrame object has no attribute queries",
 )
 def test_pivot_dynamic_subquery(session):
@@ -517,7 +517,7 @@ def test_group_by(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-977749 grouping by grouping sets not supported",
 )
 def test_group_by_grouping_sets(session):
@@ -931,7 +931,7 @@ def test_count(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: stddev not supported",
 )
 def test_stddev(session):
@@ -954,7 +954,7 @@ def test_stddev(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: variance not supported",
 )
 def test_sn_moments(session):
@@ -990,7 +990,7 @@ def test_sn_moments(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: stddev not supportedg",
 )
 def test_sn_zero_moments(session):
@@ -1029,7 +1029,7 @@ def test_sn_zero_moments(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: variance not supported",
 )
 def test_sn_null_moments(session):
@@ -1087,7 +1087,7 @@ def test_ints_in_agg_exprs_are_taken_as_groupby_ordinal(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -1160,7 +1160,7 @@ def test_distinct_and_unionall(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: count_if not suppored in snowpark python",
 )
 def test_count_if(session):
@@ -1315,7 +1315,7 @@ def test_zero_count(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: stddev not supported",
 )
 def test_zero_stddev(session):
@@ -1369,7 +1369,7 @@ def test_listagg(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: aggregate expression within group not supported",
 )
 def test_listagg_within_group(session):

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -197,7 +197,7 @@ def upload_files(session, tmp_stage_name1, tmp_stage_name2, resources_path):
 
 pytestmark = [
     pytest.mark.skipif(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="SNOW-952138 DataFrame.copy_into_table is not supported in Local Testing",
     )
 ]

--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -162,7 +162,7 @@ def test_join_with_multiple_conditions(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1235716: match error behavior",
 )
 def test_join_with_ambiguous_column_in_condition(session):
@@ -308,7 +308,7 @@ def test_cross_join(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359450: Suport ASOF join in Local Testing",
 )
 def test_asof_join_basic(session):
@@ -338,7 +338,7 @@ def test_asof_join_basic(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359450: Suport ASOF join in Local Testing",
 )
 def test_asof_join_using_columns(session):
@@ -368,7 +368,7 @@ def test_asof_join_using_columns(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359450: Suport ASOF join in Local Testing",
 )
 def test_asof_join_on_condition(session):
@@ -403,7 +403,7 @@ def test_asof_join_on_condition(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359450: Suport ASOF join in Local Testing",
 )
 def test_asof_join_with_suffix(session):
@@ -440,7 +440,7 @@ def test_asof_join_with_suffix(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359450: Suport ASOF join in Local Testing",
 )
 def test_asof_join_with_df_alias(session):
@@ -492,7 +492,7 @@ def test_asof_join_with_df_alias(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359450: Suport ASOF join in Local Testing",
 )
 def test_asof_join_negative(session):
@@ -553,7 +553,7 @@ def test_join_ambiguous_columns_with_specified_sources(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1235716: match error behavior",
 )
 def test_join_ambiguous_columns_without_specified_sources(session):
@@ -822,7 +822,7 @@ def test_aliases_multiple_levels_deep(
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is a SQL test",
     run=False,
 )
@@ -1018,7 +1018,7 @@ def test_join_of_join(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1235716: match error behavior",
 )
 def test_negative_test_join_of_join(session):
@@ -1041,7 +1041,7 @@ def test_negative_test_join_of_join(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-978584: DataFrame.drop bug",
 )
 def test_drop_on_join(
@@ -1065,7 +1065,7 @@ def test_drop_on_join(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-978584: DataFrame.drop bug",
 )
 def test_drop_on_self_join(session):  # TODO: Fix drop
@@ -1082,7 +1082,7 @@ def test_drop_on_self_join(session):  # TODO: Fix drop
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-978584: DataFrame.drop bug",
 )
 def test_with_column_on_join(session):  # TODO: Fix drop
@@ -1294,7 +1294,7 @@ def test_name_alias_on_multiple_join_unnormalized_name(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1235716: match error behavior",
 )
 def test_report_error_when_refer_common_col(session):
@@ -1487,7 +1487,7 @@ def test_select_columns_on_join_result_with_conflict_name(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1235716: match error behavior",
 )
 def test_nested_join_diamond_shape_error(
@@ -1521,7 +1521,7 @@ def test_nested_join_diamond_shape_workaround(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1373887: Support basic diamond shaped joins in Local Testing",
 )
 def test_dataframe_basic_diamond_shaped_join(session):

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -372,7 +372,7 @@ def test_read_csv_with_default_infer_schema(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370149 infer schema, Number of columns in file (3) does not match that of the corresponding table (1)",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -431,7 +431,7 @@ def test_read_csv_incorrect_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: xml not supported",
 )
 def test_save_as_table_work_with_df_created_from_read(session):
@@ -783,7 +783,7 @@ def test_read_csv_with_quotes_containing_delimiter(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370153 read metadata from stage; FEAT: parquet/avro/xml/orc support",
 )
 @pytest.mark.parametrize(
@@ -1001,11 +1001,11 @@ def test_read_json_with_infer_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: avro not supported",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1037,7 +1037,7 @@ def test_read_avro_with_no_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1068,7 +1068,7 @@ def test_for_all_parquet_compression_keywords(session, temp_schema, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1100,7 +1100,7 @@ def test_read_parquet_with_no_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1117,7 +1117,7 @@ def test_read_parquet_with_join_table_function(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 @pytest.mark.skipif(
@@ -1197,7 +1197,7 @@ def test_read_parquet_all_data_types_with_no_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 @pytest.mark.skipif(
@@ -1235,7 +1235,7 @@ def test_read_parquet_with_special_characters_in_column_names(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: orc not supported",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1267,7 +1267,7 @@ def test_read_orc_with_no_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: xml not supported",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1299,7 +1299,7 @@ def test_read_xml_with_no_schema(session, mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370138 AssertionError; FEAT: on_error support",
 )
 def test_copy(session, local_testing_mode):
@@ -1345,7 +1345,7 @@ def test_copy(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370138 unsupported force option should raise error",
 )
 def test_copy_option_force(session):
@@ -1392,7 +1392,7 @@ def test_copy_option_force(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370138 on_error option should raise error",
 )
 def test_read_file_on_error_continue_on_csv(session, db_parameters, resources_path):
@@ -1411,7 +1411,7 @@ def test_read_file_on_error_continue_on_csv(session, db_parameters, resources_pa
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: option on_error not supported",
 )
 def test_read_file_on_error_continue_on_avro(session):
@@ -1429,7 +1429,7 @@ def test_read_file_on_error_continue_on_avro(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: parquet not supported",
 )
 def test_select_and_copy_on_non_csv_format_have_same_result_schema(session):
@@ -1455,7 +1455,7 @@ def test_select_and_copy_on_non_csv_format_have_same_result_schema(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370153 should return number instead of UnicodeDecodeError: 'utf-8' codec can't decode byte 0xca in position 17",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
@@ -1472,7 +1472,7 @@ def test_pattern(session, mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -1495,7 +1495,7 @@ def test_read_staged_file_no_commit(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation",
     run=False,
 )
@@ -1517,7 +1517,7 @@ def test_read_csv_with_sql_simplifier(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation",
     run=False,
 )
@@ -1538,7 +1538,7 @@ def test_read_parquet_with_sql_simplifier(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370153 empty file path",
 )
 def test_filepath_not_exist_or_empty(session):
@@ -1567,7 +1567,7 @@ def test_filepath_not_exist_or_empty(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370149 infer schema, Number of columns in file (3) does not match that of the corresponding table (1)",
 )
 def test_filepath_with_single_quote(session):

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -352,7 +352,7 @@ def test_read_csv(session, mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1411711 to fix bug",
     run=False,
 )

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -265,7 +265,7 @@ def test_show_multi_lines_row(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -338,7 +338,7 @@ def test_cache_result(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -413,7 +413,7 @@ def test_drop_cache_result_context_manager(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -438,7 +438,7 @@ def test_non_select_query_composition(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -460,7 +460,7 @@ def test_non_select_query_composition_union(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -482,7 +482,7 @@ def test_non_select_query_composition_unionall(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -503,7 +503,7 @@ def test_non_select_query_composition_self_union(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -524,7 +524,7 @@ def test_non_select_query_composition_self_unionall(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -539,7 +539,7 @@ def test_only_use_result_scan_when_composing_queries(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing query generation",
     run=False,
 )
@@ -553,7 +553,7 @@ def test_joins_on_result_scan(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function corr not supported",
 )
 def test_df_stat_corr(session):
@@ -574,7 +574,7 @@ def test_df_stat_corr(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function covar_samp not supported",
 )
 def test_df_stat_cov(session):
@@ -595,7 +595,7 @@ def test_df_stat_cov(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function approx_percentile_accumulate not supported",
 )
 def test_df_stat_approx_quantile(session):
@@ -653,7 +653,7 @@ def test_df_stat_approx_quantile(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: RelationalGroupedDataFrame.Pivot not supported",
 )
 def test_df_stat_crosstab(session):
@@ -779,7 +779,7 @@ def test_df_stat_crosstab(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: sample by wrong result",
 )
 def test_df_stat_sampleBy(session):
@@ -836,7 +836,7 @@ def test_df_stat_sampleBy(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: RelationalGroupedDataFrame.Pivot not supported",
 )
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
@@ -1232,7 +1232,7 @@ def test_select(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: error experience mismatch, SnowparkSQLException",
 )
 def test_select_negative_select(session):
@@ -1348,7 +1348,7 @@ def test_dataframe_agg(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-977749 DataFrame.group_by_grouping_sets not supported",
 )
 def test_rollup(session):
@@ -1473,7 +1473,7 @@ def test_groupby(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-977749 DataFrame.group_by_grouping_sets not supported",
 )
 def test_cube(session):
@@ -1554,7 +1554,7 @@ def test_cube(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: table_function.Lateral is not supported.",
     run=False,
 )
@@ -1632,7 +1632,7 @@ def test_flatten(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: session.flatten not supported",
 )
 def test_flatten_in_session(session):
@@ -1685,7 +1685,7 @@ def test_flatten_in_session(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: RecursionError: maximum recursion depth exceeded while calling a Python object",
 )
 def test_createDataFrame_with_given_schema(session):
@@ -1792,7 +1792,7 @@ def test_createDataFrame_with_given_schema_time(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: assertion error timestamp type mismatch",
 )
 def test_createDataFrame_with_given_schema_timestamp(session):
@@ -1934,7 +1934,7 @@ def test_vector(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -1980,7 +1980,7 @@ def test_show_collect_with_misc_commands(session, resources_path, tmpdir):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function to_geography not supported",
 )
 def test_createDataFrame_with_given_schema_array_map_variant(session):
@@ -2523,7 +2523,7 @@ def test_agg_with_array_args(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-977749 DataFrame.group_by_grouping_sets not supported",
 )
 def test_rollup_with_array_args(session):
@@ -2560,7 +2560,7 @@ def test_rollup_with_array_args(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-977749 DataFrame.group_by_grouping_sets not supported",
 )
 def test_rollup_string_with_array_args(session):
@@ -2659,7 +2659,7 @@ def test_rename_basic(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: AttributeError: 'NoneType' object has no attribute 'expr_to_alias'",
 )
 def test_rename_function_basic(session):
@@ -2674,7 +2674,7 @@ def test_rename_function_basic(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: AttributeError: 'NoneType' object has no attribute 'expr_to_alias'",
 )
 def test_rename_function_multiple(session):
@@ -2689,7 +2689,7 @@ def test_rename_function_multiple(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: ValueError: Unable to rename column Column[A] because it doesn't exist.",
 )
 def test_rename_join_dataframe(session):
@@ -2718,7 +2718,7 @@ def test_rename_join_dataframe(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: assertion error column rename mismatch",
 )
 def test_rename_to_df_and_joined_dataframe(session):
@@ -2776,7 +2776,7 @@ def test_rename_negative_test(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function datediff not supported",
 )
 def test_with_columns_keep_order(session):
@@ -3095,7 +3095,7 @@ def test_replace(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1235716 should raise not implemented error not AttributeError: 'MockExecutionPlan' object has no attribute 'replace_repeated_subquery_with_cte'",
 )
 def test_explain(session):
@@ -3137,7 +3137,7 @@ def test_to_local_iterator(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function random not supported",
 )
 def test_random_split(session):

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -21,7 +21,7 @@ from tests.utils import TestFiles, Utils
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: support truncate and column_order in save as table",
 )
 def test_write_with_target_column_name_order(session, local_testing_mode):
@@ -84,7 +84,7 @@ def test_write_with_target_column_name_order(session, local_testing_mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query feature AUTOINCREMENT not supported",
     run=False,
 )
@@ -106,7 +106,7 @@ def test_write_with_target_table_autoincrement(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: Inserting data into table by matching columns is not supported",
 )
 def test_negative_write_with_target_column_name_order(session):
@@ -140,7 +140,7 @@ def test_negative_write_with_target_column_name_order(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: Inserting data into table by matching columns is not supported",
 )
 def test_write_with_target_column_name_order_all_kinds_of_dataframes(
@@ -250,7 +250,7 @@ def test_write_with_target_column_name_order_all_kinds_of_dataframes(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: session._table_exists not supported",
 )
 def test_write_table_names(session, db_parameters):
@@ -390,7 +390,7 @@ def test_write_table_names(session, db_parameters):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1235716 should raise not implemented error not AttributeError: 'MockExecutionPlan' object has no attribute 'replace_repeated_subquery_with_cte'",
 )
 def test_writer_csv(session, tmpdir_factory):
@@ -453,7 +453,7 @@ def test_writer_csv(session, tmpdir_factory):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1235716 should raise not implemented error not AttributeError: 'MockExecutionPlan' object has no attribute 'replace_repeated_subquery_with_cte', FEAT: parquet support",
 )
 def test_writer_json(session, tmpdir_factory):
@@ -509,7 +509,7 @@ def test_writer_json(session, tmpdir_factory):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1235716 should raise not implemented error not AttributeError: 'MockExecutionPlan' object has no attribute 'replace_repeated_subquery_with_cte', FEAT: parquet support",
 )
 def test_writer_parquet(session, tmpdir_factory, local_testing_mode):

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -131,7 +131,7 @@ STRUCTURED_TYPES_EXAMPLES = {
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function to_geography not supported",
 )
 def test_verify_datatypes_reference(session):
@@ -256,7 +256,7 @@ def test_verify_datatypes_reference_vector(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: function to_geography not supported",
 )
 def test_dtypes(session):
@@ -332,7 +332,7 @@ def test_dtypes(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1372813 Cast to StructType not supported",
 )
 @pytest.mark.parametrize(
@@ -346,11 +346,11 @@ def test_structured_dtypes(session, query, expected_dtypes, expected_schema):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('disable_sql_simplifier')",
+    "config.getoption('disable_sql_simplifier', default=False)",
     reason="without sql_simplifier returned types are all variants",
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1372813 Cast to StructType not supported",
 )
 @pytest.mark.parametrize(
@@ -392,7 +392,7 @@ def test_structured_dtypes_select(session, query, expected_dtypes, expected_sche
 
 @pytest.mark.skipif(not installed_pandas, reason="Pandas required for this test.")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1372813 Cast to StructType not supported",
 )
 @pytest.mark.parametrize(

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -264,7 +264,7 @@ def test_avg(session):
     "k, v1, v2", [("K", "V1", "V2"), (col("K"), col("V1"), col("V2"))]
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="corr is not yet supported in local testing mode.",
 )
 def test_corr(session, k, v1, v2):
@@ -293,7 +293,7 @@ def test_count(session):
     "k, v1, v2", [("K", "V1", "V2"), (col("K"), col("V1"), col("V2"))]
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="covar_samp is not yet supported in local testing mode.",
 )
 def test_covariance(session, k, v1, v2):
@@ -309,7 +309,7 @@ def test_covariance(session, k, v1, v2):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="kurtosis is not yet supported in local testing mode.",
 )
 def test_kurtosis(session):
@@ -357,7 +357,7 @@ def test_max_min_mean(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="mode is not yet supported in local testing mode.",
 )
 def test_mode(session):
@@ -378,7 +378,7 @@ def test_mode(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="skew is not yet supported in local testing mode.",
 )
 def test_skew(session):
@@ -397,7 +397,7 @@ def test_skew(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="stddev is not yet supported in local testing mode.",
 )
 def test_stddev(session):
@@ -429,7 +429,7 @@ def test_sum(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="variance is not yet supported in local testing mode.",
 )
 def test_variance(session):
@@ -488,7 +488,7 @@ def test_coalesce(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362837: equal_nan and is_null not consistent yet.",
 )
 def test_nan_and_null(session):
@@ -519,7 +519,7 @@ def test_negate_and_not(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="random is not yet supported in local testing mode.",
 )
 def test_random(session):
@@ -555,7 +555,7 @@ def test_abs(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="ceil is not yet supported in local testing mode.",
 )
 def test_ceil_floor(session):
@@ -568,7 +568,7 @@ def test_ceil_floor(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="exp is not yet supported in local testing mode.",
 )
 def test_exp(session):
@@ -594,7 +594,7 @@ def test_exp(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="log is not yet supported in local testing mode.",
 )
 def test_log(session):
@@ -627,7 +627,7 @@ def test_pow(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="repeat is not yet supported in local testing mode.",
 )
 def test_builtin_function(session):
@@ -656,7 +656,7 @@ def test_sub_string(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="translate is not yet supported in local testing mode.",
 )
 def test_translate(session):
@@ -674,7 +674,7 @@ def test_translate(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="datediff is not yet supported in local testing mode.",
 )
 def test_datediff(session):
@@ -1913,7 +1913,7 @@ def test_to_date(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="arrays_overlap is not yet supported in local testing mode.",
 )
 def test_arrays_overlap(session):
@@ -1932,7 +1932,7 @@ def test_arrays_overlap(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_intersection is not yet supported in local testing mode.",
 )
 def test_array_intersection(session):
@@ -1951,7 +1951,7 @@ def test_array_intersection(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_array is not yet supported in local testing mode.",
 )
 def test_is_array(session):
@@ -1984,7 +1984,7 @@ def test_is_array(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_boolean is not yet supported in local testing mode.",
 )
 def test_is_boolean(session):
@@ -2007,7 +2007,7 @@ def test_is_boolean(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_binary is not yet supported in local testing mode.",
 )
 def test_is_binary(session):
@@ -2030,7 +2030,7 @@ def test_is_binary(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_char is not yet supported in local testing mode.",
 )
 def test_is_char_is_varchar(session):
@@ -2067,7 +2067,7 @@ def test_is_char_is_varchar(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_date is not yet supported in local testing mode.",
 )
 def test_is_date_is_date_value(session):
@@ -2108,7 +2108,7 @@ def test_is_date_is_date_value(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_decimal is not yet supported in local testing mode.",
 )
 def test_is_decimal(session):
@@ -2135,7 +2135,7 @@ def test_is_decimal(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_double is not yet supported in local testing mode.",
 )
 def test_is_double_is_real(session):
@@ -2186,7 +2186,7 @@ def test_is_double_is_real(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_integer is not yet supported in local testing mode.",
 )
 def test_is_integer(session):
@@ -2215,7 +2215,7 @@ def test_is_integer(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_null_value is not yet supported in local testing mode.",
 )
 def test_is_null_value(session):
@@ -2236,7 +2236,7 @@ def test_is_null_value(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_object is not yet supported in local testing mode.",
 )
 def test_is_object(session):
@@ -2259,7 +2259,7 @@ def test_is_object(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_time is not yet supported in local testing mode.",
 )
 def test_is_time(session):
@@ -2282,7 +2282,7 @@ def test_is_time(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="is_timestamp_ntz is not yet supported in local testing mode.",
 )
 def test_is_timestamp_all(session):
@@ -2349,7 +2349,7 @@ def test_is_timestamp_all(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="split is not yet supported in local testing mode.",
 )
 def test_split(session):
@@ -2399,7 +2399,7 @@ def test_endswith(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="char is not yet supported in local testing mode.",
 )
 def test_char(session):
@@ -2417,7 +2417,7 @@ def test_char(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="check_json is not yet supported in local testing mode.",
 )
 def test_check_json(session):
@@ -2456,7 +2456,7 @@ def test_check_json(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="check_xml is not yet supported in local testing mode.",
 )
 def test_check_xml(session):
@@ -2495,7 +2495,7 @@ def test_check_xml(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="json_extract_path_text is not yet supported in local testing mode.",
 )
 def test_json_extract_path_text(session):
@@ -2533,7 +2533,7 @@ def test_parse_json(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="parse_xml is not yet supported in local testing mode.",
 )
 def test_parse_xml(session):
@@ -2580,7 +2580,7 @@ def test_strip_null_value(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_agg is not yet supported in local testing mode.",
 )
 @pytest.mark.parametrize("col_amount", ["amount", col("amount")])
@@ -2620,7 +2620,7 @@ def test_array_agg(session, col_amount):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="WithinGroup expressions are not yet supported by local testing mode.",
 )
 def test_array_agg_within_group(session):
@@ -2649,7 +2649,7 @@ def test_array_agg_within_group(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="WithinGroup expressions are not yet supported by local testing mode.",
 )
 def test_array_agg_within_group_order_by_desc(session):
@@ -2678,7 +2678,7 @@ def test_array_agg_within_group_order_by_desc(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="WithinGroup expressions are not yet supported by local testing mode.",
 )
 def test_array_agg_within_group_order_by_multiple_columns(session):
@@ -2698,7 +2698,7 @@ def test_array_agg_within_group_order_by_multiple_columns(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="WithinGroup expressions are not yet supported by local testing mode.",
 )
 def test_window_function_array_agg_within_group(session):
@@ -2713,7 +2713,7 @@ def test_window_function_array_agg_within_group(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_append is not yet supported in local testing mode.",
 )
 def test_array_append(session):
@@ -2782,7 +2782,7 @@ def test_array_append(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_cat is not yet supported in local testing mode.",
 )
 def test_array_cat(session):
@@ -2807,7 +2807,7 @@ def test_array_cat(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_compact is not yet supported in local testing mode.",
 )
 def test_array_compact(session):
@@ -2826,7 +2826,7 @@ def test_array_compact(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_construct is not yet supported in local testing mode.",
 )
 def test_array_construct(session):
@@ -2864,7 +2864,7 @@ def test_array_construct(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_construct_compact is not yet supported in local testing mode.",
 )
 def test_array_construct_compact(session):
@@ -2909,7 +2909,7 @@ def test_array_construct_compact(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_contains is not yet supported in local testing mode.",
 )
 def test_array_contains(session):
@@ -2948,7 +2948,7 @@ def test_array_contains(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_insert is not yet supported in local testing mode.",
 )
 def test_array_insert(session):
@@ -2967,7 +2967,7 @@ def test_array_insert(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_position is not yet supported in local testing mode.",
 )
 def test_array_position(session):
@@ -2986,7 +2986,7 @@ def test_array_position(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_prepend is not yet supported in local testing mode.",
 )
 def test_array_prepend(session):
@@ -3035,7 +3035,7 @@ def test_array_prepend(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_size is not yet supported in local testing mode.",
 )
 def test_array_size(session):
@@ -3078,7 +3078,7 @@ def test_array_size(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_slice is not yet supported in local testing mode.",
 )
 def test_array_slice(session):
@@ -3097,7 +3097,7 @@ def test_array_slice(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_to_string is not yet supported in local testing mode.",
 )
 def test_array_to_string(session):
@@ -3116,7 +3116,7 @@ def test_array_to_string(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="object_agg is not yet supported in local testing mode.",
 )
 def test_objectagg(session):
@@ -3192,7 +3192,7 @@ def test_object_construct_keep_null(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="object_delete is not yet supported in local testing mode.",
 )
 def test_object_delete(session):
@@ -3215,7 +3215,7 @@ def test_object_delete(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="object_insert is not yet supported in local testing mode.",
 )
 def test_object_insert(session):
@@ -3314,7 +3314,7 @@ def test_object_insert(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="object_pick is not yet supported in local testing mode.",
 )
 def test_object_pick(session):
@@ -3359,7 +3359,7 @@ def test_object_pick(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_array is not yet supported in local testing mode.",
 )
 def test_as_array(session):
@@ -3396,7 +3396,7 @@ def test_as_array(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_binary is not yet supported in local testing mode.",
 )
 def test_as_binary(session):
@@ -3423,7 +3423,7 @@ def test_as_binary(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_char is not yet supported in local testing mode.",
 )
 def test_as_char_as_varchar(session):
@@ -3460,7 +3460,7 @@ def test_as_char_as_varchar(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_date is not yet supported in local testing mode.",
 )
 def test_as_date(session):
@@ -3483,7 +3483,7 @@ def test_as_date(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_decimal is not yet supported in local testing mode.",
 )
 def test_as_decimal_as_number(session):
@@ -3595,7 +3595,7 @@ def test_as_decimal_as_number(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_double is not yet supported in local testing mode.",
 )
 def test_as_double_as_real(session):
@@ -3646,7 +3646,7 @@ def test_as_double_as_real(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_integer is not yet supported in local testing mode.",
 )
 def test_as_integer(session):
@@ -3675,7 +3675,7 @@ def test_as_integer(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_object is not yet supported in local testing mode.",
 )
 def test_as_object(session):
@@ -3698,7 +3698,7 @@ def test_as_object(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="timestamp_tz_from_parts is not yet supported in local testing mode.",
 )
 def test_timestamp_tz_from_parts(session, local_testing_mode):
@@ -3822,7 +3822,7 @@ def test_convert_timezone(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="time_from_parts is not yet supported in local testing mode.",
 )
 def test_time_from_parts(session):
@@ -3935,7 +3935,7 @@ def test_timestamp_from_parts_internal_negative():
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_time is not yet supported in local testing mode.",
 )
 def test_as_time(session):
@@ -4012,7 +4012,7 @@ def test_as_time(session):
     ],
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="as_timestamp_tz is not yet supported in local testing mode.",
 )
 def test_as_timestamp_all(as_type, expected, session, local_testing_mode):
@@ -4058,7 +4058,7 @@ def test_to_array(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_json is not yet supported in local testing mode.",
 )
 def test_to_json(session):
@@ -4112,7 +4112,7 @@ def test_to_variant(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_xml is not yet supported in local testing mode.",
 )
 def test_to_xml(session):
@@ -4138,7 +4138,7 @@ def test_to_xml(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_geography is not yet supported in local testing mode.",
 )
 def test_to_geography(session):
@@ -4162,7 +4162,7 @@ def test_to_geography(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_geometry is not yet supported in local testing mode.",
 )
 def test_to_geometry(session):
@@ -4187,7 +4187,7 @@ def test_to_geometry(session):
 
 @pytest.mark.parametrize("a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="typeof is not yet supported in local testing mode.",
 )
 def test_typeof(session, a):
@@ -4200,7 +4200,7 @@ def test_typeof(session, a):
 
 @pytest.mark.parametrize("obj, k", [("obj", "k"), (col("obj"), col("k"))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="get_ignore_case is not yet supported in local testing mode.",
 )
 def test_get_ignore_case(session, obj, k):
@@ -4219,7 +4219,7 @@ def test_get_ignore_case(session, obj, k):
 
 @pytest.mark.parametrize("column", ["obj", col("obj")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="object_keys is not yet supported in local testing mode.",
 )
 def test_object_keys(session, column):
@@ -4241,7 +4241,7 @@ def test_object_keys(session, column):
     ],
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="get_ignore_case is not yet supported in local testing mode.",
 )
 def test_xmlget(session, v, t2, t3, instance, zero):
@@ -4280,7 +4280,7 @@ def test_xmlget(session, v, t2, t3, instance, zero):
 
 @pytest.mark.parametrize("v, k", [("v", "k"), (col("v"), col("k"))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="get_path is not yet supported in local testing mode.",
 )
 def test_get_path(session, v, k):
@@ -4320,7 +4320,7 @@ def test_get(session):
 
 @pytest.mark.parametrize("col_a", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="approx_count_distinct is not yet supported in local testing mode.",
 )
 def test_approx_count_distinct(session, col_a):
@@ -4331,7 +4331,7 @@ def test_approx_count_distinct(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="approx_percentile is not yet supported in local testing mode.",
 )
 @pytest.mark.parametrize("col_a", ["A", col("A")])
@@ -4343,7 +4343,7 @@ def test_approx_percentile(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="approx_percentile_accumulate is not yet supported in local testing mode.",
 )
 @pytest.mark.parametrize("col_a", ["A", col("A")])
@@ -4366,7 +4366,7 @@ def test_approx_percentile_accumulate(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="approx_percentile_estimate is not yet supported in local testing mode.",
 )
 @pytest.mark.parametrize("col_a", ["A", col("A")])
@@ -4380,7 +4380,7 @@ def test_approx_percentile_estimate(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="approx_percentile_accumulate is not yet supported in local testing mode.",
 )
 @pytest.mark.parametrize("col_a, col_b", [("A", "B"), (col("A"), col("B"))])
@@ -4444,7 +4444,7 @@ def test_iff(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="cume_dist is not yet supported in local testing mode.",
 )
 def test_cume_dist(session):
@@ -4458,7 +4458,7 @@ def test_cume_dist(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="dense_rank is not yet supported in local testing mode.",
 )
 def test_dense_rank(session):
@@ -4551,7 +4551,7 @@ def test_first_value(session, col_z):
 
 @pytest.mark.parametrize("col_n", ["n", col("n"), 4, 0])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="ntile is not yet supported in local testing mode.",
 )
 def test_ntile(session, col_n):
@@ -4576,7 +4576,7 @@ def test_ntile(session, col_n):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="percent_rank is not yet supported in local testing mode.",
 )
 def test_percent_rank(session):
@@ -4590,7 +4590,7 @@ def test_percent_rank(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="rank is not yet supported in local testing mode.",
 )
 def test_rank(session):
@@ -4604,7 +4604,7 @@ def test_rank(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1374081: row_number over window does not have consistent result.",
 )
 def test_row_number(session):
@@ -4618,7 +4618,7 @@ def test_row_number(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="WithinGroup expressions are not yet supported by local testing mode.",
 )
 def test_listagg(session):
@@ -4644,7 +4644,7 @@ def test_listagg(session):
     "col_expr, col_scale", [("expr", 1), (col("expr"), col("scale"))]
 )
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="trunc is not yet supported in local testing mode.",
 )
 def test_trunc(session, col_expr, col_scale):
@@ -4654,7 +4654,7 @@ def test_trunc(session, col_expr, col_scale):
 
 @pytest.mark.parametrize("col_A, col_scale", [("A", 0), (col("A"), lit(0))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="round is not yet supported in local testing mode.",
 )
 def test_round(session, col_A, col_scale):
@@ -4666,7 +4666,7 @@ def test_round(session, col_A, col_scale):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="sin is not yet supported in local testing mode.",
 )
 def test_sin_sinh(session, col_A):
@@ -4683,7 +4683,7 @@ def test_sin_sinh(session, col_A):
 
 @pytest.mark.parametrize("col_A, col_B", [("A", "B"), (col("A"), col("B"))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="cos is not yet supported in local testing mode.",
 )
 def test_cos_cosh(session, col_A, col_B):
@@ -4700,7 +4700,7 @@ def test_cos_cosh(session, col_A, col_B):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="tan is not yet supported in local testing mode.",
 )
 def test_tan_tanh(session, col_A):
@@ -4717,7 +4717,7 @@ def test_tan_tanh(session, col_A):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="acos is not yet supported in local testing mode.",
 )
 def test_asin_acos(session, col_A):
@@ -4734,7 +4734,7 @@ def test_asin_acos(session, col_A):
 
 @pytest.mark.parametrize("col_A, col_B", [("A", "B"), (col("A"), col("B"))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="atan is not yet supported in local testing mode.",
 )
 def test_atan_atan2(session, col_A, col_B):
@@ -4757,7 +4757,7 @@ def test_atan_atan2(session, col_A, col_B):
 
 @pytest.mark.parametrize("col_A, col_B", [("A", "B"), (col("A"), col("B"))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="degrees is not yet supported in local testing mode.",
 )
 def test_degrees(session, col_A, col_B):
@@ -4774,7 +4774,7 @@ def test_degrees(session, col_A, col_B):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="radians is not yet supported in local testing mode.",
 )
 def test_radians(session, col_A):
@@ -4791,7 +4791,7 @@ def test_radians(session, col_A):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="factorial is not yet supported in local testing mode.",
 )
 def test_factorial(session, col_A):
@@ -4804,7 +4804,7 @@ def test_factorial(session, col_A):
 
 @pytest.mark.parametrize("col_0, col_2, col_4", [(0, 2, 4), (lit(0), lit(2), lit(4))])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="div0 is not yet supported in local testing mode.",
 )
 def test_div0(session, col_0, col_2, col_4):
@@ -4816,7 +4816,7 @@ def test_div0(session, col_0, col_2, col_4):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="md5 is not yet supported in local testing mode.",
 )
 def test_md5_sha1_sha2(session, col_A):
@@ -4845,7 +4845,7 @@ def test_md5_sha1_sha2(session, col_A):
 
 @pytest.mark.parametrize("col_B", ["B", col("B")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="ascii is not yet supported in local testing mode.",
 )
 def test_ascii(session, col_B):
@@ -4927,7 +4927,7 @@ def test_initcap_length_lower_upper(func, expected, use_col, session):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="lpad is not yet supported in local testing mode.",
 )
 def test_lpad_rpad(session, col_A):
@@ -4946,7 +4946,7 @@ def test_lpad_rpad(session, col_A):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="ltrim is not yet supported in local testing mode.",
 )
 def test_ltrim_rtrim_trim(session, col_A):
@@ -4967,7 +4967,7 @@ def test_ltrim_rtrim_trim(session, col_A):
 
 @pytest.mark.parametrize("col_B", ["B", col("B")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="repeat is not yet supported in local testing mode.",
 )
 def test_repeat(session, col_B):
@@ -4980,7 +4980,7 @@ def test_repeat(session, col_B):
 
 @pytest.mark.parametrize("col_A", ["A", col("A")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="soundex is not yet supported in local testing mode.",
 )
 def test_soundex(session, col_A):
@@ -4993,7 +4993,7 @@ def test_soundex(session, col_A):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="insert is not yet supported in local testing mode.",
 )
 def test_insert(session, col_a):
@@ -5006,7 +5006,7 @@ def test_insert(session, col_a):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="left is not yet supported in local testing mode.",
 )
 def test_left(session, col_a):
@@ -5019,7 +5019,7 @@ def test_left(session, col_a):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="right is not yet supported in local testing mode.",
 )
 def test_right(session, col_a):
@@ -5032,7 +5032,7 @@ def test_right(session, col_a):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="regexp_count is not yet supported in local testing mode.",
 )
 def test_regexp_count(session, col_a):
@@ -5051,7 +5051,7 @@ def test_regexp_count(session, col_a):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="replace is not yet supported in local testing mode.",
 )
 def test_replace(session, col_a):
@@ -5070,7 +5070,7 @@ def test_replace(session, col_a):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="charindex is not yet supported in local testing mode.",
 )
 def test_charindex(session, col_a):
@@ -5089,7 +5089,7 @@ def test_charindex(session, col_a):
 
 @pytest.mark.parametrize("col_a", ["a", col("a")])
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="collate is not yet supported in local testing mode.",
 )
 def test_collate(session, col_a):
@@ -5101,7 +5101,7 @@ def test_collate(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="collation is not yet supported in local testing mode.",
 )
 def test_collation(session):

--- a/tests/integ/scala/test_large_dataframe_suite.py
+++ b/tests/integ/scala/test_large_dataframe_suite.py
@@ -93,7 +93,7 @@ def test_limit_on_order_by(session, is_sample_data_available):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation.",
     run=False,
 )
@@ -191,7 +191,7 @@ def test_create_dataframe_for_large_values_basic_types(session):
 
 # TODO: enable for local testing after emulating sf data types
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_geography is not yet supported in local testing mode.",
 )
 def test_create_dataframe_for_large_values_array_map_variant(session):

--- a/tests/integ/scala/test_literal_suite.py
+++ b/tests/integ/scala/test_literal_suite.py
@@ -26,7 +26,7 @@ from tests.utils import Utils
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362917: Schema inference not fully aligned for local testing mode.",
 )
 def test_literal_basic_types(session):
@@ -83,7 +83,7 @@ def test_literal_basic_types(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362917: Schema inference not fully aligned for local testing mode.",
 )
 def test_literal_timestamp_and_instant(session):
@@ -156,7 +156,7 @@ def test_date(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362917: Schema inference not fully aligned for local testing mode.",
 )
 def test_special_literals(session):
@@ -197,7 +197,7 @@ def test_special_literals(session):
 
 # This test was originall party of scala-integ tests, but was removed.
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362917: Schema inference not fully aligned for local testing mode.",
 )
 def test_special_decimal_literals(session):
@@ -220,7 +220,7 @@ def test_special_decimal_literals(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362917: Schema inference not fully aligned for local testing mode.",
 )
 def test_array_object(session):
@@ -271,7 +271,7 @@ def test_array_object(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362917: Schema inference not fully aligned for local testing mode.",
 )
 def test_literal_variant(session):

--- a/tests/integ/scala/test_permanent_udf_suite.py
+++ b/tests/integ/scala/test_permanent_udf_suite.py
@@ -22,7 +22,7 @@ from tests.utils import TempObjectType, TestFiles, Utils
 pytestmark = [
     pytest.mark.udf,
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Local Testing does not support permanent udfs.",
         run=False,
     ),

--- a/tests/integ/scala/test_query_tag_suite.py
+++ b/tests/integ/scala/test_query_tag_suite.py
@@ -15,7 +15,7 @@ from tests.utils import Utils
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Query tag is a SQL feature",
         run=False,
     )

--- a/tests/integ/scala/test_result_attributes_suite.py
+++ b/tests/integ/scala/test_result_attributes_suite.py
@@ -27,7 +27,7 @@ from tests.utils import IS_IN_STORED_PROC, Utils
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="This is a SQL test suite",
         run=False,
     )

--- a/tests/integ/scala/test_result_schema_suite.py
+++ b/tests/integ/scala/test_result_schema_suite.py
@@ -23,7 +23,7 @@ tmp_full_types_table_name2 = Utils.random_name_for_temp_object(TempObjectType.TA
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="This is a SQL test suite",
         run=False,
     )

--- a/tests/integ/scala/test_session_suite.py
+++ b/tests/integ/scala/test_session_suite.py
@@ -27,7 +27,7 @@ from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, Utils
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing logging into Snowflake",
     run=False,
 )
@@ -129,7 +129,7 @@ def test_get_schema_database_works_after_use_role(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="_remove_config is an internal API and local testing has default schema name",
     run=False,
 )
@@ -150,7 +150,7 @@ def test_negative_test_for_missing_required_parameter_schema(
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="sql function call not supported by local testing.",
     run=False,
 )
@@ -201,7 +201,7 @@ def test_create_dataframe_from_array(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1375271: match error behavior when session is closed",
 )
 @pytest.mark.skipif(
@@ -246,7 +246,7 @@ def test_session_info(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1375271: match error behavior when session is closed",
 )
 @pytest.mark.skipif(
@@ -271,7 +271,7 @@ def test_dataframe_close_session(session, db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="transactions not supported by local testing.",
     run=False,
 )

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -23,7 +23,7 @@ else:
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="This is a SQL test suite",
         run=False,
     ),

--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -15,7 +15,7 @@ from tests.utils import IS_IN_STORED_PROC, TestFiles, Utils
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="This is a SQL test suite",
         run=False,
     )

--- a/tests/integ/scala/test_table_function_suite.py
+++ b/tests/integ/scala/test_table_function_suite.py
@@ -12,7 +12,7 @@ from tests.utils import Utils
 
 pytestmark = [
     pytest.mark.skipif(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="SNOW-952138 Table function is not supported in Local Testing",
     )
 ]

--- a/tests/integ/scala/test_table_suite.py
+++ b/tests/integ/scala/test_table_suite.py
@@ -223,7 +223,7 @@ def test_quotes_upper_and_lower_case_name(session, table_name_1):
 
 # TODO: enable for local testing after emulating snowflake data types
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="geometry and geopgrahy types not yet supported in local testing mode.",
 )
 def test_table_with_semi_structured_types(session, semi_structured_table):
@@ -261,7 +261,7 @@ def test_table_with_semi_structured_types(session, semi_structured_table):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1374013: Local testing fails to parse time '09:15:29.999999'",
 )
 def test_table_with_time_type(session, table_with_time):

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -117,7 +117,7 @@ def test_empty_expression(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_construct is not yet supported in local testing mode.",
 )
 def test_udf_with_arrays(session):
@@ -156,7 +156,7 @@ def test_udf_with_map_input(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="array_construct is not yet supported in local testing mode.",
 )
 def test_udf_with_map_return(session):
@@ -224,7 +224,7 @@ def test_filter_on_top_of_udf(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Read semistructured parquet file not yet supported in local testing mode.",
 )
 def test_compose_on_dataframe_reader(session, resources_path):
@@ -439,7 +439,7 @@ def test_binary_type(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370173: timestamp type can return NaT when None is expected.",
 )
 def test_date_and_timestamp_type(session):
@@ -467,7 +467,7 @@ def test_date_and_timestamp_type(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370173: timestamp type can return NaT when None is expected.",
 )
 def test_time_and_timestamp_type(session):
@@ -535,7 +535,7 @@ def test_time_date_timestamp_type_with_snowflake_timezone(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_geography is not yet supported in local testing mode.",
 )
 def test_geography_type(session):
@@ -571,7 +571,7 @@ def test_geography_type(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="to_geometry is not yet supported in local testing mode.",
 )
 def test_geometry_type(session):
@@ -776,7 +776,7 @@ def test_variant_date_input(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1374027: Local testing variant null not aligned with live.",
 )
 def test_variant_null(session):

--- a/tests/integ/scala/test_udtf_suite.py
+++ b/tests/integ/scala/test_udtf_suite.py
@@ -36,7 +36,7 @@ else:
 pytestmark = [
     pytest.mark.udf,
     pytest.mark.skipif(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="UDTF is not supported in Local Testing",
     ),
 ]

--- a/tests/integ/scala/test_update_delete_merge_suite.py
+++ b/tests/integ/scala/test_update_delete_merge_suite.py
@@ -75,7 +75,7 @@ def test_update_rows_in_table(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1019159 ERROR_ON_NONDETERMINISTIC_UPDATE is not supported in Local Testing",
 )
 @pytest.mark.skipif(

--- a/tests/integ/scala/test_view_suite.py
+++ b/tests/integ/scala/test_view_suite.py
@@ -60,7 +60,7 @@ def test_view_name_with_special_character(session, local_testing_mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL is not supported in Local Testing",
     run=False,
 )
@@ -78,7 +78,9 @@ def test_view_with_with_sql_statement(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')", reason="This is a SQL test", run=False
+    "config.getoption('local_testing_mode', default=False)",
+    reason="This is a SQL test",
+    run=False,
 )
 def test_only_works_on_select(session):
     view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)

--- a/tests/integ/scala/test_window_frame_suite.py
+++ b/tests/integ/scala/test_window_frame_suite.py
@@ -330,7 +330,7 @@ def test_range_between_should_accept_non_numeric_values_only_when_unbounded(
 # [Local Testing PuPr] enable for local testing when we align precision.
 # In avg, the output column has 3 more decimal digits than NUMBER(38, 0)
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1348452: Precision not fully aligned for local testing.",
 )
 def test_sliding_rows_between_with_aggregation(session):
@@ -353,7 +353,7 @@ def test_sliding_rows_between_with_aggregation(session):
 # [Local Testing PuPr] enable for local testing when we align precision.
 # In avg, the output column has 3 more decimal digits than NUMBER(38, 0)
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1348452: Precision not fully aligned for local testing.",
 )
 def test_reverse_sliding_rows_between_with_aggregation(session):

--- a/tests/integ/scala/test_window_spec_suite.py
+++ b/tests/integ/scala/test_window_spec_suite.py
@@ -45,7 +45,7 @@ from tests.utils import TestData, Utils
 # [Local Testing PuPr] enable for local testing when we align precision.
 # In avg, the output column has 3 more decimal digits than NUMBER(38, 0)
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="precision for local testing is not yet aligned.",
 )
 def test_partition_by_order_by_rows_between(session, local_testing_mode):
@@ -103,7 +103,7 @@ def test_range_between(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362852: Window functions need better alignment with live.",
 )
 def test_window_function_with_aggregates(session):
@@ -120,7 +120,7 @@ def test_window_function_with_aggregates(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1362852: Window functions need better alignment with live.",
 )
 def test_window_function_inside_where_and_having_clauses(session):
@@ -187,7 +187,7 @@ def test_reuse_window_order_by(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="ntile is not yet supported in local testing mode.",
 )
 def test_rank_functions_in_unspecific_window(session):
@@ -283,7 +283,7 @@ def test_window_function_should_fail_if_order_by_clause_is_not_specified(session
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="corr is not yet supported in local testing mode.",
 )
 def test_corr_covar_pop_stddev_pop_functions_in_specific_window(session):
@@ -349,7 +349,7 @@ def test_corr_covar_pop_stddev_pop_functions_in_specific_window(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="covar_samp is not yet supported in local testing mode.",
 )
 def test_covar_samp_var_samp_stddev_samp_functions_in_specific_window(session):
@@ -418,7 +418,7 @@ def test_aggregation_function_on_invalid_column(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="skew is not yet supported in local testing mode.",
 )
 def test_skewness_and_kurtosis_functions_in_window(session):
@@ -493,7 +493,7 @@ def test_window_functions_in_multiple_selects(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="WithinGroup expressions are not yet supported by local testing mode.",
 )
 def test_listagg_window_function(session):

--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -31,7 +31,7 @@ except ImportError:
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Variable binding is a SQL feature",
         run=False,
     )

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -166,7 +166,7 @@ def test_logical_operator_raise_error(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL expr is not supported in Local Testing",
     run=False,
 )
@@ -185,7 +185,7 @@ def test_when_accept_sql_expr(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1358930 TODO: Decimal should not be casted to int64",
 )
 def test_column_with_builtins_that_shadow_functions(session):

--- a/tests/integ/test_column_names.py
+++ b/tests/integ/test_column_names.py
@@ -84,7 +84,7 @@ def test_regexp(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1346957: Collation not supported in Local Testing",
 )
 def test_collate(session):
@@ -167,7 +167,7 @@ def test_scalar_subquery(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-982770: Rank is not supported in Local Testing",
 )
 def test_specified_window_frame(session):
@@ -205,7 +205,7 @@ def test_cast(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1355930: any_value is not supported in Local Testing",
 )
 def test_unspecified_frame(session):
@@ -226,7 +226,7 @@ def test_unspecified_frame(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-982770: Rank is not supported in Local Testing",
 )
 def test_special_frame_boundry(session):
@@ -305,7 +305,7 @@ def test_literal(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1358946: Interval is not supported in Local Testing",
 )
 def test_interval(session):
@@ -508,7 +508,7 @@ def test_udf(session, use_qualified_name, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1359104: Column alias creates incorrect column name.",
 )
 def test_unary_expression(session):
@@ -572,7 +572,7 @@ def test_unary_expression(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Window function WithinGroup is not supported",
 )
 def test_list_agg_within_group_sort_order(session):

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -29,7 +29,7 @@ from tests.utils import TestFiles, Utils
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="CTE is a SQL feature",
         run=False,
     )

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -195,7 +195,9 @@ def test_read_stage_file_show(session, resources_path, local_testing_mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')", reason="This is a SQL test", run=False
+    "config.getoption('local_testing_mode', default=False)",
+    reason="This is a SQL test",
+    run=False,
 )
 def test_show_using_with_select_statement(session):
     df = session.sql(
@@ -398,7 +400,7 @@ def test_select_star(session):
 
 @pytest.mark.udf
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Table function is not supported in Local Testing",
 )
 def test_select_table_function(session):
@@ -523,7 +525,7 @@ def test_select_table_function(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Session.generator is not supported in Local Testing",
 )
 def test_generator_table_function(session):
@@ -580,7 +582,7 @@ def test_generator_table_function(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Session.generator is not supported in Local Testing",
 )
 def test_generator_table_function_negative(session):
@@ -591,7 +593,7 @@ def test_generator_table_function_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Table function is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -632,7 +634,7 @@ def test_select_table_function_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Table function is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -690,7 +692,7 @@ def test_select_with_table_function_column_overlap(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="functions.explode is not supported in Local Testing",
 )
 def test_explode(session):
@@ -748,7 +750,7 @@ def test_explode(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="functions.explode is not supported in Local Testing",
 )
 def test_explode_negative(session):
@@ -786,7 +788,7 @@ def test_explode_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="UDTF is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -805,7 +807,7 @@ def test_with_column(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="UDTF is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -827,7 +829,7 @@ def test_with_column_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="UDTF is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -902,7 +904,7 @@ def test_with_columns(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="UDTF is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -1033,7 +1035,7 @@ def test_filter(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL is not supported in Local Testing",
     run=False,
 )
@@ -1575,7 +1577,7 @@ def test_create_dataframe_with_semi_structured_data_types(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1368516 create dataframe from pandas dataframe with datetime columns has wrong schema",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -1853,7 +1855,7 @@ def test_create_dataframe_with_single_value(session, data):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame.describe is not supported in Local Testing",
 )
 def test_create_dataframe_empty(session):
@@ -1932,7 +1934,7 @@ def test_create_dataframe_from_none_data(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Array binding is SQL feature",
     run=False,
 )
@@ -2025,7 +2027,7 @@ def test_attribute_reference_to_sql(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-936617: Selecting columns of the same name is not supported in Local Testing",
 )
 def test_dataframe_duplicated_column_names(session):
@@ -2283,7 +2285,7 @@ def test_fillna(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-929218: support coercion in Local Testing",
 )
 def test_replace_with_coercion(session):
@@ -2372,7 +2374,7 @@ def test_select_case_expr(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL expr is not supported in Local Testing",
     raises=NotImplementedError,
 )
@@ -2389,7 +2391,7 @@ def test_select_expr(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame.describe is not supported in Local Testing",
 )
 def test_describe(session):
@@ -2518,7 +2520,7 @@ def test_describe(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1369973 Truncate table with mismatching columns raises bad error",
 )
 def test_truncate_preserves_schema(session):
@@ -2538,7 +2540,7 @@ def test_truncate_preserves_schema(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1369973 Truncate table with mismatching columns raises bad error",
 )
 def test_truncate_existing_table(session):
@@ -2567,7 +2569,7 @@ def test_table_types_in_save_as_table(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1369973 Truncate table with mismatching columns raises bad error",
 )
 @pytest.mark.parametrize(
@@ -2622,7 +2624,7 @@ def test_save_as_table_respects_schema(session, save_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1373882: nullability is not enforced in Local Testing",
 )
 @pytest.mark.parametrize("large_data", [True, False])
@@ -2669,7 +2671,7 @@ def test_save_as_table_nullable_test(session, save_mode, data_type, large_data):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1373882: nullability is not enforced in Local Testing",
 )
 @pytest.mark.parametrize(
@@ -2705,7 +2707,7 @@ def test_nullable_without_create_temp_table_access(session, save_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Table Sproc is not supported in Local Testing",
 )
 @pytest.mark.udf
@@ -2736,7 +2738,7 @@ def test_save_as_table_with_table_sproc_output(session, save_mode, table_type):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Clustering is a SQL feature",
     run=False,
 )
@@ -2860,7 +2862,7 @@ def test_append_existing_table(session, local_testing_mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Dynamic table is a SQL feature",
     run=False,
 )
@@ -2881,7 +2883,7 @@ def test_create_dynamic_table(session, table_name_1):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame.copy_into_location is not supported in Local Testing",
 )
 def test_write_copy_into_location_basic(session):
@@ -2901,7 +2903,7 @@ def test_write_copy_into_location_basic(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame.copy_into_location is not supported in Local Testing",
 )
 @pytest.mark.parametrize(
@@ -2938,7 +2940,7 @@ def test_write_copy_into_location_csv(session, partition_by):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation",
     run=False,
 )
@@ -2993,7 +2995,7 @@ def test_df_columns(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame.pivot is not supported in Local Testing",
 )
 @pytest.mark.parametrize(
@@ -3077,7 +3079,7 @@ def check_df_with_query_id_result_scan(session, df):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Result scan is a SQL feature",
     run=False,
 )
@@ -3104,7 +3106,7 @@ def test_query_id_result_scan(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="statement parameters are not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -3448,7 +3450,7 @@ def test_suffix_negative(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation",
     run=False,
 )
@@ -3462,7 +3464,7 @@ def test_create_or_replace_view_with_multiple_queries(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation",
     run=False,
 )
@@ -3538,7 +3540,7 @@ def test_to_df_then_copy(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame alias is not supported in Local Testing",
 )
 def test_to_df_then_alias_and_join(session):
@@ -3633,7 +3635,7 @@ def test_to_df_then_alias_and_join(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame alias is not supported in Local Testing",
 )
 def test_dataframe_alias(session):
@@ -3727,7 +3729,7 @@ def test_dataframe_alias(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="DataFrame alias is not supported in Local Testing",
 )
 def test_dataframe_alias_negative(session):
@@ -3757,7 +3759,7 @@ def test_dataframe_result_cache_changing_schema(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="functions.seq2 is not supported in Local Testing",
 )
 @pytest.mark.parametrize("select_again", [True, False])
@@ -3788,7 +3790,7 @@ def test_dataframe_data_generator(session, select_again):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Rank is not supported in Local Testing",
 )
 @pytest.mark.parametrize("select_again", [True, False])
@@ -3827,7 +3829,7 @@ def test_select_star_select_columns(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1373887 Basic diamond shaped joins are not supported",
 )
 def test_select_star_join(session):
@@ -3862,7 +3864,7 @@ def test_drop_columns_special_names(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="TODO: Interval Expression is not supported in Local Testing",
 )
 def test_dataframe_interval_operation(session):

--- a/tests/integ/test_df_aggregate.py
+++ b/tests/integ/test_df_aggregate.py
@@ -102,7 +102,7 @@ def test_df_agg_tuples_basic_without_std(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: stddev function not supported",
 )
 def test_df_agg_tuples_basic(session):
@@ -198,7 +198,7 @@ def test_df_agg_tuples_avg_basic(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: stddev function not supported",
 )
 def test_df_agg_tuples_std_basic(session):

--- a/tests/integ/test_df_analytics.py
+++ b/tests/integ/test_df_analytics.py
@@ -32,7 +32,7 @@ def get_sample_dataframe(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG/FEAT: SNOW-1370204 improve error message, moving_agg not supported, error message windows function UnresolvedAttribute not supported is unclear",
 )
 def test_moving_agg(session):
@@ -64,7 +64,7 @@ def test_moving_agg(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG/FEAT: SNOW-1370204 improve error message, moving_agg not supported, error message windows function UnresolvedAttribute not supported is unclear",
 )
 def test_moving_agg_custom_formatting(session):
@@ -123,7 +123,7 @@ def test_moving_agg_custom_formatting(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1370204 improve error message, windows function UnresolvedAttribute not supported",
 )
 def test_moving_agg_invalid_inputs(session):
@@ -256,7 +256,7 @@ def test_moving_agg_invalid_inputs(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1370204 improve error message, windows function UnresolvedAttribute not supported",
 )
 def test_cumulative_agg_forward_direction(session):
@@ -296,7 +296,7 @@ def test_cumulative_agg_forward_direction(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1370204 improve error message windows function UnresolvedAttribute not supported",
 )
 def test_cumulative_agg_backward_direction(session):
@@ -336,7 +336,7 @@ def test_cumulative_agg_backward_direction(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: cast to float type not supported, should route reference to to_float to to_double",
 )
 def test_compute_lead(session):
@@ -374,7 +374,7 @@ def test_compute_lead(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: result data type snowpark LongType and LongType() do not match",
 )
 def test_compute_lag(session):
@@ -445,7 +445,7 @@ def test_lead_lag_invalid_inputs(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1375417: bug in calculate_type raises TypeError for Long division",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -495,7 +495,7 @@ def test_time_series_agg(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: add_month not supported",
 )
 def test_time_series_agg_month_sliding_window(session):
@@ -566,7 +566,7 @@ def test_time_series_agg_month_sliding_window(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: add_month function not supported",
 )
 def test_time_series_agg_year_sliding_window(session):
@@ -637,7 +637,7 @@ def test_time_series_agg_year_sliding_window(session):
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: result data type snowpark LongType and LongType() do not match",
 )
 def test_time_series_agg_invalid_inputs(session):

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -139,7 +139,7 @@ def test_to_pandas_cast_integer(session, to_pandas_api, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: dtype and value mismatch",
 )
 def test_to_pandas_precision_for_number_38_0(session):
@@ -173,7 +173,7 @@ def test_to_pandas_precision_for_number_38_0(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: div0 and round functions not supported",
 )
 def test_to_pandas_precision_for_non_zero_scale(session):
@@ -196,7 +196,7 @@ def test_to_pandas_precision_for_non_zero_scale(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -246,7 +246,7 @@ def test_current_date_and_time(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: regexp_replace function not supported",
 )
 @pytest.mark.parametrize("col_a", ["a", col("a")])
@@ -271,7 +271,7 @@ def test_regexp_replace(session, col_a):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: regexp_extract function not supported",
 )
 def test_regexp_extract(session):
@@ -413,7 +413,7 @@ def test_semi_structure_to_char(session, convert_func):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: round function not supported",
 )
 def test_format_number(session):
@@ -433,7 +433,7 @@ def test_format_number(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: months_between function not supported",
 )
 @pytest.mark.parametrize("col_a, col_b", [("a", "b"), (col("a"), col("b"))])
@@ -487,7 +487,7 @@ def test_startswith(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370338 KeyError: 2 raised",
 )
 def test_struct(session):
@@ -522,7 +522,7 @@ def test_struct(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: strtok_to_array function not supported",
 )
 def test_strtok_to_array(session):
@@ -576,7 +576,7 @@ def test_least(session, use_col, values, expected):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: hash function not supported",
 )
 @pytest.mark.parametrize("col_a, col_b", [("a", "b"), (col("a"), col("b"))])
@@ -644,7 +644,7 @@ def test_basic_numerical_operations_negative(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370338: substring raises unsupported operand type(s) for -: 'str' and 'int'",
 )
 def test_basic_string_operations(session):
@@ -733,7 +733,7 @@ def test_basic_string_operations(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_to_string function not supported",
 )
 def test_substring_index(session):
@@ -757,7 +757,7 @@ def test_substring_index(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_to_string function not supported",
 )
 def test_substring_index_col(session):
@@ -772,7 +772,7 @@ def test_substring_index_col(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: bitshitright function not supported",
 )
 def test_bitshiftright(session):
@@ -784,7 +784,7 @@ def test_bitshiftright(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: round function not supported",
 )
 def test_bround(session):
@@ -799,7 +799,7 @@ def test_bround(session):
 
 # Enable for local testing after addressing SNOW-850268
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370338: count_distinct raises TypeError: sequence item 0: expected str instance, list found",
 )
 def test_count_distinct(session):
@@ -908,7 +908,7 @@ def test_call_builtin_avg_from_range(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: is_array function not supported",
 )
 def test_is_negative(session):
@@ -1060,7 +1060,7 @@ def test_parse_json(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: as_array function not supported",
 )
 def test_as_negative(session):
@@ -1297,7 +1297,7 @@ def test_to_binary(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_construct function not supported",
 )
 def test_array_min_max_functions(session):
@@ -1345,7 +1345,7 @@ def test_array_min_max_functions(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_flatten function not supported",
 )
 def test_array_flatten(session):
@@ -1382,7 +1382,7 @@ def test_array_flatten(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_construct function not supported",
 )
 def test_array_sort(session):
@@ -1472,7 +1472,7 @@ def test_coalesce(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: uniform function not supported",
 )
 def test_uniform(session):
@@ -1510,7 +1510,7 @@ def test_uniform(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: uniform function not supported",
 )
 def test_uniform_negative(session):
@@ -1532,7 +1532,7 @@ def test_negate_and_not_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: random function not supported",
 )
 def test_random_negative(session):
@@ -1603,7 +1603,7 @@ def test_to_filetype_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_construct function not supported",
 )
 def test_array_distinct(session):
@@ -1756,7 +1756,7 @@ def test_date_operations_negative(session):
 
 # TODO: enable for local testing after addressing SNOW-850263
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370338 TypeError: unsupported type for timedelta days component: numpy.int64",
 )
 def test_date_add_date_sub(session):
@@ -1775,7 +1775,7 @@ def test_date_add_date_sub(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: datediff function not supported",
 )
 def test_daydiff(session):
@@ -1793,7 +1793,7 @@ def test_get_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_generate_range function not supported",
 )
 def test_array_generate_range(session):
@@ -1835,7 +1835,7 @@ def test_sequence_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_generate_range function not supported",
 )
 def test_sequence(session):
@@ -1890,7 +1890,7 @@ def test_sequence(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: array_unqite_agg function not supported",
 )
 def test_array_unique_agg(session):
@@ -1924,7 +1924,7 @@ def test_array_unique_agg(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: SNOW-1370338 KeyError: 2 raised",
 )
 def test_create_map(session):

--- a/tests/integ/test_lineage.py
+++ b/tests/integ/test_lineage.py
@@ -22,7 +22,7 @@ except ImportError:
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Lineage is a SQL feature",
         run=False,
     )

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -23,7 +23,7 @@ from snowflake.snowpark.types import DateType, StringType
 from tests.utils import IS_IN_STORED_PROC, TempObjectType, TestFiles, Utils
 
 pytestmark = pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Local Testing packaging operation is no-op",
     run=False,
 )

--- a/tests/integ/test_pandas_to_df.py
+++ b/tests/integ/test_pandas_to_df.py
@@ -71,7 +71,7 @@ def tmp_table_complex(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 @pytest.mark.parametrize("quote_identifiers", [True, False])
@@ -163,7 +163,7 @@ def test_write_pandas_with_overwrite(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 def test_write_pandas(session, tmp_table_basic):
@@ -228,7 +228,7 @@ def test_write_pandas(session, tmp_table_basic):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 def test_write_pandas_with_use_logical_type(
@@ -281,7 +281,7 @@ def test_write_pandas_with_use_logical_type(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 @pytest.mark.parametrize("table_type", ["", "temp", "temporary", "transient"])
@@ -311,7 +311,7 @@ def test_write_pandas_with_table_type(session, table_type: str):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 @pytest.mark.parametrize("table_type", ["", "temp", "temporary", "transient"])
@@ -384,7 +384,7 @@ def test_create_dataframe_from_pandas(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 @pytest.mark.parametrize("table_type", ["", "temp", "temporary", "transient"])
@@ -439,7 +439,7 @@ def test_write_pandas_with_timestamps(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: TypeError: Mock.keys() returned a non-iterable (type Mock)",
 )
 def test_auto_create_table_similar_column_names(session, local_testing_mode):
@@ -468,7 +468,7 @@ def test_auto_create_table_similar_column_names(session, local_testing_mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query feature AUTOINCREMENT not supported",
     run=False,
 )
@@ -512,7 +512,7 @@ def test_special_name_quoting(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370341: schema name mismatch",
 )
 def test_write_to_different_schema(session, local_testing_mode):

--- a/tests/integ/test_query_history.py
+++ b/tests/integ/test_query_history.py
@@ -9,7 +9,7 @@ from tests.utils import IS_IN_STORED_PROC
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Query history is a SQL feature",
         run=False,
     ),

--- a/tests/integ/test_scoped_temp_objects.py
+++ b/tests/integ/test_scoped_temp_objects.py
@@ -12,7 +12,7 @@ from snowflake.snowpark._internal.utils import (
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -28,7 +28,7 @@ from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles,
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1374069: fix RuntimeConfig for Local Testing",
 )
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot create session in SP")
@@ -72,7 +72,7 @@ def test_runtime_config(db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -92,7 +92,7 @@ def test_update_query_tag(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -102,7 +102,7 @@ def test_select_1(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -172,7 +172,7 @@ def test_session_builder(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -227,7 +227,7 @@ def test_create_session_in_sp(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="BUG: Mock object is closed undefined",
 )
 def test_close_session_in_sp(session):
@@ -244,7 +244,7 @@ def test_close_session_in_sp(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -356,7 +356,7 @@ def test_create_session_from_connection(
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing live connection feature",
     run=False,
 )
@@ -384,7 +384,7 @@ def test_create_session_from_connection_with_noise_parameters(
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Query tag is a SQL feature",
     run=False,
 )
@@ -405,7 +405,7 @@ def test_session_builder_app_name(session, db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )
@@ -612,7 +612,7 @@ def test_get_current_schema(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SQL query not supported",
     run=False,
 )

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -41,7 +41,7 @@ else:
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="This is a SQL test suite",
         run=False,
     )

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -81,7 +81,7 @@ def setup(session, resources_path, local_testing_mode):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Packaging processing is a NOOP in Local Testing",
     run=False,
 )
@@ -129,7 +129,7 @@ def test_add_packages_failures(packages, should_fail, db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Packaging processing is a NOOP in Local Testing",
     run=False,
 )
@@ -350,7 +350,7 @@ def test_call_named_stored_procedure(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Structured types are not supported in Local Testing",
 )
 @pytest.mark.skipif(
@@ -866,7 +866,7 @@ def return_datetime(_: Session) -> datetime.datetime:
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Database objects do not persist across sessions in Local Testing",
     run=False,
 )
@@ -899,7 +899,7 @@ def test_permanent_sp(session, db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Database objects do not persist across sessions in Local Testing",
     run=False,
 )
@@ -935,7 +935,7 @@ def test_permanent_sp_negative(session, db_parameters):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370028",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="Requires pandas")
@@ -1066,7 +1066,7 @@ def test_sp_negative(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Table sproc is not supported in Local Testing",
 )
 @pytest.mark.parametrize("is_permanent", [True, False])
@@ -1185,7 +1185,7 @@ def test_table_sproc(session, is_permanent, anonymous, ret_type):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-952138 Table sproc is not supported in Local Testing",
 )
 def test_table_sproc_negative(session, caplog):
@@ -1229,7 +1229,7 @@ def test_table_sproc_negative(session, caplog):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-952138 Table sproc is not supported in Local Testing",
 )
 def test_table_sproc_with_type_none_argument(session):
@@ -1340,7 +1340,7 @@ def test_temp_sp_with_import_and_upload_stage(
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1374204: align error behavior on when imports has bad input value",
 )
 def test_add_import_negative(session, resources_path, local_testing_mode):
@@ -1432,7 +1432,7 @@ def test_sp_replace(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370044: Support if_not_exists in Local Testing",
 )
 @pytest.mark.skipif(
@@ -1493,7 +1493,7 @@ def test_sp_if_not_exists(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Local Testing doesn't PUT the files, so parallel is trivial",
     run=False,
 )
@@ -1526,7 +1526,7 @@ def test_sp_parallel():
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Comment is a SQL feature",
     run=False,
 )
@@ -1550,7 +1550,7 @@ def test_create_sproc_with_comment(session, prefix):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="StoredProcedure.describe is not supported in Local Testing",
 )
 @pytest.mark.parametrize("source_code_display", [(True,), (False,)])
@@ -1594,7 +1594,7 @@ def test_describe_sp(session, source_code_display):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL feature",
     run=False,
 )
@@ -1702,7 +1702,7 @@ def test_call_sproc_with_session_as_first_argument(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370044: support strict option for stored procedures in Local Testing",
 )
 def test_strict_stored_procedure(session):
@@ -1716,7 +1716,7 @@ def test_strict_stored_procedure(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370056: Anonymous stored procedure is not supported yet",
 )
 def test_anonymous_stored_procedure(session):
@@ -1731,7 +1731,7 @@ def test_anonymous_stored_procedure(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Query tag is a SQL only feature",
     run=False,
 )
@@ -1780,7 +1780,7 @@ def test_sp_external_access_integration(session, db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is a SQL test",
     run=False,
 )

--- a/tests/integ/test_table_function.py
+++ b/tests/integ/test_table_function.py
@@ -16,7 +16,7 @@ from tests.utils import Utils
 
 pytestmark = [
     pytest.mark.skipif(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="Table function is not supported in Local Testing",
     ),
 ]

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -49,7 +49,7 @@ else:
 
 pytestmark = [
     pytest.mark.xfail(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="This is testing inbound telemetry",
         run=False,
     )

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -18,7 +18,7 @@ from tests.utils import IS_IN_STORED_PROC, IS_NOT_ON_GITHUB, TestFiles, Utils
 
 pytestmark = [
     pytest.mark.skipif(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="UDAF is not supported in Local Testing",
     ),
     pytest.mark.udf,

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -433,7 +433,7 @@ def test_register_udf_from_file(session, resources_path):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(
@@ -1004,7 +1004,7 @@ def return_dict(v: dict) -> Dict[str, str]:
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Database objects are session scoped in Local Testing",
     run=False,
 )
@@ -1037,7 +1037,7 @@ def test_permanent_udf(session, db_parameters):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Database objects are session scoped in Local Testing",
     run=False,
 )
@@ -1073,7 +1073,7 @@ def test_permanent_udf_negative(session, db_parameters):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370028: align error behavior when UDF receives bad input",
 )
 def test_udf_negative(session, local_testing_mode):
@@ -1187,7 +1187,7 @@ def test_udf_negative(session, local_testing_mode):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1374204: Align error behavior when UDF/Sproc registration receives bad import",
 )
 def test_add_import_negative(session, resources_path):
@@ -1242,7 +1242,7 @@ def test_add_import_negative(session, resources_path):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370035: date time objects are received as str inside UDF",
 )
 def test_udf_variant_type(session):
@@ -1338,7 +1338,7 @@ def test_udf_variant_type(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-946829 Support Geography datatype in Local Testing",
 )
 def test_udf_geography_type(session):
@@ -1356,7 +1356,7 @@ def test_udf_geography_type(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-946829 Support Geometry datatype in Local Testing",
 )
 def test_udf_geometry_type(session):
@@ -1447,7 +1447,7 @@ def test_udf_replace(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370035: support if_not_exists in UDF registration and enable",
 )
 @pytest.mark.skipif(
@@ -1551,7 +1551,7 @@ def test_udf_parallel(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Comment is a SQL feature",
     run=False,
 )
@@ -1568,7 +1568,7 @@ def test_udf_comment(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Describe UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(
@@ -1611,7 +1611,7 @@ def test_udf_describe(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -1667,7 +1667,7 @@ def test_basic_pandas_udf(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -1725,7 +1725,7 @@ def test_pandas_udf_type_hints(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -1839,7 +1839,7 @@ def test_pandas_udf_input_types(session, _type, data, expected_types, expected_d
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -1887,7 +1887,7 @@ def test_pandas_udf_input_variant(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -1990,7 +1990,7 @@ def test_pandas_udf_return_types(session, _type, data, expected_types, expected_
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -2039,7 +2039,7 @@ def test_pandas_udf_return_variant(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -2072,7 +2072,7 @@ def test_pandas_udf_max_batch_size(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDF is not supported in Local Testing",
 )
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
@@ -2109,7 +2109,7 @@ def test_pandas_udf_negative(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL feature",
     run=False,
 )
@@ -2204,7 +2204,7 @@ def test_udf_class_method(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Local Testing doesn't pickle",
     run=False,
 )
@@ -2223,7 +2223,7 @@ def test_udf_pickle_failure(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Comment is a SQL feature",
     run=False,
 )
@@ -2282,7 +2282,7 @@ def test_deprecate_call_udf_with_list(session, caplog):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370035: support strict UDF in Local Testing",
 )
 def test_strict_udf(session):
@@ -2299,7 +2299,7 @@ def test_strict_udf(session):
 
 
 @pytest.mark.xfail(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Secure UDF is a SQL feature",
     run=False,
 )
@@ -2333,7 +2333,7 @@ def test_numpy_udf(session, func):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="SNOW-1370447: mock_timestamp_ntz raises error",
 )
 @pytest.mark.skipif(
@@ -2397,7 +2397,7 @@ def test_udf_timestamp_type_hint(session):
 
 
 @pytest.mark.skipif(
-    "config.getvalue('local_testing_mode')",
+    "config.getoption('local_testing_mode', default=False)",
     reason="Vectorized UDTF is not supported in Local Testing",
 )
 def test_vectorized_udf_timestamp_type_hint(session):

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -46,7 +46,7 @@ except ImportError:
 pytestmark = [
     pytest.mark.udf,
     pytest.mark.skipif(
-        "config.getvalue('local_testing_mode')",
+        "config.getoption('local_testing_mode', default=False)",
         reason="UDTF not supported in Local Testing",
     ),
 ]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

config.getvalue raised ValueError if local_testing_mode/disable_sql_simplifer is not available in pytest options
in the meanwhile config.getvalue is deprecated.

not setting the option breaks regression test where we do not set pytest option local_testing_mode,  to fix the issue, we should use getoption which we can set a default value.

this PR only focus on fixing the pytest option, whether to add these option into the regression test discussion is beyond this PR