### PR TITLE
SNOW-1527038 Fix value_counts bug where the index is not sorted properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Fixed a bug in `DataFrame.rolling` and `Series.rolling` so `window=0` now throws `NotImplementedError` instead of `ValueError`
 - Fixed a bug in `DataFrame` and `Series` with `dtype=np.uint64` resulting in precision errors
 - Fixed bug where `values` is set to `index` when `index` and `columns` contain all columns in DataFrame during `pivot_table`.
+- Fixed bug where `value_counts` did not order the result correctly when `sort=True`.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -10202,8 +10202,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # otherwise, respect the original order (use the original ordering columns)
         ordered_dataframe = internal_frame.ordered_dataframe
         if sort:
-            # When sort=True, sort the value counts in descending order but maintain the
-            # original row position order.
             # Need to explicitly specify the row position identifier to enforce the original order.
             ordered_dataframe = ordered_dataframe.sort(
                 OrderingColumn(count_identifier, ascending=ascending),

--- a/tests/integ/modin/series/test_value_counts.py
+++ b/tests/integ/modin/series/test_value_counts.py
@@ -27,6 +27,47 @@ TEST_NULL_DATA = [
 ]
 
 
+NATIVE_SERIES_TEST_DATA = [
+    native_pd.Series(
+        [1, 2, 3, 2, 3, 5, 6, 7, 8, 4, 4, 5, 6, 7, 1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 7]
+    ),
+    native_pd.Series([1.1, 2.2, 1.0, 1, 1.1, 2.2, 1, 1, 1, 2, 2, 2, 2.2]),
+    native_pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]),
+    native_pd.Series(
+        [True, False, True, False, True, False, True, False, True, True], dtype=bool
+    ),
+    native_pd.Series(
+        [
+            "a",
+            "b",
+            "c",
+            "b",
+            "c",
+            "e",
+            "f",
+            "g",
+            "h",
+            "d",
+            "d",
+            "e",
+            "f",
+            "g",
+            "a",
+            "b",
+            "a",
+            "b",
+            "c",
+            "d",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+        ]
+    ),
+]
+
+
 @pytest.mark.parametrize("test_data", TEST_DATA)
 @pytest.mark.parametrize("sort", [True, False])
 @pytest.mark.parametrize("ascending", [True, False])
@@ -79,3 +120,20 @@ def test_value_counts_dropna(test_data, dropna):
 def test_value_counts_bins():
     with pytest.raises(NotImplementedError, match="bins argument is not yet supported"):
         pd.Series([1, 2, 3, 4]).value_counts(bins=3)
+
+
+@pytest.mark.parametrize("native_series", NATIVE_SERIES_TEST_DATA)
+@pytest.mark.parametrize("normalize", [True, False])
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("ascending", [True, False])
+@pytest.mark.parametrize("dropna", [True, False])
+@sql_count_checker(query_count=1)
+def test_series_value_counts(native_series, normalize, sort, ascending, dropna):
+    snow_series = pd.Series(native_series)
+    eval_snowpark_pandas_result(
+        snow_series,
+        native_series,
+        lambda s: s.value_counts(
+            normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
+        ),
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1527038

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

`Series.value_counts` is a method that counts the occurrence of each value in the given Series. There are several parameters to it, the only one relevant here is `sort`.

When `sort=True`, the result is supposed to display the value counts in descending order. When two values have the same count, maintain the ordering from the original Series. For instance, in the example below 3 appears before 2 and therefore the result is ordered as such.
```py
>>> pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]).value_counts()
1    7
3    3
2    3
Name: count, dtype: int64
```

In Snowpark pandas, the descending order behavior is followed. However, the original order of the Series is not maintained when tie breaking is necessary. The test with which I found the bug is below. Notice how the positions of 5 and 6 are swapped - 5 appears before 6 but Snowpark pandas displays 6 first.
```py
>>> native_series = native_pd.Series([1, 2, 3, 1, 2, 3, 5, 6, 7, 8, 4, 4, 5, 6, 7, 1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 7])
>>> native_series.value_counts()
1    4
2    4
3    4
4    4
5    3 <--- 
6    3 <---
7    3
8    1
Name: count, dtype: int64

>>> snow_series = pd.Series(native_series)
>>> snow_series.value_counts()
1    4
2    4
3    4
4    4
6    3 <---
5    3 <---
7    3
8    1
Name: count, dtype: int64
```

Internally, a groupby aggregation COUNT is performed on the data column in Series. Specifying `sort=False` in the `groupby_agg` method should provide a result with the required order - when `sort=False`, the original order in the Series is maintained. However in `value_counts`, after the groupby aggregation is performed, another sort is performed on the result `ordered_dataframe` which gets rid of the "row number ordering".

To fix this bug, after the groupby aggregation is performed, ensure that the row position column exists in the internal frame and explicitly specify sorting by row number.