### PR TITLE
SNOW-1264688: Remove overrides of infer_object/nunique

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -1986,6 +1986,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
             )
         )
 
+    @base_not_implemented()
     def infer_objects(
         self, copy: bool | None = None
     ) -> BasePandasDataset:  # pragma: no cover # noqa: RT01, D200
@@ -1993,8 +1994,6 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         Attempt to infer better dtypes for object columns.
         """
         # TODO: SNOW-1119855: Modin upgrade - modin.pandas.base.BasePandasDataset
-        # This method is currently overriden in dataframe_overrides.py and series_overrides.py
-        # and raises NotImplementedError
         new_query_compiler = self._query_compiler.infer_objects()
         return self._create_or_update_from_compiler(
             new_query_compiler, inplace=False if copy is None else not copy

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1947,24 +1947,18 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         >>> df.nunique()
         A    3
         B    2
-        dtype: int8
-
-        >>> df.nunique(axis=1)
-        0    1
-        1    2
-        2    2
-        dtype: int8
+        dtype: int64
 
         >>> df = pd.DataFrame({'A': [None, pd.NA, None], 'B': [1, 2, 1]})
         >>> df.nunique()
         A    0
         B    2
-        dtype: int8
+        dtype: int64
 
         >>> df.nunique(dropna=False)
         A    1
         B    2
-        dtype: int8
+        dtype: int64
         """
 
     def pct_change():

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1317,7 +1317,8 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
 
     def infer_objects():
         """
-        Attempt to infer better dtypes for object columns.
+        Attempt to infer better dtypes for object columns. This is not currently supported
+        in Snowpark pandas.
         """
 
     def convert_dtypes():
@@ -1921,7 +1922,49 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
 
     def nunique():
         """
-        Return number of unique elements in the `BasePandasDataset`.
+        Count number of distinct elements in specified axis.
+
+        Return Series with number of distinct elements. Can ignore NaN values.
+        Snowpark pandas API does not distinguish between different NaN types like None,
+        pd.NA, and np.nan, and treats them as the same.
+
+        Parameters
+        ----------
+        axis : {0 or 'index', 1 or 'columns'}, default 0
+            The axis to use. 0 or 'index' for row-wise, 1 or 'columns' for
+            column-wise. Snowpark pandas currently only supports axis=0.
+        dropna : bool, default True
+            Don't include NaN in the counts.
+
+        Returns
+        -------
+        Series
+
+        Examples
+        --------
+        >>> import snowflake.snowpark.modin.pandas as pd
+        >>> df = pd.DataFrame({'A': [4, 5, 6], 'B': [4, 1, 1]})
+        >>> df.nunique()
+        A    3
+        B    2
+        dtype: int8
+
+        >>> df.nunique(axis=1)
+        0    1
+        1    2
+        2    2
+        dtype: int8
+
+        >>> df = pd.DataFrame({'A': [None, pd.NA, None], 'B': [1, 2, 1]})
+        >>> df.nunique()
+        A    0
+        B    2
+        dtype: int8
+
+        >>> df.nunique(dropna=False)
+        A    1
+        B    2
+        dtype: int8
         """
 
     def pct_change():

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2995,7 +2995,7 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         2    5
         3    7
         4    7
-        dtype: int8
+        dtype: int64
 
         >>> s.nunique()
         4

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2969,7 +2969,43 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
 
     def nunique():
         """
-        Return number of unique elements in the object.
+        Return number of unique elements in the series.
+
+        Excludes NA values by default.
+        Snowpark pandas API does not distinguish between different NaN types like None,
+        pd.NA, and np.nan, and treats them as the same.
+
+        Parameters
+        ----------
+        dropna : bool, default True
+            Don't include NaN in the count.
+
+        Returns
+        -------
+        int
+
+        Examples
+        --------
+        >>> import snowflake.snowpark.modin.pandas as pd
+        >>> import numpy as np
+        >>> s = pd.Series([1, 3, 5, 7, 7])
+        >>> s
+        0    1
+        1    3
+        2    5
+        3    7
+        4    7
+        dtype: int8
+
+        >>> s.nunique()
+        4
+
+        >>> s = pd.Series([pd.NaT, np.nan, pd.NA, None, 1])
+        >>> s.nunique()
+        1
+
+        >>> s.nunique(dropna=False)
+        2
         """
 
     @property

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_overrides.py
@@ -12,16 +12,9 @@ from typing import Any
 import pandas as native_pd
 
 from snowflake.snowpark.modin import pandas as pd  # noqa: F401
-from snowflake.snowpark.modin.pandas import DataFrame, Series
 from snowflake.snowpark.modin.pandas.api.extensions import register_dataframe_accessor
 from snowflake.snowpark.modin.plugin._internal.telemetry import (
     snowpark_pandas_telemetry_method_decorator,
-)
-from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
-    SnowflakeQueryCompiler,
-)
-from snowflake.snowpark.modin.plugin.utils.error_message import (
-    dataframe_not_implemented,
 )
 from snowflake.snowpark.modin.utils import _inherit_docstrings
 
@@ -64,69 +57,3 @@ def memory_usage(self, index: bool = True, deep: bool = False) -> Any:
     # TODO: SNOW-1264697: push implementation down to query compiler
     columns = (["Index"] if index else []) + self._get_columns().array.tolist()
     return native_pd.Series([0] * len(columns), index=columns)
-
-
-@_inherit_docstrings(native_pd.DataFrame.infer_objects, apilink="pandas.DataFrame")
-@register_dataframe_accessor("infer_objects")
-@snowpark_pandas_telemetry_method_decorator
-@dataframe_not_implemented()
-def infer_objects(
-    self,
-) -> SnowflakeQueryCompiler:  # pragma: no cover # noqa: RT01, D200
-    """
-    Attempt to infer better dtypes for object columns.
-    """
-    return self.__constructor__(query_compiler=self._query_compiler.infer_objects())
-
-
-@_inherit_docstrings(native_pd.DataFrame.nunique, apilink="pandas.DataFrame")
-@register_dataframe_accessor("nunique")
-@snowpark_pandas_telemetry_method_decorator
-def nunique(self, axis: int = 0, dropna: bool = True) -> Series:
-    """
-    Count number of distinct elements in specified axis.
-
-    Return Series with number of distinct elements. Can ignore NaN
-    values. Snowpark pandas API does not distinguish between NaN values and treats them all as the same.
-
-    Parameters
-    ----------
-    axis : {0 or 'index', 1 or 'columns'}, default 0
-        The axis to use. 0 or 'index' for row-wise, 1 or 'columns' for
-        column-wise.
-    dropna : bool, default True
-        Don't include NaN in the counts.
-
-    Returns
-    -------
-    Series
-
-    Examples
-    --------
-    >>> import snowflake.snowpark.modin.pandas as pd
-    >>> df = pd.DataFrame({'A': [4, 5, 6], 'B': [4, 1, 1]})
-    >>> df.nunique()
-    A    3
-    B    2
-    dtype: int8
-
-    >>> df.nunique(axis=1)
-    0    1
-    1    2
-    2    2
-    dtype: int8
-
-    >>> df = pd.DataFrame({'A': [None, pd.NA, None], 'B': [1, 2, 1]})
-    >>> df.nunique()
-    A    0
-    B    2
-    dtype: int8
-
-    >>> df.nunique(dropna=False)
-    A    1
-    B    2
-    dtype: int8
-
-    """
-    # TODO: SNOW-1264688: remove this override
-    return super(DataFrame, self).nunique(axis=axis, dropna=dropna)

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
@@ -18,7 +18,6 @@ from snowflake.snowpark.modin.plugin._internal.telemetry import (
     snowpark_pandas_telemetry_method_decorator,
 )
 from snowflake.snowpark.modin.plugin._typing import ListLike
-from snowflake.snowpark.modin.plugin.utils.error_message import series_not_implemented
 from snowflake.snowpark.modin.utils import _inherit_docstrings
 
 
@@ -31,64 +30,6 @@ def memory_usage(self, index: bool = True, deep: bool = False) -> int:
     """
     # TODO: SNOW-1264697: push implementation down to query compiler
     return 0
-
-
-@_inherit_docstrings(native_pd.Series.infer_objects, apilink="pandas.Series")
-@register_series_accessor("infer_objects")
-@snowpark_pandas_telemetry_method_decorator
-@series_not_implemented()
-def infer_objects(self) -> Series:  # pragma: no cover # noqa: RT01, D200
-    """
-    Attempt to infer better dtypes for object columns.
-    """
-    return self.__constructor__(query_compiler=self._query_compiler.infer_objects())
-
-
-@_inherit_docstrings(native_pd.Series.nunique, apilink="pandas.Series")
-@register_series_accessor("nunique")
-@snowpark_pandas_telemetry_method_decorator
-def nunique(self, dropna: bool = True) -> int:
-    """
-    Return number of unique elements in the series.
-
-    Excludes NA values by default. Snowpark pandas API does not distinguish between different NaN types like None,
-    pd.NA or np.nan and treats them as the same
-
-    Parameters
-    ----------
-    dropna : bool, default True
-        Don't include NaN in the count.
-
-    Returns
-    -------
-    int
-
-    Examples
-    --------
-    >>> import snowflake.snowpark.modin.pandas as pd
-    >>> import numpy as np
-    >>> s = pd.Series([1, 3, 5, 7, 7])
-    >>> s
-    0    1
-    1    3
-    2    5
-    3    7
-    4    7
-    dtype: int8
-
-    >>> s.nunique()
-    4
-
-    >>> s = pd.Series([pd.NaT, np.nan, pd.NA, None, 1])
-    >>> s.nunique()
-    1
-
-    >>> s.nunique(dropna=False)
-    2
-
-    """
-    # TODO: SNOW-1264688: remove this override
-    return super(Series, self).nunique(dropna=dropna)
 
 
 @_inherit_docstrings(native_pd.Series.isin, apilink="pandas.Series")


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1264688

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

`infer_objects` and `nunique` were overridden as vestigial remnants of the SnowparkPandasDataFrame and SnowparkPandasSeries classes. Now that we can use the docs extension modules, there is no longer any reason to keep these overrides around.

After this PR, only 2 remaining DF/Series methods are overridden:
- `memory_usage` can also be removed pretty easily; since it has a separate ticket filed I'll remove it in a separate PR.
- `Series.isin` does some extra argument processing that I'd prefer not to touch in case something breaks.