### PR TITLE
SNOW-1374081: [Local Testing] fix test_row_number

### DIFF
--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -4621,16 +4621,14 @@ def test_rank(session):
     )
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-1374081: row_number over window does not have consistent result.",
-)
 def test_row_number(session):
     Utils.check_answer(
-        TestData.xyz(session).select(
-            row_number().over(Window.partition_by(col("X")).order_by(col("Y")))
-        ),
-        [Row(1), Row(2), Row(3), Row(1), Row(2)],
+        TestData.xyz(session)
+        .select(
+            "X", row_number().over(Window.partition_by(col("X")).order_by(col("Y")))
+        )
+        .order_by("X"),
+        [Row(1, 1), Row(1, 2), Row(2, 1), Row(2, 2), Row(2, 3)],
         sort=False,
     )
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1374081

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   After messing around with some sql queries I think the issue with this test is that the order of the window partitions is ambiguous, but seemingly stable. With some of the parameters changed the groups will sometimes be in different orders so I don't think local testing has anything to match here. I've added an order_by to remove the ambiguous ordering.