### PR TITLE
Fix test failure for test_deepcopy.py/test_selectentity 

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -381,7 +381,7 @@ class SelectableEntity(Selectable):
         self.entity = entity
 
     def __deepcopy__(self, memodict={}) -> "SelectableEntity":  # noqa: B006
-        copied = SelectableEntity(self.entity, analyzer=self.analyzer)
+        copied = SelectableEntity(deepcopy(self.entity), analyzer=self.analyzer)
         _deepcopy_selectable_fields(from_selectable=self, to_selectable=copied)
 
         return copied

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -381,7 +381,7 @@ class SelectableEntity(Selectable):
         self.entity = entity
 
     def __deepcopy__(self, memodict={}) -> "SelectableEntity":  # noqa: B006
-        copied = SelectableEntity(self.entity_name, analyzer=self.analyzer)
+        copied = SelectableEntity(self.entity, analyzer=self.analyzer)
         _deepcopy_selectable_fields(from_selectable=self, to_selectable=copied)
 
         return copied

--- a/tests/integ/test_deepcopy.py
+++ b/tests/integ/test_deepcopy.py
@@ -231,7 +231,7 @@ def test_selectentity(session):
         select_plan = df._plan.children_plan_nodes[0]
         copied_select = copy.deepcopy(select_plan)
         verify_logical_plan_node(copied_select, select_plan)
-        assert copied_select.entity_name == select_plan.entity_name
+        assert copied_select.entity.name == select_plan.entity.name
     else:
         copied_plan = copy.deepcopy(df._plan)
         check_copied_plan(copied_plan, df._plan)


### PR DESCRIPTION
The entity_name of SelectableEntity has been replaced with entity: SnowflakeTable. Update the test and deep copy to do the correct copy
