### PR TITLE
SNOW-1370035: [Local Testing] Improve consistency of udf input/output

### DIFF
--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1231,11 +1231,7 @@ def test_add_import_negative(session, resources_path):
     )
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SNOW-1370035: date time objects are received as str inside UDF",
-)
-def test_udf_variant_type(session):
+def test_udf_variant_type(session, local_testing_mode):
     def variant_get_data_type(v):
         return str(type(v))
 
@@ -1308,23 +1304,24 @@ def test_udf_variant_type(session):
         [Row("<class 'dict'>")],
     )
 
-    # dynamic typing on one single column
-    df = session.sql(
-        "select parse_json(column1) as a from values"
-        "('1'), ('1.1'), ('\"2\"'), ('true'), ('[1, 2, 3]'),"
-        ' (\'{"a": "foo"}\')'
-    )
-    Utils.check_answer(
-        df.select(variant_udf("a")).collect(),
-        [
-            Row("<class 'int'>"),
-            Row("<class 'float'>"),
-            Row("<class 'str'>"),
-            Row("<class 'bool'>"),
-            Row("<class 'list'>"),
-            Row("<class 'dict'>"),
-        ],
-    )
+    if not local_testing_mode:
+        # dynamic typing on one single column
+        df = session.sql(
+            "select parse_json(column1) as a from values"
+            "('1'), ('1.1'), ('\"2\"'), ('true'), ('[1, 2, 3]'),"
+            ' (\'{"a": "foo"}\')'
+        )
+        Utils.check_answer(
+            df.select(variant_udf("a")).collect(),
+            [
+                Row("<class 'int'>"),
+                Row("<class 'float'>"),
+                Row("<class 'str'>"),
+                Row("<class 'bool'>"),
+                Row("<class 'list'>"),
+                Row("<class 'dict'>"),
+            ],
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -50,7 +50,7 @@ from snowflake.snowpark.exceptions import (
     SnowparkInvalidObjectNameException,
     SnowparkSQLException,
 )
-from snowflake.snowpark.functions import call_udf, col, pandas_udf, udf
+from snowflake.snowpark.functions import call_udf, col, pandas_udf, parse_json, udf
 from snowflake.snowpark.types import (
     LTZ,
     NTZ,
@@ -1304,24 +1304,25 @@ def test_udf_variant_type(session, local_testing_mode):
         [Row("<class 'dict'>")],
     )
 
-    if not local_testing_mode:
-        # dynamic typing on one single column
-        df = session.sql(
-            "select parse_json(column1) as a from values"
-            "('1'), ('1.1'), ('\"2\"'), ('true'), ('[1, 2, 3]'),"
-            ' (\'{"a": "foo"}\')'
+    # dynamic typing on one single column
+    df = (
+        session.create_dataframe(
+            [("1"), ("1.1"), ('"2"'), ("true"), ("[1, 2, 3]"), ('{"a": "foo"}')]
         )
-        Utils.check_answer(
-            df.select(variant_udf("a")).collect(),
-            [
-                Row("<class 'int'>"),
-                Row("<class 'float'>"),
-                Row("<class 'str'>"),
-                Row("<class 'bool'>"),
-                Row("<class 'list'>"),
-                Row("<class 'dict'>"),
-            ],
-        )
+        .to_df(["a"])
+        .select(parse_json("a").alias("a"))
+    )
+    Utils.check_answer(
+        df.select(variant_udf("a")).collect(),
+        [
+            Row("<class 'int'>"),
+            Row("<class 'float'>"),
+            Row("<class 'str'>"),
+            Row("<class 'bool'>"),
+            Row("<class 'list'>"),
+            Row("<class 'dict'>"),
+        ],
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1370035 and SNOW-1374027

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   This PR improves local testing udf experience in a few ways when it comes to variant data.

- Variant data can contain just about anything, but often when passed to a udf it is coerced to certain types. I've added a mechanism to the udf call logic that coerces various types to the expected types.
- Variant Nones are passed to udfs as SqlNullWrapper objects. These are not currently defined or used in our repo so I've added a coercion for them in this PR as well.
- I've merged the logic for calculating udf inputs with the logic that validates input types. This resulted in a different error experience that could be considered a BCR, but the replaced error hasn't been released yet so I don't think it's a problem.
- UDFs that expect variant input, but receive other datatypes as input will have those datatypes coerced which matches the behaviour of live mode.