### PR TITLE
SNOW-1369973 Fix DataFrameWriter.save_as_table behavior when appending/truncating with mismatching columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 - Fixed a bug in the implementation of `Column.equal_nan` where null data is handled incorrectly.
 - Fixed a bug where DataFrame.drop ignore attributes from parent DataFrames after join operations.
 - Fixed a bug in mocked function `date_part` where Column type is set wrong.
+- Fixed a bug in the implementation of DataFrameWriter.save_as_table where
+  - Append or Truncate fails when incoming data has different schema than existing table.
+  - Truncate fails when incoming data does not specify columns that are nullable.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -158,6 +158,14 @@ class MockServerConnection:
                 # Fix append by index
                 if name in self.table_registry:
                     target_table = self.table_registry[name]
+
+                    if len(table.columns.to_list()) != len(
+                        target_table.columns.to_list()
+                    ):
+                        raise SnowparkLocalTestingException(
+                            f"Cannot append because incoming data has different schema {table.columns.to_list()} than existing table { target_table.columns.to_list()}"
+                        )
+
                     table.columns = target_table.columns
                     self.table_registry[name] = pandas.concat(
                         [target_table, table], ignore_index=True
@@ -178,8 +186,21 @@ class MockServerConnection:
             elif mode == SaveMode.TRUNCATE:
                 if name in self.table_registry:
                     target_table = self.table_registry[name]
-                    if table.columns != target_table.columns:
-                        raise SnowparkLocalTestingException("Column mismatch detected")
+                    input_schema = table.columns.to_list()
+                    existing_schema = target_table.columns.to_list()
+                    if len(input_schema) <= len(existing_schema) and (
+                        all(
+                            target_table[col].sf_type.nullable
+                            for col in (existing_schema[len(input_schema) :])
+                        )
+                    ):
+                        for col in existing_schema[len(input_schema) :]:
+                            table[col] = None
+                            table.sf_types[col] = target_table[col].sf_type
+                    else:
+                        raise SnowparkLocalTestingException(
+                            f"Cannot truncate because incoming data has different schema {table.columns.to_list()} than existing table { target_table.columns.to_list()}"
+                        )
 
                 self.table_registry[name] = table
             else:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2516,19 +2516,20 @@ def test_describe(session):
     assert "invalid identifier" in str(ex_info)
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-1369973 Truncate table with mismatching columns raises bad error",
-)
-def test_truncate_preserves_schema(session):
+def test_truncate_preserves_schema(session, local_testing_mode):
     tmp_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     df1 = session.create_dataframe([(1, 2), (3, 4)], schema=["a", "b"])
     df2 = session.create_dataframe([(1, 2, 3), (4, 5, 6)], schema=["a", "b", "c"])
 
     df1.write.save_as_table(tmp_table_name, table_type="temp")
+    exception_msg = (
+        "invalid identifier 'C'"
+        if not local_testing_mode
+        else "incoming data has different schema"
+    )
 
     # truncate preserves old schema
-    with pytest.raises(SnowparkSQLException, match="invalid identifier 'C'"):
+    with pytest.raises(SnowparkSQLException, match=exception_msg):
         df2.write.save_as_table(tmp_table_name, mode="truncate", table_type="temp")
 
     # overwrite drops old schema
@@ -2536,10 +2537,6 @@ def test_truncate_preserves_schema(session):
     Utils.check_answer(session.table(tmp_table_name), [Row(1, 2, 3), Row(4, 5, 6)])
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-1369973 Truncate table with mismatching columns raises bad error",
-)
 def test_truncate_existing_table(session):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     df = session.create_dataframe([(1, 2), (3, 4)]).toDF("a", "b")
@@ -2565,14 +2562,10 @@ def test_table_types_in_save_as_table(
         Utils.assert_table_type(session, table_name, table_type)
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-1369973 Truncate table with mismatching columns raises bad error",
-)
 @pytest.mark.parametrize(
     "save_mode", ["append", "overwrite", "ignore", "errorifexists", "truncate"]
 )
-def test_save_as_table_respects_schema(session, save_mode):
+def test_save_as_table_respects_schema(session, save_mode, local_testing_mode):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
 
     schema1 = StructType(
@@ -2611,7 +2604,12 @@ def test_save_as_table_respects_schema(session, save_mode):
             df2.write.save_as_table(table_name, mode=save_mode)
             saved_df = session.table(table_name)
             Utils.is_schema_same(saved_df.schema, schema1)
-            with pytest.raises(SnowparkSQLException, match="invalid identifier 'C'"):
+            exception_msg = (
+                "invalid identifier 'C'"
+                if not local_testing_mode
+                else "Cannot truncate because incoming data has different schema"
+            )
+            with pytest.raises(SnowparkSQLException, match=exception_msg):
                 df3.write.save_as_table(table_name, mode=save_mode)
         else:  # save_mode in ('append', 'errorifexists')
             with pytest.raises(SnowparkSQLException):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Previously, the expression `table.columns != target_table.columns` will raise a pandas exception when table and target_table has different schema, this PR rewrites this comparison to (1) not compare the column names but compare the length instead and (2) allow truncating a table when incoming data are only missing columns that are nullable.
