### PR TITLE
SNOW-1019479: Fix describe with duplicate column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 #### Bug Fixes
 
 - Fixed a bug that causes output of GroupBy.aggregate's columns to be ordered incorrectly.
+- Fixed a bug where `DataFrame.describe` on a frame with duplicate columns of differing dtypes could cause an error or incorrect results.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -10000,9 +10000,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         sorted_percentiles = sorted(percentiles)
         dtypes = self.dtypes
         # If we operate on the original frame's labels, then if two columns have the same name but
-        # different dtypes, the JOIN behavior of SnowflakeQueryCompiler.concat will produce incorrect
-        # results. For example, consider the following dataframe, where an `object` column and
-        # `int64` column both share the label "a":
+        # different one is `object` and one is numeric,, the JOIN behavior of SnowflakeQueryCompiler.concat
+        # will produce incorrect results. For example, consider the following dataframe, where an
+        # `object` column and `int64` column both share the label "a":
         #     +---+-----+---+-----+
         #     | a |  a  | b |  c  |
         #     +---+-----+---+-----+

--- a/tests/integ/modin/frame/test_describe.py
+++ b/tests/integ/modin/frame/test_describe.py
@@ -308,26 +308,13 @@ def test_describe_multiindex(index, columns, include, expected_union_count):
         )
 
 
-DUP_COL_FAIL_REASON = "SNOW-1019479: describe on frames with mixed object/number columns with the same name fails"
-
-
 @pytest.mark.parametrize(
     "include, exclude, expected_union_count",
     [
         (None, None, 7),
-        pytest.param(
-            "all",
-            None,
-            0,
-            marks=pytest.mark.xfail(strict=True, reason=DUP_COL_FAIL_REASON),
-        ),
+        ("all", None, 12),
         (np.number, None, 7),
-        pytest.param(
-            None,
-            float,
-            0,
-            marks=pytest.mark.xfail(strict=True, reason=DUP_COL_FAIL_REASON),
-        ),
+        (None, float, 10),
         (object, None, 5),
         (None, object, 7),
         (int, float, 5),

--- a/tests/integ/modin/frame/test_describe.py
+++ b/tests/integ/modin/frame/test_describe.py
@@ -333,6 +333,21 @@ def test_describe_duplicate_columns(include, exclude, expected_union_count):
         )
 
 
+def test_describe_duplicate_columns_mixed():
+    # Test that describing a frame where there are multiple columns (including ones with numeric data
+    # but `object` dtype) that share the same label is correct.
+    data = [[5, 0, 1.0], [6, 3, 4.0]]
+
+    def helper(df):
+        # Convert first column to `object` dtype
+        df = df.astype({0: object})
+        df.columns = ["a"] * 3
+        return df.describe()
+
+    with SqlCounter(query_count=1, union_count=7):
+        eval_snowpark_pandas_result(*create_test_dfs(data), lambda df: helper(df))
+
+
 @sql_count_checker(
     query_count=3,
     union_count=21,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1019479

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

This PR fixes a bug with `df.describe()` if `df` had columns with the same name but different dtypes. Since the method computes separate query compilers for the statistics on `object`, numeric, and `datetime` columns and concats them all together, if two columns shared a label but had different dtypes, it would try to concat them together and either error or produce an incorrect result. This PR works around this by relabeling the columns with ordinal values before performing any aggregations, and restoring the labels after concatenation.