### PR TITLE
SNOW-1457758: Disable telemetry triggering extra describe queries

### DIFF
--- a/src/snowflake/snowpark/_internal/telemetry.py
+++ b/src/snowflake/snowpark/_internal/telemetry.py
@@ -155,13 +155,6 @@ def df_collect_api_telemetry(func):
         api_calls[0][TelemetryField.SQL_SIMPLIFIER_ENABLED.value] = args[
             0
         ]._session.sql_simplifier_enabled
-        try:
-            api_calls[0][TelemetryField.QUERY_PLAN_HEIGHT.value] = plan.plan_height
-            api_calls[0][
-                TelemetryField.QUERY_PLAN_NUM_DUPLICATE_NODES.value
-            ] = plan.num_duplicate_nodes
-        except Exception:
-            pass
         args[0]._session._conn._telemetry_client.send_function_usage_telemetry(
             f"action_{func.__name__}",
             TelemetryField.FUNC_CAT_ACTION.value,

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -585,14 +585,11 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
 
     df.collect()
     # API calls don't change after query is executed
-    query_plan_height = 2 if sql_simplifier_enabled else 3
 
     assert df._plan.api_calls == [
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": query_plan_height,
-            "query_plan_num_duplicate_nodes": 0,
         },
         {"name": "DataFrame.filter"},
         {"name": "DataFrame.filter"},
@@ -604,8 +601,6 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": query_plan_height,
-            "query_plan_num_duplicate_nodes": 0,
         },
         {"name": "DataFrame.filter"},
         {"name": "DataFrame.filter"},
@@ -617,8 +612,6 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": query_plan_height,
-            "query_plan_num_duplicate_nodes": 0,
         },
         {"name": "DataFrame.filter"},
         {"name": "DataFrame.filter"},
@@ -630,8 +623,6 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": query_plan_height,
-            "query_plan_num_duplicate_nodes": 0,
         },
         {"name": "DataFrame.filter"},
         {"name": "DataFrame.filter"},
@@ -643,8 +634,6 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": query_plan_height,
-            "query_plan_num_duplicate_nodes": 0,
         },
         {"name": "DataFrame.filter"},
         {"name": "DataFrame.filter"},
@@ -779,8 +768,6 @@ def test_dataframe_stat_functions_api_calls(session):
         {
             "name": "Session.create_dataframe[values]",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": 4,
-            "query_plan_num_duplicate_nodes": 0,
         },
         {
             "name": "DataFrameStatFunctions.crosstab",
@@ -796,8 +783,6 @@ def test_dataframe_stat_functions_api_calls(session):
         {
             "name": "Session.create_dataframe[values]",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
-            "query_plan_height": 4,
-            "query_plan_num_duplicate_nodes": 0,
         }
     ]
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1457758

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Short term fix to not trigger duplicate queries when using `session.sql()` to run describe, truncate, copy queries. When collecting telemetry for finding the number of duplicate plan subtrees within the query plan, we end up calling `SelectSQL.to_subqueryable` for the `SelectSQL` plan node generated by `session.sql`. During this step, we call `analyze_attributes` for the given query twice - once during initializing a new subqueryable and second when initializing column states. When these describe queries are run from within a stored sproc, they are being detected as regular queries instead of describe queries and getting executed 3 times. We are removing telemetry calls triggering describe queries as a mitigation and will implement a root cause fix later.

![image](https://github.com/snowflakedb/snowpark-python/assets/107440467/6c42aaa7-41dd-40f6-9bfa-c938e293b61b)


