### PR TITLE
SNOW-1460351: support case when string type coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed a bug in convert_timezone that made the setting the source_timezone parameter return an error.
 - Fixed a bug where creating DataFrame with empty data of type `DateType` raises `AttributeError`.
 - Fixed a bug that table merge fails when update clause exists but no update takes place.
+- Fixed a bug that case when expression did not handle string type coercion.
 
 ### Snowpark pandas API Updates
 

--- a/src/snowflake/snowpark/mock/_snowflake_data_type.py
+++ b/src/snowflake/snowpark/mock/_snowflake_data_type.py
@@ -15,6 +15,7 @@ from snowflake.snowpark.types import (
     FloatType,
     IntegerType,
     LongType,
+    StringType,
     _IntegralType,
     _NumericType,
 )
@@ -530,3 +531,12 @@ class ColumnEmulator(PandasSeriesType):
         result = super().isnull()
         result.sf_type = ColumnType(BooleanType(), True)
         return result
+
+
+def coerce_type_if_needed(type1: DataType, type2: DataType) -> DataType:
+    from snowflake.snowpark.mock._udf_utils import types_are_compatible
+
+    if types_are_compatible(type1, type2):
+        if isinstance(type1, StringType) and isinstance(type2, StringType):
+            return StringType(max(type1.length, type2.length))
+    return type1

--- a/tests/integ/test_datatypes.py
+++ b/tests/integ/test_datatypes.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import pytest
 
 from snowflake.snowpark import DataFrame, Row
-from snowflake.snowpark.functions import lit
+from snowflake.snowpark.functions import col, lit, when
 from snowflake.snowpark.types import (
     BooleanType,
     DecimalType,
@@ -423,3 +423,12 @@ def test_join_basic(session):
             ]
         )
     )
+
+
+def test_case_when_type_coerce(session):
+    df_input = session.create_dataframe(
+        [1], StructType([StructField("col", LongType())])
+    )
+    assert df_input.withColumn(
+        "new_col", when((col("col").is_null()), lit("abc")).otherwise(lit("abcdef"))
+    ).collect() == [Row(1, "abcdef")]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

this is to fix issue: https://github.com/snowflakedb/snowpark-python/issues/1725

case when has both data of stringtype but with different length, in this case we need to coerce the output type to stringtype with large length
