### PR TITLE
SNOW-1432455: Update shift signature to match pandas 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Added partial support for `DataFrame.pivot_table` with no `index` parameter, as well as for `margins` parameter.
 - Added appropriate error messages for is_permanent/anonymous udf/sproc registration to make it more clear that those features are not yet supported.
+- Updated the signature of `DataFrame.shift`/`Series.shift`/`DataFrameGroupBy.shift`/`SeriesGroupBy.shift` to match pandas 2.2.1. Snowpark pandas does not yet support the newly-added `suffix` argument, or sequence values of `periods`.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -2983,10 +2983,11 @@ class BasePandasDataset(metaclass=TelemetryMeta):
 
     def shift(
         self,
-        periods: int = 1,
+        periods: int | Sequence[int] = 1,
         freq=None,
         axis: Axis = 0,
         fill_value: Hashable = no_default,
+        suffix: str | None = None,
     ) -> BasePandasDataset:
         # TODO: SNOW-1119855: Modin upgrade - modin.pandas.base.BasePandasDataset
         if periods == 0 and freq is None:
@@ -3006,7 +3007,9 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         if fill_value == no_default:
             fill_value = None
 
-        new_query_compiler = self._query_compiler.shift(periods, freq, axis, fill_value)
+        new_query_compiler = self._query_compiler.shift(
+            periods, freq, axis, fill_value, suffix
+        )
         return self._create_or_update_from_compiler(new_query_compiler, False)
 
     def skew(

--- a/src/snowflake/snowpark/modin/pandas/dataframe.py
+++ b/src/snowflake/snowpark/modin/pandas/dataframe.py
@@ -2254,13 +2254,14 @@ class DataFrame(BasePandasDataset):
 
     def shift(
         self,
-        periods: int = 1,
+        periods: int | Sequence[int] = 1,
         freq=None,
         axis: Axis = 0,
         fill_value: Hashable = no_default,
+        suffix: str | None = None,
     ) -> DataFrame:
         # TODO: SNOW-1063346: Modin upgrade - modin.pandas.DataFrame functions
-        return super().shift(periods, freq, axis, fill_value)
+        return super().shift(periods, freq, axis, fill_value, suffix)
 
     def set_index(
         self,

--- a/src/snowflake/snowpark/modin/pandas/groupby.py
+++ b/src/snowflake/snowpark/modin/pandas/groupby.py
@@ -328,7 +328,7 @@ class DataFrameGroupBy(metaclass=TelemetryMeta):
         # TODO: SNOW-1063349: Modin upgrade - modin.pandas.groupby.DataFrameGroupBy functions
         if isinstance(periods, Sequence):
             ErrorMessage.not_implemented(
-                "Snowpark pandas GroupBy.shift does not yet support sequence values of `periods`"
+                "Snowpark pandas GroupBy.shift does not yet support `periods` that are sequences. Only int `periods` are supported."
             )
         if suffix is not None:
             ErrorMessage.not_implemented(

--- a/src/snowflake/snowpark/modin/pandas/groupby.py
+++ b/src/snowflake/snowpark/modin/pandas/groupby.py
@@ -22,7 +22,7 @@
 """Implement GroupBy public API as pandas does."""
 
 from collections.abc import Hashable
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, Sequence, Union
 
 import numpy as np  # noqa: F401
 import numpy.typing as npt
@@ -318,9 +318,22 @@ class DataFrameGroupBy(metaclass=TelemetryMeta):
         return 2  # ndim is always 2 for DataFrames
 
     def shift(
-        self, periods: int = 1, freq: int = None, axis: Axis = 0, fill_value: Any = None
+        self,
+        periods: Union[int, Sequence[int]] = 1,
+        freq: int = None,
+        axis: Axis = 0,
+        fill_value: Any = None,
+        suffix: Optional[str] = None,
     ):
         # TODO: SNOW-1063349: Modin upgrade - modin.pandas.groupby.DataFrameGroupBy functions
+        if isinstance(periods, Sequence):
+            ErrorMessage.not_implemented(
+                "Snowpark pandas GroupBy.shift does not yet support sequence values of `periods`"
+            )
+        if suffix is not None:
+            ErrorMessage.not_implemented(
+                "Snowpark pandas GroupBy.shift does not yet support the `suffix` parameter"
+            )
         if not isinstance(periods, int):
             raise TypeError(
                 f"Periods must be integer, but {periods} is {type(periods)}."

--- a/src/snowflake/snowpark/modin/pandas/series.py
+++ b/src/snowflake/snowpark/modin/pandas/series.py
@@ -2442,10 +2442,11 @@ class Series(BasePandasDataset):
 
     def shift(
         self,
-        periods: int = 1,
+        periods: int | Sequence[int] = 1,
         freq=None,
         axis: Axis = 0,
         fill_value: Hashable = no_default,
+        suffix: str | None = None,
     ):
         """
         Shift index by desired number of periods with an optional time `freq`.
@@ -2455,7 +2456,7 @@ class Series(BasePandasDataset):
             # pandas compatible error.
             raise ValueError("No axis named 1 for object type Series")
 
-        return super().shift(periods, freq, axis, fill_value)
+        return super().shift(periods, freq, axis, fill_value, suffix)
 
     @property
     def str(self):  # noqa: RT01, D200

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1374,7 +1374,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
         if not isinstance(periods, int):
             ErrorMessage.not_implemented(
-                "Snowpark pandas DataFrame/Series.shift does not yet support sequence values of `periods`"
+                "Snowpark pandas DataFrame/Series.shift does not yet support `periods` that are sequences. Only int `periods` are supported."
             )
         # if frequency is None, shift data by periods
         # else if frequency is given, shift index only

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1379,10 +1379,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # if frequency is None, shift data by periods
         # else if frequency is given, shift index only
         if freq is None:
-            return self._shift_values(cast(int, periods), axis, fill_value)
+            # mypy isn't smart enough to recognize that periods is an int here
+            return self._shift_values(periods, axis, fill_value)  # type: ignore
         else:
             # axis parameter ignored, should be 0 for manipulating index. Revisit in SNOW-1023324
-            return self._shift_index(cast(int, periods), freq)  # pragma: no cover
+            return self._shift_index(periods, freq)  # type: ignore  # pragma: no cover
 
     @property
     def index(self) -> pd.Index:

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1351,10 +1351,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
     def shift(
         self,
-        periods: int = 1,
+        periods: Union[int, Sequence[int]] = 1,
         freq: Any = None,
-        axis: Union[Literal[0], Literal[1]] = 0,
+        axis: Literal[0, 1] = 0,
         fill_value: Hashable = no_default,
+        suffix: Optional[str] = None,
     ) -> "SnowflakeQueryCompiler":
         """
         Implements shift operation for DataFrame/Series.
@@ -1367,14 +1368,21 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler
         """
-
+        if suffix is not None:
+            ErrorMessage.not_implemented(
+                "Snowpark pandas DataFrame/Series.shift does not yet support the `suffix` parameter"
+            )
+        if not isinstance(periods, int):
+            ErrorMessage.not_implemented(
+                "Snowpark pandas DataFrame/Series.shift does not yet support sequence values of `periods`"
+            )
         # if frequency is None, shift data by periods
         # else if frequency is given, shift index only
         if freq is None:
-            return self._shift_values(periods, axis, fill_value)
+            return self._shift_values(cast(int, periods), axis, fill_value)
         else:
             # axis parameter ignored, should be 0 for manipulating index. Revisit in SNOW-1023324
-            return self._shift_index(periods, freq)  # pragma: no cover
+            return self._shift_index(cast(int, periods), freq)  # pragma: no cover
 
     @property
     def index(self) -> pd.Index:

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -2557,17 +2557,34 @@ class BasePandasDataset:  # pragma: no cover: we use this class's docstrings, bu
         Implement shared functionality between DataFrame and Series for shift. axis argument is only relevant for
         Dataframe, and should be 0 for Series.
         Args:
-            periods : int
-                Number of periods to shift. Can be positive or negative.
-            freq : not supported, default None
+            periods : int | Sequence[int]
+                Number of periods to shift. Can be positive or negative. If an iterable of ints,
+                the data will be shifted once by each int. This is equivalent to shifting by one
+                value at a time and concatenating all resulting frames. The resulting columns
+                will have the shift suffixed to their column names. For multiple periods, axis must not be 1.
+
+                Snowpark pandas does not currently support sequences of int for `periods`.
+
+            freq : DateOffset, tseries.offsets, timedelta, or str, optional
+                Offset to use from the tseries module or time rule (e.g. ‘EOM’).
+
+                Snowpark pandas does not yet support this parameter.
+
             axis : {0 or 'index', 1 or 'columns', None}, default None
                 Shift direction.
+
             fill_value : object, optional
                 The scalar value to use for newly introduced missing values.
                 the default depends on the dtype of `self`.
                 For numeric data, ``np.nan`` is used.
                 For datetime, timedelta, or period data, etc. :attr:`NaT` is used.
                 For extension dtypes, ``self.dtype.na_value`` is used.
+
+            suffix : str, optional
+                If str is specified and periods is an iterable, this is added after the column name
+                and before the shift value for each shifted column name.
+
+                Snowpark pandas does not yet support this parameter.
 
         Returns:
             BasePandasDataset

--- a/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
@@ -2671,17 +2671,34 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Parameters
         ----------
-        periods : int
-            Number of periods to shift. Can be positive or negative.
-        freq : not supported, default None
+        periods : int | Sequence[int]
+            Number of periods to shift. Can be positive or negative. If an iterable of ints,
+            the data will be shifted once by each int. This is equivalent to shifting by one
+            value at a time and concatenating all resulting frames. The resulting columns
+            will have the shift suffixed to their column names. For multiple periods, axis must not be 1.
+
+            Snowpark pandas does not currently support sequences of int for `periods`.
+
+        freq : DateOffset, tseries.offsets, timedelta, or str, optional
+            Offset to use from the tseries module or time rule (e.g. ‘EOM’).
+
+            Snowpark pandas does not yet support this parameter.
+
         axis : {0 or 'index', 1 or 'columns', None}, default None
             Shift direction.
+
         fill_value : object, optional
             The scalar value to use for newly introduced missing values.
             the default depends on the dtype of `self`.
             For numeric data, ``np.nan`` is used.
             For datetime, timedelta, or period data, etc. :attr:`NaT` is used.
             For extension dtypes, ``self.dtype.na_value`` is used.
+
+        suffix : str, optional
+            If str is specified and periods is an iterable, this is added after the column name
+            and before the shift value for each shifted column name.
+
+            Snowpark pandas does not yet support this parameter.
 
         Returns
         -------

--- a/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
@@ -582,14 +582,30 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Parameters
         ----------
-        periods : int, default 1
-            Number of periods to shift.
-        freq : str, optional
-            Frequency string.
+        periods : int | Sequence[int], default 1
+            Number of periods to shift. Can be positive or negative. If an iterable of ints,
+            the data will be shifted once by each int. This is equivalent to shifting by one
+            value at a time and concatenating all resulting frames. The resulting columns
+            will have the shift suffixed to their column names. For multiple periods, axis must not be 1.
+
+            Snowpark pandas does not currently support sequences of int for `periods`.
+
+        freq : DateOffset, tseries.offsets, timedelta, or str, optional
+            Offset to use from the tseries module or time rule (e.g. ‘EOM’).
+
+            Snowpark pandas does not yet support this parameter.
+
         axis : axis to shift, default 0
             Shift direction. Snowpark pandas does not yet support axis=1.
+
         fill_value : optional
             The scalar value to use for newly introduced missing values.
+
+        suffix : str, optional
+            If str is specified and periods is an iterable, this is added after the column name
+            and before the shift value for each shifted column name.
+
+            Snowpark pandas does not yet support this parameter.
 
         Returns
         -------

--- a/tests/integ/modin/frame/test_shift.py
+++ b/tests/integ/modin/frame/test_shift.py
@@ -90,3 +90,17 @@ def test_time_index_shift_negative(index, periods, freq):
         lambda df: df.shift(periods=periods, freq=freq),
         check_index_type=False,
     )
+
+
+@pytest.mark.parametrize(
+    "params, match",
+    [
+        ({"periods": [1, 2, 3]}, "periods"),  # sequence of periods is unsupported
+        ({"periods": [1], "suffix": "_suffix"}, "suffix"),  # suffix is unsupported
+    ],
+)
+@sql_count_checker(query_count=0)
+def test_shift_unsupported_args(params, match):
+    df = pd.DataFrame(TEST_DATAFRAMES[2])
+    with pytest.raises(NotImplementedError, match=match):
+        df.shift(**params).to_pandas()

--- a/tests/integ/modin/groupby/test_groupby_negative.py
+++ b/tests/integ/modin/groupby/test_groupby_negative.py
@@ -489,6 +489,33 @@ def test_groupby_shift_with_by_index_negative(by):
 
 
 @pytest.mark.parametrize(
+    "params",
+    [
+        {"periods": [1, 2, 3]},  # sequence periods is unsupported
+        {"periods": [1], "suffix": "_suffix"},  # suffix is unsupported
+    ],
+)
+@sql_count_checker(query_count=0)
+def test_groupby_shift_unsupported_args_negative(params):
+    pandas_df = native_pd.DataFrame(
+        data=[
+            ["Lois", 42],
+            ["Lois", 42],
+            ["Lana", 76],
+            ["Lana", 76],
+            ["Lima", 888],
+        ],
+        columns=["LEXLUTHOR", "RATING"],
+        index=["tuna", "salmon", "catfish", "goldfish", "shark"],
+    )
+    snow_df = pd.DataFrame(pandas_df)
+    with pytest.raises(NotImplementedError):
+        eval_snowpark_pandas_result(
+            snow_df, pandas_df, lambda df: df.groupby("RATING").shift(**params)
+        )
+
+
+@pytest.mark.parametrize(
     "agg_method_name", ["min", "max", "std", "var", "sum", "mean", "median"]
 )
 @pytest.mark.parametrize("numeric_only", ["TEST", 5])

--- a/tests/integ/modin/groupby/test_groupby_negative.py
+++ b/tests/integ/modin/groupby/test_groupby_negative.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 import re
+from typing import Sequence
 
 import modin.pandas as pd
 import pandas as native_pd
@@ -338,14 +339,20 @@ def test_groupby_shift_non_integer_period_negative(periods):
         index=["tuna", "salmon", "catfish", "goldfish", "shark"],
     )
     snow_df = pd.DataFrame(pandas_df)
-    eval_snowpark_pandas_result(
-        snow_df,
-        pandas_df,
-        lambda df: df.groupby("LEXLUTHOR").shift(periods=periods),
-        expect_exception=True,
-        expect_exception_type=TypeError,
-        expect_exception_match="Periods must be integer",
-    )
+    if isinstance(periods, Sequence):
+        # Technically sequence of str isn't supported by pandas (sequence of int is),
+        # but we only check if the argument is a sequence
+        with pytest.raises(NotImplementedError):
+            snow_df.groupby("LEXLUTHOR").shift(periods=periods)
+    else:
+        eval_snowpark_pandas_result(
+            snow_df,
+            pandas_df,
+            lambda df: df.groupby("LEXLUTHOR").shift(periods=periods),
+            expect_exception=True,
+            expect_exception_type=TypeError,
+            expect_exception_match="Periods must be integer",
+        )
 
 
 @sql_count_checker(query_count=0)

--- a/tests/integ/modin/series/test_shift.py
+++ b/tests/integ/modin/series/test_shift.py
@@ -53,18 +53,12 @@ def test_series_negative_axis_1():
 @pytest.mark.parametrize(
     "params, match",
     [
-        (
-            {"periods": [1, 2, 3]},
-            "does not yet support non-int scalar values of `periods`",
-        ),
-        (
-            {"periods": [1], "suffix": "_suffix"},
-            "does not yet support the `suffix` parameter",
-        ),
+        ({"periods": [1, 2, 3]}, "periods"),  # sequence of periods is unsupported
+        ({"periods": [1], "suffix": "_suffix"}, "suffix"),  # suffix is unsupported
     ],
 )
 @sql_count_checker(query_count=0)
 def test_shift_unsupported_args(params, match):
     df = pd.Series(TEST_SERIES[2])
-    with pytest.raises(NotImplementedError, match):
+    with pytest.raises(NotImplementedError, match=match):
         df.shift(**params).to_pandas()

--- a/tests/integ/modin/series/test_shift.py
+++ b/tests/integ/modin/series/test_shift.py
@@ -48,3 +48,23 @@ def test_series_negative_axis_1():
 
 
 # TODO: SNOW-1023324 add tests for freq != None
+
+
+@pytest.mark.parametrize(
+    "params, match",
+    [
+        (
+            {"periods": [1, 2, 3]},
+            "does not yet support non-int scalar values of `periods`",
+        ),
+        (
+            {"periods": [1], "suffix": "_suffix"},
+            "does not yet support the `suffix` parameter",
+        ),
+    ],
+)
+@sql_count_checker(query_count=0)
+def test_shift_unsupported_args(params, match):
+    df = pd.Series(TEST_SERIES[2])
+    with pytest.raises(NotImplementedError, match):
+        df.shift(**params).to_pandas()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1432455

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Changes the `periods` parameter to `int | Sequence[int]` rather than `int`, and adds the `suffix` parameter. If `periods` is a sequence or `suffix` is specified, we now raise NotImplementedError.