### PR TITLE
DOC: fix maxdepth to 2

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Snowflake directly without moving data to the system where your application code
 information, see the `Snowpark Developer Guide for Python <https://docs.snowflake.com/en/developer-guide/snowpark/python/index.html>`_.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    snowpark/session
    snowpark/index


### PR DESCRIPTION
DOC: fix maxdepth to 2

Fix the doc regression introduced in 1.17. Once the `maxdepth` is 2, then we can see the left bar with correct levels:
![Screenshot 2024-05-28 at 11 17 37 AM](https://github.com/snowflakedb/snowpark-python/assets/63608674/2ddd7cad-35c4-476a-9dee-6374c3762eed)
