### PR TITLE
SNOW-1041878: Throw KeyError on missing columns in getitem

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Behavior Changes
 - Given an input of type `Series`, `pd.qcut` always returns a `Series`.
 - `pd.qcut` produces `NotImplementedError` whenever `labels is not False` instead of falling back to pandas itself.
+- Throw `KeyError` when user passes in missing column labels to `__getitem__` and `loc`
 
 ### Improvements
 - Improved performance for `Series.quantile` and `Series.describe`. 

--- a/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
+++ b/src/snowflake/snowpark/modin/plugin/PANDAS_CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Behavior Changes
 - Given an input of type `Series`, `pd.qcut` always returns a `Series`.
 - `pd.qcut` produces `NotImplementedError` whenever `labels is not False` instead of falling back to pandas itself.
-- Throw `KeyError` when user passes in missing column labels to `__getitem__` and `loc`
+- Throw `KeyError` when user passes in missing column labels to `__getitem__` and `loc`.
 
 ### Improvements
 - Improved performance for `Series.quantile` and `Series.describe`. 

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -935,7 +935,7 @@ def get_valid_col_positions_from_col_labels(
             raise KeyError(f"None of {pandas.Index(col_loc)} are in the [columns]")
         elif any(label not in columns for label in col_loc):
             raise KeyError(
-                f"{[k for k in col_loc if k not in columns]} not found in index"
+                f"{[k for k in col_loc if k not in columns]} not in index"
             )
         # Convert col_loc to Index with object dtype since _get_indexer_strict() converts None values in lists to
         # np.nan. This does not filter columns with label None and errors. Not using np.array(col_loc) as the key since

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -924,7 +924,7 @@ def get_valid_col_positions_from_col_labels(
             col_loc = [col_loc]
         elif isinstance(col_loc, tuple):
             col_loc = [col_loc] if col_loc in columns else list(col_loc)
-        # Throw a KeyError in case there is no
+        # Throw a KeyError in case there are any missing column labels
         if any(label not in columns for label in col_loc):
             raise KeyError(
                 "None of {} are in the [columns]".format(

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -934,9 +934,7 @@ def get_valid_col_positions_from_col_labels(
         if len(col_loc) > 0 and all(label not in columns for label in col_loc):
             raise KeyError(f"None of {pandas.Index(col_loc)} are in the [columns]")
         elif any(label not in columns for label in col_loc):
-            raise KeyError(
-                f"{[k for k in col_loc if k not in columns]} not in index"
-            )
+            raise KeyError(f"{[k for k in col_loc if k not in columns]} not in index")
         # Convert col_loc to Index with object dtype since _get_indexer_strict() converts None values in lists to
         # np.nan. This does not filter columns with label None and errors. Not using np.array(col_loc) as the key since
         # np.array(["A", 12]) turns into array(['A', '12'].

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -769,9 +769,11 @@ def _extract_loc_set_col_info(
             union_data_columns
         ):
             raise ValueError(CANNOT_REINDEX_ON_DUPLICATE_ERROR_MESSAGE)
+        # split labels into existing and new
         new_column_pandas_labels = [
             label for label in columns if label not in frame_data_columns
         ]
+        columns = [label for label in columns if label in frame_data_columns]
         before = frame_data_columns.value_counts()
         after = union_data_columns.value_counts()
         frame_data_col_labels = frame_data_columns.tolist()

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -796,7 +796,7 @@ def _extract_loc_set_col_info(
     # When column enlargement may happen, get the list of pandas labels corresponding column key; otherwise, i.e., when
     # it is slice or boolean indexer, use the corresponding column position to get the labels
     column_pandas_labels = (
-        columns
+        new_column_pandas_labels + columns
         if enlargement_may_happen
         else [
             internal_frame.data_column_pandas_labels[pos]

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -750,6 +750,7 @@ def _extract_loc_set_col_info(
         elif not is_bool_indexer(columns):
             enlargement_may_happen = True
 
+    original_columns = columns
     if enlargement_may_happen:
         frame_data_columns = internal_frame.data_columns_index
         # This list contains the columns after loc set
@@ -796,7 +797,7 @@ def _extract_loc_set_col_info(
     # When column enlargement may happen, get the list of pandas labels corresponding column key; otherwise, i.e., when
     # it is slice or boolean indexer, use the corresponding column position to get the labels
     column_pandas_labels = (
-        new_column_pandas_labels + columns
+        original_columns
         if enlargement_may_happen
         else [
             internal_frame.data_column_pandas_labels[pos]

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -929,14 +929,10 @@ def get_valid_col_positions_from_col_labels(
             col_loc = [col_loc] if col_loc in columns else list(col_loc)
         # Throw a KeyError in case there are any missing column labels
         if len(col_loc) > 0 and all(label not in columns for label in col_loc):
-            raise KeyError(
-                "None of {} are in the [columns]".format(pandas.Index(col_loc))
-            )
+            raise KeyError(f"None of {pandas.Index(col_loc)} are in the [columns]")
         elif any(label not in columns for label in col_loc):
             raise KeyError(
-                "{} not found in index".format(
-                    [k for k in col_loc if k not in columns]
-                )
+                f"{[k for k in col_loc if k not in columns]} not found in index"
             )
         # Convert col_loc to Index with object dtype since _get_indexer_strict() converts None values in lists to
         # np.nan. This does not filter columns with label None and errors. Not using np.array(col_loc) as the key since

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -829,6 +829,9 @@ def get_valid_col_positions_from_col_labels(
         internal_frame: the main frame
         col_loc: the column labels in different types
 
+    Raises:
+        KeyError: when values are missing from `internal_frame` columns
+
     Returns:
         Column position list
     """
@@ -925,10 +928,14 @@ def get_valid_col_positions_from_col_labels(
         elif isinstance(col_loc, tuple):
             col_loc = [col_loc] if col_loc in columns else list(col_loc)
         # Throw a KeyError in case there are any missing column labels
-        if any(label not in columns for label in col_loc):
+        if len(col_loc) > 0 and all(label not in columns for label in col_loc):
             raise KeyError(
-                "None of {} are in the [columns]".format(
-                    pandas.Index([k for k in col_loc if k not in columns])
+                "None of {} are in the [columns]".format(pandas.Index(col_loc))
+            )
+        elif any(label not in columns for label in col_loc):
+            raise KeyError(
+                "{} not found in index".format(
+                    [k for k in col_loc if k not in columns]
                 )
             )
         # Convert col_loc to Index with object dtype since _get_indexer_strict() converts None values in lists to

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1598,8 +1598,8 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         - In Snowpark pandas ``.loc``, unalignable boolean Series provided as indexer will perform a join on the index
           of the main dataframe or series. (while pandas will raise an IndexingError)
         - When there is a slice key, Snowpark pandas ``.loc`` performs the same as native pandas when both the start and
-          stop are labels present in the index or either one is absert but the index is sorted. When any of the two
-          labels is absert from an unsorted index, Snowpark pandas will return rows in between while native pandas will
+          stop are labels present in the index or either one is absent but the index is sorted. When any of the two
+          labels is absent from an unsorted index, Snowpark pandas will return rows in between while native pandas will
           raise a KeyError.
         - Special indexing for DatetimeIndex is unsupported in Snowpark pandas, e.g., `partial string indexing <https://pandas.pydata.org/docs/user_guide/timeseries.html#partial-string-indexing>`_.
         - While setting rows with duplicated index, Snowpark pandas won't raise ValueError for duplicate labels to avoid

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1592,6 +1592,9 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         -----
         To meet the nature of lazy evaluation:
 
+        - Snowpark pandas ``.loc`` ignores out-of-bounds indexing for row indexers (while pandas ``.loc``
+          may raise KeyError). If all values are out-of-bound, an empty result will be returned.
+        - Out-of-bounds indexing for columns will still raise a KeyError the same way pandas does.
         - In Snowpark pandas ``.loc``, unalignable boolean Series provided as indexer will perform a join on the index
           of the main dataframe or series. (while pandas will raise an IndexingError)
         - When there is a slice key, Snowpark pandas ``.loc`` performs the same as native pandas when both the start and

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1202,17 +1202,6 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         2014-02-13    high
         Freq: None, Name: windspeed, dtype: object
 
-        Snowpark pandas indexing won't raise KeyError if any key is not found;
-        instead, it will return the results from the found keys
-        or return an empty series if no key is found.
-
-        >>> df.get(["temp_celsius", "temp_kelvin"], default="default_value")
-                    temp_celsius
-        2014-02-12          24.3
-        2014-02-13          31.0
-        2014-02-14          22.0
-        2014-02-15          35.0
-
         >>> ser.get('2014-02-10', '[unknown]')
         Series([], Freq: None, Name: windspeed, dtype: object)
 

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1603,8 +1603,6 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         -----
         To meet the nature of lazy evaluation:
 
-        - Snowpark pandas ``.loc`` ignores out-of-bounds indexing for all types of indexers (while pandas ``.loc``
-          may raise KeyError). If all values are out-of-bound, an empty result will be returned.
         - In Snowpark pandas ``.loc``, unalignable boolean Series provided as indexer will perform a join on the index
           of the main dataframe or series. (while pandas will raise an IndexingError)
         - When there is a slice key, Snowpark pandas ``.loc`` performs the same as native pandas when both the start and

--- a/tests/integ/modin/frame/test_drop_duplicates.py
+++ b/tests/integ/modin/frame/test_drop_duplicates.py
@@ -27,13 +27,30 @@ def test_drop_duplicates_with_misspelled_column_name_or_empty_subset(subset):
     join_count = 1
     if "B" in subset:
         join_count += 1
-    with SqlCounter(query_count=query_count, join_count=join_count):
-        assert_frame_equal(
-            pd.DataFrame(df).drop_duplicates(subset),
-            expected_res,
-            check_dtype=False,
-            check_index_type=False,
-        )
+    if subset == []:
+        with SqlCounter(query_count=query_count, join_count=join_count):
+            assert_frame_equal(
+                pd.DataFrame(df).drop_duplicates(subset),
+                expected_res,
+                check_dtype=False,
+                check_index_type=False,
+            )
+    else:
+        if isinstance(subset, list):
+            if all(label not in df.columns for label in subset):
+                match_str = r"None of .* are in the \[columns\]"
+            else:
+                match_str = r".* not found in index"
+        else:
+            match_str = r"None of .* are in the \[columns\]"
+        with pytest.raises(KeyError, match=match_str):
+            with SqlCounter(query_count=query_count, join_count=join_count):
+                assert_frame_equal(
+                    pd.DataFrame(df).drop_duplicates(subset),
+                    expected_res,
+                    check_dtype=False,
+                    check_index_type=False,
+                )
 
 
 @pytest.mark.parametrize("subset", ["A", ["A"], ["B"], ["A", "B"]])

--- a/tests/integ/modin/frame/test_drop_duplicates.py
+++ b/tests/integ/modin/frame/test_drop_duplicates.py
@@ -23,10 +23,11 @@ def test_drop_duplicates_with_misspelled_column_name_or_empty_subset(subset):
         if "B" in subset
         else native_pd.DataFrame(columns=["A", "B", "C"])
     )
-    query_count = 1
-    join_count = 1
-    if "B" in subset:
+    query_count = 0
+    join_count = 0
+    if subset == []:
         join_count += 1
+        query_count += 1
     with SqlCounter(query_count=query_count, join_count=join_count):
         if subset == []:
             assert_frame_equal(

--- a/tests/integ/modin/frame/test_drop_duplicates.py
+++ b/tests/integ/modin/frame/test_drop_duplicates.py
@@ -41,7 +41,7 @@ def test_drop_duplicates_with_misspelled_column_name_or_empty_subset(subset):
                 if all(label not in df.columns for label in subset):
                     match_str = r"None of .* are in the \[columns\]"
                 else:
-                    match_str = r".* not found in index"
+                    match_str = r".* not in index"
             else:
                 match_str = r"None of .* are in the \[columns\]"
             with pytest.raises(KeyError, match=match_str):

--- a/tests/integ/modin/frame/test_drop_duplicates.py
+++ b/tests/integ/modin/frame/test_drop_duplicates.py
@@ -62,9 +62,9 @@ def test_drop_duplicates(subset, keep, ignore_index):
         )
 
 
-@pytest.mark.parametrize("subset", ["A", ["A"], ["B"], ["A", "B"]])
+@pytest.mark.parametrize("subset", ["a", ["a"], ["b"], ["a", "b"]])
 @pytest.mark.parametrize("keep", ["first", "last", False])
-@sql_count_checker(query_count=1, join_count=1)
+@sql_count_checker(query_count=1, join_count=2)
 def test_drop_duplicates_on_empty_frame(subset, keep):
     pandas_df = native_pd.DataFrame(columns=["a", "b"])
     snow_df = pd.DataFrame(pandas_df)

--- a/tests/integ/modin/frame/test_drop_duplicates.py
+++ b/tests/integ/modin/frame/test_drop_duplicates.py
@@ -27,24 +27,23 @@ def test_drop_duplicates_with_misspelled_column_name_or_empty_subset(subset):
     join_count = 1
     if "B" in subset:
         join_count += 1
-    if subset == []:
-        with SqlCounter(query_count=query_count, join_count=join_count):
+    with SqlCounter(query_count=query_count, join_count=join_count):
+        if subset == []:
             assert_frame_equal(
                 pd.DataFrame(df).drop_duplicates(subset),
                 expected_res,
                 check_dtype=False,
                 check_index_type=False,
             )
-    else:
-        if isinstance(subset, list):
-            if all(label not in df.columns for label in subset):
-                match_str = r"None of .* are in the \[columns\]"
-            else:
-                match_str = r".* not found in index"
         else:
-            match_str = r"None of .* are in the \[columns\]"
-        with pytest.raises(KeyError, match=match_str):
-            with SqlCounter(query_count=query_count, join_count=join_count):
+            if isinstance(subset, list):
+                if all(label not in df.columns for label in subset):
+                    match_str = r"None of .* are in the \[columns\]"
+                else:
+                    match_str = r".* not found in index"
+            else:
+                match_str = r"None of .* are in the \[columns\]"
+            with pytest.raises(KeyError, match=match_str):
                 assert_frame_equal(
                     pd.DataFrame(df).drop_duplicates(subset),
                     expected_res,

--- a/tests/integ/modin/frame/test_duplicated.py
+++ b/tests/integ/modin/frame/test_duplicated.py
@@ -5,7 +5,6 @@
 import modin.pandas as pd
 import pandas as native_pd
 import pytest
-from pandas._libs.lib import is_scalar
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker

--- a/tests/integ/modin/frame/test_duplicated.py
+++ b/tests/integ/modin/frame/test_duplicated.py
@@ -26,22 +26,21 @@ def test_duplicated_with_misspelled_column_name_or_empty_subset(subset):
     query_count = 1
     if is_scalar(subset):
         query_count += 1
-    if subset == []:
-        with SqlCounter(query_count=query_count):
+    with SqlCounter(query_count=query_count):
+        if subset == []:
             assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
                 pd.DataFrame(df).duplicated(subset),
                 expected_res,
             )
-    else:
-        if isinstance(subset, list):
-            if all(label not in df.columns for label in subset):
-                match_str = r"None of .* are in the \[columns\]"
-            else:
-                match_str = r".* not found in index"
         else:
-            match_str = f"\\'{subset}\\'"
-        with pytest.raises(KeyError, match=match_str):
-            with SqlCounter(query_count=query_count):
+            if isinstance(subset, list):
+                if all(label not in df.columns for label in subset):
+                    match_str = r"None of .* are in the \[columns\]"
+                else:
+                    match_str = r".* not found in index"
+            else:
+                match_str = f"\\'{subset}\\'"
+            with pytest.raises(KeyError, match=match_str):
                 assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
                     pd.DataFrame(df).duplicated(subset),
                     expected_res,

--- a/tests/integ/modin/frame/test_duplicated.py
+++ b/tests/integ/modin/frame/test_duplicated.py
@@ -36,7 +36,7 @@ def test_duplicated_with_misspelled_column_name_or_empty_subset(subset):
                 if all(label not in df.columns for label in subset):
                     match_str = r"None of .* are in the \[columns\]"
                 else:
-                    match_str = r".* not found in index"
+                    match_str = r".* not in index"
             else:
                 match_str = f"\\'{subset}\\'"
             with pytest.raises(KeyError, match=match_str):

--- a/tests/integ/modin/frame/test_duplicated.py
+++ b/tests/integ/modin/frame/test_duplicated.py
@@ -23,8 +23,8 @@ def test_duplicated_with_misspelled_column_name_or_empty_subset(subset):
     with pytest.raises((KeyError, ValueError)):
         df.duplicated(subset)
     expected_res = df.duplicated(["B"]) if "B" in subset else native_pd.Series([])
-    query_count = 1
-    if is_scalar(subset):
+    query_count = 0
+    if subset == []:
         query_count += 1
     with SqlCounter(query_count=query_count):
         if subset == []:

--- a/tests/integ/modin/frame/test_getitem.py
+++ b/tests/integ/modin/frame/test_getitem.py
@@ -129,7 +129,7 @@ def test_df_getitem_with_string_labels_throws_keyerror(key):
     with pytest.raises(KeyError):
         eval_snowpark_pandas_result(
             *create_test_dfs(data),
-            lambda df: df[key] if isinstance(df, pd.DataFrame) else df.loc[:, []]
+            lambda df: df[key]
         )
 
 
@@ -250,8 +250,6 @@ def test_df_getitem_deviates_from_pandas(key):
             snow_df,
             native_df,
             lambda df: df[key]
-            if isinstance(df, pd.DataFrame)
-            else df[[k for k in key if k in columns]],
         )
 
 

--- a/tests/integ/modin/frame/test_getitem.py
+++ b/tests/integ/modin/frame/test_getitem.py
@@ -127,8 +127,8 @@ def test_df_getitem_with_string_labels(key):
 def test_df_getitem_with_string_labels_throws_keyerror(key):
     data = {"A": [1, 2, None], "B": [3.1, 5, 6], "C": [None, "abc", "xyz"]}
     with pytest.raises(
-            KeyError,
-            match=r"None of .* are in the \[columns\]",
+        KeyError,
+        match=r"None of .* are in the \[columns\]",
     ):
         eval_snowpark_pandas_result(
             *create_test_dfs(data),
@@ -254,8 +254,8 @@ def test_df_getitem_throws_key_error(key):
         match_str = r".* not in index"
 
     with pytest.raises(
-            KeyError,
-            match=match_str,
+        KeyError,
+        match=match_str,
     ):
         eval_snowpark_pandas_result(
             snow_df,
@@ -388,7 +388,7 @@ def test_df_getitem_boolean_df_comparator():
         *create_test_dfs(
             [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
         ),
-        lambda df: df[df > 7]
+        lambda df: df[df > 7],
     )
 
 

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -377,8 +377,8 @@ def test_df_loc_get_out_of_bound_col(
     key, str_index_native_df, str_index_snowpark_pandas_df
 ):
     match_str = r".* not found in index" if not is_scalar(key) else f"{key}"
-    with pytest.raises(KeyError, match=match_str):
-        with SqlCounter(query_count=2 if is_scalar(key) else 1):
+    with SqlCounter(query_count=2 if is_scalar(key) else 1):
+        with pytest.raises(KeyError, match=match_str):
             eval_snowpark_pandas_result(
                 str_index_snowpark_pandas_df,
                 str_index_native_df,

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -382,8 +382,7 @@ def test_df_loc_get_out_of_bound_col(
             eval_snowpark_pandas_result(
                 str_index_snowpark_pandas_df,
                 str_index_native_df,
-                lambda df: df.loc[:, key]
-                ],
+                lambda df: df.loc[:, key],
             )
 
 

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -377,7 +377,7 @@ def test_df_loc_get_out_of_bound_col(
     key, str_index_native_df, str_index_snowpark_pandas_df
 ):
     match_str = r".* not found in index" if not is_scalar(key) else f"{key}"
-    with SqlCounter(query_count=2 if is_scalar(key) else 1):
+    with SqlCounter(query_count=0):
         with pytest.raises(KeyError, match=match_str):
             eval_snowpark_pandas_result(
                 str_index_snowpark_pandas_df,

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -376,7 +376,7 @@ def test_df_loc_get_negative_row_diff2native(
 def test_df_loc_get_out_of_bound_col(
     key, str_index_native_df, str_index_snowpark_pandas_df
 ):
-    match_str = r".* not found in index" if not is_scalar(key) else f"{key}"
+    match_str = r".* not in index" if not is_scalar(key) else f"{key}"
     with SqlCounter(query_count=0):
         with pytest.raises(KeyError, match=match_str):
             eval_snowpark_pandas_result(

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -382,11 +382,7 @@ def test_df_loc_get_out_of_bound_col(
             eval_snowpark_pandas_result(
                 str_index_snowpark_pandas_df,
                 str_index_native_df,
-                lambda df: df.loc[
-                    :,
-                    key
-                    if isinstance(df, pd.DataFrame)
-                    else [k for k in key if k in str_index_native_df.columns],
+                lambda df: df.loc[:, key]
                 ],
             )
 
@@ -466,7 +462,6 @@ def test_mi_df_loc_get_non_boolean_list_col_key(mi_table_df, key, native_error):
         if native_error:
             with pytest.raises(native_error):
                 _ = mi_table_df.loc[:, key]
-                assert df.loc[:, key].empty
         else:
             eval_snowpark_pandas_result(
                 df,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1041878

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Throw `KeyError` when user passes in missing column labels to `__getitem__` and `loc`