### PR TITLE
SNOW-1552465: Push `result.name = None` from frontend to QC

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -2286,13 +2286,6 @@ class BasePandasDataset(metaclass=TelemetryMeta):
             **kwargs,
         )
         result_qc = self._reduce_dimension(result_qc)
-        # TODO: SNOW-1119855: Modin upgrade - modin.pandas.base.BasePandasDataset
-        # This pattern is seen throughout this file so we should try to correct it
-        # when we have a more general way of resetting the name to None
-        from snowflake.snowpark.modin.pandas import Series
-
-        if isinstance(result_qc, Series):
-            result_qc.name = None
         return result_qc
 
     def memory_usage(self, index=True, deep=False):  # noqa: PR01, RT01, D200
@@ -2381,14 +2374,10 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         Return number of unique elements in the `BasePandasDataset`.
         """
         # TODO: SNOW-1119855: Modin upgrade - modin.pandas.base.BasePandasDataset
-        from snowflake.snowpark.modin.pandas import Series
-
         axis = self._get_axis_number(axis)
         result = self._reduce_dimension(
             self._query_compiler.nunique(axis=axis, dropna=dropna)
         )
-        if isinstance(result, Series):
-            result.name = None
         return result
 
     def pad(

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -5415,6 +5415,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # In this branch, the concatenated frame is a 1-row frame, but needs to be converted
             # into a 1-column frame so the frontend can wrap it as a Series
             result = result.transpose_single_row()
+            # Set the single column's name to MODIN_UNNAMED_SERIES_LABEL
+            result = result.set_columns([MODIN_UNNAMED_SERIES_LABEL])
         return result
 
     def insert(
@@ -7797,7 +7799,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # Result is basically a series with the column labels as index and the distinct count as values
         # for each data column
         # frame holds rows with nunique values, but result must be a series so transpose single row
-        return self._nunique_columns(dropna).transpose_single_row()
+        result = self._nunique_columns(dropna).transpose_single_row()
+        # Set the single column's name to MODIN_UNNAMED_SERIES_LABEL
+        return result.set_columns([MODIN_UNNAMED_SERIES_LABEL])
 
     def unique(self) -> "SnowflakeQueryCompiler":
         """Compute unique elements for series. Preserves order of how elements are encountered. Keyword arguments are


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1552465

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

When a Snowpark pandas aggregation returns a Series, we often use `transpose_single_row` in the query compiler to force the result to conform to the expected dimensions. After this operation, the column name is the string "NULL", which we fix using an `isinstance(result, Series)` check that guards `result.name = None`. This check does not exist in modin, and for consistency with other methods that return a Series, the name setting operation should be performed within the query compiler.

This PR modifies the query compiler `agg` and `nunique` methods to set column names to `MODIN_UNNAMED_SERIES_LABEL` after calling `transpose_single_row`, and removes the name setting operation in the corresponding frontend methods. I opted to change the columns after rather than within `transpose_single_row` in case other query compiler options would want to set the resulting column name to something different.