### PR TITLE
Basic select API working

### DIFF
--- a/src/snowflake/snowpark/_internal/ast.py
+++ b/src/snowflake/snowpark/_internal/ast.py
@@ -6,17 +6,19 @@
 import base64
 import itertools
 import sys
-from typing import Tuple
 import uuid
+from typing import Tuple
 
 import snowflake.snowpark._internal.proto.ast_pb2 as proto
+
 
 # TODO: currently unused.
 def expr_to_dataframe_expr(expr):
     dfe = proto.SpDataframeExpr()
-    variant = expr.WhichOneof('variant')
+    variant = expr.WhichOneof("variant")
     getattr(dfe, variant).CopyFrom(getattr(expr, variant))
     return dfe
+
 
 class AstBatch:
     def __init__(self, session):
@@ -25,13 +27,13 @@ class AstBatch:
         self._init_batch()
         # TODO: extended version from the branch snowpark-ir.
 
-    def assign(self, symbol = None):
+    def assign(self, symbol=None):
         stmt = self._request.body.add()
         stmt.assign.uid = next(self._id_gen)
         stmt.assign.var_id.bitfield1 = stmt.assign.uid
         stmt.assign.symbol = symbol if isinstance(symbol, str) else ""
         return stmt.assign
-    
+
     def eval(self, target):
         stmt = self._request.body.add()
         stmt.eval.uid = next(self._id_gen)

--- a/src/snowflake/snowpark/_internal/ast.py
+++ b/src/snowflake/snowpark/_internal/ast.py
@@ -27,7 +27,7 @@ class AstBatch:
         self._init_batch()
         # TODO: extended version from the branch snowpark-ir.
 
-    def assign(self, symbol=None):
+    def assign(self, symbol = None):
         stmt = self._request.body.add()
         stmt.assign.uid = next(self._id_gen)
         stmt.assign.var_id.bitfield1 = stmt.assign.uid

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -698,7 +698,11 @@ class ServerConnection:
     def create_coprocessor(self) -> None:
         id = str(uuid.uuid4())
         print(f"create cp start rid={id}")
-        self._conn._rest.request(f"/queries/v1/query-request?requestId={id}", { 'dataframeAst': 'new-session' }, _no_results=True)
+        self._conn._rest.request(
+            f"/queries/v1/query-request?requestId={id}",
+            {"dataframeAst": "new-session"},
+            _no_results=True,
+        )
         time.sleep(5)  # TODO: need to send a response once the TCM is created.
         print("create cp complete")
 
@@ -708,7 +712,9 @@ class ServerConnection:
             "dataframeAst": ast,
         }
         print(f"query rid={request_id}")
-        return self._conn._rest.request(f"/queries/v1/query-request?requestId={request_id}", req)
+        return self._conn._rest.request(
+            f"/queries/v1/query-request?requestId={request_id}", req
+        )
 
 
 def _fix_pandas_df_fixed_type(

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -7,6 +7,7 @@ import sys
 from typing import Optional, Union
 
 import snowflake.snowpark
+import snowflake.snowpark._internal.proto.ast_pb2 as proto
 from snowflake.snowpark._internal.analyzer.binary_expression import (
     Add,
     And,
@@ -79,7 +80,6 @@ from snowflake.snowpark.types import (
     TimestampType,
 )
 from snowflake.snowpark.window import Window, WindowSpec
-import snowflake.snowpark._internal.proto.ast_pb2 as proto
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
@@ -227,7 +227,10 @@ class Column:
     """
 
     def __init__(
-        self, expr1: Union[str, Expression], expr2: Optional[str] = None, ast: Optional[proto.SpColumnExpr] = None
+        self,
+        expr1: Union[str, Expression],
+        expr2: Optional[str] = None,
+        ast: Optional[proto.SpColumnExpr] = None,
     ) -> None:
         self._ast = proto.SpColumnExpr() if ast is None else ast
 
@@ -237,9 +240,7 @@ class Column:
                     self._expression = Star([], df_alias=expr1)
                 else:
                     col_name = quote_name(expr2)
-                    self._expression = UnresolvedAttribute(
-                        col_name, df_alias=expr1
-                    )
+                    self._expression = UnresolvedAttribute(col_name, df_alias=expr1)
                     # TODO: figure out why basic aliasing is breaking above
                     self._ast.sp_column_alias.col.sp_column.name = col_name
                     self._ast.sp_column_alias.name = expr1

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -253,7 +253,7 @@ class Column:
             else:
                 self._expression = UnresolvedAttribute(quote_name(expr1))
 
-            # some repitition here, but _expression logic will be eliminated eventually
+            # some repetition here, but _expression logic will be eliminated eventually
             if self._ast is None:
                 self._ast = proto.SpColumnExpr()
                 if expr1 == "*":

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -232,8 +232,7 @@ class Column:
         expr2: Optional[str] = None,
         ast: Optional[proto.SpColumnExpr] = None,
     ) -> None:
-        if ast is not None:
-            self._ast = ast
+        self._ast = ast
 
         if expr2 is not None:
             # TODO: Find correct entities in AST for df_aliasing
@@ -249,16 +248,18 @@ class Column:
                     "When Column constructor gets two arguments, both need to be <str>"
                 )
         elif isinstance(expr1, str):
-            if ast is None:
-                self._ast = proto.SpColumnExpr()
             if expr1 == "*":
                 self._expression = Star([])
-                # TODO: Determine whether SpColumnSqlExpr is correct entity here
-                self._ast.sp_column_sql_expr.sql = "*"
             else:
-                col_name = quote_name(expr1)
-                self._expression = UnresolvedAttribute(col_name)
-                self._ast.sp_column.name = col_name
+                self._expression = UnresolvedAttribute(quote_name(expr1))
+
+            # some repitition here, but _expression logic will be eliminated eventually
+            if self._ast is None:
+                self._ast = proto.SpColumnExpr()
+                if expr1 == "*":
+                    self._ast.sp_column_sql_expr.sql = "*"
+                else:
+                    self._ast.sp_column.name = quote_name(expr1)
 
         elif isinstance(expr1, Expression):
             self._expression = expr1

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 import snowflake.snowpark
+import snowflake.snowpark._internal.proto.ast_pb2 as proto
 from snowflake.connector.options import installed_pandas
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,
@@ -86,7 +87,6 @@ from snowflake.snowpark._internal.analyzer.unary_plan_node import (
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.open_telemetry import open_telemetry_context_manager
-import snowflake.snowpark._internal.proto.ast_pb2 as proto
 from snowflake.snowpark._internal.telemetry import (
     add_api_call,
     adjust_api_subcalls,
@@ -1126,7 +1126,7 @@ class DataFrame:
         exprs = parse_positional_args_to_list(*cols)
         if not exprs:
             raise ValueError("The input of select() cannot be empty")
-        
+
         stmt = self._session._ast_batch.assign()
         ast = stmt.expr
         ast.sp_dataframe_select__columns.df.sp_dataframe_ref.id.bitfield1 = self._ast_id
@@ -1348,14 +1348,14 @@ class DataFrame:
                 self._select_statement.filter(
                     _to_col_if_sql_expr(expr, "filter/where")._expression
                 ),
-                ast_stmt=stmt
+                ast_stmt=stmt,
             )
         return self._with_plan(
             Filter(
                 _to_col_if_sql_expr(expr, "filter/where")._expression,
                 self._plan,
             ),
-            ast_stmt=stmt
+            ast_stmt=stmt,
         )
 
     @df_api_usage
@@ -3320,10 +3320,10 @@ class DataFrame:
             repr = self._session._ast_batch.assign()
             repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
             self._session._ast_batch.eval(repr)
-            
-            print(f'Original: {self._plan.queries}')
-            print(f'AST: {self._session._ast_batch._request}')
-            
+
+            print(f"Original: {self._plan.queries}")
+            print(f"AST: {self._session._ast_batch._request}")
+
             ast = self._session._ast_batch.flush()
             # TODO: Phase 0: prepend this as comment; Phase 1: invoke REST API.
             # preview_sql = f"select system$snowpark_coprocessor('{ast}')"

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1134,7 +1134,7 @@ class DataFrame:
         stmt = self._session._ast_batch.assign()
         ast = stmt.expr
         ast.sp_dataframe_select__columns.df.sp_dataframe_ref.id.bitfield1 = self._ast_id
-        ast.sp_dataframe_select__columns.variadic = (len(cols) > 1 or isinstance(cols[0], (list, tuple, set)))
+        ast.sp_dataframe_select__columns.variadic = (len(cols) > 1 or not isinstance(cols[0], (list, tuple, set)))
 
         names = []
         table_func = None

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from typing import Dict, List, NamedTuple, Optional, Union, overload
 
 import snowflake.snowpark
+import snowflake.snowpark._internal.proto.ast_pb2 as proto
 from snowflake.snowpark._internal.analyzer.binary_plan_node import create_join_type
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import UnresolvedRelation
 from snowflake.snowpark._internal.analyzer.table_merge_expression import (
@@ -20,7 +21,6 @@ from snowflake.snowpark._internal.analyzer.table_merge_expression import (
 )
 from snowflake.snowpark._internal.analyzer.unary_plan_node import Sample
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
-import snowflake.snowpark._internal.proto.ast_pb2 as proto
 from snowflake.snowpark._internal.telemetry import add_api_call, set_api_call_source
 from snowflake.snowpark._internal.type_utils import ColumnOrLiteral
 from snowflake.snowpark.column import Column
@@ -277,7 +277,9 @@ class Table(DataFrame):
         stmt.expr.sp_table.table = table_name
 
         super().__init__(
-            session, session._analyzer.resolve(UnresolvedRelation(table_name)), ast_stmt=stmt
+            session,
+            session._analyzer.resolve(UnresolvedRelation(table_name)),
+            ast_stmt=stmt,
         )
         self.is_cached: bool = self.is_cached  #: Whether the table is cached.
         self.table_name: str = table_name  #: The table name

--- a/tests/thin-client/select_outputs.py
+++ b/tests/thin-client/select_outputs.py
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from snowflake.snowpark import Session
+from snowflake.snowpark.functions import col, contains
+
+session = Session.builder.create()
+df = session.table("test_table").filter("STR LIKE '%e%'")
+df2 = df.select("A", df.col("STR"), col("B"), df.STR)
+print(session._ast_batch._request)

--- a/tests/thin-client/steel-thread.py
+++ b/tests/thin-client/steel-thread.py
@@ -2,6 +2,7 @@ from snowflake.snowpark import Session
 from snowflake.snowpark.functions import col, contains
 
 session = Session.builder.create()
-df = session.table('test_table')
-df = df.filter("STR LIKE '%e%'")
-df.show()
+df = session.table('test_table').filter("STR LIKE '%e%'")
+# col = df.col("STR") # TODO: determine whether this should create and assign statement or not
+df2 = df.select("A", df.col("STR"), col("B"), df.STR, col("A") + col("B"))
+print(session._ast_batch._request)

--- a/tests/thin-client/steel-thread.py
+++ b/tests/thin-client/steel-thread.py
@@ -1,12 +1,7 @@
-#
-# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
-#
-
 from snowflake.snowpark import Session
 from snowflake.snowpark.functions import col, contains
 
 session = Session.builder.create()
-df = session.table("test_table").filter("STR LIKE '%e%'")
-# col = df.col("STR") # TODO: determine whether this should create and assign statement or not
-df2 = df.select("A", df.col("STR"), col("B"), df.STR, col("A") + col("B"))
-print(session._ast_batch._request)
+df = session.table('test_table')
+df = df.filter("STR LIKE '%e%'")
+df.show()

--- a/tests/thin-client/steel-thread.py
+++ b/tests/thin-client/steel-thread.py
@@ -1,8 +1,12 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
 from snowflake.snowpark import Session
 from snowflake.snowpark.functions import col, contains
 
 session = Session.builder.create()
-df = session.table('test_table').filter("STR LIKE '%e%'")
+df = session.table("test_table").filter("STR LIKE '%e%'")
 # col = df.col("STR") # TODO: determine whether this should create and assign statement or not
 df2 = df.select("A", df.col("STR"), col("B"), df.STR, col("A") + col("B"))
 print(session._ast_batch._request)


### PR DESCRIPTION
- `Column`s are created with no reference to the parent `Dataframe` in the current Snowpark API
- Following this pattern when generating the AST (invoking `proto` IR entity constructors directly)
- `ast` parameter added to `Column` constructor to enable `Column` methods to create and push-down ASTs
- `ast` property added to `Column` class to enable backwards compatibility with `col._expression: Expression` using `SpColumnSqlExpr` as a backup

Current test case output AST
```
client_version {
  major: 42
}
client_language {
  python_language {
    version {
      major: 3
      minor: 8
    }
  }
}
body {
  assign {
    uid: 1
    var_id {
      bitfield1: 1
    }
    expr {
      sp_table {
        table: "test_table"
      }
    }
  }
}
body {
  assign {
    uid: 2
    var_id {
      bitfield1: 2
    }
    expr {
      sp_dataframe_filter {
        df {
          sp_dataframe_ref {
            id {
              bitfield1: 1
            }
          }
        }
        condition {
          sp_column_sql_expr {
            sql: "STR LIKE \'%e%\'"
          }
        }
      }
    }
  }
}
body {
  assign {
    uid: 3
    var_id {
      bitfield1: 3
    }
    expr {
      sp_dataframe_select__columns {
        df {
          sp_dataframe_ref {
            id {
              bitfield1: 2
            }
          }
        }
        cols {
          sp_column {
            name: "\"A\""
          }
        }
        cols {
          sp_column_sql_expr {
            sql: "\"STR\""
          }
        }
        cols {
          sp_column {
            name: "\"B\""
          }
        }
        cols {
          sp_column_sql_expr {
            sql: "\"STR\""
          }
        }
        cols {
          sp_column_sql_expr {
            sql: "ADD(\"A\", \"B\")"
          }
        }
      }
    }
  }
}
```