### PR TITLE
SNOW-1492846: Get rid of converting non-select SQL to select SQL in `SelectSQL` when finding duplicate subtrees

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -418,6 +418,14 @@ class SelectSQL(Selectable):
         return None
 
     @property
+    def _id(self) -> Optional[str]:
+        """
+        Returns the id of this SelectSQL logical plan. The original SQL is used to encode its ID,
+        which might be a non-select SQL.
+        """
+        return encode_id(self.original_sql, self.query_params)
+
+    @property
     def query_params(self) -> Optional[Sequence[Any]]:
         return self._query_param
 

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -166,6 +166,13 @@ def test_plan_height(session, temp_table, sql_simplifier_enabled):
         assert union1._plan.plan_height == 9
 
 
+def test_plan_num_duplicate_nodes_describe_query(session, temp_table):
+    df1 = session.sql(f"describe table {temp_table}")
+    with session.query_history() as query_history:
+        assert df1._plan.num_duplicate_nodes == 0
+    assert len(query_history.queries) == 0
+
+
 def test_create_scoped_temp_table(session):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -349,8 +349,16 @@ def test_table(session):
     assert count_number_of_ctes(df_result.queries["queries"][-1]) == 1
 
 
-def test_sql(session):
-    df = session.sql("select 1 as a, 2 as b").filter(col("a") == 1)
+@pytest.mark.parametrize(
+    "query",
+    [
+        "select 1 as a, 2 as b",
+        "show tables in schema limit 10",
+        "describe result last_query_id()",
+    ],
+)
+def test_sql(session, query):
+    df = session.sql(query).filter(lit(True))
     df_result = df.union_all(df).select("*")
     check_result(session, df_result, expect_cte_optimized=True)
     assert count_number_of_ctes(df_result.queries["queries"][-1]) == 1


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1492846

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Before this change, we call to_subqueryable() in search algorithm of CTE to convert non-select SQL to select SQL, and use it to encode ID. But it is unnecessary and we can always use original SQL here. 
