### PR TITLE
[SNOW-1533733] Add execution_queries property for SnowflakePlan to get the final query will be sent over to server for execution

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -250,6 +250,14 @@ class SnowflakePlan(LogicalPlan):
 
     @property
     def execution_queries(self) -> Dict["PlanQueryType", List["Query"]]:
+        """
+        Get the list of queries that will be sent over to server evaluation. The queries
+        have optimizations applied of optimizations are enabled.
+
+        Returns
+        -------
+        A mapping between the PlanQueryType and the list of Queries corresponds to the type.
+        """
         # apply optimizations
         final_plan = self.replace_repeated_subquery_with_cte()
         return {

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -254,7 +254,7 @@ class SnowflakePlan(LogicalPlan):
         final_plan = self.replace_repeated_subquery_with_cte()
         return {
             PlanQueryType.QUERIES: final_plan.queries,
-            PlanQueryType.POST_ACTIONS: final_plan.post_actions
+            PlanQueryType.POST_ACTIONS: final_plan.post_actions,
         }
 
     @property
@@ -1403,6 +1403,7 @@ class SnowflakePlanBuilder:
                 api_calls=plan.api_calls,
                 session=self.session,
             )
+
 
 class PlanQueryType(Enum):
     # the queries to execute for the plan

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -42,8 +42,8 @@ from snowflake.snowpark._internal.analyzer.schema_utils import (
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan import (
     BatchInsertQuery,
-    SnowflakePlan,
     PlanQueryType,
+    SnowflakePlan,
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.telemetry import TelemetryClient

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -43,6 +43,7 @@ from snowflake.snowpark._internal.analyzer.schema_utils import (
 from snowflake.snowpark._internal.analyzer.snowflake_plan import (
     BatchInsertQuery,
     SnowflakePlan,
+    PlanQueryType,
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.telemetry import TelemetryClient
@@ -561,21 +562,23 @@ class ServerConnection:
     ]:
         action_id = plan.session._generate_new_action_id()
         # potentially optimize the query using CTEs
-        plan = plan.replace_repeated_subquery_with_cte()
+        # plan = plan.replace_repeated_subquery_with_cte()
+        plan_queries = plan.execution_queries
         result, result_meta = None, None
         try:
+            main_queries = plan_queries[PlanQueryType.QUERIES]
             placeholders = {}
             is_batch_insert = False
-            for q in plan.queries:
+            for q in main_queries:
                 if isinstance(q, BatchInsertQuery):
                     is_batch_insert = True
                     break
             # since batch insert does not support async execution (? in the query), we handle it separately here
-            if len(plan.queries) > 1 and not block and not is_batch_insert:
+            if len(main_queries) > 1 and not block and not is_batch_insert:
                 params = []
                 final_queries = []
                 last_place_holder = None
-                for q in plan.queries:
+                for q in main_queries:
                     final_queries.append(
                         q.sql.replace(f"'{last_place_holder}'", "LAST_QUERY_ID()")
                         if last_place_holder
@@ -588,13 +591,13 @@ class ServerConnection:
                     ";".join(final_queries),
                     to_pandas,
                     to_iter,
-                    is_ddl_on_temp_object=plan.queries[0].is_ddl_on_temp_object,
+                    is_ddl_on_temp_object=main_queries[0].is_ddl_on_temp_object,
                     block=block,
                     data_type=data_type,
                     async_job_plan=plan,
                     log_on_exception=log_on_exception,
                     case_sensitive=case_sensitive,
-                    num_statements=len(plan.queries),
+                    num_statements=len(main_queries),
                     params=params,
                     ignore_results=ignore_results,
                     **kwargs,
@@ -606,18 +609,18 @@ class ServerConnection:
                 if action_id < plan.session._last_canceled_id:
                     raise SnowparkClientExceptionMessages.SERVER_QUERY_IS_CANCELLED()
             else:
-                for i, query in enumerate(plan.queries):
+                for i, query in enumerate(main_queries):
                     if isinstance(query, BatchInsertQuery):
                         self.run_batch_insert(query.sql, query.rows, **kwargs)
                     else:
-                        is_last = i == len(plan.queries) - 1 and not block
+                        is_last = i == len(main_queries) - 1 and not block
                         final_query = query.sql
                         for holder, id_ in placeholders.items():
                             final_query = final_query.replace(holder, id_)
                         result = self.run_query(
                             final_query,
                             to_pandas,
-                            to_iter and (i == len(plan.queries) - 1),
+                            to_iter and (i == len(main_queries) - 1),
                             is_ddl_on_temp_object=query.is_ddl_on_temp_object,
                             block=not is_last,
                             data_type=data_type,
@@ -637,7 +640,7 @@ class ServerConnection:
         finally:
             # delete created tmp object
             if block:
-                for action in plan.post_actions:
+                for action in plan_queries[PlanQueryType.POST_ACTIONS]:
                     self.run_query(
                         action.sql,
                         is_ddl_on_temp_object=action.is_ddl_on_temp_object,

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -561,8 +561,6 @@ class ServerConnection:
         Union[List[ResultMetadata], List["ResultMetadataV2"]],
     ]:
         action_id = plan.session._generate_new_action_id()
-        # potentially optimize the query using CTEs
-        # plan = plan.replace_repeated_subquery_with_cte()
         plan_queries = plan.execution_queries
         result, result_meta = None, None
         try:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4055,8 +4055,12 @@ class DataFrame:
         # plan = self._plan.replace_repeated_subquery_with_cte()
         plan_queries = self._plan.execution_queries
         return {
-            "queries": [query.sql.strip() for query in plan_queries[PlanQueryType.QUERIES]],
-            "post_actions": [query.sql.strip() for query in plan_queries[PlanQueryType.POST_ACTIONS]],
+            "queries": [
+                query.sql.strip() for query in plan_queries[PlanQueryType.QUERIES]
+            ],
+            "post_actions": [
+                query.sql.strip() for query in plan_queries[PlanQueryType.POST_ACTIONS]
+            ],
         }
 
     def explain(self) -> None:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4052,7 +4052,6 @@ class DataFrame:
         evaluate this DataFrame with the key `queries`, and a list of post-execution
         actions (e.g., queries to clean up temporary objects) with the key `post_actions`.
         """
-        # plan = self._plan.replace_repeated_subquery_with_cte()
         plan_queries = self._plan.execution_queries
         return {
             "queries": [
@@ -4074,7 +4073,6 @@ class DataFrame:
         print(self._explain_string())  # noqa: T201: we need to print here.
 
     def _explain_string(self) -> str:
-        # plan = self._plan.replace_repeated_subquery_with_cte()
         plan_queries = self._plan.execution_queries[PlanQueryType.QUERIES]
         output_queries = "\n---\n".join(
             f"{i+1}.\n{query.sql.strip()}" for i, query in enumerate(plan_queries)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -55,6 +55,7 @@ from snowflake.snowpark._internal.analyzer.select_statement import (
     SelectStatement,
     SelectTableFunction,
 )
+from snowflake.snowpark._internal.analyzer.snowflake_plan import PlanQueryType
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     CopyIntoTableNode,
     Limit,
@@ -4051,10 +4052,11 @@ class DataFrame:
         evaluate this DataFrame with the key `queries`, and a list of post-execution
         actions (e.g., queries to clean up temporary objects) with the key `post_actions`.
         """
-        plan = self._plan.replace_repeated_subquery_with_cte()
+        # plan = self._plan.replace_repeated_subquery_with_cte()
+        plan_queries = self._plan.execution_queries
         return {
-            "queries": [query.sql.strip() for query in plan.queries],
-            "post_actions": [query.sql.strip() for query in plan.post_actions],
+            "queries": [query.sql.strip() for query in plan_queries[PlanQueryType.QUERIES]],
+            "post_actions": [query.sql.strip() for query in plan_queries[PlanQueryType.POST_ACTIONS]],
         }
 
     def explain(self) -> None:
@@ -4068,20 +4070,21 @@ class DataFrame:
         print(self._explain_string())  # noqa: T201: we need to print here.
 
     def _explain_string(self) -> str:
-        plan = self._plan.replace_repeated_subquery_with_cte()
+        # plan = self._plan.replace_repeated_subquery_with_cte()
+        plan_queries = self._plan.execution_queries[PlanQueryType.QUERIES]
         output_queries = "\n---\n".join(
-            f"{i+1}.\n{query.sql.strip()}" for i, query in enumerate(plan.queries)
+            f"{i+1}.\n{query.sql.strip()}" for i, query in enumerate(plan_queries)
         )
         msg = f"""---------DATAFRAME EXECUTION PLAN----------
 Query List:
 {output_queries}"""
         # if query list contains more then one queries, skip execution plan
-        if len(plan.queries) == 1:
-            exec_plan = self._session._explain_query(plan.queries[0].sql)
+        if len(plan_queries) == 1:
+            exec_plan = self._session._explain_query(plan_queries[0].sql)
             if exec_plan:
                 msg = f"{msg}\nLogical Execution Plan:\n{exec_plan}"
             else:
-                msg = f"{plan.queries[0].sql} can't be explained"
+                msg = f"{plan_queries[0].sql} can't be explained"
 
         return f"{msg}\n--------------------------------------------"
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -95,7 +95,11 @@ from snowflake.snowpark._internal.analyzer.expression import (
     SubfieldString,
     UnresolvedAttribute,
 )
-from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
+from snowflake.snowpark._internal.analyzer.snowflake_plan import (
+    PlanQueryType,
+    Query,
+    SnowflakePlan,
+)
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     LogicalPlan,
     Range,
@@ -216,6 +220,13 @@ class MockExecutionPlan(LogicalPlan):
     @property
     def post_actions(self):
         return []
+
+    @property
+    def execution_queries(self) -> Dict[PlanQueryType, List[Query]]:
+        return {
+            PlanQueryType.QUERIES: self.queries,
+            PlanQueryType.POST_ACTIONS: self.post_actions,
+        }
 
 
 class MockFileOperation(MockExecutionPlan):

--- a/tests/perf/perf_runner.py
+++ b/tests/perf/perf_runner.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
         print("SQL execution time elapsed: ", t2 - t1)
         print("Total execution time elapsed: ", t2 - t0)
         if args.cte:
-            _ = dataframe._plan.replace_repeated_subquery_with_cte()
+            _ = dataframe._plan.execution_queries
             t3 = time.time()
             print("CTE optimization client time elapsed: ", t3 - t2)
     finally:

--- a/tests/perf/perf_runner.py
+++ b/tests/perf/perf_runner.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
         print("SQL execution time elapsed: ", t2 - t1)
         print("Total execution time elapsed: ", t2 - t0)
         if args.cte:
-            _ = dataframe._plan.execution_queries
+            _ = dataframe.queries
             t3 = time.time()
             print("CTE optimization client time elapsed: ", t3 - t2)
     finally:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
SNOW-1533733

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] This is a pure refactoring change, relying on the existing testing to be finished.

3. Please describe how your code solves the related issue.

With https://docs.google.com/document/d/1DKFgGOHSTuI8gvHOaU2Xj_wzfFvMSPuKKtLgDxfvNeA/edit?pli=1, we are separating queries used for final execution and queries for intermediate process, and the queries for final execution will have optimizations applied.

In this pr, we add a new property execution_queries for the SnowflakePlan, which is used to get the final query will be sent over to server for execution, the returned exuecution_queries will have optimization applied if the optimization is enabeld.

