### PR TITLE
SNOW-1545615: Change snowflake.snowpark.modin.pandas to modin.pandas in DF/Series doc generation

### DIFF
--- a/docs/source/_templates/autosummary/modin_accessor.rst
+++ b/docs/source/_templates/autosummary/modin_accessor.rst
@@ -1,0 +1,6 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. automodinaccessor:: {{ objname }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,9 +148,17 @@ class ModinAccessorDocumenter(PropertyDocumenter):
     priority = 0.55
 
     def import_object(self, raiseerror=False):
+        # Set `self.object` and related fields after importing the object, since sphinx has difficulty
+        # trying to import the top-level Series.str and Series.dt objects.
+        # Returns True if the object was successfully imported.
+        # See definition on parent classes:
+        # https://github.com/sphinx-doc/sphinx/blob/907d27dc6506c542c11a7dd16b560eb4be7da5fc/sphinx/ext/autodoc/__init__.py#L2714
+        # https://github.com/sphinx-doc/sphinx/blob/907d27dc6506c542c11a7dd16b560eb4be7da5fc/sphinx/ext/autodoc/__init__.py#L400
         import modin.pandas as pd
         self.module = pd
         self.parent = pd.Series
+        # objpath is an array like ["Series", "str"]
+        # object_name should be the name of the property (in this case "str")
         self.object_name = self.objpath[-1]
         self.object = getattr(pd.Series, self.object_name)
         self.isclassmethod = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,8 +144,8 @@ class ModinAccessorDocumenter(PropertyDocumenter):
     objtype = "modinaccessor"
     directivetype = "attribute"
 
-    # lower priority than the other custom attribute documenter (defined below)
-    priority = 0.55
+    # lower priority than the default PropertyDocumenter so it is not chosen for normal properties
+    priority = 0.6
 
     def import_object(self, raiseerror=False):
         # Set `self.object` and related fields after importing the object, since sphinx has difficulty

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,7 +133,12 @@ class ModinAccessorDocumenter(PropertyDocumenter):
     Generates documentation for properties of Modin objects like Series.str and Series.dt that
     are themselves accessor classes.
     This class is necessary because we need to monkeypatch the Series.str/dt property objects
-    with the actual classes in order for autosummary-generate to produce stubs for them.
+    with the actual classes (StringMethods/DatetimeProperties) in order for autosummary-generate
+    to produce stubs for them. We override sphinx's `import_object` hook here to ensure it can
+    resolve these classes correctly.
+
+    TODO SNOW-1063347: check whether this is still needed after removing series.py since upstream
+    modin uses CachedAccessor wrapper for str/dt
 
     This class is not responsible for properties of those accessors like Series.str.capitalize.
 
@@ -301,6 +306,9 @@ def setup(app):
     # Because we're replacing the `property` object, we also need to set the __doc__ of the new
     # values of Series.str/dt to make sure autodoc can pick them up. The custom ModinAttributeDocumenter
     # class allows the top-level Series.str/dt objects to be properly documented.
+    #
+    # TODO SNOW-1063347: check whether this is still needed after removing series.py since upstream
+    # modin uses CachedAccessor wrapper for str/dt rather than a property
     old_series_dt = pd.Series.dt
     old_series_str = pd.Series.str
     pd.Series.dt = pd.series_utils.DatetimeProperties

--- a/docs/source/modin/dataframe.rst
+++ b/docs/source/modin/dataframe.rst
@@ -2,7 +2,7 @@
 DataFrame
 =============================
 
-.. currentmodule:: snowflake.snowpark.modin.pandas
+.. currentmodule:: modin.pandas
 .. rubric:: :doc:`All supported DataFrame APIs <supported/dataframe_supported>`
 
 .. rubric:: Constructor

--- a/docs/source/modin/series.rst
+++ b/docs/source/modin/series.rst
@@ -2,7 +2,7 @@
 Series
 =============================
 
-.. currentmodule:: snowflake.snowpark.modin.pandas
+.. currentmodule:: modin.pandas
 .. rubric:: :doc:`All supported Series APIs <supported/series_supported>`
 
 .. rubric:: Constructor
@@ -226,15 +226,10 @@ Series
 
 .. autosummary::
     :toctree: pandas_api/
+    :template: autosummary/modin_accessor.rst
 
     Series.str
     Series.dt
-
-
-.. Series.str and Series.dt are imported from upstream modin.pandas, so we need to swap
-.. the current module here.
-
-.. currentmodule:: modin.pandas
 
 
 .. rubric:: Datetime accessor properties

--- a/src/snowflake/snowpark/modin/pandas/io.py
+++ b/src/snowflake/snowpark/modin/pandas/io.py
@@ -514,7 +514,7 @@ def read_excel(
     storage_options: StorageOptions = None,
     dtype_backend: DtypeBackend | NoDefault = no_default,
     engine_kwargs: dict | None = None,
-) -> DataFrame | dict[IntStrT, DataFrame]:  # pragma: no cover
+) -> pd.DataFrame | dict[IntStrT, pd.DataFrame]:  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     from snowflake.snowpark.modin.core.execution.dispatching.factories.dispatcher import (
         FactoryDispatcher,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1545615

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

This PR adds extra customization to allow sphinx documentation to use `modin.pandas` as the defined module rather than `snowflake.snowpark.modin.pandas`, in anticipation of the removal of the vendored copies of our DataFrame and Series classes.

Currently, our rst files only reference `modin.pandas` for the `StringMethods` and `DatetimeProperties` classes, which are taken from upstream modin. The other `currentmodule `directives referencing `snowflake.snowpark.modin.pandas` would indirectly trigger an import of `snowflake.snowpark.modin.plugin`, which implicitly initialized the extension and set the correct docstrings. Now, with the absence of this `currentmodule` directives in `Series.rst`, we need to properly initialize the plugin to set the modin namespace correctly from within `conf.py`.

Unfortunately, this creates complications in documentation generation:
1. Sphinx's `autosummary-generate` script, responsible for generating stub .rst files (those found in `docs/source/pandas_api/`) recognizes `Series.str` and `Series.dt` as property objects rather than classes when trying to access properties like `Series.str.capitalize`, and errors out when trying to import them. It is unclear why this was not previously the case.
    - **Solution:** Within the `setup` function of `conf.py`, which runs before `autosummary-generate`, we replace `Series.str`/`dt` with the actual `StringMethods`/`DatetimeProperties` classes, allowing sphinx to correctly access their namespaces. However...
2. After monkeypatching `str`/`dt` to fix accesses to `Series.str.*` and `Series.dt.*`, sphinx now cannot document the top-level properties `Series.str` and `Series.dt`.
    - **Solution:** We create a custom template and directive (`modin_accessor.rst`, `automodinaccessor`) that controls name resolution for these top-level properties.

The change to the signature of pd.read_excel is necessary to circumvent an ambiguous reference warning, as for some reason sphinx cannot resolve whether the `DataFrame` in the return type is a `modin.pandas.DataFrame`, `snowflake.snowpark.modin.pandas.DataFrame`, or `snowpark.DataFrame`.