### PR TITLE
SNOW-1413958: Skip optimizing dynamic pivot query plan using CTE 

### DIFF
--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -422,6 +422,13 @@ def test_pivot_unpivot(session):
     check_result(session, df_result, expect_cte_optimized=True)
     assert count_number_of_ctes(df_result.queries["queries"][-1]) == 1
 
+    # Because of SNOW-1375062, dynamic pivot doesn't work with nested CTE
+    # TODO: SNOW-1413967 Remove it when the bug is fixed
+    df_nested = session.table("monthly_sales").select("*")
+    df_nested = df_nested.union_all(df_nested).select("*")
+    df_dynamic_pivot = df_nested.pivot("month").sum("amount")
+    check_result(session, df_dynamic_pivot, expect_cte_optimized=False)
+
 
 def test_window_function(session):
     window1 = (

--- a/tests/unit/test_cte.py
+++ b/tests/unit/test_cte.py
@@ -14,6 +14,7 @@ def test_case1():
     nodes = [mock.create_autospec(SnowflakePlan) for _ in range(7)]
     for i, node in enumerate(nodes):
         node._id = i
+        node.source_plan = None
     nodes[0].children_plan_nodes = [nodes[1], nodes[3]]
     nodes[1].children_plan_nodes = [nodes[2], nodes[2]]
     nodes[2].children_plan_nodes = [nodes[4]]
@@ -30,6 +31,7 @@ def test_case2():
     nodes = [mock.create_autospec(SnowflakePlan) for _ in range(7)]
     for i, node in enumerate(nodes):
         node._id = i
+        node.source_plan = None
     nodes[0].children_plan_nodes = [nodes[1], nodes[3]]
     nodes[1].children_plan_nodes = [nodes[2], nodes[2]]
     nodes[2].children_plan_nodes = [nodes[4], nodes[4]]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1413958

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Due to https://snowflakecomputing.atlassian.net/browse/SNOW-1375062, we need to skip optimizing dynamic pivot query plan using CTE. Specifically, any subquery under dynamic pivot plan will not be converted to a CTE.
