### PR TITLE
SNOW-1348700 Fix to_char's implementation when incoming column has inconsecutive row index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 #### Improvements
 
-
 #### Bug Fixes
 
 - Fixed a bug where python stored procedure with table return type fails when run in a task.
@@ -22,6 +21,7 @@
 - Fixed a bug in convert_timezone that made the setting the source_timezone parameter return an error.
 - Fixed a bug where creating DataFrame with empty data of type `DateType` raises `AttributeError`.
 - Fixed a bug that table merge fails when update clause exists but no update takes place.
+- Fixed a bug in mock implementation of `to_char` that raises `IndexError` when incoming column has inconsecutive row index.
 
 ### Snowpark pandas API Updates
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -1023,7 +1023,6 @@ def mock_to_char(
                 raise_error=NotImplementedError,
             )
 
-    # row index information is needed to retrieve format information in another pd series, thus calling to_frame here
     res = column.combine(fmt, convert_char)
     res.sf_type = ColumnType(StringType(), column.sf_type.nullable)
     return res

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -906,11 +906,8 @@ def mock_to_char(
     """
     source_datatype = column.sf_type.datatype
 
-    fmt = (
-        ColumnEmulator([fmt] * len(column))
-        if not isinstance(fmt, ColumnEmulator)
-        else fmt
-    )
+    if not isinstance(fmt, ColumnEmulator):
+        fmt = ColumnEmulator([fmt] * len(column), index=column.index)
 
     def convert_char(data, _fmt):
         if isinstance(source_datatype, _NumericType):

--- a/tests/mock/test_functions.py
+++ b/tests/mock/test_functions.py
@@ -18,6 +18,7 @@ from snowflake.snowpark.functions import (  # count,; is_null,;
     lit,
     max,
     min,
+    to_char,
     to_date,
 )
 
@@ -281,3 +282,10 @@ def test_show(session):
 |3....|4   |de...|
 ----------------\n""".lstrip()
     )
+
+
+def test_to_char_is_row_index_agnostic(session):
+    df = session.create_dataframe([[1, 2], [3, 4], [5, 6]], schema=["a", "b"])
+    assert df.filter(col("a") > 3).select(to_char(col("a")), col("b")).collect() == [
+        Row("5", 6)
+    ]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1348700 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Previously the implementation of mock_to_char relies on the incoming column has index of [0,1,...,n-1], this is not always true and causes the code raise `IndexError`, this PR fixes that and adds a test for this specific scenario.

   
