### PR TITLE
SNOW-978584 Populate expr_to_alias map in DataFrame.drop by executing the plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Fixed a bug that integer precision of large value gets lost when converted to pandas DataFrame.
 - Fixed a bug that the schema of datetime object is wrong when create DataFrame from a pandas DataFrame.
 - Fixed a bug in the implementation of `Column.equal_nan` where null data is handled incorrectly.
+- Fixed a bug where DataFrame.drop ignore attributes from parent DataFrames after join operations.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1267,6 +1267,11 @@ class DataFrame:
             if isinstance(c, str):
                 names.append(c)
             elif isinstance(c, Column) and isinstance(c._expression, Attribute):
+                from snowflake.snowpark.mock._connection import MockServerConnection
+
+                if isinstance(self._session._conn, MockServerConnection):
+                    self.schema  # to execute the plan and populate expr_to_alias
+
                 names.append(
                     self._plan.expr_to_alias.get(
                         c._expression.expr_id, c._expression.name

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -590,7 +590,7 @@ class MockServerConnection:
                 raise_error=NotImplementedError,
             )
 
-        res = execute_mock_plan(plan)
+        res = execute_mock_plan(plan, plan.expr_to_alias)
         if isinstance(res, TableEmulator):
             # stringfy the variant type in the result df
             for col in res.columns:
@@ -777,7 +777,7 @@ $$"""
     def get_result_and_metadata(
         self, plan: SnowflakePlan, **kwargs
     ) -> Tuple[List[Row], List[Attribute]]:
-        res = execute_mock_plan(plan)
+        res = execute_mock_plan(plan, plan.expr_to_alias)
         attrs = [
             Attribute(
                 name=quote_name(column_name.strip()),

--- a/tests/integ/scala/test_dataframe_join_suite.py
+++ b/tests/integ/scala/test_dataframe_join_suite.py
@@ -1040,13 +1040,9 @@ def test_negative_test_join_of_join(session):
         session.table(table_name1).drop_table()
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-978584: DataFrame.drop bug",
-)
 def test_drop_on_join(
     session,
-):  # TODO: [Local Testing] Fix drop
+):
     table_name_1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     table_name_2 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
 
@@ -1064,11 +1060,7 @@ def test_drop_on_join(
     Utils.check_answer(df4, [Row(3), Row(4)])
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-978584: DataFrame.drop bug",
-)
-def test_drop_on_self_join(session):  # TODO: Fix drop
+def test_drop_on_self_join(session):
     table_name_1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     session.create_dataframe([[1, "a", True], [2, "b", False]]).to_df(
         "a", "b", "c"
@@ -1081,11 +1073,7 @@ def test_drop_on_self_join(session):  # TODO: Fix drop
     Utils.check_answer(df4, [Row(1), Row(2)])
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-978584: DataFrame.drop bug",
-)
-def test_with_column_on_join(session):  # TODO: Fix drop
+def test_with_column_on_join(session):
     table_name_1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     table_name_2 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     session.create_dataframe([[1, "a", True], [2, "b", False]]).to_df(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-978584

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

    The current implementation of DataFrame.drop relies on query generation being eager (i.e. `plan.expr_to_alias` is always populated) and checks if the dropped columns are present in the child query results. However, Local Testing does not execute the plan until the dataframe is evaluated, meaning the child query has not been executed when DataFrame.drop is called, so expr_to_alias (the dictionary used to keep track of expression id to column name mappings, enables usage like df.select(ancestor["col1"])) is empty. As a result, DataFrame.drop will ignore ancestor attributes like df1["b"]. This pull request proposes a **hacky** solution that evaluates the dataframe and populates the mapping when it sees an `Attribute` is passed to `DataFrame.drop`.
