### PR TITLE
SNOW-1411701: fix regression test failure

### DIFF
--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1840,7 +1840,7 @@ def test_to_timestamp_variant_column(to_type, expected, session, local_testing_m
         datetime(2017, 12, 24, 12, 55, 59, 123456),  # timestamp
     ]
 
-    if to_type == to_timestamp_ntz:
+    if to_type == to_timestamp_ntz and IS_IN_STORED_PROC:
         # integer in variant type depends on local time zone of the server
         # while in sproc reg test, the timezone is non-deterministic leading to non-deterministic result
         # here we pop the case of integer in variant type

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1792,8 +1792,9 @@ def test_to_timestamp_numeric_scale_column(
                 # https://docs.snowflake.com/en/sql-reference/functions/to_timestamp#usage-notes
                 # integer + variant depends on server local time zone, reg server is of timezone UTC different from
                 # public deployments
-                Row(datetime(2361, 3, 21, 11, 15))
-                if str(datetime.now().astimezone().tzinfo) != "UTC"
+                Row(datetime(2361, 3, 21, 19, 15))
+                if str(datetime.now().astimezone().tzinfo) == "UTC"
+                and IS_IN_STORED_PROC
                 else Row(datetime(2361, 3, 21, 19, 15)),
                 Row(datetime(2361, 3, 21, 19, 15)),
                 Row(datetime(2024, 2, 1, 12, 34, 56, 789000)),

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1795,7 +1795,7 @@ def test_to_timestamp_numeric_scale_column(
                 Row(datetime(2361, 3, 21, 19, 15))
                 if str(datetime.now().astimezone().tzinfo) == "UTC"
                 and IS_IN_STORED_PROC
-                else Row(datetime(2361, 3, 21, 19, 15)),
+                else Row(datetime(2361, 3, 21, 11, 15)),
                 Row(datetime(2361, 3, 21, 19, 15)),
                 Row(datetime(2024, 2, 1, 12, 34, 56, 789000)),
                 Row(datetime(2017, 12, 24, 12, 55, 59, 123456)),

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1789,7 +1789,12 @@ def test_to_timestamp_numeric_scale_column(
         (
             to_timestamp_ntz,
             [
-                Row(datetime(2361, 3, 21, 11, 15)),
+                # https://docs.snowflake.com/en/sql-reference/functions/to_timestamp#usage-notes
+                # integer + variant depends on server local time zone, reg server is of timezone UTC different from
+                # public deployments
+                Row(datetime(2361, 3, 21, 11, 15))
+                if str(datetime.now().astimezone().tzinfo) != "UTC"
+                else Row(datetime(2361, 3, 21, 19, 15)),
                 Row(datetime(2361, 3, 21, 19, 15)),
                 Row(datetime(2024, 2, 1, 12, 34, 56, 789000)),
                 Row(datetime(2017, 12, 24, 12, 55, 59, 123456)),

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -265,7 +265,9 @@ def test_to_pandas_batches(session, local_testing_mode):
         break
 
 
-@pytest.mark.localtest
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="SNOW-1362480, backend optimization in different reg env"
+)
 def test_df_to_pandas_df(session):
     df = session.create_dataframe(
         [
@@ -365,15 +367,23 @@ def test_df_to_pandas_df(session):
             "A": pd.Series(["[\n  1,\n  2,\n  3,\n  4\n]"], dtype=object),
             "B": pd.Series([b"123"], dtype=object),
             "C": pd.Series([True], dtype=bool),
-            "D": pd.Series([1], dtype=np.int64),
+            "D": pd.Series(
+                [1], dtype=np.int64
+            ),  # in reg env, there can be backend optimization resulting in np.int8
             "E": pd.Series([datetime.date(year=2023, month=10, day=30)], dtype=object),
             "F": pd.Series([decimal.Decimal(1)], dtype=np.int64),
             "G": pd.Series([1.23], dtype=np.float64),
             "H": pd.Series([1.23], dtype=np.float64),
-            "I": pd.Series([100], dtype=np.int64),
-            "J": pd.Series([100], dtype=np.int64),
+            "I": pd.Series(
+                [100], dtype=np.int64
+            ),  # in reg env, there can be backend optimization resulting in np.int8
+            "J": pd.Series(
+                [100], dtype=np.int64
+            ),  # in reg env, there can be backend optimization resulting in np.int8
             "K": pd.Series([None], dtype=object),
-            "L": pd.Series([100], dtype=np.int64),
+            "L": pd.Series(
+                [100], dtype=np.int64
+            ),  # in reg env, there can be backend optimization resulting in np.int8
             "M": pd.Series(["abc"], dtype=object),
             "N": pd.Series(
                 [datetime.datetime(2023, 10, 30, 12, 12, 12)], dtype="datetime64[ns]"

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -163,6 +163,8 @@ from snowflake.snowpark.types import (
     StringType,
     StructField,
     StructType,
+    TimestampTimeZone,
+    TimestampType,
     VariantType,
 )
 from tests.utils import TestData, Utils
@@ -388,7 +390,7 @@ def test_date_or_time_to_char(session, convert_func):
             datetime.datetime(2021, 12, 21, 9, 12, 56),
             datetime.datetime(1969, 1, 1, 1, 1, 1),
         ],
-        schema=["a"],
+        schema=StructType([StructField("a", TimestampType(TimestampTimeZone.NTZ))]),
     )
     assert df.select(convert_func(col("a"), "mm-dd-yyyy mi:ss:hh24")).collect() == [
         Row("12-21-2021 12:56:09"),

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -396,7 +396,9 @@ def test_date_or_time_to_char(session, convert_func):
         Row("12-21-2021 12:56:09"),
         Row("01-01-1969 01:01:01"),
     ]
-    assert df.select(convert_func(col("a"))).collect() == [
+    # we explicitly set format here because in some test env the default output format is changed
+    # leading to different result
+    assert df.select(convert_func(col("a"), "yyyy-mm-dd hh24:mi:ss.FF3")).collect() == [
         Row("2021-12-21 09:12:56.000"),
         Row("1969-01-01 01:01:01.000"),
     ]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.
fix test failure caused by:

1). reg env variable optimization leading to pandas dtype diff
 in reg env, there is a parameter turned on which optimized data type according to the value.
the parameter is not turned on in production.

sql team is investigating, we skip the test to run in sproc

2). reg env timestamp output format different, by default sp in reg env outputs time with tz info, fix the test by explicitly using timestsamp ntz


3). to_timestamp applied to integer with variant type depends on server timezone which we can't control. the reg server uses tz UTC

