### PR TITLE
SNOW-1434962: Make groupby.apply sort result deterministic.

### DIFF
--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -874,7 +874,11 @@ class TestFuncReturnsScalar:
             pd.DataFrame(diamonds_pd),
             diamonds_pd,
             lambda diamonds: diamonds.groupby("cut").apply(
-                lambda x: x.nlargest(5, columns=["price"]),
+                # Use the stable "mergesort" algorithm to make the result order
+                # deterministic (see SNOW-1434962).
+                lambda x: x.sort_values(
+                    "price", ascending=False, kind="mergesort"
+                ).head(5),
                 include_groups=True,
             ),
         )

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -863,9 +863,6 @@ class TestFuncReturnsScalar:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    @pytest.mark.xfail(
-        reason="SNOW-1434962 groupby.apply order is not deterministic",
-    )
     def test_group_apply_return_df_from_lambda(self):
         diamonds_path = (
             pathlib.Path(__file__).parent.parent.parent.parent
@@ -877,7 +874,7 @@ class TestFuncReturnsScalar:
             pd.DataFrame(diamonds_pd),
             diamonds_pd,
             lambda diamonds: diamonds.groupby("cut").apply(
-                lambda x: x.sort_values("price", ascending=False).head(5),
+                lambda x: x.nlargest(5, columns=["price"]),
                 include_groups=True,
             ),
         )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1434962

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   [`sort_values`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.sort_values.html) by default is not stable since it uses `kind="quicksort"`. Use a stable `nlargest` call with the default of `keep="first"` so that when multiple rows have the same price, we get them in the order that they appear in the input dataframe.

    Unfortunately I couldn't reproduce the flake locally by running the test repeatedly unless I manually changed the order of the input dataframe before the `sort_values` to simulate instability of `sort_values`. However, I think now we should be able to count on the stability of `nlargest`.
