### PR TITLE
SNOW-1370276 Fix minor bug in date_part implementation and add more target types support for Column.cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,13 @@
 - Fixed a bug that the schema of datetime object is wrong when create DataFrame from a pandas DataFrame.
 - Fixed a bug in the implementation of `Column.equal_nan` where null data is handled incorrectly.
 - Fixed a bug where DataFrame.drop ignore attributes from parent DataFrames after join operations.
+- Fixed a bug in mocked function `date_part` where Column type is set wrong.
 
 #### Improvements
 
 - Improved error experience of `DataFrameAnalyticsFunctions.moving_agg` and `DataFrameAnalyticsFunctions.cumulative_agg` methods that `NotImplementError` will be raised when called.
 - Removed dependency check for `pyarrow` as it is not used.
+- Improved target type coverage of `Column.cast`, adding suppot for casting to boolean and all integral types.
 
 ## 1.17.0 (2024-05-21)
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -1533,7 +1533,7 @@ def mock_date_part(part: str, datetime_expr: ColumnEmulator):
                 f"{part} is an invalid date part for column of type {datatype.__class__.__name__}"
             )
         )
-    return ColumnEmulator(res, sf_type=ColumnType(LongType, nullable=True))
+    return ColumnEmulator(res, sf_type=ColumnType(LongType(), nullable=True))
 
 
 @patch("date_trunc")

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -174,6 +174,7 @@ from snowflake.snowpark.types import (
     TimestampType,
     TimeType,
     VariantType,
+    _IntegralType,
     _NumericType,
 )
 
@@ -1907,14 +1908,26 @@ def calculate_expression(
                 scale=exp.to.scale,
                 try_cast=exp.try_,
             )
-        elif isinstance(exp.to, IntegerType):
+        elif isinstance(
+            exp.to, _IntegralType
+        ):  # includes ByteType, ShortType, IntegerType, LongType
             res = _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_decimal"](
                 column, try_cast=exp.try_
             )
-            res.set_sf_type(ColumnType(IntegerType(), nullable=column.sf_type.nullable))
+            res.set_sf_type(ColumnType(exp.to, nullable=column.sf_type.nullable))
+            return res
+        elif isinstance(exp.to, LongType):
+            res = _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_decimal"](
+                column, try_cast=exp.try_
+            )
+            res.set_sf_type(ColumnType(LongType(), nullable=column.sf_type.nullable))
             return res
         elif isinstance(exp.to, BinaryType):
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_binary"](
+                column, try_cast=exp.try_
+            )
+        elif isinstance(exp.to, BooleanType):
+            return _MOCK_FUNCTION_IMPLEMENTATION_MAP["boolean"](
                 column, try_cast=exp.try_
             )
         elif isinstance(exp.to, StringType):

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1916,12 +1916,6 @@ def calculate_expression(
             )
             res.set_sf_type(ColumnType(exp.to, nullable=column.sf_type.nullable))
             return res
-        elif isinstance(exp.to, LongType):
-            res = _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_decimal"](
-                column, try_cast=exp.try_
-            )
-            res.set_sf_type(ColumnType(LongType(), nullable=column.sf_type.nullable))
-            return res
         elif isinstance(exp.to, BinaryType):
             return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_binary"](
                 column, try_cast=exp.try_

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1921,7 +1921,7 @@ def calculate_expression(
                 column, try_cast=exp.try_
             )
         elif isinstance(exp.to, BooleanType):
-            return _MOCK_FUNCTION_IMPLEMENTATION_MAP["boolean"](
+            return _MOCK_FUNCTION_IMPLEMENTATION_MAP["to_boolean"](
                 column, try_cast=exp.try_
             )
         elif isinstance(exp.to, StringType):

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -778,10 +778,6 @@ def test_df_stat_crosstab(session):
     )
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="BUG: sample by wrong result",
-)
 def test_df_stat_sampleBy(session):
     sample_by = (
         TestData.monthly_sales(session)
@@ -798,13 +794,7 @@ def test_df_stat_sampleBy(session):
         [2, 800, "APR"],
         [2, 4500, "APR"],
     ]
-    assert len(sample_by) == len(expected_data)
-    for i, row in enumerate(sample_by):
-        assert (
-            row["EMPID"] == expected_data[i][0]
-            and row["AMOUNT"] == expected_data[i][1]
-            and row["MONTH"] == expected_data[i][2]
-        )
+    Utils.check_answer(sample_by, expected_data)
 
     sample_by_2 = (
         TestData.monthly_sales(session)
@@ -817,13 +807,7 @@ def test_df_stat_sampleBy(session):
         [2, 4500, "JAN"],
         [2, 35000, "JAN"],
     ]
-    assert len(sample_by_2) == len(expected_data_2)
-    for i, row in enumerate(sample_by_2):
-        assert (
-            row["EMPID"] == expected_data_2[i][0]
-            and row["AMOUNT"] == expected_data_2[i][1]
-            and row["MONTH"] == expected_data_2[i][2]
-        )
+    Utils.check_answer(sample_by_2, expected_data_2)
 
     sample_by_3 = TestData.monthly_sales(session).stat.sample_by(col("month"), {})
     schema_names = sample_by_3.schema.names

--- a/tests/integ/test_df_analytics.py
+++ b/tests/integ/test_df_analytics.py
@@ -369,10 +369,6 @@ def test_compute_lead(session):
 
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="BUG: result data type snowpark LongType and LongType() do not match",
-)
 def test_compute_lag(session):
     """Tests df.analytics.compute_lag() happy path."""
 
@@ -632,10 +628,6 @@ def test_time_series_agg_year_sliding_window(session):
 
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="BUG: result data type snowpark LongType and LongType() do not match",
-)
 def test_time_series_agg_invalid_inputs(session):
     """Tests time_series_agg function with invalid inputs."""
 

--- a/tests/integ/test_df_analytics.py
+++ b/tests/integ/test_df_analytics.py
@@ -628,6 +628,10 @@ def test_time_series_agg_year_sliding_window(session):
 
 
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="[Bug] Aggregate expression UnresolvedAttribute is not supported",
+)
 def test_time_series_agg_invalid_inputs(session):
     """Tests time_series_agg function with invalid inputs."""
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1370276 and [SNOW-1370165](https://snowflakecomputing.atlassian.net/browse/SNOW-1370165)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

This PR tries to enable 3 tests:

- `test_df_stat_sampleBy` is enabled after refactoring the test to ignore order. There's no bug to fix.
-   `test_compute_lag` is enabled after fixing the minor issue in `date_part`'s implementation. 
-  `test_time_series_agg_invalid_inputs` had multiple issues, first being `date_part`, then it requires `Column.cast` to support casting to `Boolean`, I added all target types we support of now. However it is still blocked by an error from computing aggregating.


[SNOW-1370165]: https://snowflakecomputing.atlassian.net/browse/SNOW-1370165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ