### PR TITLE
Fix Pandas FutureWarning about integer indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Fixed a bug that Window Functions LEAD and LAG do not handle option `ignore_nulls` properly.
 - Fixed a bug where values were not populated into the result DataFrame during the insertion of table merge operation.
 
+#### Improvements
+- Fix pandas FutureWarning about integer indexing.
+
 ### Snowpark pandas API Updates
 #### New Features
 - Added support for `DataFrame.backfill`, `DataFrame.bfill`, `Series.backfill`, and `Series.bfill`.

--- a/src/snowflake/snowpark/mock/_pandas_util.py
+++ b/src/snowflake/snowpark/mock/_pandas_util.py
@@ -78,9 +78,9 @@ def _extract_schema_and_data_from_pandas_df(
                     # pandas PANDAS_INTEGER_TYPES (e.g. INT8Dtye) will also store data in the format of float64
                     # here we use the col dtype info to convert data
                     plain_data[row_idx][col_idx] = (
-                        int(data.iloc[row_idx][col_idx])
-                        if isinstance(data.dtypes[col_idx], PANDAS_INTEGER_TYPES)
-                        else float(str(data.iloc[row_idx][col_idx]))
+                        int(data.iloc[row_idx, col_idx])
+                        if isinstance(data.dtypes.iloc[col_idx], PANDAS_INTEGER_TYPES)
+                        else float(str(data.iloc[row_idx, col_idx]))
                     )
             elif isinstance(plain_data[row_idx][col_idx], numpy.float32):
                 # convert str first and then to float to avoid precision drift as its stored in float32 format
@@ -93,7 +93,7 @@ def _extract_schema_and_data_from_pandas_df(
             ):
                 plain_data[row_idx][col_idx] = int(plain_data[row_idx][col_idx])
             elif isinstance(plain_data[row_idx][col_idx], pd.Timestamp):
-                if isinstance(data.dtypes[col_idx], pd.DatetimeTZDtype):
+                if isinstance(data.dtypes.iloc[col_idx], pd.DatetimeTZDtype):
                     # this is to align with the current snowflake behavior that it
                     # apply the tz diff to time and then removes the tz information during ingestion
                     plain_data[row_idx][col_idx] = (

--- a/tests/mock/test_pandas_util.py
+++ b/tests/mock/test_pandas_util.py
@@ -3,6 +3,7 @@
 #
 import pandas as pd
 import pytest
+
 from snowflake.snowpark import DataFrame
 
 

--- a/tests/mock/test_pandas_util.py
+++ b/tests/mock/test_pandas_util.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+import pandas as pd
+import pytest
+from snowflake.snowpark import DataFrame
+
+
+@pytest.mark.filterwarnings("error::FutureWarning")
+def test_extract_schema_from_df_without_future_warning(session):
+    """
+    Make sure that while converting a Pandas dataframe to a Snowflake dataframe no
+    FutureWarnings are thrown, which hint at upcoming incompatibilities.
+    """
+    pandas_df = pd.DataFrame({"A": [1.0]}, dtype=float)
+    df = session.create_dataframe(pandas_df)
+    assert isinstance(df, DataFrame)
+
+    pandas_df = pd.DataFrame({"Timestamp": [pd.to_datetime(1490195805, unit="s")]})
+    df = session.create_dataframe(pandas_df)
+    assert isinstance(df, DataFrame)


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-NNNNNNN

   Github Issue #1967 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Pandas prefers integer indexing with the `.iloc[]` accessor instead of implicitly assuming that an integer key is not a label but an index. It also issues a `FutureWarning` that in the future also integer keys will be treated as labels and not as integer index, which will most likely cause an error when this behavior is implemented.

   The former code used either used `data[x]` instead of `data.iloc[x]` or (maybe unintentionally) `data.iloc[x][y]` instead of `data.iloc[x, y]` and caused this warning.

   Not sure if an additional test is really necessary to check for warnings in the future, but I've added it anyway, please feel free to omit the test from the PR if you don't see it as necessary.