### PR TITLE
SNOW-1549173: Fix AssertionError in  Series/DataFrame drop_duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 #### Bug Fixes
 - Made passing an unsupported aggregation function to `pivot_table` raise `NotImplementedError` instead of `KeyError`.
 - Removed axis labels and callable names from error messages and telemetry about unsupported aggregations.
+- Fixed AssertionError in `Series.drop_duplicates` and `DataFrame.drop_duplicates` when called after `sort_values`.
+
 
 ## 1.20.0 (2024-07-17)
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -12819,7 +12819,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             data_column_pandas_index_names=frame.data_column_pandas_index_names,
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=[
-                frame.row_position_snowflake_quoted_identifier
+                row_position_post_dedup.row_position_snowflake_quoted_identifier
             ],
         )
 

--- a/tests/integ/modin/frame/test_drop_duplicates.py
+++ b/tests/integ/modin/frame/test_drop_duplicates.py
@@ -93,3 +93,18 @@ def test_drop_duplicates_on_empty_frame(subset, keep):
         check_dtype=False,
         check_index_type=False,
     )
+
+
+@sql_count_checker(query_count=1, join_count=2)
+def test_drop_duplicates_post_sort_values():
+    pandas_df = native_pd.DataFrame(
+        {"A": [0, 1, 1, 2, 0], "B": ["a", "b", "c", "b", "a"]}
+    )
+    snow_df = pd.DataFrame(pandas_df)
+
+    assert_frame_equal(
+        snow_df.sort_values("A").drop_duplicates(),
+        pandas_df.sort_values("A").drop_duplicates(),
+        check_dtype=False,
+        check_index_type=False,
+    )

--- a/tests/integ/modin/series/test_drop_duplicates.py
+++ b/tests/integ/modin/series/test_drop_duplicates.py
@@ -60,3 +60,16 @@ def test_drop_duplicates_nan_none(keep, expected):
         check_dtype=False,
         check_index_type=False,
     )
+
+
+@sql_count_checker(query_count=1, join_count=2)
+def test_drop_duplicates_post_sort_values():
+    pandas_ser = native_pd.Series(["a", "b", "b", "c", "a"], name="name")
+    snow_ser = pd.Series(pandas_ser)
+
+    assert_series_equal(
+        snow_ser.sort_values().drop_duplicates(),
+        pandas_ser.sort_values().drop_duplicates(),
+        check_dtype=False,
+        check_index_type=False,
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1549173

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Calling drop_duplicates on a Series or DataFrame where row_postion_column is not cached results in an error similar to following: `AssertionError: dataframe column="__row_position_gvdf__" not found in snowpark dataframe schema`. This happens due to incorrect reference to row_position_column from old frame. This PR fixes the issues by using the row position from updated frame.
