### PR TITLE
Pylance throws errors when using copy_options with copy_into_location method

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -12,6 +12,7 @@ from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanNodeCategory,
     sum_node_complexities,
 )
+from snowflake.snowpark._internal.type_utils import CopyOptions
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import StructType
 
@@ -232,7 +233,7 @@ class CopyIntoLocationNode(LogicalPlan):
         file_format_type: Optional[str] = None,
         format_type_options: Optional[Dict[str, str]] = None,
         header: bool = False,
-        copy_options: Dict[str, Any],
+        copy_options: CopyOptions,
     ) -> None:
         super().__init__()
         self.child = child

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -25,6 +25,7 @@ from typing import (  # noqa: F401
     Optional,
     Tuple,
     Type,
+    TypedDict,
     Union,
     get_args,
     get_origin,
@@ -834,3 +835,10 @@ ColumnOrLiteralStr = Union["snowflake.snowpark.column.Column", str]
 ColumnOrSqlExpr = Union["snowflake.snowpark.column.Column", str]
 LiteralType = Union[VALID_PYTHON_TYPES_FOR_LITERAL_VALUE]
 ColumnOrLiteral = Union["snowflake.snowpark.column.Column", LiteralType]
+
+class CopyOptions(TypedDict, total=False):
+    overwrite: bool
+    single: bool
+    max_file_size: float
+    include_query_id: bool
+    detailed_output: bool

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -4,6 +4,7 @@
 
 import sys
 from typing import Any, Dict, List, Literal, Optional, Union, overload
+from typing_extensions import Unpack
 
 import snowflake.snowpark  # for forward references of type hints
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
@@ -16,7 +17,7 @@ from snowflake.snowpark._internal.telemetry import (
     add_api_call,
     dfw_collect_api_telemetry,
 )
-from snowflake.snowpark._internal.type_utils import ColumnOrName, ColumnOrSqlExpr
+from snowflake.snowpark._internal.type_utils import ColumnOrName, ColumnOrSqlExpr, CopyOptions
 from snowflake.snowpark._internal.utils import (
     SUPPORTED_TABLE_TYPES,
     normalize_remote_file_or_dir,
@@ -249,7 +250,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: Literal[True] = True,
-        **copy_options: Optional[Dict[str, Any]],
+        **copy_options: Unpack[CopyOptions],
     ) -> List[Row]:
         ...  # pragma: no cover
 
@@ -265,8 +266,24 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: Literal[False] = False,
-        **copy_options: Optional[Dict[str, Any]],
+        **copy_options: Unpack[CopyOptions],
     ) -> AsyncJob:
+        ...  # pragma: no cover
+
+    @overload
+    def copy_into_location(
+        self,
+        location: str,
+        *,
+        partition_by: Optional[ColumnOrSqlExpr] = None,
+        file_format_name: Optional[str] = None,
+        file_format_type: Optional[str] = None,
+        format_type_options: Optional[Dict[str, str]] = None,
+        header: bool = False,
+        statement_params: Optional[Dict[str, str]] = None,
+        block: bool = True,
+        **copy_options: Unpack[CopyOptions],
+    ) -> Union[List[Row], AsyncJob]:
         ...  # pragma: no cover
 
     def copy_into_location(
@@ -280,7 +297,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        **copy_options: Optional[Dict[str, Any]],
+        **copy_options: Unpack[CopyOptions],
     ) -> Union[List[Row], AsyncJob]:
         """Executes a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into one or more files in a stage or external stage.
 
@@ -359,7 +376,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        **copy_options: Optional[str],
+        **copy_options: Unpack[CopyOptions],
     ) -> Union[List[Row], AsyncJob]:
         """Executes internally a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into one or more CSV files in a stage or external stage.
 
@@ -405,7 +422,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        **copy_options: Optional[str],
+        **copy_options: Unpack[CopyOptions],
     ) -> Union[List[Row], AsyncJob]:
         """Executes internally a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into a JSON file in a stage or external stage.
 
@@ -452,7 +469,7 @@ class DataFrameWriter:
         header: bool = False,
         statement_params: Optional[Dict[str, str]] = None,
         block: bool = True,
-        **copy_options: Optional[str],
+        **copy_options: Unpack[CopyOptions],
     ) -> Union[List[Row], AsyncJob]:
         """Executes internally a `COPY INTO <location> <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html>`__ to unload data from a ``DataFrame`` into a PARQUET file in a stage or external stage.
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1417060

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

    - Enhanced Type Safety with TypedDict: We've replaced the generic Dict[str, Any] for the copy_options argument with a TypedDict. This enforces stricter type checking, ensuring that only expected options are passed to the function. This improves code reliability and maintainability.
    - Overload Method for Pylance Recognition: An additional overload method has been added specifically for the block option when its type is bool. This improves code clarity and type recognition within development tools like Pylance, making the code easier to understand and navigate.