### PR TITLE
SNOW-1019448 Fix bad error message when referencing missing table in Local Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fixed a bug that when processing time format, fractional second part is not handled properly.
 - Fixed a bug that caused DecimalType data to have incorrect precision in some cases.
+- Fixed a bug where referencing missing table or view raises confusing `IndexError`.
 
 ## 1.17.0 (2024-05-21)
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1117,9 +1117,20 @@ def execute_mock_plan(
             res_df = execute_mock_plan(execution_plan)
             return res_df
         else:
-            db_schme_table = parse_table_name(entity_name)
+            obj_name_tuple = parse_table_name(entity_name)
+            obj_database = (
+                obj_name_tuple[0]
+                if len(obj_name_tuple) > 2
+                else analyzer.session.get_current_database()
+            )
+            obj_schema = (
+                obj_name_tuple[-2]
+                if len(obj_name_tuple) > 1
+                else analyzer.session.get_current_schema()
+            )
+            obj_name = obj_name_tuple[-1]
             raise SnowparkLocalTestingException(
-                f"Object '{db_schme_table[0][1:-1]}.{db_schme_table[1][1:-1]}.{db_schme_table[2][1:-1]}' does not exist or not authorized."
+                f"Object '{obj_database[1:-1]}.{obj_schema[1:-1]}.{obj_name[1:-1]}' does not exist or not authorized."
             )
     if isinstance(source_plan, Sample):
         res_df = execute_mock_plan(source_plan.child)

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1118,17 +1118,17 @@ def execute_mock_plan(
             return res_df
         else:
             obj_name_tuple = parse_table_name(entity_name)
-            obj_database = (
-                obj_name_tuple[0]
-                if len(obj_name_tuple) > 2
-                else analyzer.session.get_current_database()
-            )
+            obj_name = obj_name_tuple[-1]
             obj_schema = (
                 obj_name_tuple[-2]
                 if len(obj_name_tuple) > 1
                 else analyzer.session.get_current_schema()
             )
-            obj_name = obj_name_tuple[-1]
+            obj_database = (
+                obj_name_tuple[-3]
+                if len(obj_name_tuple) > 2
+                else analyzer.session.get_current_database()
+            )
             raise SnowparkLocalTestingException(
                 f"Object '{obj_database[1:-1]}.{obj_schema[1:-1]}.{obj_name[1:-1]}' does not exist or not authorized."
             )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1019448

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Previously, the error message assumes that `table_name` is a tuple of length 3, with schema and database name specified, this is not true. `db_schema_table` could be length of 1 or 2 as well. This PR fixes this issue by using the default database and schema associated with the session when needed.
