### PR TITLE
SNOW-1445536: Fix Jenkins failure in test_strings.py::test_index_raises_not_implemented_error

### DIFF
--- a/tests/integ/modin/strings/test_strings.py
+++ b/tests/integ/modin/strings/test_strings.py
@@ -359,7 +359,7 @@ def test_index_raises_not_implemented_error(method):
     msg = f"{method} is not yet implemented for Series.str"
 
     with pytest.raises(NotImplementedError, match=msg):
-        getattr(obj.str, method)(0)
+        getattr(obj.str, method)("sub")
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

The OSS modin version of StringMethods provides some frontend validation that we skipped for the unimplemented `Series.str.index`/`rindex` methods. This PR changes the argument to the correct type.