### PR TITLE
[feature branch] Phase 0 client

### DIFF
--- a/src/snowflake/snowpark/_internal/ast.py
+++ b/src/snowflake/snowpark/_internal/ast.py
@@ -25,10 +25,10 @@ class AstBatch:
         self._session = session
         self._id_gen = itertools.count(start=1)
         self._init_batch()
-        # TODO: extended version from the branch snowpark-ir.
 
     def assign(self, symbol = None):
         stmt = self._request.body.add()
+        # TODO: extended BindingId spec from the branch snowpark-ir.
         stmt.assign.uid = next(self._id_gen)
         stmt.assign.var_id.bitfield1 = stmt.assign.uid
         stmt.assign.symbol = symbol if isinstance(symbol, str) else ""
@@ -43,14 +43,6 @@ class AstBatch:
         """Ties off a batch and starts a new one. Returns the tied-off batch."""
         batch = str(base64.b64encode(self._request.SerializeToString()), "utf-8")
         self._init_batch()
-
-        print(f"encoded {batch}")
-        d1 = base64.b64decode(batch)
-        print(f"{len(d1)} bytes")
-        p = proto.Request()
-        p.ParseFromString(d1)
-        print(f"parsed {p}")
-
         return (str(self._request_id), batch)
 
     def _init_batch(self):

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -696,6 +696,7 @@ class ServerConnection:
         )
 
     def create_coprocessor(self) -> None:
+        """Invoked during session initialization to create a server-side coprocessor."""
         id = str(uuid.uuid4())
         print(f"create cp start rid={id}")
         self._conn._rest.request(
@@ -706,6 +707,8 @@ class ServerConnection:
         time.sleep(5)  # TODO: need to send a response once the TCM is created.
         print("create cp complete")
 
+    # TODO: This function is currently invoked to prototype Phase 1 while maintaining most of the code
+    # targeting Phase 0. This function will likely disappear once Phase 1 is placed in a separate branch.
     def ast_query(self, request_id__ast) -> Any:
         (request_id, ast) = request_id__ast
         req = {
@@ -715,6 +718,9 @@ class ServerConnection:
         return self._conn._rest.request(
             f"/queries/v1/query-request?requestId={request_id}", req
         )
+    
+    def phase1_enabled(self) -> bool:
+        return os.getenv("SNOWPARK_PHASE_1", False)
 
 
 def _fix_pandas_df_fixed_type(

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -719,7 +719,7 @@ class ServerConnection:
             f"/queries/v1/query-request?requestId={request_id}", req
         )
     
-    def phase1_enabled(self) -> bool:
+    def is_phase1_enabled(self) -> bool:
         return os.getenv("SNOWPARK_PHASE_1", False)
 
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3323,23 +3323,17 @@ class DataFrame:
     def _show_string(self, n: int = 10, max_width: int = 50, **kwargs) -> str:
         query = self._plan.queries[-1].sql.strip().lower()
 
-        # TODO: A little hack to prevent infinite recursion.
-        if not "snowpark_coprocessor" in query:
-            # Add an Assign node that applies SpDataframeShow() to the input, followed by its Eval.
-            repr = self._session._ast_batch.assign()
-            repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
-            self._session._ast_batch.eval(repr)
+        # Add an Assign node that applies SpDataframeShow() to the input, followed by its Eval.
+        repr = self._session._ast_batch.assign()
+        repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
+        self._session._ast_batch.eval(repr)
 
-            print(f"Original: {self._plan.queries}")
-            print(f"AST: {self._session._ast_batch._request}")
-
+        if self._session._conn.phase1_enabled():
             ast = self._session._ast_batch.flush()
-            # TODO: Phase 0: prepend this as comment; Phase 1: invoke REST API.
-            # preview_sql = f"select system$snowpark_coprocessor('{ast}')"
-            # print(f'Base 64: {preview_sql}')
-            # self._session.sql(preview_sql).show()
             res = self._session._conn.ast_query(ast)
             print(f"AST response: {res}")
+        else:
+            (_, kwargs["_dataframe_ast"]) = self._session._ast_batch.flush()
 
         if is_sql_select_statement(query):
             result, meta = self._session._conn.get_result_and_metadata(

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3328,12 +3328,12 @@ class DataFrame:
         repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
         self._session._ast_batch.eval(repr)
 
-        if self._session._conn.phase1_enabled():
+        if self._session._conn.is_phase1_enabled():
             ast = self._session._ast_batch.flush()
             res = self._session._conn.ast_query(ast)
             print(f"AST response: {res}")
         else:
-            (_, kwargs["_dataframe_ast"]) = self._session._ast_batch.flush()
+            _, kwargs["_dataframe_ast"] = self._session._ast_batch.flush()
 
         if is_sql_select_statement(query):
             result, meta = self._session._conn.get_result_and_metadata(

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -800,6 +800,9 @@ $$"""
         # It's not necessary to mock this call.
         pass
 
+    def phase1_enabled(self):
+        return False
+
 
 def _fix_pandas_df_fixed_type(table_res: TableEmulator) -> "pandas.DataFrame":
     pd_df = pandas.DataFrame()

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -800,7 +800,8 @@ $$"""
         # It's not necessary to mock this call.
         pass
 
-    def phase1_enabled(self):
+    def is_phase1_enabled(self):
+        # We don't yet mock Phase 1.
         return False
 
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -505,7 +505,7 @@ class Session:
         self._runtime_version_from_requirement: str = None
 
         # Initialize the server-side session.
-        if self._conn.phase1_enabled():
+        if self._conn.is_phase1_enabled():
             self._conn.create_coprocessor()
 
         self._ast_batch = AstBatch(self)

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -505,7 +505,8 @@ class Session:
         self._runtime_version_from_requirement: str = None
 
         # Initialize the server-side session.
-        self._conn.create_coprocessor()
+        if self._conn.phase1_enabled():
+            self._conn.create_coprocessor()
 
         self._ast_batch = AstBatch(self)
 

--- a/tests/ast/run-unparser.sh
+++ b/tests/ast/run-unparser.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-java -cp $1 com.snowflake.snowpark.experimental.unparser.Unparser ${@:2}

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -12,8 +12,6 @@ TEST_DIR = pathlib.Path(__file__).parent
 
 DATA_DIR = TEST_DIR / "data"
 
-UNPARSER_SCRIPT = TEST_DIR / "run-unparser.sh"
-
 @dataclass
 class TestCase:
     filename: str
@@ -60,10 +58,11 @@ def render(ast_base64: str) -> str:
     """Uses the unparser to render the AST."""
     assert pytest.unparser_jar, "A valid Unparser JAR path must be supplied either via --unparser-jar=<path> or the environment variable SNOWPARK_UNPARSER_JAR"
     res = subprocess.run([
-        UNPARSER_SCRIPT,
+        "java",
+        "-cp",
         pytest.unparser_jar,
+        "com.snowflake.snowpark.experimental.unparser.UnparserCli",
         ast_base64,
-        "--lang", "python"
     ], capture_output=True, text=True)
     return res.stdout
 


### PR DESCRIPTION
As of this diff, we continue to pursue Phase 0 and Phase 1 client on top of the same codebase to minimize development overhead. `ServerConnection.phase1_enabled()` can be used to branch based on the phase.

Phase 0 is the default and Phase 1 is enabled via the env var `SNOWPARK_PHASE_1=1`.

This diff makes Phase 0 behave as it's going to appear in the actual design. Phase 1 is still a total hack which issues a parallel request just to test the TCM. We will need to make the Phase 1 code path more real soon as well – in order to enable a proper end-to-end test.