### PR TITLE
SNOW-1359009 Change classpaths in pandas general APIs to be `modin.pandas.<>`

### DIFF
--- a/docs/source/_templates/autosummary/base.rst
+++ b/docs/source/_templates/autosummary/base.rst
@@ -1,7 +1,7 @@
 {% if "modin.pandas" in fullname %}
     {% set fullname = "modin.pandas." + objname %}
 {% endif %}
-{% if "modin.pandas.general" in module %}
+{% if "modin.pandas.general" in module or ("modin.pandas" in module and name in ["read_csv", "read_json", "read_parquet", "read_snowflake", "to_snowpark", "to_pandas"])%}
     {% set module = "modin.pandas" %}
 {% endif %}
 {% extends "!autosummary/base.rst" %}

--- a/docs/source/_templates/autosummary/base.rst
+++ b/docs/source/_templates/autosummary/base.rst
@@ -1,4 +1,7 @@
 {% if "modin.pandas" in fullname %}
     {% set fullname = "modin.pandas." + objname %}
 {% endif %}
+{% if "modin.pandas.general" in module %}
+    {% set module = "modin.pandas" %}
+{% endif %}
 {% extends "!autosummary/base.rst" %}

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -3,10 +3,6 @@
 {% endif %}
 {{ fullname | escape | underline}}
 
-{% if "modin.pandas" in module %}
-    {% set module = "modin.pandas" %}
-{% endif %}
-
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -3,6 +3,10 @@
 {% endif %}
 {{ fullname | escape | underline}}
 
+{% if "modin.pandas" in module %}
+    {% set module = "modin.pandas" %}
+{% endif %}
+
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,7 @@ extensions = [
 autodoc_default_options = {
     "autosummary-generate": True,
     "member-order": "alphabetical",  # 'alphabetical', by member type ('groupwise') or source order (value 'bysource')
-    "undoc-members": True,  # If set, autodoc will also generate document for the members not having docstrings
+    "undoc-members": True,  # If set, autodoc will also generate the document for the members not having docstrings
     "show-inheritance": True,
 }
 
@@ -91,10 +91,9 @@ html_show_sourcelink = False  # Hide "view page source" link
 html_show_sphinx = False
 
 
-# Construct URL to corresponding section in the snowpark-python repo
+# Construct URL to the corresponding section in the snowpark-python repo
 def linkcode_resolve(domain, info):
-    import warnings, inspect, pkg_resources
-    import snowflake.snowpark
+    import inspect
 
     if domain != "py":
         return None


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1359009

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Change classpaths for pandas general APIs to be `modin.pandas.<>` instead of `snowflake.snowpark.modin.pandas.[general].<>`.