### PR TITLE
Fix Snowpark pandas daily tests

### DIFF
--- a/.github/workflows/daily_modin_precommit.yml
+++ b/.github/workflows/daily_modin_precommit.yml
@@ -89,7 +89,7 @@ jobs:
         run: .github/scripts/decrypt_parameters.sh
         env:
           PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
-          CLOUD_PROVIDER: ${{ matrix.cloud-provider }}
+          CLOUD_PROVIDER: "aws"
       - name: Upgrade setuptools and pip
         run: python -m pip install -U setuptools pip
       - name: Install tox

--- a/.github/workflows/daily_modin_precommit.yml
+++ b/.github/workflows/daily_modin_precommit.yml
@@ -84,6 +84,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+      - name: Decrypt parameters.py
+        shell: bash
+        run: .github/scripts/decrypt_parameters.sh
+        env:
+          PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
+          CLOUD_PROVIDER: ${{ matrix.cloud-provider }}
       - name: Upgrade setuptools and pip
         run: python -m pip install -U setuptools pip
       - name: Install tox

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -5,7 +5,6 @@
 import sys
 import warnings
 
-from modin.pandas.series_utils import DatetimeProperties  # type: ignore
 from packaging import version
 
 import snowflake.snowpark._internal.utils
@@ -103,4 +102,4 @@ def isocalendar(self):  # type: ignore
     return DataFrame(query_compiler=self._query_compiler.dt_isocalendar())
 
 
-DatetimeProperties.isocalendar = isocalendar
+modin.pandas.series_utils.DatetimeProperties.isocalendar = isocalendar


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

See failure: https://github.com/snowflakedb/snowpark-python/actions/runs/9676725704

The job that checks that importing Snowpark pandas on python 3.8 broke with https://github.com/snowflakedb/snowpark-python/commit/0e2ac6b2dd1bfaae7989835840cd87aece0f6dce because isort floated an `import modin` to the top of `plugin/__init__.py` before version checks occurred; the reference to the imported class has been moved to the bottom of the file after the checks.

The job checking our numpy version compatibility was failing because `parameters.py` was not decrypted.