### PR TITLE
SIT-1383: Added support to set the app_name to the session query_tag in JSON format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Improved error message for `write_pandas` when target table does not exists and `auto_create_table=False`.
 - Added open telemetry tracing on UDxF functions in snowpark.
 - Added open telemetry tracing on stored procedure registration in snowpark.
+- Added a new optional parameter called `format_json` to the `Session.SessionBuilder.app_name` function that allows to set the app name in the `Session.query_tag` in JSON format. By default, this parameter is set to `False`.
 
 #### Bug Fixes
 - Fixed a bug regarding precision loss when converting to Snowpark pandas `DataFrame` or `Series` with `dtype=np.uint64`.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -356,6 +356,19 @@ class Session:
         def app_name(self, app_name: str) -> "Session.SessionBuilder":
             """
             Adds the app name to the :class:`SessionBuilder` to set in the query_tag after session creation
+
+            Note:
+                Since version ``1.19.1``, the app name is set to the query tag in JSON format. For example:
+
+                >>> session = Session.builder.app_name("my_app").configs(db_parameters).create() # doctest: +SKIP
+                >>> print(session.query_tag) # doctest: +SKIP
+                {"APPNAME": "my_app"}
+
+                In previous versions it is set using a key=value format. For example:
+
+                >>> session = Session.builder.app_name("my_app").configs(db_parameters).create() # doctest: +SKIP
+                >>> print(session.query_tag) # doctest: +SKIP
+                APPNAME=my_app
             """
             self._app_name = app_name
             return self
@@ -392,8 +405,8 @@ class Session:
                 session = self._create_internal(self._options.get("connection"))
 
             if self._app_name:
-                app_name_tag = f"APPNAME={self._app_name}"
-                session.append_query_tag(app_name_tag)
+                app_name_tag = {"APPNAME": self._app_name}
+                session.update_query_tag(app_name_tag)
 
             return session
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -375,12 +375,23 @@ def test_create_session_from_connection_with_noise_parameters(
     run=False,
 )
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot create session in SP")
-def test_session_builder_app_name(session, db_parameters):
+@pytest.mark.parametrize(
+    "app_name,format_json,expected_query_tag",
+    [
+        ("my_app_name", False, "APPNAME=my_app_name"),
+        ("my_app_name", True, '{"APPNAME": "my_app_name"}'),
+    ],
+)
+def test_session_builder_app_name(
+    session, db_parameters, app_name, format_json, expected_query_tag
+):
     builder = session.builder
-    app_name = "my_app"
-    expected_query_tag = f'{{"APPNAME": "{app_name}"}}'
-    same_session = builder.app_name(app_name).getOrCreate()
-    new_session = builder.app_name(app_name).configs(db_parameters).create()
+    same_session = builder.app_name(app_name, format_json=format_json).getOrCreate()
+    new_session = (
+        builder.app_name(app_name, format_json=format_json)
+        .configs(db_parameters)
+        .create()
+    )
     try:
         assert session == same_session
         assert same_session.query_tag is None

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -378,7 +378,7 @@ def test_create_session_from_connection_with_noise_parameters(
 def test_session_builder_app_name(session, db_parameters):
     builder = session.builder
     app_name = "my_app"
-    expected_query_tag = f"APPNAME={app_name}"
+    expected_query_tag = f'{{"APPNAME": "{app_name}"}}'
     same_session = builder.app_name(app_name).getOrCreate()
     new_session = builder.app_name(app_name).configs(db_parameters).create()
     try:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -537,7 +537,7 @@ def test_session_builder_app_name_no_existing_query_tag(
         ),
     ],
 )
-def test_session_builder_app_name_existing_valid_query_tag(
+def test_session_builder_app_name_existing_query_tag(
     app_name, format_json, existing_query_tag, expected_query_tag
 ):
     mocked_session = Session(
@@ -566,7 +566,7 @@ def test_session_builder_app_name_existing_valid_query_tag(
         assert created_session.query_tag == expected_query_tag
 
 
-def test_session_builder_app_name_existing_invalid_query_tag():
+def test_session_builder_app_name_existing_invalid_json_query_tag():
     mocked_session = Session(
         ServerConnection(
             {"": ""},

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -544,7 +544,9 @@ def test_session_builder_app_name_existing_valid_query_tag():
         assert builder.app_name(app_name) is builder
         created_session = builder.getOrCreate()
         m.assert_called_once()
-        assert created_session.query_tag == '{"key1": "value1", "APPNAME": "my_app_name"}'
+        assert (
+            created_session.query_tag == '{"key1": "value1", "APPNAME": "my_app_name"}'
+        )
 
 
 def test_session_builder_app_name_existing_invalid_query_tag():
@@ -570,9 +572,9 @@ def test_session_builder_app_name_existing_invalid_query_tag():
     with mock.patch.object(
         builder, "_create_internal", return_value=mocked_session
     ), pytest.raises(
-        ValueError, match="Expected query tag to be valid json. Current query tag: tag",
+        ValueError,
+        match="Expected query tag to be valid json. Current query tag: tag",
     ):
         app_name = "my_app_name"
         assert builder.app_name(app_name) is builder
         builder.getOrCreate()
-

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -489,7 +489,16 @@ def test_connection_expiry():
             m.assert_called_once()
 
 
-def test_session_builder_app_name_no_existing_query_tag():
+@pytest.mark.parametrize(
+    "app_name,format_json,expected_query_tag",
+    [
+        ("my_app_name", False, "APPNAME=my_app_name"),
+        ("my_app_name", True, '{"APPNAME": "my_app_name"}'),
+    ],
+)
+def test_session_builder_app_name_no_existing_query_tag(
+    app_name, format_json, expected_query_tag
+):
     mocked_session = Session(
         ServerConnection(
             {"": ""},
@@ -510,14 +519,27 @@ def test_session_builder_app_name_no_existing_query_tag():
     with mock.patch.object(
         builder, "_create_internal", return_value=mocked_session
     ) as m:
-        app_name = "my_app_name"
-        assert builder.app_name(app_name) is builder
+        assert builder.app_name(app_name, format_json=format_json) is builder
         created_session = builder.getOrCreate()
         m.assert_called_once()
-        assert created_session.query_tag == f'{{"APPNAME": "{app_name}"}}'
+        assert created_session.query_tag == expected_query_tag
 
 
-def test_session_builder_app_name_existing_valid_query_tag():
+@pytest.mark.parametrize(
+    "app_name,format_json,existing_query_tag,expected_query_tag",
+    [
+        ("my_app_name", False, "tag", "tag,APPNAME=my_app_name"),
+        (
+            "my_app_name",
+            True,
+            '{"key": "value"}',
+            '{"key": "value", "APPNAME": "my_app_name"}',
+        ),
+    ],
+)
+def test_session_builder_app_name_existing_valid_query_tag(
+    app_name, format_json, existing_query_tag, expected_query_tag
+):
     mocked_session = Session(
         ServerConnection(
             {"": ""},
@@ -531,8 +553,6 @@ def test_session_builder_app_name_existing_valid_query_tag():
         ),
     )
 
-    existing_query_tag = '{"key1": "value1"}'
-
     mocked_session._get_remote_query_tag = MagicMock(return_value=existing_query_tag)
 
     builder = Session.builder
@@ -540,13 +560,10 @@ def test_session_builder_app_name_existing_valid_query_tag():
     with mock.patch.object(
         builder, "_create_internal", return_value=mocked_session
     ) as m:
-        app_name = "my_app_name"
-        assert builder.app_name(app_name) is builder
+        assert builder.app_name(app_name, format_json=format_json) is builder
         created_session = builder.getOrCreate()
         m.assert_called_once()
-        assert (
-            created_session.query_tag == '{"key1": "value1", "APPNAME": "my_app_name"}'
-        )
+        assert created_session.query_tag == expected_query_tag
 
 
 def test_session_builder_app_name_existing_invalid_query_tag():
@@ -576,5 +593,5 @@ def test_session_builder_app_name_existing_invalid_query_tag():
         match="Expected query tag to be valid json. Current query tag: tag",
     ):
         app_name = "my_app_name"
-        assert builder.app_name(app_name) is builder
+        assert builder.app_name(app_name, format_json=True) is builder
         builder.getOrCreate()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes [SIT-1383](https://snowflakecomputing.atlassian.net/browse/SIT-1383)

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Added a new optional parameter to the `Session.SessionBuilder.app_name` function that allows to set the app name in the `Session.query_tag` in JSON format.

[SIT-1383]: https://snowflakecomputing.atlassian.net/browse/SIT-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ