### PR TITLE
SNOW-1504601 Use any_value with filter to ensure determinism during transpose

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
@@ -7,7 +7,7 @@ from typing import Union
 import pandas as native_pd
 from modin.core.dataframe.algebra.default2pandas import DataFrameDefault  # type: ignore
 
-from snowflake.snowpark.functions import first_value, get
+from snowflake.snowpark.functions import any_value, get, lit
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
     OrderedDataFrame,
@@ -27,7 +27,6 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     parse_object_construct_snowflake_quoted_identifier_and_extract_pandas_label,
     serialize_pandas_labels,
 )
-from snowflake.snowpark.window import Window
 
 TRANSPOSE_INDEX = "TRANSPOSE_IDX"
 # transpose value column used in unpivot
@@ -89,15 +88,12 @@ def prepare_and_unpivot_for_transpose(
             if identifier == row_position_snowflake_quoted_identifier:
                 new_columns.append((pandas_lit(-1)).as_(identifier))
             else:
-                # We use first_value to select a value in the dummy column to make sure its dtypes are
+                # We use any_value to select a value in the dummy column to make sure its dtypes are
                 # the same as the column in the original dataframe. This helps avoid type incompatibility
-                # issues in union_all.  Note that we do not use any_value to ensure the results are deterministic.
-                new_columns.append(
-                    first_value(identifier)
-                    .over(Window.orderBy(identifier))
-                    .as_(identifier)
-                )
-        dummy_df = ordered_dataframe.agg(new_columns)
+                # issues in union_all.  To ensure the results are deterministic we filter the results to
+                # the first row position, if the dataset is empty it will be all null instead.
+                new_columns.append(any_value(identifier).as_(identifier))
+        dummy_df = ordered_dataframe.filter(lit(False)).agg(new_columns)
         ordered_dataframe = ordered_dataframe.union_all(dummy_df)
 
     return _prepare_unpivot_internal(

--- a/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
@@ -91,7 +91,7 @@ def prepare_and_unpivot_for_transpose(
                 # We use any_value to select a value in the dummy column to make sure its dtypes are
                 # the same as the column in the original dataframe. This helps avoid type incompatibility
                 # issues in union_all.  To ensure the results are deterministic we filter the results to
-                # the first row position, if the dataset is empty it will be all null instead.
+                # empty (WHERE false) so any_value returns null values but preserves the data type information.
                 new_columns.append(any_value(identifier).as_(identifier))
         dummy_df = ordered_dataframe.filter(lit(False)).agg(new_columns)
         ordered_dataframe = ordered_dataframe.union_all(dummy_df)

--- a/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
@@ -7,7 +7,7 @@ from typing import Union
 import pandas as native_pd
 from modin.core.dataframe.algebra.default2pandas import DataFrameDefault  # type: ignore
 
-from snowflake.snowpark.functions import min as snowpark_min, get
+from snowflake.snowpark.functions import get, min as snowpark_min
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
     OrderedDataFrame,

--- a/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
@@ -7,7 +7,7 @@ from typing import Union
 import pandas as native_pd
 from modin.core.dataframe.algebra.default2pandas import DataFrameDefault  # type: ignore
 
-from snowflake.snowpark.functions import any_value, get
+from snowflake.snowpark.functions import min as snowpark_min, get
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
     OrderedDataFrame,
@@ -88,10 +88,10 @@ def prepare_and_unpivot_for_transpose(
             if identifier == row_position_snowflake_quoted_identifier:
                 new_columns.append((pandas_lit(-1)).as_(identifier))
             else:
-                # We use any_value to select any value in the dummy column to make sure its dtypes are
+                # We use min to select a value in the dummy column to make sure its dtypes are
                 # the same as the column in the original dataframe. This helps avoid type incompatibility
-                # issues in union_all.
-                new_columns.append(any_value(identifier).as_(identifier))
+                # issues in union_all.  Note that we do not use any_value to ensure the results are deterministic.
+                new_columns.append(snowpark_min(identifier).as_(identifier))
         dummy_df = ordered_dataframe.agg(new_columns)
         ordered_dataframe = ordered_dataframe.union_all(dummy_df)
 


### PR DESCRIPTION
SNOW-1504601 Use any_value with filter to ensure determinism during transpose

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1504601 Use any_value with filter to ensure determinism during transpose

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

The transpose operation internally used any_value prior to a pivot, so the output would have a column based on these valuse, however, it later dropped them, however, because pivot internally executes a subquery it's possible any_value can return different results.  We found in some tests there was a flakiness attributed to this nondeterminism.  To address this the code will use a min so it is deterministic on a given data set.

