### PR TITLE
SNOW-1421247: Remove skipped doctests that previously defaulted to pandas

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/general.py
+++ b/src/snowflake/snowpark/modin/pandas/general.py
@@ -658,7 +658,6 @@ def to_numeric(
     errors: Literal["ignore", "raise", "coerce"] = "raise",
     downcast: Literal["integer", "signed", "unsigned", "float"] | None = None,
 ) -> Series | Scalar | None:
-    # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
     """
     Convert argument to a numeric type.
 
@@ -719,12 +718,6 @@ def to_numeric(
     2   -3.0
     dtype: float64
     >>> s = pd.Series(['apple', '1.0', '2', -3])
-    >>> pd.to_numeric(s, errors='ignore')  # doctest: +SKIP
-    0    apple
-    1      1.0
-    2        2
-    3       -3
-    dtype: object
     >>> pd.to_numeric(s, errors='coerce')
     0    NaN
     1    1.0
@@ -1263,7 +1256,6 @@ def to_datetime(
     origin: Any = "unix",
     cache: bool = True,
 ) -> Series | DatetimeScalar | NaTType | None:
-    # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
     """
     Convert argument to datetime.
 
@@ -1498,11 +1490,6 @@ def to_datetime(
 
     Passing ``errors='coerce'`` will force an out-of-bounds date to :const:`NaT`,
     in addition to forcing non-dates (or non-parseable dates) to :const:`NaT`.
-
-    >>> pd.to_datetime(['13000101', 'abc'], format='%Y%m%d', errors='ignore')  # doctest: +SKIP
-    0    13000101
-    1         abc
-    dtype: object
 
     >>> pd.to_datetime(['13000101', 'abc'], format='%Y%m%d', errors='coerce')
     0   NaT
@@ -2070,14 +2057,6 @@ def date_range(
     3   2018-10-31
     4   2019-01-31
     dtype: datetime64[ns]
-
-    Specify `tz` to set the timezone.
-
-    >>> pd.date_range(start='1/1/2018', periods=5, tz='Asia/Tokyo')  # doctest: +SKIP
-    DatetimeIndex(['2018-01-01 00:00:00+09:00', '2018-01-02 00:00:00+09:00',
-                   '2018-01-03 00:00:00+09:00', '2018-01-04 00:00:00+09:00',
-                   '2018-01-05 00:00:00+09:00'],
-                  dtype='datetime64[ns, Asia/Tokyo]', freq='D')
 
     `inclusive` controls whether to include `start` and `end` that are on the
     boundary. The default, "both", includes boundary points on either end.

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -2620,7 +2620,6 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         """
 
     def sort_values():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Sort by the values along either axis.
 
@@ -2730,17 +2729,6 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         2     B     9     9    c
         0     A     2     0    a
         1     A     1     1    B
-
-        Sorting with a key function
-
-        >>> df.sort_values(by='col4', key=lambda col: col.str.lower())  # doctest: +SKIP
-           col1  col2  col3 col4
-        0     A     2     0    a
-        1     A     1     1    B
-        2     B     9     9    c
-        3  None     8     4    D
-        4     D     7     2    e
-        5     C     4     3    F
         """
 
     @doc(

--- a/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
@@ -219,7 +219,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
         """
 
     def dropna():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Remove missing values.
 
@@ -282,14 +281,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
         >>> df.dropna()
              name        toy       born
         1  Batman  Batmobile 1940-04-25
-
-        Drop the columns where at least one element is missing.
-
-        >>> df.dropna(axis='columns')  # doctest: +SKIP
-               name
-        0    Alfred
-        1    Batman
-        2  Catwoman
 
         Drop the rows where all elements are missing.
 
@@ -645,15 +636,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
            0  1
         0  3  4
         1  5  5
-
-        Like Series.map, NA values can be ignored: (TODO SNOW-888095: re-enable the test once fallback solution is used)
-
-        >>> df_copy = df.copy()
-        >>> df_copy.iloc[0, 0] = pd.NA
-        >>> df_copy.applymap(lambda x: len(str(x)), na_action='ignore')  # doctest: +SKIP
-             0  1
-        0  NaN  4
-        1  5.0  5
 
         When you use the applymap function, a user-defined function (UDF) is generated and
         applied to each column. However, in many cases, you can achieve the same results
@@ -1180,7 +1162,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
         """
 
     def fillna():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Fill NA/NaN values using the specified method.
 
@@ -1268,15 +1249,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
         1  3.0  4.0  2.0  1.0
         2  0.0  1.0  2.0  3.0
         3  0.0  3.0  2.0  4.0
-
-        Only replace the first NaN element.
-
-        >>> df.fillna(value=values, limit=1)  # doctest: +SKIP
-             A    B    C    D
-        0  0.0  2.0  2.0  0.0
-        1  3.0  4.0  NaN  1.0
-        2  NaN  1.0  NaN  3.0
-        3  NaN  3.0  NaN  4.0
 
         When filling using a DataFrame, replacement happens along
         the same column names and same indices
@@ -2187,7 +2159,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
         """
 
     def rename():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Rename columns or index labels.
 
@@ -2272,8 +2243,6 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         >>> df.index
         Index([0, 1, 2], dtype='int64')
-        >>> df.rename(index=str).index  # doctest: +SKIP
-        Index(['0', '1', '2'], dtype='object')
 
         >>> df.rename(columns={"A": "a", "B": "b", "C": "c"}, errors="raise")
         Traceback (most recent call last):

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -1113,7 +1113,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         """
 
     def fillna():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Fill NA/NaN values using the specified method.
 
@@ -1202,15 +1201,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         2  0.0  1.0  2.0  3.0
         3  0.0  3.0  2.0  4.0
 
-        Only replace the first NaN element.
-
-        >>> df.fillna(value=values, limit=1)  # doctest: +SKIP
-             A    B    C    D
-        0  0.0  2.0  2.0  0.0
-        1  3.0  4.0  NaN  1.0
-        2  NaN  1.0  NaN  3.0
-        3  NaN  3.0  NaN  4.0
-
         When filling using a DataFrame, replacement happens along
         the same column names and same indices
 
@@ -1236,7 +1226,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         pass
 
     def groupby():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Group Series using a mapper or by a Series of columns.
 
@@ -1291,10 +1280,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
             Parrot     30.0
             Parrot     20.0
             Name: Max Speed, dtype: float64
-            >>> ser.groupby(["a", "b", "a", "b"]).mean()  # doctest: +SKIP
-            a    210.0
-            b    185.0
-            Name: Max Speed, dtype: float64
             >>> ser.groupby(level=0).mean()
             Falcon    370.0
             Parrot     25.0
@@ -1326,21 +1311,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
             Captive    210.0
             Wild       185.0
             Name: Max Speed, dtype: float64
-
-            We can also choose to include `NA` in group keys or not by defining
-            `dropna` parameter, the default setting is `True`.
-
-            >>> ser = pd.Series([1, 2, 3, 3], index=["a", 'a', 'b', np.nan])
-            >>> ser.groupby(level=0).sum()      # doctest: +SKIP
-            a    3
-            b    3
-            dtype: int64
-
-            >>> ser.groupby(level=0, dropna=False).sum()        # doctest: +SKIP
-            a    3
-            b    3
-            NaN  3
-            dtype: int64
         """
 
     @_create_operator_docstring(pandas.core.series.Series.gt, overwrite_existing=True)
@@ -1722,7 +1692,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         """
 
     def rename():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Alter Series index labels or name.
 
@@ -1775,11 +1744,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         1    2
         2    3
         Name: my_name, dtype: int64
-        >>> s.rename(lambda x: x ** 2)  # function, changes labels  # doctest: +SKIP
-        0    1
-        1    2
-        4    3
-        dtype: int8
         >>> s.rename({1: 3, 2: 5})  # mapping, changes labels
         0    1
         3    2
@@ -2242,7 +2206,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         """
 
     def sort_values():
-        # TODO: SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda
         """
         Sort by the values.
 
@@ -2371,36 +2334,6 @@ class Series:  # pragma: no cover: we use this class's docstrings, but we never 
         2    c
         4    e
         dtype: object
-        >>> s.sort_values(key=lambda x: x.str.lower())  # doctest: +SKIP
-        0    a
-        1    B
-        2    c
-        3    D
-        4    e
-        dtype: object
-
-        NumPy ufuncs work well here. For example, we can
-        sort by the ``sin`` of the value
-
-        >>> s = pd.Series([-4, -2, 0, 2, 4])
-        >>> s.sort_values(key=np.sin)  # doctest: +SKIP
-        1   -2
-        4    4
-        2    0
-        0   -4
-        3    2
-        dtype: int8
-
-        More complicated user-defined functions can be used,
-        as long as they expect a Series and return an array-like
-
-        >>> s.sort_values(key=lambda x: (np.tan(x.cumsum())))  # doctest: +SKIP
-        0   -4
-        3    2
-        4    4
-        1   -2
-        2    0
-        dtype: int8
         """
 
     def squeeze():


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1421247

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Removes doctests that previously defaulted to pandas, but now fail.

These can be identified by their presence in the modin dependency PR in our old repo (https://github.com/snowflakedb/snowpandas/pull/995/files), or grepping for SNOW-1336091 and doctest: +SKIP.

I did not touch the docstrings for `apply` and `transform` even though they mostly fail. Most of these examples previously defaulted to pandas, so removing them would remove most of the docstring.