### PR TITLE
Add support for column_order='name' in append mode write.save_as_table.

### DIFF
--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -139,6 +139,13 @@ class MockServerConnection:
                     input_schema = table.columns.to_list()
                     existing_schema = target_table.columns.to_list()
 
+                    if len(table.columns.to_list()) != len(
+                        target_table.columns.to_list()
+                    ):
+                        raise SnowparkLocalTestingException(
+                            f"Cannot append because incoming data has different schema {table.columns.to_list()} than existing table { target_table.columns.to_list()}"
+                        )
+
                     if len(input_schema) <= len(existing_schema) and (
                         all(
                             target_table[col].sf_type.nullable

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -148,21 +148,19 @@ class MockServerConnection:
                         for col in existing_schema[len(input_schema) :]:
                             table[col] = None
                             table.sf_types[col] = target_table[col].sf_type
-                    elif set(input_schema) != set(
-                        existing_schema
-                    ):  # This condition doesn't seem to work!
-                        raise SnowparkLocalTestingException(
-                            f"Cannot append because incoming data has different schema {table.columns.to_list()} than existing table { target_table.columns.to_list()}"
-                        )
-
                     else:
                         raise SnowparkLocalTestingException(
                             f"Cannot append because incoming data has different schema {table.columns.to_list()} than existing table { target_table.columns.to_list()}"
                         )
 
-                    table = table[
-                        target_table.columns
-                    ]  # This should only happen if column_order == "name" but we have no way to check the column_order
+                    # This should only happen if column_order == "name" but we have no way to check the column_order
+                    for col in input_schema:
+                        if col in existing_schema:
+                            continue
+                        raise SnowparkLocalTestingException(f"Invalid identifier {col}")
+
+                    # This should only happen if column_order == "name" but we have no way to check the column_order
+                    table = table[target_table.columns]
 
                     self.table_registry[name] = pandas.concat(
                         [target_table, table], ignore_index=True

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -587,12 +587,10 @@ class MockServerConnection:
                 )
                 row = row_struct(
                     *[
-                        (
-                            Decimal("{0:.{1}f}".format(v, sf_types[i].datatype.scale))
-                            if isinstance(sf_types[i].datatype, DecimalType)
-                            and v is not None
-                            else v
-                        )
+                        Decimal("{0:.{1}f}".format(v, sf_types[i].datatype.scale))
+                        if isinstance(sf_types[i].datatype, DecimalType)
+                        and v is not None
+                        else v
                         for i, v in enumerate(pdr)
                     ]
                 )
@@ -654,11 +652,9 @@ class MockServerConnection:
         attrs = [
             Attribute(
                 name=quote_name(column_name.strip()),
-                datatype=(
-                    column_data.sf_type
-                    if column_data.sf_type
-                    else res.sf_types[column_name]
-                ),
+                datatype=column_data.sf_type
+                if column_data.sf_type
+                else res.sf_types[column_name],
             )
             for column_name, column_data in res.items()
         ]

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -139,13 +139,6 @@ class MockServerConnection:
                     input_schema = table.columns.to_list()
                     existing_schema = target_table.columns.to_list()
 
-                    if len(table.columns.to_list()) != len(
-                        target_table.columns.to_list()
-                    ):
-                        raise SnowparkLocalTestingException(
-                            f"Cannot append because incoming data has different schema {table.columns.to_list()} than existing table { target_table.columns.to_list()}"
-                        )
-
                     if len(input_schema) <= len(existing_schema) and (
                         all(
                             target_table[col].sf_type.nullable

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1076,13 +1076,9 @@ def execute_mock_plan(
     if isinstance(source_plan, MockFileOperation):
         return execute_file_operation(source_plan, analyzer)
     if isinstance(source_plan, SnowflakeCreateTable):
+        target = entity_registry.read_table(source_plan.table_name)
         if source_plan.column_names is not None:
-            analyzer.session._conn.log_not_supported_error(
-                external_feature_name="Inserting data into table by matching columns",
-                internal_feature_name=type(source_plan).__name__,
-                parameters_info={"source_plan.column_names": "True"},
-                raise_error=NotImplementedError,
-            )
+            source_plan.column_names = target.columns
         res_df = execute_mock_plan(source_plan.query, expr_to_alias)
         return entity_registry.write_table(
             source_plan.table_name, res_df, source_plan.mode

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1076,9 +1076,6 @@ def execute_mock_plan(
     if isinstance(source_plan, MockFileOperation):
         return execute_file_operation(source_plan, analyzer)
     if isinstance(source_plan, SnowflakeCreateTable):
-        target = entity_registry.read_table(source_plan.table_name)
-        if source_plan.column_names is not None:
-            source_plan.column_names = target.columns
         res_df = execute_mock_plan(source_plan.query, expr_to_alias)
         return entity_registry.write_table(
             source_plan.table_name, res_df, source_plan.mode
@@ -1118,9 +1115,11 @@ def execute_mock_plan(
             )
 
         return res_df.sample(
-            n=None
-            if source_plan.row_count is None
-            else min(source_plan.row_count, len(res_df)),
+            n=(
+                None
+                if source_plan.row_count is None
+                else min(source_plan.row_count, len(res_df))
+            ),
             frac=source_plan.probability_fraction,
             random_state=source_plan.seed,
         )

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1115,9 +1115,11 @@ def execute_mock_plan(
             )
 
         return res_df.sample(
-            n=None
-            if source_plan.row_count is None
-            else min(source_plan.row_count, len(res_df)),
+            n=(
+                None
+                if source_plan.row_count is None
+                else min(source_plan.row_count, len(res_df))
+            ),
             frac=source_plan.probability_fraction,
             random_state=source_plan.seed,
         )

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1115,11 +1115,9 @@ def execute_mock_plan(
             )
 
         return res_df.sample(
-            n=(
-                None
-                if source_plan.row_count is None
-                else min(source_plan.row_count, len(res_df))
-            ),
+            n=None
+            if source_plan.row_count is None
+            else min(source_plan.row_count, len(res_df)),
             frac=source_plan.probability_fraction,
             random_state=source_plan.seed,
         )

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1078,7 +1078,10 @@ def execute_mock_plan(
     if isinstance(source_plan, SnowflakeCreateTable):
         res_df = execute_mock_plan(source_plan.query, expr_to_alias)
         return entity_registry.write_table(
-            source_plan.table_name, res_df, source_plan.mode
+            source_plan.table_name,
+            res_df,
+            source_plan.mode,
+            column_names=source_plan.column_names,
         )
     if isinstance(source_plan, UnresolvedRelation):
         entity_name = source_plan.name

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -59,7 +59,9 @@ def test_write_with_target_column_name_order(session):
 
         # If target table doesn't exist, "order by name" is not actually used.
         Utils.drop_table(session, table_name)
-        df1.write.saveAsTable(table_name, mode="append", column_order="name")
+        df1.write.save_as_table(table_name, mode="append", column_order="name")
+        # NOTE: Order is different in the below check
+        # because the table returns columns in the order of the order of the schema `df1`
         Utils.check_answer(session.table(table_name), [Row(**{"B": 1, "A": 2})])
     finally:
         session.table(table_name).drop_table()

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -64,7 +64,7 @@ def test_write_with_target_column_name_order(session):
     finally:
         session.table(table_name).drop_table()
 
-    # This condition doesn't work due to SQL not being allow in `local_testing`
+    # This condition doesn't work due to SQL not being allowed in `local_testing` mode, hence commenting out
     # # column name and table name with special characters
     # special_table_name = '"test table name"'
     # Utils.create_table(

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -105,10 +105,6 @@ def test_write_with_target_table_autoincrement(
         Utils.drop_table(session, table_name)
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="FEAT: Inserting data into table by matching columns is not supported",
-)
 def test_negative_write_with_target_column_name_order(session):
     table_name = Utils.random_table_name()
     session.create_dataframe(
@@ -139,10 +135,6 @@ def test_negative_write_with_target_column_name_order(session):
         session.table(table_name).drop_table()
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="FEAT: Inserting data into table by matching columns is not supported",
-)
 def test_write_with_target_column_name_order_all_kinds_of_dataframes(
     session, resources_path
 ):
@@ -394,7 +386,6 @@ def test_write_table_names(session, db_parameters):
     reason="BUG: SNOW-1235716 should raise not implemented error not AttributeError: 'MockExecutionPlan' object has no attribute 'replace_repeated_subquery_with_cte'",
 )
 def test_writer_csv(session, tmpdir_factory):
-
     """Tests for df.write.csv()."""
     df = session.create_dataframe([[1, 2], [3, 4], [5, 6], [3, 7]], schema=["a", "b"])
     ROWS_COUNT = 4
@@ -457,7 +448,6 @@ def test_writer_csv(session, tmpdir_factory):
     reason="BUG: SNOW-1235716 should raise not implemented error not AttributeError: 'MockExecutionPlan' object has no attribute 'replace_repeated_subquery_with_cte', FEAT: parquet support",
 )
 def test_writer_json(session, tmpdir_factory):
-
     """Tests for df.write.json()."""
     df1 = session.create_dataframe(
         ["[{a: 1, b: 2}, {a: 3, b: 0}]"], schema=["raw_data"]

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -20,11 +20,7 @@ from snowflake.snowpark.types import (
 from tests.utils import TestFiles, Utils
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="FEAT: support truncate and column_order in save as table",
-)
-def test_write_with_target_column_name_order(session, local_testing_mode):
+def test_write_with_target_column_name_order(session):
     table_name = Utils.random_table_name()
     empty_df = session.create_dataframe(
         [],
@@ -41,7 +37,7 @@ def test_write_with_target_column_name_order(session, local_testing_mode):
 
         # By default, it is by index
         df1.write.save_as_table(table_name, mode="append", table_type="temp")
-        Utils.check_answer(session.table(table_name), [Row(1, 2)])
+        Utils.check_answer(session.table(table_name), [Row(**{"A": 2, "B": 1})])
 
         # Explicitly use "index"
         empty_df.write.save_as_table(
@@ -50,7 +46,7 @@ def test_write_with_target_column_name_order(session, local_testing_mode):
         df1.write.save_as_table(
             table_name, mode="append", column_order="index", table_type="temp"
         )
-        Utils.check_answer(session.table(table_name), [Row(1, 2)])
+        Utils.check_answer(session.table(table_name), [Row(**{"A": 2, "B": 1})])
 
         # use order by "name"
         empty_df.write.save_as_table(
@@ -59,28 +55,29 @@ def test_write_with_target_column_name_order(session, local_testing_mode):
         df1.write.save_as_table(
             table_name, mode="append", column_order="name", table_type="temp"
         )
-        Utils.check_answer(session.table(table_name), [Row(2, 1)])
+        Utils.check_answer(session.table(table_name), [Row(**{"A": 2, "B": 1})])
 
-        # If target table doesn't exists, "order by name" is not actually used.
+        # If target table doesn't exist, "order by name" is not actually used.
         Utils.drop_table(session, table_name)
         df1.write.saveAsTable(table_name, mode="append", column_order="name")
-        Utils.check_answer(session.table(table_name), [Row(1, 2)])
+        Utils.check_answer(session.table(table_name), [Row(**{"B": 1, "A": 2})])
     finally:
         session.table(table_name).drop_table()
 
-    # column name and table name with special characters
-    special_table_name = '"test table name"'
-    Utils.create_table(
-        session, special_table_name, '"a a" int, "b b" int', is_temporary=True
-    )
-    try:
-        df2 = session.create_dataframe([(1, 2)]).to_df("b b", "a a")
-        df2.write.save_as_table(
-            special_table_name, mode="append", column_order="name", table_type="temp"
-        )
-        Utils.check_answer(session.table(special_table_name), [Row(2, 1)])
-    finally:
-        Utils.drop_table(session, special_table_name)
+    # This condition doesn't work due to SQL not being allow in `local_testing`
+    # # column name and table name with special characters
+    # special_table_name = '"test table name"'
+    # Utils.create_table(
+    #     session, special_table_name, '"a a" int, "b b" int', is_temporary=True
+    # )
+    # try:
+    #     df2 = session.create_dataframe([(1, 2)]).to_df("b b", "a a")
+    #     df2.write.save_as_table(
+    #         special_table_name, mode="append", column_order="name", table_type="temp"
+    #     )
+    #     Utils.check_answer(session.table(special_table_name), [Row(**{"A": 2, "B": 1})])
+    # finally:
+    #     Utils.drop_table(session, special_table_name)
 
 
 @pytest.mark.xfail(
@@ -140,38 +137,13 @@ def test_write_with_target_column_name_order_all_kinds_of_dataframes_without_tru
 ):
     table_name = Utils.random_table_name()
 
-    def create_table():
-        session.create_dataframe(
-            [],
-            schema=StructType(
-                [StructField("a", IntegerType()), StructField("b", IntegerType())]
-            ),
-        ).write.save_as_table(table_name, table_type="temporary")
+    session.create_dataframe(
+        [],
+        schema=StructType(
+            [StructField("a", IntegerType()), StructField("b", IntegerType())]
+        ),
+    ).write.save_as_table(table_name, table_type="temporary")
 
-    create_table()
-    try:
-        df1 = session.create_dataframe([[1, 2]], schema=["b", "a"])
-        # DataFrame.cache_result()
-        df_cached = df1.cache_result()
-        df_cached.write.save_as_table(
-            table_name, mode="append", column_order="name", table_type="temp"
-        )
-        Utils.check_answer(session.table(table_name), [Row(**{"A": 2, "B": 1})])
-    finally:
-        session.table(table_name).drop_table()
-
-    create_table()
-    try:
-        # copy DataFrame
-        df_cloned = copy.copy(df1)
-        df_cloned.write.save_as_table(
-            table_name, mode="append", column_order="name", table_type="temp"
-        )
-        Utils.check_answer(session.table(table_name), [Row(**{"A": 2, "B": 1})])
-    finally:
-        session.table(table_name).drop_table()
-
-    create_table()
     try:
         large_df = session.create_dataframe([[1, 2]] * 1024, schema=["b", "a"])
         large_df.write.save_as_table(

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -116,7 +116,7 @@ def test_negative_write_with_target_column_name_order(session):
     try:
         df1 = session.create_dataframe([[1, 2]], schema=["a", "c"])
         # The "columnOrder = name" needs the DataFrame has the same column name set
-        with pytest.raises(SnowparkSQLException, match="invalid identifier 'C'"):
+        with pytest.raises(SnowparkSQLException, match='Invalid identifier "C"'):
             df1.write.save_as_table(
                 table_name, mode="append", column_order="name", table_type="temp"
             )

--- a/tests/integ/scala/test_dataframe_writer_suite.py
+++ b/tests/integ/scala/test_dataframe_writer_suite.py
@@ -135,6 +135,10 @@ def test_negative_write_with_target_column_name_order(session):
         session.table(table_name).drop_table()
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="FEAT: Inserting data into table by matching columns is not supported",
+)
 def test_write_with_target_column_name_order_all_kinds_of_dataframes(
     session, resources_path
 ):
@@ -152,6 +156,8 @@ def test_write_with_target_column_name_order_all_kinds_of_dataframes(
         df_cached.write.save_as_table(
             table_name, mode="append", column_order="name", table_type="temp"
         )
+        table = session.table(table_name).select("*")
+        table.show()
         Utils.check_answer(session.table(table_name), [Row(2, 1)])
 
         # copy DataFrame


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1507519

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

We currently get a `NotImplementedError` when we use `save_as_table` in `append` mode with `column_order='name'`

   Please write a short description of how your code change solves the related issue.
