### PR TITLE
SNOW-1509090: Add overrides outside extension module

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/__init__.py
+++ b/src/snowflake/snowpark/modin/pandas/__init__.py
@@ -161,6 +161,7 @@ import snowflake.snowpark.modin.plugin.extensions.dataframe_extensions  # isort:
 import snowflake.snowpark.modin.plugin.extensions.dataframe_overrides  # isort: skip  # noqa: E402,F401
 import snowflake.snowpark.modin.plugin.extensions.series_extensions  # isort: skip  # noqa: E402,F401
 import snowflake.snowpark.modin.plugin.extensions.series_overrides  # isort: skip  # noqa: E402,F401
+import snowflake.snowpark.modin.plugin.extensions.other_overrides  # isort: skip  # noqa: E402,F401
 
 
 def __getattr__(name: str) -> Any:

--- a/src/snowflake/snowpark/modin/pandas/series.py
+++ b/src/snowflake/snowpark/modin/pandas/series.py
@@ -2343,12 +2343,6 @@ class Series(BasePandasDataset):
 
         from modin.pandas.series_utils import DatetimeProperties
 
-        if DatetimeProperties._Series is not Series:
-            del (
-                DatetimeProperties._Series
-            )  # Replace modin's Series class with Snowpark pandas Series
-            DatetimeProperties._Series = Series
-
         return DatetimeProperties(self)
 
     @property
@@ -2479,14 +2473,7 @@ class Series(BasePandasDataset):
         current_dtype = self.dtype
         if not is_string_dtype(current_dtype):
             raise AttributeError("Can only use .str accessor with string values!")
-
         from modin.pandas.series_utils import StringMethods
-
-        if StringMethods._Series is not Series:
-            del (
-                StringMethods._Series
-            )  # Replace modin's Series class with Snowpark pandas Series
-            StringMethods._Series = Series
 
         return StringMethods(self)
 

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -5,7 +5,6 @@
 import sys
 import warnings
 
-from modin.pandas.series_utils import DatetimeProperties  # type: ignore
 from packaging import version
 
 import snowflake.snowpark._internal.utils
@@ -90,17 +89,3 @@ modin.utils._inherit_docstrings(
 snowflake.snowpark._internal.utils.should_warn_dynamic_pivot_is_in_private_preview = (
     False
 )
-
-
-# TODO: SNOW-1504302: Modin upgrade - use Snowpark pandas DataFrame for isocalendar
-# OSS Modin's DatetimeProperties frontend class wraps the returned query compiler with `modin.pandas.DataFrame`.
-# Since we currently replace `pd.DataFrame` with our own Snowpark pandas DataFrame object, this causes errors
-# since OSS Modin explicitly imports its own DataFrame class here. This override can be removed once the frontend
-# DataFrame class is removed from our codebase.
-def isocalendar(self):  # type: ignore
-    from snowflake.snowpark.modin.pandas import DataFrame
-
-    return DataFrame(query_compiler=self._query_compiler.dt_isocalendar())
-
-
-DatetimeProperties.isocalendar = isocalendar

--- a/src/snowflake/snowpark/modin/plugin/extensions/other_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/other_overrides.py
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from modin.pandas.series_utils import DatetimeProperties, StringMethods
+
+from snowflake.snowpark.modin.pandas import Series
+
+# We need to override some methods on DatetimeProperties, defined in upstream Modin, in order to
+# return the correct Series/DT class.
+
+del DatetimeProperties._Series
+DatetimeProperties._Series = Series
+
+del StringMethods._Series
+StringMethods._Series = Series
+
+
+# TODO: SNOW-1504302: Modin upgrade - use Snowpark pandas DataFrame for isocalendar
+# OSS Modin's DatetimeProperties frontend class wraps the returned query compiler with `modin.pandas.DataFrame`.
+# Since we currently replace `pd.DataFrame` with our own Snowpark pandas DataFrame object, this causes errors
+# since OSS Modin explicitly imports its own DataFrame class here. This override can be removed once the frontend
+# DataFrame class is removed from our codebase.
+def isocalendar(self):  # type: ignore
+    from snowflake.snowpark.modin.pandas import DataFrame
+
+    return DataFrame(query_compiler=self._query_compiler.dt_isocalendar())
+
+
+DatetimeProperties.isocalendar = isocalendar

--- a/tests/integ/modin/test_modin_stored_procedure.py
+++ b/tests/integ/modin/test_modin_stored_procedure.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+# Tests to ensure Snowpark pandas can run in stored procedures, and that overrides are properly
+# performed. These methods are chosen in particular because we overwrite them using ordinary
+# Python means, rather than modin.pandas.api.extensions, and are therefore vulnerable to
+# an importlib.reload call and sensitive to import order.
+#
+# We're not worried about the correctness of results here, just that the returned object is the
+# correct type.
+
+import os
+from typing import Any, Callable
+
+import modin.pandas as pd
+import pytest
+
+import snowflake.snowpark.modin.plugin as plugin  # noqa: F401
+from snowflake.snowpark.session import Session
+from tests.integ.modin.sql_counter import sql_count_checker
+from tests.utils import running_on_public_ci
+
+
+def run_modin_sproc_func(func: Callable, session: Session) -> Any:
+    SNOWPARK_PANDAS_IMPORT = (
+        # move from $BASE/tests/integ/modin up to $BASE/src/snowflake
+        os.path.join(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            ),
+            "src/snowflake/snowpark",
+        ),
+        "snowflake.snowpark",
+    )
+    packages = list(session.get_packages().values())
+    PACKAGING_REQUIREMENT = "packaging>=21.0"
+    MODIN_REQUIREMENT = "modin==" + plugin.supported_modin_version
+    if PACKAGING_REQUIREMENT not in packages:
+        packages.append(PACKAGING_REQUIREMENT)
+    if MODIN_REQUIREMENT not in packages:
+        packages.append(MODIN_REQUIREMENT)
+    func_proc = session.sproc.register(
+        func,
+        imports=[SNOWPARK_PANDAS_IMPORT],
+        packages=packages,
+    )
+    return func_proc()
+
+
+# !!!
+# test_reimport_in_sproc and test_dt_isocalendar_in_sproc are deliberately kept as part of the merge gate
+# to ensure no weird import shenanigans
+# !!!
+
+
+@sql_count_checker(query_count=4, sproc_count=1)
+def test_reimport_in_sproc(session: Session):
+    # Returns a DataFrame
+    def func(session: Session) -> str:
+        import modin.pandas as pd
+
+        import snowflake.snowpark.modin.plugin as plugin  # noqa: F401
+
+        return type(pd.Series(pd.Timestamp("2020-01-01")).dt.isocalendar())
+
+    assert (
+        run_modin_sproc_func(func, session)
+        == "<class 'snowflake.snowpark.modin.pandas.dataframe.DataFrame'>"
+    )
+
+
+@sql_count_checker(query_count=4, sproc_count=1)
+def test_dt_isocalendar_in_sproc(session: Session):
+    # Returns a DataFrame
+    def func(session: Session) -> str:
+        return type(pd.Series(pd.Timestamp("2020-01-01")).dt.isocalendar())
+
+    assert (
+        run_modin_sproc_func(func, session)
+        == "<class 'snowflake.snowpark.modin.pandas.dataframe.DataFrame'>"
+    )
+
+
+@pytest.mark.skipif(running_on_public_ci(), reason="slow sproc test")
+@sql_count_checker(query_count=4, sproc_count=1)
+def test_dt_date_in_sproc(session: Session):
+    # Returns a Series
+    def func(session: Session) -> str:
+        return type(pd.Series(pd.Timestamp("2020-01-01")).dt.date)
+
+    assert (
+        run_modin_sproc_func(func, session)
+        == "<class 'snowflake.snowpark.modin.pandas.series.Series'>"
+    )
+
+
+@pytest.mark.skipif(running_on_public_ci(), reason="slow sproc test")
+@sql_count_checker(query_count=4, sproc_count=1)
+def test_str_len_in_sproc(session: Session):
+    # Returns a Series
+    def func(session: Session) -> str:
+        return type(pd.Series("a").str.len())
+
+    assert (
+        run_modin_sproc_func(func, session)
+        == "<class 'snowflake.snowpark.modin.pandas.series.Series'>"
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1509090

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Snowpark pandas may need to add or override methods on classes like StringMethods, DatetimeProperties, and DataFrameGroupBy that we currently or eventually will inherit from upstream Modin. The modin.pd.api.extensions module only offers register_pd_accessor, register_dataframe_accessor, and register_series_accessor, meaning that all other overrides need to be performed with a manual set (DatetimeProperties.method = our_method).

This PR consolidates these monkeypatch operations into a single file, and adds tests to ensure that running Snowpark pandas in a sproc does not cause any stray importlib.reload or import order changes that would break them. 2 of the 4 new tests are added to the merge gate.