### PR TITLE
SNOW-1478684: Remove index.equals workaround from compare

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -15991,16 +15991,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         >>> other = df2._query_compiler
         """
 
-        # TODO(SNOW-1478684): Stop calling to_pandas() to work around Index.equals() bug.
-        def pandas_index(index: Union[native_pd.Index, pd.Index]) -> native_pd.Index:
-            if isinstance(index, native_pd.Index):
-                return index
-            return index.to_pandas()
-
-        if not (
-            pandas_index(self.columns).equals(pandas_index(other.columns))
-            and pandas_index(self.index).equals(pandas_index(other.index))
-        ):
+        if not (self.columns.equals(other.columns) and self.index.equals(other.index)):
             raise ValueError("Can only compare identically-labeled objects")
 
         # align the two frames on index values, which should be equal. We don't

--- a/tests/integ/modin/frame/test_compare.py
+++ b/tests/integ/modin/frame/test_compare.py
@@ -10,8 +10,8 @@ import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import create_test_dfs, eval_snowpark_pandas_result
 
-# (+1 query, +0 join) materialize first frame's index for comparison
-# (+1 query, +0 join) materialize second frame's index for comparison
+# (+1 query, +0 join) materialize first frame's index for comparison if multi-index
+# (+1 query, +0 join) materialize second frame's index for comparison if multi-index
 # (+1 query, +1 join) row count query for joining the two frames and checking
 #                     for columns where all rows match.
 # (+1 query, +1 join) materialize query that joins the two frames and checks
@@ -102,7 +102,7 @@ class TestDefaultParameters:
             ),
         )
 
-    @sql_count_checker(query_count=QUERY_COUNT, join_count=JOIN_COUNT)
+    @sql_count_checker(query_count=4, join_count=4)
     def test_default_index_on_both_axes(self, base_df):
         position = (0, 0)
         new_value = "c"
@@ -138,8 +138,9 @@ class TestDefaultParameters:
         )
 
     @sql_count_checker(
-        # Execute a query to materialize each index for comparison.
-        query_count=2
+        # Execute a query with join to compare lazy indices.
+        query_count=1,
+        join_count=1,
     )
     def test_different_index(self):
         df = native_pd.DataFrame([1], index=["a"])

--- a/tests/integ/modin/index/test_equals.py
+++ b/tests/integ/modin/index/test_equals.py
@@ -70,3 +70,10 @@ def test_index_lazy_with_non_lazy():
     index2 = pd.Index([1, 2], convert_to_lazy=False)
     assert index1.equals(index2)
     assert index2.equals(index1)
+
+
+@sql_count_checker(query_count=0)
+def test_index_columns_self_compare():
+    # Bug SNOW-1478684
+    df = pd.DataFrame([1])
+    assert df.columns.equals(df.columns)

--- a/tests/integ/modin/series/test_compare.py
+++ b/tests/integ/modin/series/test_compare.py
@@ -10,8 +10,8 @@ import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import create_test_series, eval_snowpark_pandas_result
 
-# (+1 query, +0 join) materialize first series's index for comparison
-# (+1 query, +0 join) materialize second series's index for comparison
+# (+1 query, +0 join) materialize first series's index for comparison if multi-index
+# (+1 query, +0 join) materialize second series's index for comparison if multi-index
 # (+1 query, +1 join) row count query for joining the two series and checking
 #                     whether all rows match.
 # (+1 query, +1 join) materialize query that joins the two series and checks
@@ -83,7 +83,7 @@ class TestDefaultParameters:
             ),
         )
 
-    @sql_count_checker(query_count=QUERY_COUNT, join_count=JOIN_COUNT)
+    @sql_count_checker(query_count=4, join_count=4)
     def test_default_index_and_name(self, base_series):
         position = 1
         new_value = 2
@@ -117,7 +117,7 @@ class TestDefaultParameters:
             ),
         )
 
-    @sql_count_checker(query_count=QUERY_COUNT, join_count=JOIN_COUNT)
+    @sql_count_checker(query_count=4, join_count=4)
     def test_different_names(self):
         series = native_pd.Series([1], name="a")
         other_series = native_pd.Series([2], name="b")
@@ -131,8 +131,9 @@ class TestDefaultParameters:
         )
 
     @sql_count_checker(
-        # Execute a query to materialize each index for comparison.
-        query_count=2
+        # Execute a query with join to compare lazy indices.
+        query_count=1,
+        join_count=1,
     )
     def test_different_index(self):
         series = native_pd.Series([1], index=["a"])


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1478684

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   This bug is no longer reproducible. Possibly due to recent changes in Index.equals (https://snowflakecomputing.atlassian.net/browse/SNOW-1458148). This PR adds the new test as validation before closing the issue.
