### PR TITLE
[SNOW-1545149] Ensure source plan is attached for Table and View create SnowflakePlan

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -981,7 +981,7 @@ class Analyzer:
                 ],
                 logical_plan.comment,
                 resolved_children[logical_plan.children[0]],
-                logical_plan
+                logical_plan,
             )
 
         if isinstance(logical_plan, Limit):
@@ -1110,6 +1110,7 @@ class Analyzer:
                 resolved_children[logical_plan.child],
                 is_temp,
                 logical_plan.comment,
+                logical_plan,
             )
 
         if isinstance(logical_plan, CreateDynamicTableCommand):
@@ -1119,6 +1120,7 @@ class Analyzer:
                 logical_plan.lag,
                 logical_plan.comment,
                 resolved_children[logical_plan.child],
+                logical_plan,
             )
 
         if isinstance(logical_plan, CopyIntoTableNode):
@@ -1135,6 +1137,7 @@ class Analyzer:
                 path=logical_plan.file_path,
                 table_name=logical_plan.table_name,
                 files=logical_plan.files,
+                source_plan=logical_plan,
                 pattern=logical_plan.pattern,
                 file_format=logical_plan.file_format,
                 format_type_options=format_type_options,
@@ -1155,6 +1158,7 @@ class Analyzer:
             return self.plan_builder.copy_into_location(
                 query=resolved_children[logical_plan.child],
                 stage_location=logical_plan.stage_location,
+                source_plan=logical_plan,
                 partition_by=self.analyze(
                     logical_plan.partition_by, df_aliased_col_name_to_real_col_name
                 )

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -981,6 +981,7 @@ class Analyzer:
                 ],
                 logical_plan.comment,
                 resolved_children[logical_plan.children[0]],
+                logical_plan
             )
 
         if isinstance(logical_plan, Limit):

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -301,8 +301,8 @@ class SnowflakePlan(LogicalPlan):
         # When the source plan node is an instance of nodes in pre_handled_logical_node,
         # the cte optimization has been pre-handled during the plan build step, skip the
         # optimization step for now.
-        # Once SNOW-1541094 is done, we will be able to unify all the optimization steps, and
-        # there is no need for such check anymore.
+        # TODO: Once SNOW-1541094 is done, we will be able to unify all the optimization steps, and
+        #       there is no need for such check anymore.
         pre_handled_logical_node = (
             CreateDynamicTableCommand,
             CreateViewCommand,

--- a/src/snowflake/snowpark/mock/_analyzer.py
+++ b/src/snowflake/snowpark/mock/_analyzer.py
@@ -764,6 +764,7 @@ class MockAnalyzer:
             return self.plan_builder.copy_into_location(
                 query=resolved_children[logical_plan.child],
                 stage_location=logical_plan.stage_location,
+                source_plan=logical_plan,
                 partition_by=self.analyze(logical_plan.partition_by, expr_to_alias)
                 if logical_plan.partition_by
                 else None,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -206,7 +206,8 @@ def test_same_duplicate_subtree(session):
     assert count_number_of_ctes(df_result2.queries["queries"][-1]) == 3
 
 
-@pytest.mark.parametrize("mode", ["append", "overwrite", "errorifexists", "ignore"])
+# @pytest.mark.parametrize("mode", ["append", "overwrite", "errorifexists", "ignore"])
+@pytest.mark.parametrize("mode", ["append"])
 def test_save_as_table(session, mode):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     with session.query_history() as query_history:

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -206,8 +206,7 @@ def test_same_duplicate_subtree(session):
     assert count_number_of_ctes(df_result2.queries["queries"][-1]) == 3
 
 
-# @pytest.mark.parametrize("mode", ["append", "overwrite", "errorifexists", "ignore"])
-@pytest.mark.parametrize("mode", ["append"])
+@pytest.mark.parametrize("mode", ["append", "overwrite", "errorifexists", "ignore"])
 def test_save_as_table(session, mode):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     with session.query_history() as query_history:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1545149

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Theoretically, all snowflake plan should be associated with a source logical plan, however, the SnowflakePlan resolved for table/view create node doesn't have any source plan associated with it. Furthermore, the newly added compilation stage performs optimization on the logical plan level, missing source logical plan can miss some optimization opportunity.

In this pr, we ensures the original source plan is attached for the create table/view nodes.
