### PR TITLE
SNOW-1428349: local testing align with snowflake behavior on substr 0-based start_expr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed a bug that when processing datetime format, fractional second part is not handled properly.
 - Fixed a bug that on Windows platform that file operations was unable to properly handle file separator in directory name.
 - Fixed a bug that on Windows platform that when reading a pandas dataframe, IntervalType column with integer data can not be processed.
+- Fixed a bug that function `substr` and `substring` can not handle 0-based `start_expr`.
 
 ## 1.16.0 (TBD)
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -1186,8 +1186,10 @@ def mock_substring(
     base_expr: ColumnEmulator, start_expr: ColumnEmulator, length_expr: ColumnEmulator
 ):
     res = [
-        x[y - 1 : y + z - 1] if y != 0 else x[y : y + z] if x is not None else None
-        for x, y, z in zip(base_expr, start_expr, length_expr)
+        None if string is None else string[start : start + length]
+        for string, start, length in zip(
+            base_expr, [max(0, s - 1) for s in start_expr], length_expr
+        )
     ]
     res = ColumnEmulator(
         res, sf_type=ColumnType(StringType(), base_expr.sf_type.nullable), dtype=object

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -1186,7 +1186,7 @@ def mock_substring(
     base_expr: ColumnEmulator, start_expr: ColumnEmulator, length_expr: ColumnEmulator
 ):
     res = [
-        x[y - 1 : y + z - 1] if x is not None else None
+        x[y - 1 : y + z - 1] if y != 0 else x[y : y + z] if x is not None else None
         for x, y, z in zip(base_expr, start_expr, length_expr)
     ]
     res = ColumnEmulator(

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -132,6 +132,14 @@ def test_substring(session):
         sort=False,
     )
 
+    Utils.check_answer(
+        TestData.string4(session).select(
+            col("a").substring(0, 3), col("a").substr(1, 3)
+        ),
+        [Row("app", "app"), Row("ban", "ban"), Row("pea", "pea")],
+        sort=False,
+    )
+
 
 @pytest.mark.localtest
 def test_contains(session):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

snowflake implicitly support 0-based start expr in function substr/substring (it's not documented in the doc: https://docs.snowflake.com/en/sql-reference/functions/substr)

in this PR we add support to 0-based start expr to align the behavior
