### PR TITLE
SNOW-1335467 Add the vector_cosine_similarity built-in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Snowpark Python API Updates
 
+#### New Features
+
+- Added the `vector_cosine_similarity` built-in function.
+
 #### Improvements
 
 ### Snowpark Local Testing Updates

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -5774,6 +5774,9 @@ def object_pick(obj: ColumnOrName, key1: ColumnOrName, *keys: ColumnOrName) -> C
 def vector_cosine_distance(v1: ColumnOrName, v2: ColumnOrName) -> Column:
     """Returns the cosine distance between two vectors of equal dimension and element type.
 
+    This function has been deprecated in favor of vector_cosine_similarity, whose semantics are
+    the same.
+
     Example::
         >>> from snowflake.snowpark.functions import vector_cosine_distance
         >>> df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
@@ -5788,6 +5791,25 @@ def vector_cosine_distance(v1: ColumnOrName, v2: ColumnOrName) -> Column:
     v1 = _to_col_if_str(v1, "vector_cosine_distance")
     v2 = _to_col_if_str(v2, "vector_cosine_distance")
     return builtin("vector_cosine_distance")(v1, v2)
+
+
+def vector_cosine_similarity(v1: ColumnOrName, v2: ColumnOrName) -> Column:
+    """Returns the cosine similarity metric between two vectors of equal dimension and element type.
+
+    Example::
+        >>> from snowflake.snowpark.functions import vector_cosine_similarity
+        >>> df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
+        >>> df.select(vector_cosine_similarity(df.a, df.b).as_("dist")).show()
+        ----------------------
+        |"DIST"              |
+        ----------------------
+        |0.9925833339709303  |
+        ----------------------
+        <BLANKLINE>
+    """
+    v1 = _to_col_if_str(v1, "vector_cosine_similarity")
+    v2 = _to_col_if_str(v2, "vector_cosine_similarity")
+    return builtin("vector_cosine_similarity")(v1, v2)
 
 
 def vector_l2_distance(v1: ColumnOrName, v2: ColumnOrName) -> Column:

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -1744,9 +1744,11 @@ def test_createDataFrame_with_given_schema(session, local_testing_mode):
             StructField("binary", BinaryType()),
             StructField(
                 "timestamp",
-                TimestampType(TimestampTimeZone.NTZ)
-                if not local_testing_mode
-                else TimestampType(),
+                (
+                    TimestampType(TimestampTimeZone.NTZ)
+                    if not local_testing_mode
+                    else TimestampType()
+                ),
             ),  # depends on TIMESTAMP_TYPE_MAPPING
             StructField("timestamp_ntz", TimestampType(TimestampTimeZone.NTZ)),
             StructField("timestamp_ltz", TimestampType(TimestampTimeZone.LTZ)),
@@ -1839,6 +1841,10 @@ def test_createDataFrame_with_given_schema_vector(session):
     Utils.check_answer(df, data_float)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="vectors are not yet supported in local testing mode.",
+)
 def test_vector(session):
     schema_int = StructType([StructField("vec", VectorType(int, 3))])
     data_int = [Row([1, 2, 3]), Row([4, 5, 6]), Row(None)]

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -1839,7 +1839,6 @@ def test_createDataFrame_with_given_schema_vector(session):
     Utils.check_answer(df, data_float)
 
 
-@pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_vector(session):
     schema_int = StructType([StructField("vec", VectorType(int, 3))])
     data_int = [Row([1, 2, 3]), Row([4, 5, 6]), Row(None)]

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -604,6 +604,10 @@ def test_geometry_type(session):
     )
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="vectors are not yet supported in local testing mode.",
+)
 def test_vector_type(session):
     int_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(session, int_table_name, "v vector(int,3)", is_temporary=True)

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -604,7 +604,6 @@ def test_geometry_type(session):
     )
 
 
-@pytest.mark.xfail(reason="SNOW-974852 vectors are not yet rolled out", strict=False)
 def test_vector_type(session):
     int_table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(session, int_table_name, "v vector(int,3)", is_temporary=True)

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -1399,6 +1399,10 @@ def test_array_sort(session):
     Utils.check_answer(res, [Row(SORTED_A="[\n  null,\n  20,\n  10,\n  0\n]")])
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="vectors are not yet supported in local testing mode.",
+)
 def test_vector_distances(session):
     df = session.sql("select [1,2,3]::vector(int,3) as a, [2,3,4]::vector(int,3) as b")
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
   
Fixes SNOW-1335467

This PR adds the new `vector_cosine_similarity` built-in function that replaces the now-deprecated `vector_cosine_distance` function. It also removes `xfail`s from the various vector tests, now that the data type is in GA.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

The source changes just add a new built-in function definition