### PR TITLE
SNOW-864083: Remove unnecessary count query from is_series_like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 #### Improvements
 - Removed the public preview warning message upon importing Snowpark pandas.
+- Removed unnecessary count query from `SnowflakeQueryCompiler.is_series_like` method.
 
 #### Bug Fixes
 - Made passing an unsupported aggregation function to `pivot_table` raise `NotImplementedError` instead of `KeyError`.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -7205,11 +7205,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns
         -------
         bool
-            Return True if QueryCompiler has a single column or single row, False
-             otherwise.
+            Return True if QueryCompiler has a single column, False otherwise.
         """
-        # TODO SNOW-864083: look into why len(self.index) == 1 is also considered as series-like
-        return self.get_axis_len(axis=1) == 1 or self.get_axis_len(axis=0) == 1
+        return self.get_axis_len(axis=1) == 1
 
     def pivot(
         self,

--- a/tests/integ/modin/frame/test_isin.py
+++ b/tests/integ/modin/frame/test_isin.py
@@ -197,7 +197,7 @@ def test_isin_with_Dataframe(df, other):
         else:
             values = other
         #  3 queries: 2 for the isin of which one is caused by set, 1 extra query to handle empty dataframe special case
-        return _test_isin_with_snowflake_logic(df, values, query_count=3)
+        return _test_isin_with_snowflake_logic(df, values, query_count=2)
 
     eval_snowpark_pandas_result(
         snow_df,
@@ -228,7 +228,7 @@ def test_isin_with_dict(df, values):
     )
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=1)
 def test_isin_duplicate_columns_negative():
     with pytest.raises(ValueError, match="cannot compute isin with a duplicate axis."):
         df = pd.DataFrame({"A": [1, 2, 3]})

--- a/tests/integ/modin/series/test_isin.py
+++ b/tests/integ/modin/series/test_isin.py
@@ -64,7 +64,7 @@ def _test_isin_with_snowflake_logic(s, values):
         # (native_pd.Series([2, 3], index=["A", "B"]), 1), # not supported anymore because of index type mismatch
         # (native_pd.Series(index=["A", "B"]), 1), # not supported anymore because of index type mismatch
         (native_pd.Series([None, -10]), 5),
-        (native_pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}), 5),
+        (native_pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}), 4),
         (native_pd.Index([4, 5, 6]), 5),
     ],
 )
@@ -114,7 +114,7 @@ def test_isin_with_incompatible_index(values, expected_query_count):
         ([], native_pd.Series([]), 5),
         ([1, 2, 3], native_pd.Series([]), 5),
         ([], native_pd.Series([2, 3, 4]), 5),
-        ([1, 2, 3, 8], native_pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), 5),
+        ([1, 2, 3, 8], native_pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), 4),
         (["A", "B", ""], [], 3),
         (["A", "B", ""], ["A"], 3),
         (["A", "B", ""], ["A", "B", "C", "D"], 3),


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-864083

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   In Snowpark pandas series is always is represented as single column query compiler, we don't need to check if query compiler represent single row.
