### PR TITLE
[SNOW-1551115] Fix test failure for test_execution_queries_and_queries when sql_simplifier is disabled

### DIFF
--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -169,6 +169,11 @@ def test_execution_queries_and_queries(session):
         # from the original plan queries
         session.cte_optimization_enabled = True
         check_plan_queries(
+            # the cte optimization is not kicking in when sql simplifier disabled, because
+            # the cte_optimization_enabled is set to False when constructing the plan for df2,
+            # and place_holder is not propogated.
+            # TODO (SNOW-1541096): revisit this test once the cte optimization is switched to the
+            #   new compilation infra.
             cte_applied=session.sql_simplifier_enabled,
             exec_queries=df2._plan.execution_queries,
         )

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -3,6 +3,7 @@
 #
 
 import sys
+from typing import Dict, List
 
 import pytest
 
@@ -130,32 +131,46 @@ def test_execution_queries_and_queries(session):
     # create a df where cte optimization can be applied
     df2 = df1.union(df1)
     original_cte_enabled_value = session.cte_optimization_enabled
+
+    plan_queries = {
+        PlanQueryType.QUERIES: df2._plan.queries,
+        PlanQueryType.POST_ACTIONS: df2._plan.post_actions,
+    }
+
+    def check_plan_queries(
+        cte_applied: bool, exec_queries: Dict[PlanQueryType, List["Query"]]
+    ) -> None:
+        assert (
+            exec_queries[PlanQueryType.POST_ACTIONS]
+            == plan_queries[PlanQueryType.POST_ACTIONS]
+            == []
+        )
+        if cte_applied:
+            assert (
+                exec_queries[PlanQueryType.QUERIES][-1].sql
+                != plan_queries[PlanQueryType.QUERIES][-1].sql
+            )
+            assert exec_queries[PlanQueryType.QUERIES][-1].sql.startswith("WITH")
+            assert not plan_queries[PlanQueryType.QUERIES][-1].sql.startswith("WITH")
+        else:
+            assert (
+                exec_queries[PlanQueryType.QUERIES]
+                == plan_queries[PlanQueryType.QUERIES]
+            )
+            assert not (exec_queries[PlanQueryType.QUERIES][-1].sql.startswith("WITH"))
+
     try:
         # when cte is disabled, verify that the execution query got is the same as
         # the plan queries and post actions
         session.cte_optimization_enabled = False
-        execution_queries = df2._plan.execution_queries
-        assert execution_queries[PlanQueryType.QUERIES] == df2._plan.queries
-        assert not (execution_queries[PlanQueryType.QUERIES][-1].sql.startswith("WITH"))
-        assert (
-            execution_queries[PlanQueryType.POST_ACTIONS]
-            == df2._plan.post_actions
-            == []
-        )
+        check_plan_queries(cte_applied=False, exec_queries=df2._plan.execution_queries)
+
         # when cte is enabled, verify that the execution query got is different
         # from the original plan queries
         session.cte_optimization_enabled = True
-        execution_queries = df2._plan.execution_queries
-        assert (
-            execution_queries[PlanQueryType.QUERIES][-1].sql
-            != df2._plan.queries[-1].sql
-        )
-        assert execution_queries[PlanQueryType.QUERIES][-1].sql.startswith("WITH")
-        assert not df2._plan.queries[-1].sql.startswith("WITH")
-        assert (
-            execution_queries[PlanQueryType.POST_ACTIONS]
-            == df2._plan.post_actions
-            == []
+        check_plan_queries(
+            cte_applied=session.sql_simplifier_enabled,
+            exec_queries=df2._plan.execution_queries,
         )
 
     finally:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

SNOW-1551115

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

 test_execution_queries_and_queries is failing when sql simplifier is disabled because the cte optimization actually didn't kick in. update test to verify the result based on the sql simplifier configuration
