### PR TITLE
Fix reference to snowflakedb/snowflake-connector-python@server-side-snowpark

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
 MODIN_DEPENDENCY_VERSION = (
     "==0.28.1"  # Snowpark pandas requires modin 0.28.1, which depends on pandas 2.2.1
 )
-# Use HEAD of server-side-snowpark branch in connector.
-CONNECTOR_DEPENDENCY = "snowflake-connector-python @ git+https://github.com/snowflakedb/snowflake-connector-python@server-side-snowpark#egg=snowflake-connector-python"
+# Use HEAD of main branch in connector.
+CONNECTOR_DEPENDENCY = "snowflake-connector-python @ git+https://github.com/snowflakedb/snowflake-connector-python@main#egg=snowflake-connector-python"
 INSTALL_REQ_LIST = [
     "setuptools>=40.6.0",
     "wheel",


### PR DESCRIPTION
The `server-side-snowpark` branch no longer exists in `snowflakedb/snowflake-connector-python` after https://github.com/snowflakedb/snowflake-connector-python/pull/1964

Refer to `snowflakedb/snowflake-connector-python@main` instead.

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Prerequisite for SNOW-1491327.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Since the Snowflake Python connector does not support the dataframe AST functionality in any released version yet, `setup.py` in `snowflakedb/snowpark-python@server-side-snowpark` refers to the dependency by git repository URL and commit.
   Fix the pointer to refer to the `main` branch instead of the topic branch that no longer exists.