### PR TITLE
Only raise explicit errors for Snowpark non-internal API calls

### DIFF
--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -15,7 +15,7 @@ import snowflake.snowpark._internal.proto.ast_pb2 as proto
 
 # This flag causes an explicit error to be raised if any Snowpark object instance is missing an AST or field, when this
 # AST or field is required to populate the AST field of a different Snowpark object instance.
-FAIL_ON_MISSING_AST = True
+FAIL_ON_MISSING_AST = False
 
 
 def build_const_from_python_val(obj: Any, ast: proto.Expr) -> None:

--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -15,7 +15,7 @@ import snowflake.snowpark._internal.proto.ast_pb2 as proto
 
 # This flag causes an explicit error to be raised if any Snowpark object instance is missing an AST or field, when this
 # AST or field is required to populate the AST field of a different Snowpark object instance.
-FAIL_ON_MISSING_AST = False
+FAIL_ON_MISSING_AST = True
 
 
 def build_const_from_python_val(obj: Any, ast: proto.Expr) -> None:

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -5,6 +5,7 @@
 
 import inspect
 import sys
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import snowflake.snowpark
@@ -1008,11 +1009,12 @@ class Column:
                     while call_stack and __file__ == curr_frame.filename:
                         column_api = curr_frame.function
                         curr_frame = call_stack.pop(0)
-                    raise NotImplementedError(
-                        f'Calling Column API "{column_api}" which supports AST logging, from File "{curr_frame.filename}", line {curr_frame.lineno}\n'
-                        f"\t{curr_frame.code_context[0].strip()}\n"
-                        f"A Snowpark API which returns a Column instance used above has not yet implemented AST logging."
-                    )
+                    if not Path(__file__).parents[0] in Path(curr_frame.filename).parents:
+                        raise NotImplementedError(
+                            f'Calling Column API "{column_api}" which supports AST logging, from File "{curr_frame.filename}", line {curr_frame.lineno}\n'
+                            f"\t{curr_frame.code_context[0].strip()}\n"
+                            f"A Snowpark API which returns a Column instance used above has not yet implemented AST logging."
+                        )
                 elif msg is not None:
                     getattr(prop_ast, attr).CopyFrom(msg)
             for attr, other in fill_expr_asts.items():

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -960,7 +960,6 @@ class DataFrame:
         ast.variadic = is_variadic
         set_src_position(ast.src)
 
-        # TODO: SNOW-1507432 (currently to_df expectation test will fail due to incomplete AST logging)
         new_cols = []
         for attr, name in zip(self._output, col_names):
             new_cols.append(Column(attr).alias(name))


### PR DESCRIPTION
Ensures all tests pass on main branch