### PR TITLE
SNOW-1467815: Fix Jenkins runner regression related to test_lstrip_rstrip in test_strings

### DIFF
--- a/tests/integ/modin/strings/test_strings.py
+++ b/tests/integ/modin/strings/test_strings.py
@@ -430,11 +430,6 @@ def test_slice_replace(start, stop, repl, expected):
     assert_snowpark_pandas_equal_to_pandas(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "method, exp",
     [
@@ -442,7 +437,7 @@ def test_slice_replace(start, stop, repl, expected):
         ["rstrip", ["  aa", " bb", np.nan, "cc"]],
     ],
 )
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
+@sql_count_checker(query_count=1)
 def test_lstrip_rstrip(method, exp):
     ser = pd.Series(["  aa   ", " bb \n", np.nan, "cc  "], dtype=object)
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1467815

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Fix Jenkins runner regression related to test_lstrip_rs trip in test_strings.
