### PR TITLE
[Prototype] Snowpandas non deterministic mode

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
@@ -301,6 +301,7 @@ def compute_bin_indices(
         + [new_data_identifier],
         ordering_columns=[OrderingColumn(value_row_position_identifier)],
         row_position_snowflake_quoted_identifier=value_row_position_identifier,
+        ordering_enforced=values_frame.ordered_dataframe.ordering_enforced,
     )
 
     new_frame = InternalFrame.create(

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -756,4 +756,5 @@ def perform_asof_join_on_frame(
             left_timecol_snowflake_quoted_identifier
         ],
         data_column_pandas_index_names=referenced_frame.data_column_pandas_index_names,
+        ordering_enforced=preserving_frame.ordered_dataframe.ordering_enforced or referenced_frame.ordered_dataframe.ordering_enforced
     )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -727,7 +727,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         name_or_query: Union[str, Iterable[str]],
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
-        deterministic_ordering: bool = True,
+        ordering_enforced: bool = True,
     ) -> "SnowflakeQueryCompiler":
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
@@ -741,7 +741,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             ordered_dataframe,
             row_position_snowflake_quoted_identifier,
         ) = create_initial_ordered_dataframe(
-            table_name_or_query=name_or_query, deterministic_ordering=deterministic_ordering
+            table_name_or_query=name_or_query,
+            ordering_enforced=ordering_enforced,
         )
         pandas_labels_to_snowflake_quoted_identifiers_map = {
             # pandas labels of resulting Snowpark pandas dataframe will be snowflake identifier
@@ -4818,6 +4819,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             projected_column_snowflake_quoted_identifiers=data_column_snowflake_quoted_identifiers,
             ordering_columns=ordering_columns,
             row_position_snowflake_quoted_identifier=query_compiler._modin_frame.row_position_snowflake_quoted_identifier,
+            ordering_enforced=ordered_frame.ordering_enforced,
         )
 
         new_col_map = {}
@@ -11745,6 +11747,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             sampled_row_positions_odf = OrderedDataFrame(
                 dataframe_ref=DataFrameReference(sampled_row_positions_snowpark_frame),
                 projected_column_snowflake_quoted_identifiers=snowflake_quoted_identifiers,
+                ordering_enforced=self._modin_frame.ordered_dataframe.ordering_enforced,
             )
             sampled_odf = cache_result(
                 sampled_row_positions_odf.join(
@@ -15792,7 +15795,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     frame.ordered_dataframe._dataframe_ref.snowpark_dataframe.agg(
                         new_columns
                     )
-                )
+                ),
+                ordering_enforced=frame.ordered_dataframe.ordering_enforced,
             )
 
             new_frame = InternalFrame.create(

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -293,8 +293,8 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     check_valid_pandas_labels,
     count_rows,
     create_frame_with_data_columns,
+    create_initial_ordered_dataframe,
     create_ordered_dataframe_from_pandas,
-    create_ordered_dataframe_with_readonly_temp_table,
     extract_all_duplicates,
     extract_pandas_label_from_snowflake_quoted_identifier,
     fill_missing_levels_for_pandas_label,
@@ -727,6 +727,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         name_or_query: Union[str, Iterable[str]],
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
+        determistic_ordering: bool = True,
     ) -> "SnowflakeQueryCompiler":
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
@@ -739,8 +740,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         (
             ordered_dataframe,
             row_position_snowflake_quoted_identifier,
-        ) = create_ordered_dataframe_with_readonly_temp_table(
-            table_name_or_query=name_or_query
+        ) = create_initial_ordered_dataframe(
+            table_name_or_query=name_or_query, determistic_ordering=determistic_ordering
         )
         pandas_labels_to_snowflake_quoted_identifiers_map = {
             # pandas labels of resulting Snowpark pandas dataframe will be snowflake identifier

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -727,7 +727,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         name_or_query: Union[str, Iterable[str]],
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
-        determistic_ordering: bool = True,
+        deterministic_ordering: bool = True,
     ) -> "SnowflakeQueryCompiler":
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
@@ -741,7 +741,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             ordered_dataframe,
             row_position_snowflake_quoted_identifier,
         ) = create_initial_ordered_dataframe(
-            table_name_or_query=name_or_query, determistic_ordering=determistic_ordering
+            table_name_or_query=name_or_query, deterministic_ordering=deterministic_ordering
         )
         pandas_labels_to_snowflake_quoted_identifiers_map = {
             # pandas labels of resulting Snowpark pandas dataframe will be snowflake identifier

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -30,7 +30,7 @@ def read_snowflake(
     name_or_query: Union[str, Iterable[str]],
     index_col: Union[str, list[str], None] = None,
     columns: Optional[list[str]] = None,
-    deterministic_ordering:bool=True, 
+    ordering_enforced: bool = True,
 ) -> DataFrame:
     """
     Read a Snowflake table or SQL Query to a Snowpark pandas DataFrame.
@@ -359,7 +359,10 @@ def read_snowflake(
 
     return DataFrame(
         query_compiler=FactoryDispatcher.read_snowflake(
-            name_or_query, index_col=index_col, columns=columns, deterministic_ordering=deterministic_ordering
+            name_or_query,
+            index_col=index_col,
+            columns=columns,
+            ordering_enforced=ordering_enforced,
         )
     )
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -30,6 +30,7 @@ def read_snowflake(
     name_or_query: Union[str, Iterable[str]],
     index_col: Union[str, list[str], None] = None,
     columns: Optional[list[str]] = None,
+    deterministic_ordering:bool=True, 
 ) -> DataFrame:
     """
     Read a Snowflake table or SQL Query to a Snowpark pandas DataFrame.
@@ -358,7 +359,7 @@ def read_snowflake(
 
     return DataFrame(
         query_compiler=FactoryDispatcher.read_snowflake(
-            name_or_query, index_col=index_col, columns=columns
+            name_or_query, index_col=index_col, columns=columns, deterministic_ordering=deterministic_ordering
         )
     )
 

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -182,14 +182,14 @@ class PandasOnSnowflakeIO(BaseIO):
         name_or_query: Union[str, Iterable[str]],
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
-        determistic_ordering=True,
+        deterministic_ordering=True,
     ):
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/pandas/io.py
         """
         return cls.query_compiler_cls.from_snowflake(
-            name_or_query, index_col, columns, determistic_ordering
+            name_or_query, index_col, columns, deterministic_ordering
         )
 
     @classmethod

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -182,12 +182,15 @@ class PandasOnSnowflakeIO(BaseIO):
         name_or_query: Union[str, Iterable[str]],
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
+        determistic_ordering=True,
     ):
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/pandas/io.py
         """
-        return cls.query_compiler_cls.from_snowflake(name_or_query, index_col, columns)
+        return cls.query_compiler_cls.from_snowflake(
+            name_or_query, index_col, columns, determistic_ordering
+        )
 
     @classmethod
     def to_snowflake(

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -182,14 +182,14 @@ class PandasOnSnowflakeIO(BaseIO):
         name_or_query: Union[str, Iterable[str]],
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
-        deterministic_ordering=True,
+        ordering_enforced=True,
     ):
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/pandas/io.py
         """
         return cls.query_compiler_cls.from_snowflake(
-            name_or_query, index_col, columns, deterministic_ordering
+            name_or_query, index_col, columns, ordering_enforced
         )
 
     @classmethod

--- a/tests/integ/modin/test_utils.py
+++ b/tests/integ/modin/test_utils.py
@@ -16,7 +16,7 @@ from snowflake.snowpark.modin.pandas.utils import (
     try_convert_index_to_native,
 )
 from snowflake.snowpark.modin.plugin._internal.utils import (
-    create_ordered_dataframe_with_readonly_temp_table,
+    create_initial_ordered_dataframe,
 )
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import assert_index_equal
@@ -34,7 +34,7 @@ def test_create_snowpark_dataframe_with_readonly_temp_table(session, columns):
     (
         ordered_df,
         row_position_quoted_identifier,
-    ) = create_ordered_dataframe_with_readonly_temp_table(test_table_name)
+    ) = create_initial_ordered_dataframe(test_table_name)
 
     # verify the ordered df columns are row_position_quoted_identifier + quoted_identifiers
     assert ordered_df.projected_column_snowflake_quoted_identifiers == [


### PR DESCRIPTION
# Unordered Snowpandas
## Problem
Ordering for DataFrames is not needed in many common data engineering problems. Ordering semantics are enforced by materializing data to a temp table, which can be expensive depending on the dataset size. In other cases a customer may not be able to create a temp table. Beyond the creation of the initial temp table ordering semantics are enforced in each query.
## Proposal
We allow users to specify non-deterministic ordering mode with the parameter `deterministic_ordering=False` on the `read_snowflake` call. This will skip the temp table creation. This mode will also be set as a local variable on the OrderedDataFrame, where, despite the class name, we will circumvent the ordering directives as needed. This second effort (removing ORDER BY in queries ) will be an ongoing optimization effort after the initial parameter is checked in.
## Implementation
For the first effort to remove the temp table creation we will modify the read_snowflake, from_snowflake, and early dataframe creation methods. 
* `modin/plugin/_internal/utils.py`
* `modin/plugin/compiler/snowflake_query_compiler.py`
* `snowpark/modin/plugin/io/snow_io.py`

Additional optimizations to remove `ORDER BY` will require some on-going effort to determine whether the semantics of each individual API call can support non-deterministic ordering. Some operations such as `df.where`, or `pd.concat` should be OK, but operations like pivot and operations which are sensitive to the index may need a more detailed analysis.