### PR TITLE
SNOW-1455291: fix dataframe creation of empty data with DateType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
 - Added support for named aggregations in `DataFrame.aggregate` and `Series.aggregate` with `axis=0`.
 - `pd.read_csv` reads using the native pandas CSV parser, then uploads data to snowflake using parquet. This enables most of the parameters supported by `read_csv` including date parsing and numeric conversions. Uploading via parquet is roughly twice as fast as uploading via CSV.
 
+### Snowpark Local Testing Updates
+
+#### Bug Fixes
+
+- Fixed a bug that creating DataFrame with empty data of type `DateType` raises `AttributeError`.
+
 ## 1.18.0 (2024-05-28)
 
 ### Snowpark Python API Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Bug Fixes
 
 - Fixed a bug in convert_timezone that made the setting the source_timezone parameter return an error.
+- Fixed a bug where creating DataFrame with empty data of type `DateType` raises `AttributeError`.
 
 ### Snowpark pandas API Updates
 
@@ -30,12 +31,6 @@
 
 - Added support for named aggregations in `DataFrame.aggregate` and `Series.aggregate` with `axis=0`.
 - `pd.read_csv` reads using the native pandas CSV parser, then uploads data to snowflake using parquet. This enables most of the parameters supported by `read_csv` including date parsing and numeric conversions. Uploading via parquet is roughly twice as fast as uploading via CSV.
-
-### Snowpark Local Testing Updates
-
-#### Bug Fixes
-
-- Fixed a bug where creating DataFrame with empty data of type `DateType` raises `AttributeError`.
 
 ## 1.18.0 (2024-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 #### Bug Fixes
 
-- Fixed a bug that creating DataFrame with empty data of type `DateType` raises `AttributeError`.
+- Fixed a bug where creating DataFrame with empty data of type `DateType` raises `AttributeError`.
 
 ## 1.18.0 (2024-05-28)
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -340,10 +340,8 @@ def mock_to_date(
 
     fmt = [fmt] * len(column) if not isinstance(fmt, ColumnEmulator) else fmt
 
-    def convert_date(row):
+    def convert_date(data, _fmt):
         try:
-            _fmt = fmt[row.name]
-            data = row[0]
             auto_detect = _fmt is None or _fmt.lower() == "auto"
             date_format, _ = convert_snowflake_datetime_format(
                 _fmt, default_format="%Y-%m-%d"
@@ -400,11 +398,7 @@ def mock_to_date(
                 SnowparkLocalTestingException.raise_from_error(exc)
 
     # if there is no data in the column, then apply will not be not executed
-    res = (
-        column.to_frame().apply(convert_date, axis=1)
-        if len(column)
-        else ColumnEmulator()
-    )
+    res = column.combine(fmt, convert_date)
     res.sf_type = ColumnType(DateType(), column.sf_type.nullable)
     return res
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -399,7 +399,12 @@ def mock_to_date(
             else:
                 SnowparkLocalTestingException.raise_from_error(exc)
 
-    res = column.to_frame().apply(convert_date, axis=1)
+    # if there is no data in the column, then apply will not be not executed
+    res = (
+        column.to_frame().apply(convert_date, axis=1)
+        if len(column)
+        else ColumnEmulator()
+    )
     res.sf_type = ColumnType(DateType(), column.sf_type.nullable)
     return res
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -338,7 +338,8 @@ def mock_to_date(
     """
     import dateutil.parser
 
-    fmt = [fmt] * len(column) if not isinstance(fmt, ColumnEmulator) else fmt
+    if not isinstance(fmt, ColumnEmulator):
+        fmt = ColumnEmulator([fmt] * len(column), index=column.index)
 
     def convert_date(data, _fmt):
         try:

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -397,7 +397,6 @@ def mock_to_date(
             else:
                 SnowparkLocalTestingException.raise_from_error(exc)
 
-    # if there is no data in the column, then apply will not be not executed
     res = column.combine(fmt, convert_date)
     res.sf_type = ColumnType(DateType(), column.sf_type.nullable)
     return res

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -70,6 +70,7 @@ from snowflake.snowpark.types import (
     IntegerType,
     LongType,
     MapType,
+    NullType,
     ShortType,
     StringType,
     StructField,
@@ -3983,3 +3984,28 @@ def test_dataframe_to_local_iterator_isolation(session):
     assert (
         row_counter == ROW_NUMBER
     ), f"Expect {ROW_NUMBER} rows, Got {row_counter} instead"
+
+
+def test_create_empty_dataframe(session):
+    schema = StructType(
+        [
+            StructField("COL1", IntegerType()),
+            StructField("COL2", ByteType()),
+            StructField("COL3", ShortType()),
+            StructField("COL4", LongType()),
+            StructField("COL5", FloatType()),
+            StructField("COL6", DoubleType()),
+            StructField("COL7", DecimalType()),
+            StructField("COL8", BooleanType()),
+            StructField("COL9", BinaryType()),
+            StructField("COL10", VariantType()),
+            StructField("COL11", StringType()),
+            StructField("COL12", DateType()),
+            StructField("COL13", TimestampType()),
+            StructField("COL14", TimeType()),
+            StructField("COL15", TimestampType(TimestampTimeZone.NTZ)),
+            StructField("COL16", MapType()),
+            StructField("COL17", NullType()),
+        ]
+    )
+    assert not session.create_dataframe(data=[], schema=schema).collect()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

there is a bug in mock to_date implementation that when the input is empty, the function will return a TableEmulator instead of a ColumnEmulator.
