### PR TITLE
SNOW-1370305: [Local Testing] fix test_compute_lead test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - snowflake.snowpark.Session:
     - cancel_all
 - Introduced a new exception class `snowflake.snowpark.mock.exceptions.SnowparkLocalTestingException`.
+- Added support for casting to FloatType
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1815,7 +1815,7 @@ def calculate_expression(
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_char"](
                 column, try_cast=exp.try_
             )
-        elif isinstance(exp.to, DoubleType):
+        elif isinstance(exp.to, (DoubleType, FloatType)):
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_double"](
                 column, try_cast=exp.try_
             )

--- a/tests/integ/test_df_analytics.py
+++ b/tests/integ/test_df_analytics.py
@@ -335,10 +335,6 @@ def test_cumulative_agg_backward_direction(session):
 
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="BUG: cast to float type not supported, should route reference to to_float to to_double",
-)
 def test_compute_lead(session):
     """Tests df.analytics.compute_lead() happy path."""
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1370305

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Local testing did not have a converter mapped for FloatType which led to this test failures. I've added FloatType to the double converter which matches the behavior in live mode.