### PR TITLE
SNOW-1374293: Fix property method typing.

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed bug when creating a DataFrame with a dict of Series objects.
 - Fixed support for `display.max_rows` and `display.max_cols` being set to `None`.
 - Fixed bug when performing multiple DataFrameGroupBy apply/transform operations on the same DataFrame.
+- Fixed type hints for property methods, e.g. Series.empty.
 
 ### Improvements
 - Improved performance of `pd.qcut` by removing joins in generated sql query.

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -44,9 +44,9 @@ ARG_TRUNCATE_SIZE = 100
 
 @unique
 class PropertyMethodType(Enum):
-    FGET = auto()
-    FSET = auto()
-    FDEL = auto()
+    FGET = "get"
+    FSET = "set"
+    FDEL = "delete"
 
 
 @safe_telemetry
@@ -227,8 +227,9 @@ def _gen_func_name(
         func: the main function
         property_name: the property name if the function is used by a property, e.g., `index`, `name`, `iloc`, `loc`,
         `dtype`, etc
-        property_method_type: The property method that this function implements,
-        if this method is for a property, e.g. `FGET` to get a property.
+        property_method_type: The property method (`FGET`/`FSET`/`FDEL`) that 
+        this function implements, if this method is used by a property.
+        `property_name` must also be specified.
 
     Returns:
         The generated function name
@@ -269,8 +270,9 @@ def _telemetry_helper(
         in Python is a function defined outside a class or any other enclosing structure, callable directly without
         an instance of a class.
         property_name: the property name if the `func` is from a property.
-        property_method_type: The property method that this function implements,
-        if this method is for a property, e.g. `FGET` to get a property.
+        property_method_type: The property method (`FGET`/`FSET`/`FDEL`) that 
+        this function implements, if this method is used by a property.
+        `property_name` must also be specified.
 
     Returns:
         The return value of the API function.

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -422,6 +422,8 @@ def snowpark_pandas_telemetry_method_decorator(
             property_method_type=property_method_type,
         )
 
+    # need cast to convince mypy that we are returning a function with the same
+    # signature as func.
     return cast(T, wrap)
 
 
@@ -453,6 +455,8 @@ def snowpark_pandas_telemetry_standalone_function_decorator(func: T) -> T:
             is_standalone_function=True,
         )
 
+    # need cast to convince mypy that we are returning a function with the same
+    # signature as func.
     return cast(T, wrap)
 
 

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -527,6 +527,7 @@ def _del_iloc(df: pd.DataFrame) -> None:
     [("set", "iloc", _set_iloc, "setter"), ("delete", "iloc", _del_iloc, "deleter")],
 )
 def test_telemetry_property_missing_methods(method_verb, name, method, method_noun):
+    """Test telemetry for property methods that don't exist, e.g. users can't assign a value to the `iloc` property."""
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     df._query_compiler.snowpark_pandas_api_calls.clear()
     # Clear connector telemetry client buffer to avoid flush triggered by the next API call, ensuring log extraction.

--- a/tests/unit/modin/test_type_annotations.py
+++ b/tests/unit/modin/test_type_annotations.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from typing import get_type_hints
+
+import modin.pandas as pd
+import pandas
+import pytest
+
+import snowflake.snowpark.modin.plugin  # noqa: F401
+
+
+@pytest.mark.parametrize(
+    "method,type_hints",
+    [
+        (pd.Series.empty.fget, {"return": bool}),
+        (pd.DataFrame.columns.fget, {"return": pandas.Index}),
+    ],
+)
+def test_properties_snow_1374293(method, type_hints):
+    assert get_type_hints(method) == type_hints
+
+
+def test_dataframe_method():
+    # Use a method with a simple signature to avoid
+    # https://github.com/python/cpython/issues/118919
+    assert get_type_hints(pd.DataFrame.compare) == {
+        "keep_shape": bool,
+        "keep_equal": bool,
+        "return": pd.DataFrame,
+    }


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1374293

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Carry property method type hints through the `TelemetryMeta` class.

	Prior this commit, we would lose the type hints [here](https://github.com/snowflakedb/snowpark-python/blob/cc3d2898d4170cc68ca8d59a7872e9c2b1ba7929/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py#L486-L491) because the type hints come from `fget`,`fset`, and `fdel` rather than from `__get__`, `__set__`, or `__delete__` respectively.

   Also, the annotations [here](https://github.com/snowflakedb/snowpark-python/blob/cc3d2898d4170cc68ca8d59a7872e9c2b1ba7929/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py#L381) and [here](https://github.com/snowflakedb/snowpark-python/blob/cc3d2898d4170cc68ca8d59a7872e9c2b1ba7929/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py#L413) incorrectly say that wrapped methods always return a `Callable`. It turned out that what we put for the return type there doesn't seem to matter, but we should fix the misleading type there while we're here anyway.

 	I had to work with and around some really puzzling behavior of properties and python typing while working on this fix. Hopefully this commit makes sense.


----
Signed-off-by: sfc-gh-mvashishtha <mahesh.vashishtha@snowflake.com