### PR TITLE
SNOW-1555397 Fix index.to_frame()'s wrong result column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Made passing an unsupported aggregation function to `pivot_table` raise `NotImplementedError` instead of `KeyError`.
 - Removed axis labels and callable names from error messages and telemetry about unsupported aggregations.
 - Fixed AssertionError in `Series.drop_duplicates` and `DataFrame.drop_duplicates` when called after `sort_values`.
+- Fixed a bug in `Index.to_frame` where the result frame's column name may be wrong where name is unspecified.  
 
 
 ## 1.20.0 (2024-07-17)

--- a/src/snowflake/snowpark/modin/plugin/extensions/index.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/index.py
@@ -1662,26 +1662,22 @@ class Index:
         #       0               100
         #       1               200
         #       2               300
-        # If `name` is specified, use it as new column name; otherwise, set new column name to the original index name.
-        # Note there is one exception case: when the original index name is None, the new column name should be 0.
-        if name != native_pd._libs.lib.no_default:
-            new_col_name = name
-        else:
-            new_col_name = self._query_compiler.get_index_name()
-            if new_col_name is None:
-                new_col_name = 0
-
+        new_qc = self._query_compiler.reset_index()
         # if index is true, we want self to be in the index and data columns of the df,
         # so set the index as the data column and set the name of the index
         if index:
-            new_qc = self._query_compiler.reset_index()
-            new_qc = (
-                new_qc.set_index([new_qc.columns[0]], drop=False)
-                .set_columns([new_col_name])
-                .set_index_names([self._query_compiler.get_index_name()])
+            new_qc = new_qc.set_index([new_qc.columns[0]], drop=False).set_index_names(
+                [self.name]
             )
+        # If `name` is specified, use it as new column name; otherwise, set new column name to the original index name.
+        # Note there is one exception case: when the original index name is None, the new column name should be 0.
+        if name != lib.no_default:
+            new_col_name = name
         else:
-            new_qc = self._query_compiler.reset_index(names=[new_col_name])
+            new_col_name = self.name
+            if new_col_name is None:
+                new_col_name = 0
+        new_qc = new_qc.set_columns([new_col_name])
 
         return DataFrame(query_compiler=new_qc)
 

--- a/tests/integ/modin/index/test_index_methods.py
+++ b/tests/integ/modin/index/test_index_methods.py
@@ -3,9 +3,9 @@
 #
 
 import modin.pandas as pd
-import pandas as native_pd
 import pytest
 from numpy.testing import assert_equal
+from pandas._libs import lib
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.index.conftest import (
@@ -240,9 +240,7 @@ def test_df_index_columns_to_list(native_df):
     assert_equal(native_df.columns.to_list(), snow_df.columns.to_list())
 
 
-@pytest.mark.parametrize(
-    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
-)
+@pytest.mark.parametrize("name", [None, "name", True, 1, lib.no_default])
 @pytest.mark.parametrize("generate_extra_index", [True, False])
 @pytest.mark.parametrize("native_index", NATIVE_INDEX_TEST_DATA)
 def test_index_to_series(native_index, generate_extra_index, name):
@@ -259,9 +257,7 @@ def test_index_to_series(native_index, generate_extra_index, name):
         )
 
 
-@pytest.mark.parametrize(
-    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
-)
+@pytest.mark.parametrize("name", [None, "name", True, 1, lib.no_default])
 @pytest.mark.parametrize("generate_extra_index", [True, False])
 @pytest.mark.parametrize("native_df", TEST_DFS)
 def test_df_index_columns_to_series(native_df, generate_extra_index, name):
@@ -296,9 +292,7 @@ def test_df_index_columns_to_series(native_df, generate_extra_index, name):
 
 
 @sql_count_checker(query_count=1)
-@pytest.mark.parametrize(
-    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
-)
+@pytest.mark.parametrize("name", [None, "name", True, 1, lib.no_default])
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("native_index", NATIVE_INDEX_TEST_DATA)
 def test_index_to_frame(native_index, name, index):
@@ -312,9 +306,7 @@ def test_index_to_frame(native_index, name, index):
 
 
 @sql_count_checker(query_count=2)
-@pytest.mark.parametrize(
-    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
-)
+@pytest.mark.parametrize("name", [None, "name", True, 1, lib.no_default])
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("native_df", TEST_DFS)
 def test_df_index_columns_to_frame(native_df, index, name):

--- a/tests/integ/modin/index/test_index_methods.py
+++ b/tests/integ/modin/index/test_index_methods.py
@@ -3,6 +3,7 @@
 #
 
 import modin.pandas as pd
+import pandas as native_pd
 import pytest
 from numpy.testing import assert_equal
 
@@ -239,7 +240,9 @@ def test_df_index_columns_to_list(native_df):
     assert_equal(native_df.columns.to_list(), snow_df.columns.to_list())
 
 
-@pytest.mark.parametrize("name", [None, "name", True, 1])
+@pytest.mark.parametrize(
+    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
+)
 @pytest.mark.parametrize("generate_extra_index", [True, False])
 @pytest.mark.parametrize("native_index", NATIVE_INDEX_TEST_DATA)
 def test_index_to_series(native_index, generate_extra_index, name):
@@ -256,7 +259,9 @@ def test_index_to_series(native_index, generate_extra_index, name):
         )
 
 
-@pytest.mark.parametrize("name", [None, "name", True, 1])
+@pytest.mark.parametrize(
+    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
+)
 @pytest.mark.parametrize("generate_extra_index", [True, False])
 @pytest.mark.parametrize("native_df", TEST_DFS)
 def test_df_index_columns_to_series(native_df, generate_extra_index, name):
@@ -291,7 +296,9 @@ def test_df_index_columns_to_series(native_df, generate_extra_index, name):
 
 
 @sql_count_checker(query_count=1)
-@pytest.mark.parametrize("name", [None, "name", True, 1])
+@pytest.mark.parametrize(
+    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
+)
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("native_index", NATIVE_INDEX_TEST_DATA)
 def test_index_to_frame(native_index, name, index):
@@ -305,7 +312,9 @@ def test_index_to_frame(native_index, name, index):
 
 
 @sql_count_checker(query_count=2)
-@pytest.mark.parametrize("name", [None, "name", True, 1])
+@pytest.mark.parametrize(
+    "name", [None, "name", True, 1, native_pd._libs.lib.no_default]
+)
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("native_df", TEST_DFS)
 def test_df_index_columns_to_frame(native_df, index, name):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1555397

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Fix the result column name for `Index.to_frame` when `name` is not specified.