### PR TITLE
(Readability) Replace all instances of suppress_ast with emit_ast to avoid negated logic

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1177,6 +1177,7 @@ class DataFrame:
             *cols: A :class:`Column`, :class:`str`, :class:`table_function.TableFunctionCall`, or a list of those. Note that at most one
                    :class:`table_function.TableFunctionCall` object is supported within a select call.
             _ast_stmt: when invoked internally, supplies the AST to use for the resulting dataframe.
+            _emit_ast: Whether to emit AST statements.
         """
         exprs, is_variadic = parse_positional_args_to_list_variadic(*cols)
         if not exprs:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4501,7 +4501,7 @@ class DataFrame:
                     SKIP_LEVELS_TWO,
                 ),
             )
-        cached_df = self._session.table(temp_table_name, emit_ast=False)
+        cached_df = self._session.table(temp_table_name, _emit_ast=False)
         cached_df.is_cached = True
         cached_df._ast_id = stmt.var_id.bitfield1
         return cached_df

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1834,7 +1834,7 @@ class Session:
                     f"Expected query tag to be valid json. Current query tag: {tag_str}"
                 )
 
-    def table(self, name: Union[str, Iterable[str]], emit_ast: bool = True) -> Table:
+    def table(self, name: Union[str, Iterable[str]], _emit_ast: bool = True) -> Table:
         """
         Returns a Table that points the specified table.
 
@@ -1842,7 +1842,7 @@ class Session:
             name: A string or list of strings that specify the table name or
                 fully-qualified object identifier (database name, schema name, and table name).
 
-            emit_ast: Enables AST generation if True.
+            _emit_ast: Enables AST generation if True.
 
             Note:
                 If your table name contains special characters, use double quotes to mark it like this, ``session.table('"my table"')``.
@@ -1860,7 +1860,7 @@ class Session:
             >>> session.table([current_db, current_schema, "my_table"]).collect()
             [Row(A=1, B=2), Row(A=3, B=4)]
         """
-        if emit_ast:
+        if _emit_ast:
             stmt = self._ast_batch.assign()
             ast = with_src_position(stmt.expr.sp_table)
             if isinstance(name, str):
@@ -1874,7 +1874,7 @@ class Session:
         if not isinstance(name, str) and isinstance(name, Iterable):
             name = ".".join(name)
         validate_object_name(name)
-        t = Table(name, self, stmt, emit_ast)
+        t = Table(name, self, stmt, _emit_ast)
         # Replace API call origin for table
         set_api_call_source(t, "Session.table")
         return t

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1842,7 +1842,7 @@ class Session:
             name: A string or list of strings that specify the table name or
                 fully-qualified object identifier (database name, schema name, and table name).
 
-            _emit_ast: Enables AST generation if True.
+            _emit_ast: Whether to emit AST statements.
 
             Note:
                 If your table name contains special characters, use double quotes to mark it like this, ``session.table('"my table"')``.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1834,9 +1834,7 @@ class Session:
                     f"Expected query tag to be valid json. Current query tag: {tag_str}"
                 )
 
-    def table(
-        self, name: Union[str, Iterable[str]], suppress_ast: bool = False
-    ) -> Table:
+    def table(self, name: Union[str, Iterable[str]], emit_ast: bool = True) -> Table:
         """
         Returns a Table that points the specified table.
 
@@ -1844,7 +1842,7 @@ class Session:
             name: A string or list of strings that specify the table name or
                 fully-qualified object identifier (database name, schema name, and table name).
 
-            suppress_ast: Skips AST generation if True.
+            emit_ast: Enables AST generation if True.
 
             Note:
                 If your table name contains special characters, use double quotes to mark it like this, ``session.table('"my table"')``.
@@ -1862,7 +1860,7 @@ class Session:
             >>> session.table([current_db, current_schema, "my_table"]).collect()
             [Row(A=1, B=2), Row(A=3, B=4)]
         """
-        if not suppress_ast:
+        if emit_ast:
             stmt = self._ast_batch.assign()
             ast = with_src_position(stmt.expr.sp_table)
             if isinstance(name, str):
@@ -1876,7 +1874,7 @@ class Session:
         if not isinstance(name, str) and isinstance(name, Iterable):
             name = ".".join(name)
         validate_object_name(name)
-        t = Table(name, self, stmt, suppress_ast)
+        t = Table(name, self, stmt, emit_ast)
         # Replace API call origin for table
         set_api_call_source(t, "Session.table")
         return t

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -273,9 +273,9 @@ class Table(DataFrame):
         table_name: str,
         session: Optional["snowflake.snowpark.session.Session"] = None,
         ast_stmt: Optional[proto.Assign] = None,
-        emit_ast: bool = True,
+        _emit_ast: bool = True,
     ) -> None:
-        if ast_stmt is None and session is not None and emit_ast:
+        if ast_stmt is None and session is not None and _emit_ast:
             ast_stmt = session._ast_batch.assign()
             ast = with_src_position(ast_stmt.expr.sp_table)
             ast.name.sp_table_name_flat.name = table_name

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -273,9 +273,9 @@ class Table(DataFrame):
         table_name: str,
         session: Optional["snowflake.snowpark.session.Session"] = None,
         ast_stmt: Optional[proto.Assign] = None,
-        suppress_ast: bool = False,
+        emit_ast: bool = True,
     ) -> None:
-        if ast_stmt is None and session is not None and not suppress_ast:
+        if ast_stmt is None and session is not None and emit_ast:
             ast_stmt = session._ast_batch.assign()
             ast = with_src_position(ast_stmt.expr.sp_table)
             ast.name.sp_table_name_flat.name = table_name


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-0000000

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Stylistic change - prefer direct logic instead of inverted logic.

Use `emit_ast` (default = `True`) everywhere instead of `suppress_ast` (default = `False`).

To get ASTs out of public APIs, do nothing. To prevent public APIs from emitting ASTs, provide `emit_ast = False`.

Name the argument `_emit_ast` on public APIs and `emit_ast` on internal APIs.