### PR TITLE
SNOW-1437846: Enforce to_timestamp_ntz in resample

### DIFF
--- a/tests/integ/modin/resample/test_resample.py
+++ b/tests/integ/modin/resample/test_resample.py
@@ -65,26 +65,6 @@ def test_resample_date_before_snowflake_alignment_date():
     )
 
 
-@sql_count_checker(query_count=2, join_count=1)
-def test_resample_date_general_ntz():
-    date_data = native_pd.to_datetime(
-        [
-            "2018-12-01",
-            "2018-12-30",
-            "2018-12-31",
-            "2019-01-02",
-            "2019-01-05",
-            "2019-01-06",
-            "2019-01-10",
-        ]
-    )
-    eval_snowpark_pandas_result(
-        *create_test_dfs({"A": np.random.randn(7)}, index=date_data),
-        lambda df: df.resample("2D").min(),
-        check_freq=False,
-    )
-
-
 @interval
 @sql_count_checker(query_count=2, join_count=1)
 def test_resample_date_wraparound_snowflake_alignment_date(interval):

--- a/tests/integ/modin/resample/test_resample.py
+++ b/tests/integ/modin/resample/test_resample.py
@@ -65,6 +65,26 @@ def test_resample_date_before_snowflake_alignment_date():
     )
 
 
+@sql_count_checker(query_count=2, join_count=1)
+def test_resample_date_general_ntz():
+    date_data = native_pd.to_datetime(
+        [
+            "2018-12-01",
+            "2018-12-30",
+            "2018-12-31",
+            "2019-01-02",
+            "2019-01-05",
+            "2019-01-06",
+            "2019-01-10",
+        ]
+    )
+    eval_snowpark_pandas_result(
+        *create_test_dfs({"A": np.random.randn(7)}, index=date_data),
+        lambda df: df.resample("2D").min(),
+        check_freq=False,
+    )
+
+
 @interval
 @sql_count_checker(query_count=2, join_count=1)
 def test_resample_date_wraparound_snowflake_alignment_date(interval):

--- a/tests/integ/modin/resample/test_resample_negative.py
+++ b/tests/integ/modin/resample/test_resample_negative.py
@@ -104,3 +104,22 @@ def test_resample_ffill_negative():
         match="Parameter limit of resample.ffill has not been implemented",
     ):
         snow_df.resample("1D").ffill(limit=10)
+
+
+@sql_count_checker(query_count=1)
+def test_resample_tz_negative():
+    snow_df = pd.DataFrame(
+        {"a": range(3)},
+        index=native_pd.to_datetime(
+            [
+                "2014-08-01 09:00:00+02:00",
+                "2014-08-01 10:00:00+02:00",
+                "2014-08-01 11:00:00+02:00",
+            ]
+        ),
+    )
+    with pytest.raises(
+        TypeError,
+        match="Cannot subtract tz-naive and tz-aware datetime-like objects.",
+    ):
+        snow_df.resample("2D").min()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1437846

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Enforces all datetimes to be converted to TIMESTAMP_NTZ as timestamps with timezones are not supported in Snowpark pandas resample
