### PR TITLE
Add type to expression when there is ignore nulls and offset != 0

### DIFF
--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -2076,28 +2076,32 @@ def calculate_expression(
                     cur_idx = row_idx + delta
                     cur_count = 0
                     while 0 <= cur_idx < len(w):
-                        target_expr = calculate_expression(
+                        calc_expr = calculate_expression(
                             window_function.expr,
                             w.iloc[[cur_idx]],
                             analyzer,
                             expr_to_alias,
-                        ).iloc[0]
+                        )
+                        target_expr = calc_expr.iloc[0]
                         if target_expr is not None:
                             cur_count += 1
                             if cur_count == abs(offset):
                                 break
                         cur_idx += delta
                     if cur_idx < 0 or cur_idx >= len(w):
+                        calc_expr = calculate_expression(
+                            window_function.expr,
+                            w.iloc[[cur_idx]],
+                            analyzer,
+                            expr_to_alias,
+                        )
                         res_cols.append(
-                            calculate_expression(
-                                window_function.default,
-                                w,
-                                analyzer,
-                                expr_to_alias,
-                            ).iloc[0]
+                            calc_expr.iloc[0]
                         )
                     else:
                         res_cols.append(target_expr)
+                    if not calculated_sf_type:
+                        calculated_sf_type = calc_expr.sf_type
             res_col = ColumnEmulator(
                 data=res_cols, dtype=object
             )  # dtype=object prevents implicit converting None to Nan

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -2095,9 +2095,7 @@ def calculate_expression(
                             analyzer,
                             expr_to_alias,
                         )
-                        res_cols.append(
-                            calc_expr.iloc[0]
-                        )
+                        res_cols.append(calc_expr.iloc[0])
                     else:
                         res_cols.append(target_expr)
                     if not calculated_sf_type:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.


   Fixes SNOW-1526571

https://github.com/snowflakedb/snowpark-python/issues/1887

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Previously, when using lead and lag on the specified table, they returned a NullType column in local testing. Now it should return the proper type.
