### PR TITLE
Fix test_lock_function failures on windows

### DIFF
--- a/tests/unit/test_generated_udf_lock.py
+++ b/tests/unit/test_generated_udf_lock.py
@@ -4,7 +4,7 @@
 
 import threading
 import time
-from threading import RLock
+from threading import Event, RLock
 
 import cachetools
 import pytest
@@ -12,18 +12,13 @@ import pytest
 lock = RLock()
 
 
-class InvokedFlag:
-    def __init__(self) -> None:
-        self.invoked = False
-
-
 def lock_function_once(f, flag):
     def wrapper(*args, **kwargs):
-        if not flag.invoked:
+        if not flag.is_set():
             with lock:
-                if not flag.invoked:
+                if not flag.is_set():
                     result = f(*args, **kwargs)
-                    flag.invoked = True
+                    flag.set()
                     return result
                 return f(*args, **kwargs)
         return f(*args, **kwargs)
@@ -34,18 +29,19 @@ def lock_function_once(f, flag):
 @pytest.mark.parametrize("has_lock", [True, False])
 def test_lock_function(has_lock):
     load_model_called = 0
+    inc_lock = RLock()
 
     @cachetools.cached({})
     def load_model():
         nonlocal load_model_called
-        time.sleep(0.5)  # simulate a long operation
-        with lock:
+        time.sleep(1.0)  # simulate a long operation
+        with inc_lock:
             load_model_called += 1
 
     def mock_udf_handler():
         load_model()
 
-    locked_mock_udf_handler = lock_function_once(mock_udf_handler, InvokedFlag())
+    locked_mock_udf_handler = lock_function_once(mock_udf_handler, Event())
 
     threads = []
     for _ in range(10):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   In this PR I've done a few things to improve `test_lock_function`.

- Removed the InvokedFlag class and replaced with similar functionality of the threading.Event object.
- Added a unique lock for incrementing load_model_called so that `lock_function_once` lock and the increment lock don't unintentionally block each other.
- Increased the sleep time. Windows is a little slower to create and manage threads so I think increasing the sleep time will better ensure that multiple invocations of the udf run concurrently.