### PR TITLE
Ignore modin import paths in mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ ignore_missing_imports = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True
+
+[mypy-modin.*]
+ignore_missing_imports = True


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

This PR sets `ignore_missing_imports = True` for `modin` in mypy configuration, as we already do for `pandas` and `snowflake`. This is needed to suppress `error: Cannot find implementation or library stub for module named "modin.pandas.base"  [import]`.

This error isn't majorly affecting the codebase yet, but I'm making the change now as an independent PR to make sure snowpark-python-api-reviewers doesn't get pinged on the larger followup PRs that basically only touch Snowpark pandas code.