### PR TITLE
SNOW-1474971: Re-enable telemetry for collecting plan heights and number of duplicate nodes

### DIFF
--- a/src/snowflake/snowpark/_internal/telemetry.py
+++ b/src/snowflake/snowpark/_internal/telemetry.py
@@ -157,6 +157,10 @@ def df_collect_api_telemetry(func):
             0
         ]._session.sql_simplifier_enabled
         try:
+            api_calls[0][TelemetryField.QUERY_PLAN_HEIGHT.value] = plan.plan_height
+            api_calls[0][
+                TelemetryField.QUERY_PLAN_NUM_DUPLICATE_NODES.value
+            ] = plan.num_duplicate_nodes
             api_calls[0][TelemetryField.QUERY_PLAN_COMPLEXITY.value] = {
                 key.value: value
                 for key, value in plan.cumulative_node_complexity.items()

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -171,6 +171,9 @@ def test_plan_num_duplicate_nodes_describe_query(session, temp_table):
     with session.query_history() as query_history:
         assert df1._plan.num_duplicate_nodes == 0
     assert len(query_history.queries) == 0
+    with session.query_history() as query_history:
+        df1.collect()
+    assert len(query_history.queries) == 1
 
 
 def test_create_scoped_temp_table(session):

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -585,11 +585,14 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
 
     df.collect()
     # API calls don't change after query is executed
+    query_plan_height = 2 if sql_simplifier_enabled else 3
 
     assert df._plan.api_calls == [
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": query_plan_height,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {
                 "filter": 1,
                 "low_impact": 3,
@@ -610,6 +613,8 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": query_plan_height,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {
                 "filter": 1,
                 "low_impact": 3,
@@ -630,6 +635,8 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": query_plan_height,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {
                 "filter": 1,
                 "low_impact": 3,
@@ -650,6 +657,8 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": query_plan_height,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {
                 "filter": 1,
                 "low_impact": 3,
@@ -670,6 +679,8 @@ def test_execute_queries_api_calls(session, sql_simplifier_enabled):
         {
             "name": "Session.range",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": query_plan_height,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {
                 "filter": 1,
                 "low_impact": 3,
@@ -813,6 +824,8 @@ def test_dataframe_stat_functions_api_calls(session):
         {
             "name": "Session.create_dataframe[values]",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": 4,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {"group_by": 1, "column": 6, "literal": 48},
         },
         {
@@ -829,6 +842,8 @@ def test_dataframe_stat_functions_api_calls(session):
         {
             "name": "Session.create_dataframe[values]",
             "sql_simplifier_enabled": session.sql_simplifier_enabled,
+            "query_plan_height": 4,
+            "query_plan_num_duplicate_nodes": 0,
             "query_plan_complexity": {"group_by": 1, "column": 6, "literal": 48},
         }
     ]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1474971

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   The telemetry for these two stats were previously disabled due to a bug in CTE search algorithm, now we can re-enable it after the fix. 
