### PR TITLE
Fill colum expr src positions, raise explicit errors on missing AST

### DIFF
--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -13,6 +13,7 @@ from typing import Any, List, Optional
 
 import snowflake.snowpark._internal.proto.ast_pb2 as proto
 
+FAIL_ON_MISSING_AST = True
 
 def build_const_from_python_val(obj: Any, ast: proto.Expr) -> None:
     """Infer the Const AST expression from obj, and populate the provided ast.Expr() instance

--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -9,13 +9,14 @@ import re
 import sys
 from functools import reduce
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import snowflake.snowpark._internal.proto.ast_pb2 as proto
 
 # This flag causes an explicit error to be raised if any Snowpark object instance is missing an AST or field, when this
 # AST or field is required to populate the AST field of a different Snowpark object instance.
 FAIL_ON_MISSING_AST = True
+
 
 def build_const_from_python_val(obj: Any, ast: proto.Expr) -> None:
     """Infer the Const AST expression from obj, and populate the provided ast.Expr() instance

--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -13,6 +13,8 @@ from typing import Any, List, Optional
 
 import snowflake.snowpark._internal.proto.ast_pb2 as proto
 
+# This flag causes an explicit error to be raised if any Snowpark object instance is missing an AST or field, when this
+# AST or field is required to populate the AST field of a different Snowpark object instance.
 FAIL_ON_MISSING_AST = True
 
 def build_const_from_python_val(obj: Any, ast: proto.Expr) -> None:

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -41,7 +41,9 @@ class SnowparkClientExceptionMessages:
     # use this for now to surface errors
     @staticmethod
     def IR_MESSAGE(message: str):
-        return _SnowparkInternalException(f"Internal Snowpark coprocessor/IR message: {message}.", error_code="1011")
+        return _SnowparkInternalException(
+            f"Internal Snowpark coprocessor/IR message: {message}.", error_code="1011"
+        )
 
     @staticmethod
     def INTERNAL_TEST_MESSAGE(message: str) -> _SnowparkInternalException:

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -993,6 +993,7 @@ class Column:
         ast = proto.Expr()
         if property is not None:
             prop_ast = getattr(ast, property)
+            fill_src_position(prop_ast.src)
             for attr, value in assign_fields.items():
                 setattr_if_not_none(prop_ast, attr, value)
             for attr, value in assign_opt_fields.items():

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -5,7 +5,6 @@
 
 import inspect
 import sys
-from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import snowflake.snowpark
@@ -69,8 +68,8 @@ from snowflake.snowpark._internal.analyzer.unary_expression import (
 from snowflake.snowpark._internal.ast_utils import (
     FAIL_ON_MISSING_AST,
     build_const_from_python_val,
-    setattr_if_not_none,
     set_src_position,
+    setattr_if_not_none,
 )
 from snowflake.snowpark._internal.type_utils import (
     VALID_PYTHON_TYPES_FOR_LITERAL_VALUE,
@@ -1011,8 +1010,8 @@ class Column:
                         curr_frame = call_stack.pop(0)
                     raise NotImplementedError(
                         f'Calling Column API "{column_api}" which supports AST logging, from File "{curr_frame.filename}", line {curr_frame.lineno}\n'
-                        f'\t{curr_frame.code_context[0].strip()}\n'
-                        f'A Snowpark API which returns a Column instance used above has not yet implemented AST logging.'
+                        f"\t{curr_frame.code_context[0].strip()}\n"
+                        f"A Snowpark API which returns a Column instance used above has not yet implemented AST logging."
                     )
                 elif msg is not None:
                     getattr(prop_ast, attr).CopyFrom(msg)
@@ -1034,8 +1033,8 @@ class Column:
         if isinstance(value, cls):
             if value._ast is None and FAIL_ON_MISSING_AST:
                 raise NotImplementedError(
-                            f'Column({value._expression})._ast is None due to the use of a Snowpark API which does not support AST logging yet.'
-                        )
+                    f"Column({value._expression})._ast is None due to the use of a Snowpark API which does not support AST logging yet."
+                )
             elif value._ast is not None:
                 ast.CopyFrom(value._ast)
         elif isinstance(value, VALID_PYTHON_TYPES_FOR_LITERAL_VALUE):

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -1032,7 +1032,12 @@ class Column:
             TypeError: An SpColumnExpr can only be populated from another SpColumnExpr or a valid Literal type
         """
         if isinstance(value, cls):
-            return ast.CopyFrom(value._ast)
+            if value._ast is None and FAIL_ON_MISSING_AST:
+                raise NotImplementedError(
+                            f'Column({value._expression})._ast is None due to the use of a Snowpark API which does not support AST logging yet.'
+                        )
+            elif value._ast is not None:
+                ast.CopyFrom(value._ast)
         elif isinstance(value, VALID_PYTHON_TYPES_FOR_LITERAL_VALUE):
             build_const_from_python_val(value, ast)
         elif isinstance(value, Expression):

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -91,8 +91,8 @@ from snowflake.snowpark._internal.ast import (
 )
 from snowflake.snowpark._internal.ast_utils import (
     FAIL_ON_MISSING_AST,
-    set_src_position,
     get_symbol,
+    set_src_position,
     setattr_if_not_none,
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
@@ -1099,9 +1099,13 @@ class DataFrame:
         col_expr_ast = proto.Expr()
         if self._ast_id is None and FAIL_ON_MISSING_AST:
             _logger.debug(self._explain_string())
-            raise NotImplementedError(f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging.")
-        elif self._ast_id is not None:        
-            col_expr_ast.sp_dataframe_col.df.sp_dataframe_ref.id.bitfield1 = self._ast_id
+            raise NotImplementedError(
+                f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging."
+            )
+        elif self._ast_id is not None:
+            col_expr_ast.sp_dataframe_col.df.sp_dataframe_ref.id.bitfield1 = (
+                self._ast_id
+            )
         set_src_position(col_expr_ast.sp_dataframe_col.src)
         if col_name == "*":
             col_expr_ast.sp_dataframe_col.col_name = "*"
@@ -1189,7 +1193,7 @@ class DataFrame:
                 if ast:
                     if e._ast is None and FAIL_ON_MISSING_AST:
                         raise NotImplementedError(
-                            f'Column({e._expression})._ast is None due to the use of a Snowpark API which does not support AST logging yet.'
+                            f"Column({e._expression})._ast is None due to the use of a Snowpark API which does not support AST logging yet."
                         )
                     elif e._ast is not None:
                         ast.cols.append(e._ast)
@@ -3382,7 +3386,9 @@ class DataFrame:
         repr = self._session._ast_batch.assign()
         if self._ast_id is None and FAIL_ON_MISSING_AST:
             _logger.debug(self._explain_string())
-            raise NotImplementedError(f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging.")
+            raise NotImplementedError(
+                f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging."
+            )
         elif self._ast_id is not None:
             repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
         self._session._ast_batch.eval(repr)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1097,7 +1097,7 @@ class DataFrame:
         """Returns a reference to a column in the DataFrame."""
         col_expr_ast = proto.Expr()
         if self._ast_id is None and FAIL_ON_MISSING_AST:
-            print(self._explain_string())
+            _logger.debug(self._explain_string())
             raise NotImplementedError(f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging.")
         elif self._ast_id is not None:        
             col_expr_ast.sp_dataframe_col.df.sp_dataframe_ref.id.bitfield1 = self._ast_id

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3380,7 +3380,11 @@ class DataFrame:
 
         # Add an Assign node that applies SpDataframeShow() to the input, followed by its Eval.
         repr = self._session._ast_batch.assign()
-        repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
+        if self._ast_id is None and FAIL_ON_MISSING_AST:
+            _logger.debug(self._explain_string())
+            raise NotImplementedError(f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging.")
+        elif self._ast_id is not None:
+            repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
         self._session._ast_batch.eval(repr)
 
         if self._session._conn.is_phase1_enabled():

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1096,7 +1096,11 @@ class DataFrame:
     def col(self, col_name: str) -> Column:
         """Returns a reference to a column in the DataFrame."""
         col_expr_ast = proto.Expr()
-        col_expr_ast.sp_dataframe_col.df.sp_dataframe_ref.id.bitfield1 = self._ast_id
+        if self._ast_id is None and FAIL_ON_MISSING_AST:
+            print(self._explain_string())
+            raise NotImplementedError(f"DataFrame with API usage {self._plan.api_calls} is missing complete AST logging.")
+        elif self._ast_id is not None:        
+            col_expr_ast.sp_dataframe_col.df.sp_dataframe_ref.id.bitfield1 = self._ast_id
         set_src_position(col_expr_ast.sp_dataframe_col.src)
         if col_name == "*":
             col_expr_ast.sp_dataframe_col.col_name = "*"
@@ -1184,7 +1188,7 @@ class DataFrame:
                 if ast:
                     if e._ast is None and FAIL_ON_MISSING_AST:
                         raise NotImplementedError(
-                            f'Column({e._expression}) does not have a logged AST in Column._ast, likely due to the use of a Snowpark API which does not support AST logging yet.'
+                            f'Column({e._expression})._ast is None due to the use of a Snowpark API which does not support AST logging yet.'
                         )
                     elif e._ast is not None:
                         ast.cols.append(e._ast)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -960,6 +960,7 @@ class DataFrame:
         ast.variadic = is_variadic
         set_src_position(ast.src)
 
+        # TODO: SNOW-1507432 (currently to_df expectation test will fail due to incomplete AST logging)
         new_cols = []
         for attr, name in zip(self._output, col_names):
             new_cols.append(Column(attr).alias(name))

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -90,6 +90,7 @@ from snowflake.snowpark._internal.ast import (
     decode_ast_response_from_snowpark,
 )
 from snowflake.snowpark._internal.ast_utils import (
+    FAIL_ON_MISSING_AST,
     set_src_position,
     get_symbol,
     setattr_if_not_none,
@@ -1181,7 +1182,12 @@ class DataFrame:
             if isinstance(e, Column):
                 names.append(e._named())
                 if ast:
-                    ast.cols.append(e._ast)
+                    if e._ast is None and FAIL_ON_MISSING_AST:
+                        raise NotImplementedError(
+                            f'Column({e._expression}) does not have a logged AST in Column._ast, likely due to the use of a Snowpark API which does not support AST logging yet.'
+                        )
+                    elif e._ast is not None:
+                        ast.cols.append(e._ast)
 
             elif isinstance(e, str):
                 if ast:

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from typing import Dict, List, NamedTuple, Optional, Union, overload
 
 import snowflake.snowpark
-import snowflake.snowpark._internal.proto.ast_pb2 as proto
 from snowflake.snowpark._internal.analyzer.binary_plan_node import create_join_type
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import UnresolvedRelation
 from snowflake.snowpark._internal.analyzer.table_merge_expression import (

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -28,14 +28,14 @@ def parse_file(file):
 
     try:
         test_case_start = src.index("## TEST CASE\n")
-    except ValueError as e:
+    except ValueError:
         raise ValueError(
             "Required header ## TEST CASE missing in the file: " + file.name
         )
 
     try:
         expected_output_start = src.index("## EXPECTED OUTPUT\n")
-    except ValueError as e:
+    except ValueError:
         raise ValueError(
             "Required header ## EXPECTED OUTPUT missing in the file: " + file.name
         )

--- a/tests/ast/update-unparser.sh
+++ b/tests/ast/update-unparser.sh
@@ -31,10 +31,18 @@ JAR_HOME="$REMOTE_HOME/$UNPARSER_DIR/target/scala-2.13/unparser-assembly-0.1.jar
 LOCAL_TARGET_FILENAME="unparser-assembly-0.1.jar"
 
 
-# Step 1: Build the Unparser JAR using sbt if it does not exist
-ssh $HOST "bash -c 'cd Snowflake/trunk;bazel build //Snowpark/unparser:unparser'"
-JAR_HOME=$(ssh $HOST "bash -c 'cd Snowflake/trunk;bazel cquery --output=files //Snowpark/unparser:unparser.jar'")
-JAR_HOME=$REMOTE_HOME/Snowflake/trunk/$JAR_HOME
+# Step 1: Build the Unparser JAR using bazel or sbt if it does not exist
+if [ -z "$2" ]
+  then 
+    echo "Building Unparser JAR with Bazel"
+    ssh $HOST "bash -c 'cd Snowflake/trunk;bazel build //Snowpark/unparser:unparser'"
+    JAR_HOME=$(ssh $HOST "bash -c 'cd Snowflake/trunk;bazel cquery --output=files //Snowpark/unparser:unparser.jar'")
+    JAR_HOME=$REMOTE_HOME/Snowflake/trunk/$JAR_HOME
+elif [ -n "$2" ]
+  then
+    echo "Building Unparser JAR with SBT"
+    ssh $HOST "bash -c 'cd Snowflake/trunk/Snowpark/unparser;sbt assembly'" || true
+fi
 echo "Remote JAR_HOME=$JAR_HOME"
 
 # Step 2: Copy file to local


### PR DESCRIPTION
- Adding src position information to Column AST building APIs
- Adding a flag in `ast_utils.py` to signal whether to fail loudly on missing AST fields
  - Generate useful error message in Column APIs if any Snowpark API generates a column and does not log its AST