### PR TITLE
SNOW-1375119: Track error messages for `NotImplementedError` in Snowpark pandas telemetry

### DIFF
--- a/src/snowflake/snowpark/_internal/telemetry.py
+++ b/src/snowflake/snowpark/_internal/telemetry.py
@@ -42,6 +42,7 @@ class TelemetryField(Enum):
     KEY_DURATION = "duration"
     KEY_FUNC_NAME = "func_name"
     KEY_MSG = "msg"
+    KEY_ERROR_MSG = "error_msg"
     KEY_VERSION = "version"
     KEY_PYTHON_VERSION = "python_version"
     KEY_CLIENT_LANGUAGE = "client_language"

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -54,6 +54,7 @@ def _send_snowpark_pandas_telemetry_helper(
     *,
     session: Session,
     telemetry_type: str,
+    error_msg: Optional[str] = None,
     func_name: str,
     query_history: Optional[QueryHistory],
     api_calls: Union[str, list[dict[str, Any]]],
@@ -65,6 +66,7 @@ def _send_snowpark_pandas_telemetry_helper(
     Args:
         session: The Snowpark session.
         telemetry_type: telemetry type. e.g. TYPE_SNOWPARK_PANDAS_FUNCTION_USAGE.value
+        error_msg: Optional error message if telemetry_type is a Snowpark pandas error
         func_name: The name of the function being tracked.
         query_history: The query history context manager to record queries that are pushed down to the Snowflake
         database in the session.
@@ -73,9 +75,10 @@ def _send_snowpark_pandas_telemetry_helper(
     Returns:
         None
     """
-    data: dict[str, Union[str, list[dict[str, Any]], list[str]]] = {
+    data: dict[str, Union[str, list[dict[str, Any]], list[str], Optional[str]]] = {
         TelemetryField.KEY_FUNC_NAME.value: func_name,
         TelemetryField.KEY_CATEGORY.value: SnowparkPandasTelemetryField.FUNC_CATEGORY_SNOWPARK_PANDAS.value,
+        TelemetryField.KEY_ERROR_MSG.value: error_msg,
     }
     if len(api_calls) > 0:
         data[TelemetryField.KEY_API_CALLS.value] = api_calls
@@ -327,6 +330,7 @@ def _telemetry_helper(
         _send_snowpark_pandas_telemetry_helper(
             session=session,
             telemetry_type=error_to_telemetry_type(e),
+            error_msg=e.args[0] if e.args else None,
             func_name=func_name,
             query_history=query_history,
             api_calls=existing_api_calls + [curr_api_call],

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -330,7 +330,10 @@ def _telemetry_helper(
         _send_snowpark_pandas_telemetry_helper(
             session=session,
             telemetry_type=error_to_telemetry_type(e),
-            error_msg=e.args[0] if e.args else None,
+            # Only track error messages for NotImplementedError
+            error_msg=e.args[0]
+            if isinstance(e, NotImplementedError) and e.args
+            else None,
             func_name=func_name,
             query_history=query_history,
             api_calls=existing_api_calls + [curr_api_call],

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -140,7 +140,13 @@ def test_snowpark_pandas_telemetry_method_decorator(test_table_name):
         expected_func_name="DataFrame.to_snowflake",
         session=df1._query_compiler._modin_frame.ordered_dataframe.session,
     )
-    assert set(data.keys()) == {"category", "api_calls", "sfqids", "func_name"}
+    assert set(data.keys()) == {
+        "category",
+        "api_calls",
+        "sfqids",
+        "func_name",
+        "error_msg",
+    }
     assert data["category"] == "snowpark_pandas"
     assert data["api_calls"] == df1_expected_api_calls + [
         {
@@ -183,7 +189,11 @@ def test_send_snowpark_pandas_telemetry_helper(send_mock):
             "python_version": ANY,
             "operating_system": ANY,
             "type": "test_send_type",
-            "data": {"func_name": "test_send_func", "category": "snowpark_pandas"},
+            "data": {
+                "func_name": "test_send_func",
+                "category": "snowpark_pandas",
+                "error_msg": None,
+            },
         }
     )
 
@@ -351,10 +361,11 @@ def test_telemetry_with_not_implemented_error():
 
     snowpark_pandas_error_test_helper(
         func=snowpark_pandas_telemetry_method_decorator,
-        error=NotImplementedError,
+        error=NotImplementedError("Method bfill is not implemented for Resampler!"),
         telemetry_type=error_to_telemetry_type(
             NotImplementedError("Method bfill is not implemented for Resampler!")
         ),
+        error_msg="Method bfill is not implemented for Resampler!",
         loc_pref="mock_class",
         mock_arg=mock_arg,
     )

--- a/tests/unit/modin/test_telemetry.py
+++ b/tests/unit/modin/test_telemetry.py
@@ -36,10 +36,11 @@ def snowpark_pandas_error_test_helper(
     telemetry_type: str,
     loc_pref: Optional[str] = "SnowflakeQueryCompiler",
     mock_arg: Optional[MagicMock] = None,
+    error_msg: Optional[str] = None,
 ):
     decorated_func = MagicMock(side_effect=error)
     decorated_func.__qualname__ = "magic_mock"
-    with pytest.raises(error):
+    with pytest.raises(type(error)):
         wrap_func = func(decorated_func)
         wrap_func(mock_arg)
     send_telemetry_helper_mock.assert_called_with(
@@ -52,6 +53,7 @@ def snowpark_pandas_error_test_helper(
         ],
         query_history=ANY,
         telemetry_type=telemetry_type,
+        error_msg=error_msg,
     )
 
 
@@ -112,6 +114,7 @@ def test_snowpark_pandas_telemetry_method_decorator(
         ],
         query_history=ANY,
         telemetry_type="snowpark_pandas_type_error",
+        error_msg="Mock Real Error",
     )
     assert len(mock_arg2._query_compiler.snowpark_pandas_api_calls) == 0
 
@@ -129,23 +132,24 @@ def test_snowpark_pandas_telemetry_method_decorator(
         ],
         query_history=ANY,
         telemetry_type="snowpark_pandas_type_error",
+        error_msg="Mock Real Error",
     )
 
 
 @pytest.mark.parametrize(
     "error",
     [
-        NotImplementedError,
-        TypeError,
-        ValueError,
-        KeyError,
-        AttributeError,
-        ZeroDivisionError,
-        IndexError,
-        AssertionError,
-        IndexingError,
-        SpecificationError,
-        DatabaseError,
+        NotImplementedError("test"),
+        TypeError("test"),
+        ValueError("test"),
+        KeyError("test"),
+        AttributeError("test"),
+        ZeroDivisionError("test"),
+        IndexError("test"),
+        AssertionError("test"),
+        IndexingError("test"),
+        SpecificationError("test"),
+        DatabaseError("test"),
     ],
 )
 def test_snowpark_pandas_telemetry_method_error(error):
@@ -155,9 +159,10 @@ def test_snowpark_pandas_telemetry_method_error(error):
     snowpark_pandas_error_test_helper(
         func=snowpark_pandas_telemetry_method_decorator,
         error=error,
-        telemetry_type=error_to_telemetry_type(error("error_msg")),
+        telemetry_type=error_to_telemetry_type(error),
         loc_pref="mock_class",
         mock_arg=mock_arg,
+        error_msg="test",
     )
 
 

--- a/tests/unit/modin/test_telemetry.py
+++ b/tests/unit/modin/test_telemetry.py
@@ -114,7 +114,7 @@ def test_snowpark_pandas_telemetry_method_decorator(
         ],
         query_history=ANY,
         telemetry_type="snowpark_pandas_type_error",
-        error_msg="Mock Real Error",
+        error_msg=None,
     )
     assert len(mock_arg2._query_compiler.snowpark_pandas_api_calls) == 0
 
@@ -132,7 +132,7 @@ def test_snowpark_pandas_telemetry_method_decorator(
         ],
         query_history=ANY,
         telemetry_type="snowpark_pandas_type_error",
-        error_msg="Mock Real Error",
+        error_msg=None,
     )
 
 
@@ -162,7 +162,7 @@ def test_snowpark_pandas_telemetry_method_error(error):
         telemetry_type=error_to_telemetry_type(error),
         loc_pref="mock_class",
         mock_arg=mock_arg,
-        error_msg="test",
+        error_msg="test" if isinstance(error, NotImplementedError) else None,
     )
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1375119

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This PR enables tracking of error messages for NotImplementedError only in Snowpark pandas telemetry.
