### PR TITLE
SNOW-1435489 Add class links in groupby return annotations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,9 +65,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
+html_theme = 'alabaster'
 # html_theme = 'sphinx_rtd_theme'
-html_theme = "empty"
+# html_theme = "empty"
 
 html_theme_path = [
     "_themes",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,9 +65,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+# html_theme = 'alabaster'
 # html_theme = 'sphinx_rtd_theme'
-# html_theme = "empty"
+html_theme = "empty"
 
 html_theme_path = [
     "_themes",

--- a/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
@@ -57,7 +57,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
     Parameters
     ----------
-    data : DataFrame, Series, pandas.DataFrame, ndarray, Iterable or dict, optional
+    data : DataFrame, Series, `pandas.DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_, ndarray, Iterable or dict, optional
         Dict can contain ``Series``, arrays, constants, dataclass or list-like objects.
         If data is a dict, column order follows insertion-order.
     index : Index or array-like, optional
@@ -253,8 +253,8 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` or None
-            Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` with NA entries dropped from it or None if ``inplace=True``.
+        DataFrame
+            DataFrame with NA entries dropped from it or None if ``inplace=True``.
 
         See Also
         --------
@@ -383,7 +383,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series`
+        Series
             Boolean series for each duplicated rows.
 
         See Also
@@ -615,8 +615,8 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
-            Transformed Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`.
+        DataFrame
+            Transformed DataFrame.
 
         See Also
         --------
@@ -764,7 +764,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        Series or DataFrame
             Result of applying ``func`` along the given axis of the DataFrame.
 
         See Also
@@ -1033,7 +1033,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
             Note that a copy is always required for mixed dtype DataFrames, or for DataFrames with any extension types.
 
         Returns:
-            Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+            DataFrame
                 The transposed DataFrame.
 
         Examples::
@@ -1585,7 +1585,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Parameters
         ----------
-        other : :class:`~snowflake.snowpark.modin.pandas.DataFrame`, :class:`~snowflake.snowpark.modin.pandas.Series`, or a list containing any combination of them
+        other : DataFrame, Series, or a list containing any combination of them
             Index should be similar to one of the columns in this one. If a
             Series is passed, its name attribute must be set, and that will be
             used as the column name in the resulting joined DataFrame.
@@ -1625,7 +1625,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowapark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        DataFrame
             A dataframe containing columns from both the caller and `other`.
 
         Notes
@@ -1957,7 +1957,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        DataFrame
             An Excel style pivot table.
 
         Notes
@@ -2194,7 +2194,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` or None
+        DataFrame or None
             DataFrame with the renamed axis labels or None if ``inplace=True``.
 
         Raises
@@ -2832,7 +2832,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`, Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series`, or scalar
+        DataFrame, Series, or scalar
             The projection after squeezing `axis` or all the axes.
 
         See Also
@@ -3086,9 +3086,8 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
-            Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` with the
-            first differences of the Series.
+        DataFrame
+            DataFrame with the first differences of the Series.
 
         Notes
         -----
@@ -3190,8 +3189,8 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` or None
-            Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` without the removed index or column labels or
+        DataFrame or None
+            DataFrame without the removed index or column labels or
             None if ``inplace=True``.
 
         Raises
@@ -3312,7 +3311,7 @@ class DataFrame:  # pragma: no cover: we use this class's docstrings, but we nev
 
         See Also
         --------
-        :func:`Series.map <snowflake.snowpark.modin.pandas.Series.>` : Equivalent method on Series.
+        :func:`Series.value_counts <snowflake.snowpark.modin.pandas.Series.value_counts>` : Equivalent method on Series.
 
         Notes
         -----

--- a/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
@@ -232,7 +232,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
 
         Examples
         --------
@@ -593,7 +593,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Object shifted within each group.
 
         Examples
@@ -648,7 +648,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-            Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
 
         See also
         --------
@@ -743,7 +743,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
 
         See also
         --------
@@ -821,7 +821,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
 
         See Also
         --------
@@ -920,7 +920,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
 
         See also
         --------
@@ -1006,7 +1006,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Standard deviation of values within each group.
 
         Examples
@@ -1127,7 +1127,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame with ranking of values within each group
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame` with ranking of values within each group
 
         Examples
         --------
@@ -1229,7 +1229,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Variance of values within each group.
 
         Examples
@@ -1401,7 +1401,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Median of values within each group.
 
         Examples
@@ -1459,7 +1459,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Subset of the original Series or DataFrame as determined by n.
 
         See also
@@ -1643,7 +1643,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Count of values within each group.
 
         Examples
@@ -1752,7 +1752,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Subset of the original Series or DataFrame as determined by n.
 
         See also
@@ -1842,7 +1842,7 @@ class DataFrameGroupBy:  # pragma: no cover: we use this class's docstrings, but
 
         Returns
         -------
-        Series or DataFrame
+        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
             Return type determined by caller of GroupBy object.
         """
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -10,6 +10,7 @@ as `DataFrame.to_snowflake`.
 from collections.abc import Iterable
 from typing import Any, Literal, Optional, Union
 
+import pandas
 from pandas._typing import IndexLabel
 
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
@@ -204,9 +205,9 @@ def to_pandas(
     *,
     statement_params: Optional[dict[str, str]] = None,
     **kwargs: Any,
-) -> pd.DataFrame:
+) -> pandas.DataFrame:
     """
-    Convert Snowpark pandas DataFrame to pandas DataFrame
+    Convert Snowpark pandas DataFrame to `pandas.DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_
 
     Args:
         statement_params: Dictionary of statement level parameters to be set while executing this action.

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -10,11 +10,11 @@ as `Series.to_snowflake`.
 from collections.abc import Iterable
 from typing import Any, Literal, Optional, Union
 
+import pandas
 from pandas._typing import IndexLabel
 
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
 from snowflake.snowpark.modin import pandas as pd  # noqa: F401
-from snowflake.snowpark.modin.pandas import Series
 from snowflake.snowpark.modin.pandas.api.extensions import register_series_accessor
 from snowflake.snowpark.modin.plugin._internal.telemetry import (
     snowpark_pandas_telemetry_method_decorator,
@@ -178,9 +178,9 @@ def to_pandas(
     *,
     statement_params: Optional[dict[str, str]] = None,
     **kwargs: Any,
-) -> Series:
+) -> pandas.Series:
     """
-    Convert Snowpark pandas Series to pandas Series
+    Convert Snowpark pandas Series to `pandas.Series <https://pandas.pydata.org/docs/reference/api/pandas.Series.html>`_
 
     Args:
         statement_params: Dictionary of statement level parameters to be set while executing this action.


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1435489

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This PR adds rst link tags in GroupBy docstrings so they properly link. DataFrame and Series now automatically link to the correct class, so this PR also removes unnecessary "Snowpark pandas DataFrame" qualifications from return types for consistency, and adds links to native pandas docs for `to_pandas` methods that return a native pandas frame.