### PR TITLE
SNOW-1461192: Fix StringMethods and DatetimeProperties docs

### DIFF
--- a/src/snowflake/snowpark/modin/conftest.py
+++ b/src/snowflake/snowpark/modin/conftest.py
@@ -7,7 +7,7 @@ import modin.pandas as pd  # pragma: no cover
 import numpy as np  # pragma: no cover
 import pytest  # pragma: no cover
 
-import snowflake.snowpark.modin.plugin as plugin
+import snowflake.snowpark.modin.plugin  # pragma: no cover # noqa: F401
 
 
 @pytest.fixture(autouse=True, scope="module")  # pragma: no cover
@@ -17,4 +17,3 @@ def add_doctest_imports(doctest_namespace) -> None:  # pragma: no cover
     """
     doctest_namespace["np"] = np  # pragma: no cover
     doctest_namespace["pd"] = pd  # pragma: no cover
-    doctest_namespace["plugin"] = plugin  # pragma: no cover

--- a/src/snowflake/snowpark/modin/conftest.py
+++ b/src/snowflake/snowpark/modin/conftest.py
@@ -7,7 +7,7 @@ import modin.pandas as pd  # pragma: no cover
 import numpy as np  # pragma: no cover
 import pytest  # pragma: no cover
 
-import snowflake.snowpark.modin.plugin  # pragma: no cover # noqa: F401
+import snowflake.snowpark.modin.plugin as plugin
 
 
 @pytest.fixture(autouse=True, scope="module")  # pragma: no cover
@@ -17,3 +17,4 @@ def add_doctest_imports(doctest_namespace) -> None:  # pragma: no cover
     """
     doctest_namespace["np"] = np  # pragma: no cover
     doctest_namespace["pd"] = pd  # pragma: no cover
+    doctest_namespace["plugin"] = plugin  # pragma: no cover

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -51,18 +51,23 @@ warnings.warn(
     stacklevel=1,
 )
 
-# We need this import here to prevent circular dependency issues, since snowflake.snowpark.modin.pandas
-# currently imports some internal utilities from snowflake.snowpark.modin.plugin. Test cases will
-# import snowflake.snowpark.modin.plugin before snowflake.snowpark.modin.pandas, so in order to prevent
-# circular dependencies from manifesting, apparently snowflake.snowpark.modin.pandas needs to
-# be imported first.
-# These imports also all need to occur after modin + pandas dependencies are validated.
-from snowflake.snowpark.modin import pandas  # isort: skip  # noqa: E402,F401
+from modin.config import DocModule as ModinDocModule  # isort: skip  # noqa: E402
 from snowflake.snowpark.modin.config import DocModule  # isort: skip  # noqa: E402
 from snowflake.snowpark.modin.plugin import docstrings  # isort: skip  # noqa: E402
 
+ModinDocModule.put(docstrings.__name__)
 DocModule.put(docstrings.__name__)
 
+# We need to import snowflake.snowpark.modin.pandas here to prevent circular dependency issues, since
+# snowflake.snowpark.modin.pandas currently imports some internal utilities from
+# snowflake.snowpark.modin.plugin. Test cases will import snowflake.snowpark.modin.plugin before
+# snowflake.snowpark.modin.pandas, so in order to prevent circular dependencies from manifesting,
+# apparently snowflake.snowpark.modin.pandas needs to be imported first.
+# Furthermore, this initialization needs to occur after dependency versions validation and
+# after documentation overrides, as ModinDocModule.put will produce a call to `importlib.reload`
+# that will overwrite our extensions.
+# See https://github.com/modin-project/modin/issues/7122
+from snowflake.snowpark.modin import pandas  # isort: skip  # noqa: E402,F401
 
 # Don't warn the user about our internal usage of private preview pivot
 # features. The user should have already been warned that Snowpark pandas

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -51,7 +51,7 @@ warnings.warn(
     stacklevel=1,
 )
 
-from modin.config import DocModule as ModinDocModule  # isort: skip  # noqa: E402
+from modin.config import DocModule as ModinDocModule  # type: ignore[import]  # isort: skip  # noqa: E402
 from snowflake.snowpark.modin.config import DocModule  # isort: skip  # noqa: E402
 from snowflake.snowpark.modin.plugin import docstrings  # isort: skip  # noqa: E402
 

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -51,7 +51,6 @@ warnings.warn(
     stacklevel=1,
 )
 
-
 # We need this import here to prevent circular dependency issues, since snowflake.snowpark.modin.pandas
 # currently imports some internal utilities from snowflake.snowpark.modin.plugin. Test cases will
 # import snowflake.snowpark.modin.plugin before snowflake.snowpark.modin.pandas, so in order to prevent

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -67,8 +67,8 @@ DocModule.put(docstrings.__name__)
 # We cannot call ModinDocModule.put directly because it will produce a call to `importlib.reload`
 # that will overwrite our extensions. We instead directly call the _inherit_docstrings annotation
 # See https://github.com/modin-project/modin/issues/7122
-import modin.utils  # isort: skip  # noqa: E402
-import modin.pandas.series_utils  # isort: skip  # noqa: E402
+import modin.utils  # type: ignore[import]  # isort: skip  # noqa: E402
+import modin.pandas.series_utils  # type: ignore[import]  # isort: skip  # noqa: E402
 
 modin.utils._inherit_docstrings(
     docstrings.series_utils.StringMethods,

--- a/tests/unit/modin/test_docstrings.py
+++ b/tests/unit/modin/test_docstrings.py
@@ -3,9 +3,32 @@
 #
 
 import modin.pandas as pd
+import pandas as native_pd
 
-import snowflake.snowpark.modin.plugin  # noqa: F401
+import snowflake.snowpark.modin.plugin as plugin
 
 
 def test_base_property_snow_1305329():
     assert "Snowpark pandas" in pd.base.BasePandasDataset.iloc.__doc__
+
+
+def test_series_utils_snow_1461192():
+    # Checks that StringMethods and DatetimeProperties correctly inherit documentation
+    # Series.dt.date differs from pandas because we don't support DatetimeIndex
+    assert (
+        pd.series_utils.DatetimeProperties.date.__doc__
+        != native_pd.core.indexes.accessors.DatetimeProperties.date.__doc__
+    )
+    assert (
+        pd.series_utils.DatetimeProperties.date.__doc__
+        == plugin.docstrings.CombinedDatetimelikeProperties.date.__doc__
+    )
+    # Series.str.split differs from pandas because we don't yet support the `regex` arg
+    assert (
+        pd.series_utils.StringMethods.split.__doc__
+        != native_pd.core.strings.accessor.StringMethods.split.__doc__
+    )
+    assert (
+        pd.series_utils.StringMethods.split.__doc__
+        == plugin.docstrings.StringMethods.split.__doc__
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1461192

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

SNOW-1445536 removed our copies of the `StringMethods` and `DatetimeProperties` classes in favor of their upstream modin versions. After this PR, doctests (run via `pytest src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py`) still passed, but the `__doc__` attributes of these classes' methods were not correctly updated since we did not use `modin.config.DocModule` (only `snowflake.snowpark.modin.config.DocModule`).

This PR sets modin's `DocModule` attribute so the docstrings are appropriately overridden, and changes some module initialization order to accommodate this change.