### PR TITLE
SNOW-1527038 Fix Jenkins failure, explain `Series.value_counts` behavior 

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2912,15 +2912,16 @@ class Series:
             frequencies of the unique values. Being different from native pandas,
             Snowpark pandas will return a Series with `decimal.Decimal` values.
         sort : bool, default True
-            Sort by the count when True. Preserve the order of the data when False.
+            Sort by frequencies when True. Preserve the order of the data when False.
             When there is a tie between counts, the order is still deterministic, but
             may be different from the result from native pandas. Snowpark pandas will
             always respect the order of insertion during ties. Native pandas is not
-            deterministic since the original order/order of insertion is based on the
-            Python hashmap which may produce different results on different versions.
+            deterministic when `sort=True` since the original order/order of insertion
+            is based on the Python hashmap which may produce different results on
+            different versions.
             Refer to: https://github.com/pandas-dev/pandas/issues/15833
         ascending : bool, default False
-            Whether to sort the count in ascending order or descending order.
+            Whether to sort the frequencies in ascending order or descending order.
         bins : int, optional
             Rather than count values, group them into half-open bins,
             a convenience for ``pd.cut``, only works with numeric data.

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2912,11 +2912,15 @@ class Series:
             frequencies of the unique values. Being different from native pandas,
             Snowpark pandas will return a Series with `decimal.Decimal` values.
         sort : bool, default True
-            Sort by frequencies when True. Preserve the order of the data when False.
+            Sort by the count when True. Preserve the order of the data when False.
             When there is a tie between counts, the order is still deterministic, but
-            may be different from the result from native pandas.
+            may be different from the result from native pandas. Snowpark pandas will
+            always respect the order of insertion during ties. Native pandas is not
+            deterministic since the original order/order of insertion is based on the
+            Python hashmap which may produce different results on different versions.
+            Refer to: https://github.com/pandas-dev/pandas/issues/15833
         ascending : bool, default False
-            Sort in ascending order.
+            Whether to sort the count in ascending order or descending order.
         bins : int, optional
             Rather than count values, group them into half-open bins,
             a convenience for ``pd.cut``, only works with numeric data.

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2913,12 +2913,12 @@ class Series:
             Snowpark pandas will return a Series with `decimal.Decimal` values.
         sort : bool, default True
             Sort by frequencies when True. Preserve the order of the data when False.
-            When there is a tie between counts, the order is still deterministic, but
-            may be different from the result from native pandas. Snowpark pandas will
-            always respect the order of insertion during ties. Native pandas is not
-            deterministic when `sort=True` since the original order/order of insertion
-            is based on the Python hashmap which may produce different results on
-            different versions.
+            When there is a tie between counts, the order is still deterministic where
+            the order in the original data is preserved, but may be different from the
+            result from native pandas. Snowpark pandas will always respect the order of
+            insertion during ties. Native pandas is not deterministic when `sort=True`
+            since the original order/order of insertion is based on the Python hashmap
+            which may produce different results on different versions.
             Refer to: https://github.com/pandas-dev/pandas/issues/15833
         ascending : bool, default False
             Whether to sort the frequencies in ascending order or descending order.

--- a/tests/integ/modin/series/test_value_counts.py
+++ b/tests/integ/modin/series/test_value_counts.py
@@ -10,6 +10,7 @@ import pytest
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import (
+    assert_series_equal,
     assert_snowpark_pandas_equals_to_pandas_with_coerce_to_float64,
     eval_snowpark_pandas_result,
 )
@@ -66,6 +67,39 @@ NATIVE_SERIES_TEST_DATA = [
         ]
     ),
 ]
+
+SERIES1 = native_pd.Series(
+    [1, 2, 3, 2, 3, 5, 6, 7, 8, 4, 4, 5, 6, 7, 1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 7]
+)
+SERIES2 = native_pd.Series(
+    [
+        "a",
+        "b",
+        "c",
+        "b",
+        "c",
+        "e",
+        "f",
+        "g",
+        "h",
+        "d",
+        "d",
+        "e",
+        "f",
+        "g",
+        "a",
+        "b",
+        "a",
+        "b",
+        "c",
+        "d",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+    ]
+)
 
 
 @pytest.mark.parametrize("test_data", TEST_DATA)
@@ -129,10 +163,10 @@ def test_value_counts_bins():
 @pytest.mark.parametrize("dropna", [True, False])
 @sql_count_checker(query_count=1)
 def test_series_value_counts(native_series, normalize, sort, ascending, dropna):
-    # If `sort=True`, sort by the count. If `sort=False`, maintain the original ordering.
+    # If `sort=True`, sort by the frequencies. If `sort=False`, maintain the original ordering.
     # `ascending` controls whether to sort the count in ascending or descending order.
 
-    # When there is a tie between counts, the order is still deterministic, but
+    # When there is a tie between frequencies, the order is still deterministic, but
     # may be different from the result from native pandas. Snowpark pandas will
     # always respect the order of insertion during ties. Native pandas is not
     # deterministic since the original order/order of insertion is based on the
@@ -146,3 +180,123 @@ def test_series_value_counts(native_series, normalize, sort, ascending, dropna):
             normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "native_series, expected, normalize, sort, ascending, dropna",
+    [
+        (
+            SERIES1,
+            native_pd.Series(
+                [0.04, 0.12, 0.12, 0.12, 0.12, 0.16, 0.16, 0.16],
+                index=[8, 1, 5, 6, 7, 2, 3, 4],
+                name="proportion",
+            ),
+            True,
+            True,
+            True,
+            True,
+        ),
+        (
+            SERIES1,
+            native_pd.Series(
+                [0.04, 0.12, 0.12, 0.12, 0.12, 0.16, 0.16, 0.16],
+                index=[8, 1, 5, 6, 7, 2, 3, 4],
+                name="proportion",
+            ),
+            True,
+            True,
+            True,
+            False,
+        ),
+        (
+            SERIES1,
+            native_pd.Series(
+                [1, 3, 3, 3, 3, 4, 4, 4], index=[8, 1, 5, 6, 7, 2, 3, 4], name="count"
+            ),
+            False,
+            True,
+            True,
+            True,
+        ),
+        (
+            SERIES1,
+            native_pd.Series(
+                [1, 3, 3, 3, 3, 4, 4, 4], index=[8, 1, 5, 6, 7, 2, 3, 4], name="count"
+            ),
+            False,
+            True,
+            True,
+            False,
+        ),
+        (
+            SERIES2,
+            native_pd.Series(
+                [0.04, 0.12, 0.12, 0.12, 0.12, 0.16, 0.16, 0.16],
+                index=["h", "a", "e", "f", "g", "b", "c", "d"],
+                name="proportion",
+            ),
+            True,
+            True,
+            True,
+            True,
+        ),
+        (
+            SERIES2,
+            native_pd.Series(
+                [0.04, 0.12, 0.12, 0.12, 0.12, 0.16, 0.16, 0.16],
+                index=["h", "a", "e", "f", "g", "b", "c", "d"],
+                name="proportion",
+            ),
+            True,
+            True,
+            True,
+            False,
+        ),
+        (
+            SERIES2,
+            native_pd.Series(
+                [1, 3, 3, 3, 3, 4, 4, 4],
+                index=["h", "a", "e", "f", "g", "b", "c", "d"],
+                name="count",
+            ),
+            False,
+            True,
+            True,
+            True,
+        ),
+        (
+            SERIES2,
+            native_pd.Series(
+                [1, 3, 3, 3, 3, 4, 4, 4],
+                index=["h", "a", "e", "f", "g", "b", "c", "d"],
+                name="count",
+            ),
+            False,
+            True,
+            True,
+            False,
+        ),
+    ],
+)
+@sql_count_checker(query_count=1)
+def test_series_value_counts_non_deterministic_pandas_behavior(
+    native_series, expected, normalize, sort, ascending, dropna
+):
+    # Native pandas produces different results locally and on Jenkins when the above data is used.
+    # Therefore, explicitly compare the actual and expected results.
+
+    # If `sort=True`, sort by the frequencies. If `sort=False`, maintain the original ordering.
+    # `ascending` controls whether to sort the count in ascending or descending order.
+
+    # When there is a tie between frequencies, the order is still deterministic, but
+    # may be different from the result from native pandas. Snowpark pandas will
+    # always respect the order of insertion during ties. Native pandas is not
+    # deterministic since the original order/order of insertion is based on the
+    # Python hashmap which may produce different results on different versions.
+    # Refer to: https://github.com/pandas-dev/pandas/issues/15833
+    snow_series = pd.Series(native_series)
+    actual = snow_series.value_counts(
+        normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
+    )
+    assert_series_equal(actual, expected)

--- a/tests/integ/modin/series/test_value_counts.py
+++ b/tests/integ/modin/series/test_value_counts.py
@@ -31,11 +31,11 @@ NATIVE_SERIES_TEST_DATA = [
     native_pd.Series(
         [1, 2, 3, 2, 3, 5, 6, 7, 8, 4, 4, 5, 6, 7, 1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 7]
     ),
-    # native_pd.Series([1.1, 2.2, 1.0, 1, 1.1, 2.2, 1, 1, 1, 2, 2, 2, 2.2]),
-    # native_pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]),
-    # native_pd.Series(
-    #     [True, False, True, False, True, False, True, False, True, True], dtype=bool
-    # ),
+    native_pd.Series([1.1, 2.2, 1.0, 1, 1.1, 2.2, 1, 1, 1, 2, 2, 2, 2.2]),
+    native_pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]),
+    native_pd.Series(
+        [True, False, True, False, True, False, True, False, True, True], dtype=bool
+    ),
     native_pd.Series(
         [
             "a",
@@ -124,25 +124,21 @@ def test_value_counts_bins():
 
 @pytest.mark.parametrize("native_series", NATIVE_SERIES_TEST_DATA)
 @pytest.mark.parametrize("normalize", [True, False])
-@pytest.mark.parametrize("sort", [True])
+@pytest.mark.parametrize("sort", [True, False])
 @pytest.mark.parametrize("ascending", [True, False])
 @pytest.mark.parametrize("dropna", [True, False])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=1)
 def test_series_value_counts(native_series, normalize, sort, ascending, dropna):
+    # If `sort=True`, sort by the count. If `sort=False`, maintain the original ordering.
+    # `ascending` controls whether to sort the count in ascending or descending order.
+
+    # When there is a tie between counts, the order is still deterministic, but
+    # may be different from the result from native pandas. Snowpark pandas will
+    # always respect the order of insertion during ties. Native pandas is not
+    # deterministic since the original order/order of insertion is based on the
+    # Python hashmap which may produce different results on different versions.
+    # Refer to: https://github.com/pandas-dev/pandas/issues/15833
     snow_series = pd.Series(native_series)
-    print(f"\n___PANDAS VERSION___\n{native_pd.__version__}")
-    print("\n___NATIVE PANDAS VALUE COUNTS RESULT___")
-    print(
-        native_series.value_counts(
-            normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
-        )
-    )
-    print("\nSNOWPARK PANDAS VALUE COUNTS RESULT___")
-    print(
-        snow_series.value_counts(
-            normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
-        )
-    )
     eval_snowpark_pandas_result(
         snow_series,
         native_series,

--- a/tests/integ/modin/series/test_value_counts.py
+++ b/tests/integ/modin/series/test_value_counts.py
@@ -29,42 +29,10 @@ TEST_NULL_DATA = [
 
 
 NATIVE_SERIES_TEST_DATA = [
-    native_pd.Series(
-        [1, 2, 3, 2, 3, 5, 6, 7, 8, 4, 4, 5, 6, 7, 1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 7]
-    ),
     native_pd.Series([1.1, 2.2, 1.0, 1, 1.1, 2.2, 1, 1, 1, 2, 2, 2, 2.2]),
     native_pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]),
     native_pd.Series(
         [True, False, True, False, True, False, True, False, True, True], dtype=bool
-    ),
-    native_pd.Series(
-        [
-            "a",
-            "b",
-            "c",
-            "b",
-            "c",
-            "e",
-            "f",
-            "g",
-            "h",
-            "d",
-            "d",
-            "e",
-            "f",
-            "g",
-            "a",
-            "b",
-            "a",
-            "b",
-            "c",
-            "d",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-        ]
     ),
 ]
 

--- a/tests/integ/modin/series/test_value_counts.py
+++ b/tests/integ/modin/series/test_value_counts.py
@@ -31,11 +31,11 @@ NATIVE_SERIES_TEST_DATA = [
     native_pd.Series(
         [1, 2, 3, 2, 3, 5, 6, 7, 8, 4, 4, 5, 6, 7, 1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 7]
     ),
-    native_pd.Series([1.1, 2.2, 1.0, 1, 1.1, 2.2, 1, 1, 1, 2, 2, 2, 2.2]),
-    native_pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]),
-    native_pd.Series(
-        [True, False, True, False, True, False, True, False, True, True], dtype=bool
-    ),
+    # native_pd.Series([1.1, 2.2, 1.0, 1, 1.1, 2.2, 1, 1, 1, 2, 2, 2, 2.2]),
+    # native_pd.Series([1, 3, 1, 1, 1, 3, 1, 1, 1, 2, 2, 2, 3]),
+    # native_pd.Series(
+    #     [True, False, True, False, True, False, True, False, True, True], dtype=bool
+    # ),
     native_pd.Series(
         [
             "a",
@@ -124,12 +124,25 @@ def test_value_counts_bins():
 
 @pytest.mark.parametrize("native_series", NATIVE_SERIES_TEST_DATA)
 @pytest.mark.parametrize("normalize", [True, False])
-@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("sort", [True])
 @pytest.mark.parametrize("ascending", [True, False])
 @pytest.mark.parametrize("dropna", [True, False])
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_series_value_counts(native_series, normalize, sort, ascending, dropna):
     snow_series = pd.Series(native_series)
+    print(f"\n___PANDAS VERSION___\n{native_pd.__version__}")
+    print("\n___NATIVE PANDAS VALUE COUNTS RESULT___")
+    print(
+        native_series.value_counts(
+            normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
+        )
+    )
+    print("\nSNOWPARK PANDAS VALUE COUNTS RESULT___")
+    print(
+        snow_series.value_counts(
+            normalize=normalize, sort=sort, ascending=ascending, dropna=dropna
+        )
+    )
     eval_snowpark_pandas_result(
         snow_series,
         native_series,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1527038

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

This PR is here since there were some issues with running the `series/test_value_counts.py::test_series_value_counts` test. When run locally, the Snowpark pandas output matches native pandas. However, when run on Jenkins, the output differs.

Jenkins runs to refer to: prod runs 604, 605, and 606 (this run has clearer console output so that you can see the difference).

On closer inspection, the Snowpark pandas output is deterministic - native pandas' output is the one that differed on both platforms. 

There are two parameters to `Series.value_counts` that control the ordering: `sort` and `ascending`. `sort` sorts the value counts when True. `ascending` specifies whether this count is going to be sorted in ascending order or descending order. 

In the event of a tie, native pandas is supposed to respect the original ordering in the Series. This is done with the help of Python hashmaps. However, the hashmap's behavior can differ based on Python versions and platforms, making the result of `value_counts` in native Pandas non-deterministic. Snowpark pandas does not have this determinism issue and respects the original ordering in the Series.

Refer to pandas GitHub issue: https://github.com/pandas-dev/pandas/issues/15833

This PR is to make this behavior clear in the Series documentation and in the test where this discrepancy arises.