### PR TITLE
[ThinClient] Use connector with server-side-snowpark changes in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,12 @@ SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
 MODIN_DEPENDENCY_VERSION = (
     "==0.28.1"  # Snowpark pandas requires modin 0.28.1, which depends on pandas 2.2.1
 )
-CONNECTOR_DEPENDENCY_VERSION = ">=3.10.0, <4.0.0"
+# Use HEAD of server-side-snowpark branch in connector.
+CONNECTOR_DEPENDENCY = "snowflake-connector-python @ git+https://github.com/snowflakedb/snowflake-connector-python@server-side-snowpark#egg=snowflake-connector-python"
 INSTALL_REQ_LIST = [
     "setuptools>=40.6.0",
     "wheel",
-    f"snowflake-connector-python{CONNECTOR_DEPENDENCY_VERSION}",
+    CONNECTOR_DEPENDENCY,
     # snowpark directly depends on typing-extension, so we should not remove it even if connector also depends on it.
     "typing-extensions>=4.1.0, <5.0.0",
     "protobuf",
@@ -31,7 +32,7 @@ if os.getenv("SNOWFLAKE_IS_PYTHON_RUNTIME_TEST", False):
     REQUIRED_PYTHON_VERSION = ">=3.8"
 
 PANDAS_REQUIREMENTS = [
-    f"snowflake-connector-python[pandas]{CONNECTOR_DEPENDENCY_VERSION}",
+    f"{CONNECTOR_DEPENDENCY}[pandas]",
 ]
 MODIN_REQUIREMENTS = [
     *PANDAS_REQUIREMENTS,
@@ -114,7 +115,7 @@ setup(
         "pandas": PANDAS_REQUIREMENTS,
         "modin": MODIN_REQUIREMENTS,
         "secure-local-storage": [
-            f"snowflake-connector-python[secure-local-storage]{CONNECTOR_DEPENDENCY_VERSION}",
+            f"{CONNECTOR_DEPENDENCY}[secure-local-storage]",
         ],
         "development": DEVELOPMENT_REQUIREMENTS,
         "modin-development": [


### PR DESCRIPTION
Modifies `setup.py` to use the latest HEAD of https://github.com/snowflakedb/snowflake-connector-python/tree/server-side-snowpark which includes connector changes (most notable adding the `_dataframe_ast` field for phase 0).

To update your local dev environment run
```
pip uninstall snowflake-connector-python -y
python -m pip install --no-cache -e ".[development,pandas]"
```
Running the pip command should show `git clone` in the logs.

