### PR TITLE
Exclude numeric data type mismatches from casewhen type checking

### DIFF
--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1995,6 +1995,8 @@ def calculate_expression(
                 if (
                     not isinstance(output_data.sf_type.datatype, NullType)
                     and output_data.sf_type != value.sf_type
+                    and not (isinstance(output_data.sf_type.datatype, _NumericType)
+                             and isinstance(value.sf_type.datatype, _NumericType))
                 ):
                     raise SnowparkLocalTestingException(
                         f"CaseWhen expressions have conflicting data types: {output_data.sf_type} != {value.sf_type}"
@@ -2011,6 +2013,8 @@ def calculate_expression(
                 if (
                     not isinstance(output_data.sf_type.datatype, NullType)
                     and output_data.sf_type.datatype != value.sf_type.datatype
+                    and not (isinstance(output_data.sf_type.datatype, _NumericType)
+                             and isinstance(value.sf_type.datatype, _NumericType))
                 ):
                     raise SnowparkLocalTestingException(
                         f"CaseWhen expressions have conflicting data types: {output_data.sf_type.datatype} != {value.sf_type.datatype}"


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

No Jira issue created. This PR was opened per a conversation with @sfc-gh-jrose.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Resolves an issue with Local Testing mode where numeric data types used in a CaseWhen expression return an error if there is a precision mismatch.