### PR TITLE
SNOW-1284606 Move running_on_* to tests/utils.py

### DIFF
--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -4,7 +4,6 @@
 #
 
 import os
-import uuid
 from typing import Dict
 
 import pytest
@@ -14,11 +13,7 @@ from snowflake.snowpark import Session
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.mock._connection import MockServerConnection
 from tests.parameters import CONNECTION_PARAMETERS
-from tests.utils import Utils, running_on_jenkins, running_on_public_ci
-
-TEST_SCHEMA = f"GH_JOB_{(str(uuid.uuid4()).replace('-', '_'))}"
-if running_on_jenkins():
-    TEST_SCHEMA = f"JENKINS_JOB_{(str(uuid.uuid4()).replace('-', '_'))}"
+from tests.utils import TEST_SCHEMA, Utils, running_on_jenkins, running_on_public_ci
 
 
 def print_help() -> None:

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -14,23 +14,11 @@ from snowflake.snowpark import Session
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.mock._connection import MockServerConnection
 from tests.parameters import CONNECTION_PARAMETERS
-from tests.utils import Utils
+from tests.utils import Utils, running_on_jenkins, running_on_public_ci
 
-RUNNING_ON_GH = os.getenv("GITHUB_ACTIONS") == "true"
-RUNNING_ON_JENKINS = "JENKINS_HOME" in os.environ
 TEST_SCHEMA = f"GH_JOB_{(str(uuid.uuid4()).replace('-', '_'))}"
-if RUNNING_ON_JENKINS:
+if running_on_jenkins():
     TEST_SCHEMA = f"JENKINS_JOB_{(str(uuid.uuid4()).replace('-', '_'))}"
-
-
-def running_on_public_ci() -> bool:
-    """Whether or not tests are currently running on one of our public CIs."""
-    return RUNNING_ON_GH
-
-
-def running_on_jenkins() -> bool:
-    """Whether or not tests are currently running on a Jenkins node."""
-    return RUNNING_ON_JENKINS
 
 
 def print_help() -> None:

--- a/tests/integ/modin/binary/test_binary_op.py
+++ b/tests/integ/modin/binary/test_binary_op.py
@@ -17,7 +17,6 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.modin.pandas.utils import try_convert_index_to_native
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.series.test_bitwise_operators import try_cast_to_snow_series
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
@@ -27,6 +26,7 @@ from tests.integ.modin.utils import (
     create_test_series,
     eval_snowpark_pandas_result,
 )
+from tests.utils import running_on_public_ci
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/modin/conftest.py
+++ b/tests/integ/modin/conftest.py
@@ -14,7 +14,6 @@ from pandas.core.indexing import IndexingError
 from pytest import fail
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.pandas_api_coverage import PandasAPICoverageGenerator
 from tests.integ.modin.sql_counter import (
     SqlCounter,
@@ -22,7 +21,7 @@ from tests.integ.modin.sql_counter import (
     generate_sql_count_report,
     is_sql_counter_called,
 )
-from tests.utils import Utils
+from tests.utils import Utils, running_on_public_ci
 
 INTEG_PANDAS_SUBPATH = "tests/integ/modin/"
 

--- a/tests/integ/modin/frame/test_iloc.py
+++ b/tests/integ/modin/frame/test_iloc.py
@@ -19,7 +19,6 @@ from pandas.errors import IndexingError
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.modin.pandas.utils import try_convert_index_to_native
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.frame.test_head_tail import eval_result_and_query_with_no_join
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
@@ -27,6 +26,7 @@ from tests.integ.modin.utils import (
     assert_snowpark_pandas_equal_to_pandas,
     eval_snowpark_pandas_result,
 )
+from tests.utils import running_on_public_ci
 
 # default_index_snowpark_pandas_df and default_index_native_df have size of axis_len x axis_len
 AXIS_LEN = 7

--- a/tests/integ/modin/frame/test_itertuples.py
+++ b/tests/integ/modin/frame/test_itertuples.py
@@ -9,9 +9,9 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.modin.pandas.snow_partition_iterator import PARTITION_SIZE
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.utils import running_on_public_ci
 
 # To generate seeded random data.
 rng = np.random.default_rng(12345)

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -15,7 +15,6 @@ from pandas.errors import IndexingError
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.modin.pandas.utils import try_convert_index_to_native
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_frame_equal,
@@ -24,6 +23,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
     generate_a_random_permuted_list_exclude_self,
 )
+from tests.utils import running_on_public_ci
 
 EMPTY_LIST_LIKE_VALUES = [
     [],

--- a/tests/integ/modin/frame/test_transpose.py
+++ b/tests/integ/modin/frame/test_transpose.py
@@ -17,13 +17,13 @@ from snowflake.snowpark._internal.utils import (
 from snowflake.snowpark.modin.plugin._internal.unpivot_utils import (
     UNPIVOT_NULL_REPLACE_VALUE,
 )
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equal_to_pandas,
     assert_snowpark_pandas_equals_to_pandas_with_coerce_to_float64,
     eval_snowpark_pandas_result,
 )
+from tests.utils import running_on_public_ci
 
 transpose_and_double_transpose_parameterize = pytest.mark.parametrize(
     "transpose_operation, expected_query_count",

--- a/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
+++ b/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
@@ -7,7 +7,6 @@ import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.groupby.conftest import multiindex_data
 from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import (
@@ -15,6 +14,7 @@ from tests.integ.modin.utils import (
     create_test_dfs,
     eval_snowpark_pandas_result,
 )
+from tests.utils import running_on_public_ci
 
 
 @pytest.mark.parametrize("grouping_columns", ["B", ["A", "B"]])

--- a/tests/integ/modin/groupby/test_quantile.py
+++ b/tests/integ/modin/groupby/test_quantile.py
@@ -9,9 +9,9 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
+from tests.utils import running_on_public_ci
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/modin/series/test_rename.py
+++ b/tests/integ/modin/series/test_rename.py
@@ -14,9 +14,9 @@ import pytest
 from modin.pandas import Index, MultiIndex, Series
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import assert_index_equal, assert_series_equal
+from tests.utils import running_on_public_ci
 
 
 class TestRename:

--- a/tests/integ/modin/strings/test_cat.py
+++ b/tests/integ/modin/strings/test_cat.py
@@ -9,9 +9,9 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter
 from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
+from tests.utils import running_on_public_ci
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/integ/modin/strings/test_extract.py
+++ b/tests/integ/modin/strings/test_extract.py
@@ -9,9 +9,9 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
+from tests.utils import running_on_public_ci
 
 
 # TODO (SNOW-767685): This whole suite is skipped in ci run because those are tests for unsupported

--- a/tests/integ/modin/strings/test_get_dummies.py
+++ b/tests/integ/modin/strings/test_get_dummies.py
@@ -8,9 +8,9 @@ import pytest
 from pandas import _testing as tm
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
+from tests.utils import running_on_public_ci
 
 
 # TODO (SNOW-767685): This whole suite is skipped in ci run because those are tests for unsupported

--- a/tests/integ/modin/strings/test_strings.py
+++ b/tests/integ/modin/strings/test_strings.py
@@ -9,13 +9,13 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
-from tests.integ.conftest import running_on_public_ci
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equal_to_pandas,
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
     eval_snowpark_pandas_result,
 )
+from tests.utils import running_on_public_ci
 
 
 # This whole suite is skipped in ci run because those are tests for unsupported

--- a/tests/integ/modin/test_session.py
+++ b/tests/integ/modin/test_session.py
@@ -16,9 +16,9 @@ from snowflake.snowpark.session import (
     _get_active_sessions,
     _remove_session,
 )
-from tests.integ.conftest import running_on_jenkins, running_on_public_ci
 from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import create_test_dfs, eval_snowpark_pandas_result
+from tests.utils import running_on_jenkins, running_on_public_ci
 
 NO_ACTIVE_SESSION_ERROR_PATTERN = (
     r"Snowpark pandas requires an active snowpark session, but there is none. "

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ import os
 import platform
 import random
 import string
+import uuid
 from datetime import date, datetime, time
 from decimal import Decimal
 from typing import List, NamedTuple, Optional, Union
@@ -88,6 +89,22 @@ IS_STRUCTURED_TYPES_SUPPORTED = (
 )
 ICEBERG_ENVIRONMENTS = {"dev", "aws"}
 IS_ICEBERG_SUPPORTED = os.getenv("cloud_provider", "dev") in ICEBERG_ENVIRONMENTS
+
+RUNNING_ON_GH = os.getenv("GITHUB_ACTIONS") == "true"
+RUNNING_ON_JENKINS = "JENKINS_HOME" in os.environ
+TEST_SCHEMA = f"GH_JOB_{(str(uuid.uuid4()).replace('-', '_'))}"
+if RUNNING_ON_JENKINS:
+    TEST_SCHEMA = f"JENKINS_JOB_{(str(uuid.uuid4()).replace('-', '_'))}"
+
+
+def running_on_public_ci() -> bool:
+    """Whether tests are currently running on one of our public CIs."""
+    return RUNNING_ON_GH
+
+
+def running_on_jenkins() -> bool:
+    """Whether tests are currently running on a Jenkins node."""
+    return RUNNING_ON_JENKINS
 
 
 class Utils:


### PR DESCRIPTION
Those running_on_* methods was in `tests/integ/conftest.py` which requires `tests.parameters` available. It blocks us to use them in sproc tests since there is no `tests.parameters` there.