### PR TITLE
SNOW-1372258 - Print warning when calling __array__()

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -3781,6 +3781,12 @@ class BasePandasDataset(metaclass=TelemetryMeta):
             NumPy representation of Modin object.
         """
         # TODO: SNOW-1119855: Modin upgrade - modin.pandas.base.BasePandasDataset
+        WarningMessage.single_warning(
+            "Calling __array__ on a modin object materializes all data into local memory.\n"
+            + "Since this can be called by 3rd party libraries silently, it can lead to \n"
+            + "unexpected delays or high memory usage. Use to_pandas() or to_numpy() to do \n"
+            + "this once explicitly.",
+        )
         arr = self.to_numpy(dtype)
         return arr
 


### PR DESCRIPTION
SNOW-1372258 - Print warning when calling __array__()

3rd party libraries call __array__() frequently to get a numpy array for local processing. We do not warn users of this so certain types of pandas code (iterating through columns to print) may take a very long time. Here we make calls to __array__ print a single warning, and we point users at the to_pandas or to_numpy API calls.