### PR TITLE
SNOW-1557229: Add method to replace child for LogicalPlan and derivatives

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -60,7 +60,6 @@ from snowflake.snowpark._internal.analyzer.expression import (
 from snowflake.snowpark._internal.analyzer.schema_utils import analyze_attributes
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
-    LeafNode,
     LogicalPlan,
     SnowflakeTable,
 )
@@ -374,7 +373,7 @@ class Selectable(LogicalPlan, ABC):
         self._column_states = deepcopy(value)
 
 
-class SelectableEntity(Selectable, LeafNode):
+class SelectableEntity(Selectable):
     """Query from a table, view, or any other Snowflake objects.
     Mainly used by session.table().
     """

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -60,6 +60,7 @@ from snowflake.snowpark._internal.analyzer.expression import (
 from snowflake.snowpark._internal.analyzer.schema_utils import analyze_attributes
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    LeafNode,
     LogicalPlan,
     SnowflakeTable,
 )
@@ -373,7 +374,7 @@ class Selectable(LogicalPlan, ABC):
         self._column_states = deepcopy(value)
 
 
-class SelectableEntity(Selectable):
+class SelectableEntity(Selectable, LeafNode):
     """Query from a table, view, or any other Snowflake objects.
     Mainly used by session.table().
     """

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -252,6 +252,8 @@ class SnowflakePlan(LogicalPlan):
         self._cumulative_node_complexity: Optional[Dict[PlanNodeCategory, int]] = None
 
     def __eq__(self, other: "SnowflakePlan") -> bool:
+        if not isinstance(other, SnowflakePlan):
+            return False
         if self._id is not None and other._id is not None:
             return isinstance(other, SnowflakePlan) and self._id == other._id
         else:
@@ -290,6 +292,12 @@ class SnowflakePlan(LogicalPlan):
                 return self.source_plan.children
         else:
             return []
+
+    def replace_child(self, old_node, new_node) -> None:
+        if self.source_plan:
+            # Child node from a snowflake plan is derived from its source plan so call
+            # replace_child on the source plan.
+            self.source_plan.replace_child(old_node, new_node)
 
     def replace_repeated_subquery_with_cte(self) -> "SnowflakePlan":
         # parameter protection

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -293,21 +293,6 @@ class SnowflakePlan(LogicalPlan):
         else:
             return []
 
-    def replace_child(self, old_node, new_node) -> None:
-        """This method is called during optimization stage to cut plan tree at a certain node.
-
-        It must only be called on a deep copied plan node, otherwise it will raise an exception.
-        """
-        if not self._is_deep_copied:
-            raise ValueError(
-                "replace child can only be called on a deep copied plan node."
-            )
-
-        if self.source_plan:
-            # Child node from a snowflake plan is derived from its source plan so call
-            # replace_child on the source plan.
-            self.source_plan.replace_child(old_node, new_node)
-
     def replace_repeated_subquery_with_cte(self) -> "SnowflakePlan":
         # parameter protection
         if not self.session._cte_optimization_enabled:
@@ -494,9 +479,9 @@ class SnowflakePlan(LogicalPlan):
             # session object after deepcopy
             session=self.session,
         )
-        copied_plan._is_deep_copied = True
+        copied_plan._is_valid_for_replacement = True
         if copied_source_plan:
-            copied_source_plan._is_deep_copied = True
+            copied_source_plan._is_valid_for_replacement = True
 
         return copied_plan
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -34,6 +34,8 @@ class LogicalPlan:
         self._cumulative_node_complexity: Optional[Dict[PlanNodeCategory, int]] = None
         # This flag is used to determine if the current node is a valid candidate for
         # replacement in plan tree during optimization stage using replace_child method.
+        # Currently deepcopied nodes or nodes that are introduced during optimization stage
+        # are not valid candidates for replacement.
         self._is_valid_for_replacement: bool = False
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -32,6 +32,7 @@ class LogicalPlan:
     def __init__(self) -> None:
         self.children = []
         self._cumulative_node_complexity: Optional[Dict[PlanNodeCategory, int]] = None
+        self._is_deep_copied: bool = False
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:
@@ -61,6 +62,15 @@ class LogicalPlan:
         self._cumulative_node_complexity = value
 
     def replace_child(self, old_node, new_node) -> None:
+        """This method is called during optimization stage to cut plan tree at a certain node.
+
+        It must only be called on a deep copied plan node, otherwise it will raise an exception.
+        """
+        if not self._is_deep_copied:
+            raise ValueError(
+                "replace child can only be called on a deep copied plan node."
+            )
+
         if old_node not in self.children:
             raise ValueError(
                 "old_node to be replaced is not found in the children nodes."

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -32,6 +32,8 @@ class LogicalPlan:
     def __init__(self) -> None:
         self.children = []
         self._cumulative_node_complexity: Optional[Dict[PlanNodeCategory, int]] = None
+        # This flag is used to determine if the current node is a valid candidate for
+        # replacement in plan tree during optimization stage using replace_child method.
         self._is_valid_for_replacement: bool = False
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -60,6 +60,15 @@ class LogicalPlan:
     def cumulative_node_complexity(self, value: Dict[PlanNodeCategory, int]):
         self._cumulative_node_complexity = value
 
+    def replace_child(self, old_node, new_node) -> None:
+        if old_node not in self.children:
+            raise ValueError(
+                "old_node to be replaced is not found in the children nodes."
+            )
+        self.children = [
+            child if child != old_node else new_node for child in self.children
+        ]
+
 
 class LeafNode(LogicalPlan):
     pass

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -109,8 +109,8 @@ class SnowflakeTable(LeafNode):
                 self, session._dec_temp_table_ref_count, name
             )
 
-    # def __deepcopy__(self, memodict={}) -> "SnowflakeTable":  #noqa: B006
-    #     return SnowflakeTable(self.name, session=self.session)
+    def __deepcopy__(self, memodict={}) -> "SnowflakeTable":  # noqa: B006
+        return SnowflakeTable(self.name, session=self.session)
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -109,9 +109,6 @@ class SnowflakeTable(LeafNode):
                 self, session._dec_temp_table_ref_count, name
             )
 
-    def __deepcopy__(self, memodict={}) -> "SnowflakeTable":  # noqa: B006
-        return SnowflakeTable(self.name, session=self.session)
-
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:
         # SELECT * FROM name

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -32,7 +32,7 @@ class LogicalPlan:
     def __init__(self) -> None:
         self.children = []
         self._cumulative_node_complexity: Optional[Dict[PlanNodeCategory, int]] = None
-        self._is_deep_copied: bool = False
+        self._is_valid_for_replacement: bool = False
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:
@@ -60,24 +60,6 @@ class LogicalPlan:
     @cumulative_node_complexity.setter
     def cumulative_node_complexity(self, value: Dict[PlanNodeCategory, int]):
         self._cumulative_node_complexity = value
-
-    def replace_child(self, old_node, new_node) -> None:
-        """This method is called during optimization stage to cut plan tree at a certain node.
-
-        It must only be called on a deep copied plan node, otherwise it will raise an exception.
-        """
-        if not self._is_deep_copied:
-            raise ValueError(
-                "replace child can only be called on a deep copied plan node."
-            )
-
-        if old_node not in self.children:
-            raise ValueError(
-                "old_node to be replaced is not found in the children nodes."
-            )
-        self.children = [
-            child if child != old_node else new_node for child in self.children
-        ]
 
 
 class LeafNode(LogicalPlan):
@@ -126,6 +108,9 @@ class SnowflakeTable(LeafNode):
             self._finalizer = weakref.finalize(
                 self, session._dec_temp_table_ref_count, name
             )
+
+    # def __deepcopy__(self, memodict={}) -> "SnowflakeTable":  #noqa: B006
+    #     return SnowflakeTable(self.name, session=self.session)
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -11,7 +11,6 @@ from snowflake.snowpark._internal.analyzer.select_statement import (
     Selectable,
     SelectSnowflakePlan,
     SelectStatement,
-    SetOperand,
     SetStatement,
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
@@ -103,12 +102,9 @@ def replace_child(
             node if node != old_child else new_child_as_selectable
             for node in parent._nodes
         ]
-        parent.set_operands = tuple(
-            operand
-            if operand.selectable != old_child
-            else SetOperand(new_child_as_selectable, operand.operator)
-            for operand in parent.set_operands
-        )
+        for operand in parent.set_operands:
+            if operand.selectable == old_child:
+                operand.selectable = new_child_as_selectable
         return
 
     if isinstance(parent, Selectable):

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -20,6 +20,11 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     LogicalPlan,
     SnowflakeCreateTable,
 )
+from snowflake.snowpark._internal.analyzer.table_merge_expression import (
+    TableDelete,
+    TableMerge,
+    TableUpdate,
+)
 from snowflake.snowpark._internal.analyzer.unary_plan_node import UnaryNode
 from snowflake.snowpark._internal.compiler.query_generator import (
     QueryGenerator,
@@ -115,6 +120,18 @@ def replace_child(
     if isinstance(parent, SnowflakeCreateTable):
         parent.children = [new_child]
         parent.query = new_child
+        return
+
+    if isinstance(parent, (TableUpdate, TableDelete)):
+        snowflake_plan = new_child.snowflake_plan
+        parent.children = [snowflake_plan]
+        parent.source_data = snowflake_plan
+        return
+
+    if isinstance(parent, TableMerge):
+        snowflake_plan = new_child.snowflake_plan
+        parent.children = [snowflake_plan]
+        parent.source = snowflake_plan
         return
 
     if isinstance(parent, LogicalPlan):

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -60,7 +60,7 @@ def replace_child(
     Helper function to replace the child node in the plan.
     """
     if not parent._is_valid_for_replacement:
-        raise ValueError(f"node {parent} is not valid for replacement.")
+        raise ValueError(f"parent node {parent} is not valid for replacement.")
 
     if old_node not in getattr(parent, "children_plan_nodes", parent.children):
         raise ValueError(f"old_node {old_node} is not a child of parent {parent}.")

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -8,7 +8,9 @@ from typing import Optional, Union
 from snowflake.snowpark._internal.analyzer.binary_plan_node import BinaryNode
 from snowflake.snowpark._internal.analyzer.select_statement import (
     Selectable,
+    SelectableEntity,
     SelectStatement,
+    SetOperand,
     SetStatement,
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
@@ -54,60 +56,70 @@ def create_query_generator(plan: SnowflakePlan) -> QueryGenerator:
 
 
 def replace_child(
-    parent: PlanTreeNode, old_node: PlanTreeNode, new_node: Selectable
+    parent: PlanTreeNode, old_child: PlanTreeNode, new_child: SelectableEntity
 ) -> None:
     """
-    Helper function to replace the child node in the plan.
+    Helper function to replace the child node in the plan with a new selectable entity.
     """
     if not parent._is_valid_for_replacement:
         raise ValueError(f"parent node {parent} is not valid for replacement.")
 
-    if old_node not in getattr(parent, "children_plan_nodes", parent.children):
-        raise ValueError(f"old_node {old_node} is not a child of parent {parent}.")
+    if old_child not in getattr(parent, "children_plan_nodes", parent.children):
+        raise ValueError(f"old_child {old_child} is not a child of parent {parent}.")
+
+    assert isinstance(
+        new_child, SelectableEntity
+    ), f"expecting new_child to be SelectableEntity, got {type(new_child)}"
 
     if isinstance(parent, SnowflakePlan):
         assert parent.source_plan is not None
-        replace_child(parent.source_plan, old_node, new_node)
+        replace_child(parent.source_plan, old_child, new_child)
         return
 
     if isinstance(parent, SelectStatement):
-        parent.from_ = new_node
+        parent.from_ = new_child
         return
 
     if isinstance(parent, SetStatement):
         parent._nodes = [
-            node if node != old_node else new_node for node in parent._nodes
+            node if node != old_child else new_child for node in parent._nodes
+        ]
+        parent.set_operands = [
+            operand
+            if operand.selectable != old_child
+            else SetOperand(operand.operator, new_child)
+            for operand in parent.set_operands
         ]
         return
 
     if isinstance(parent, Selectable):
         assert parent.snowflake_plan.source_plan is not None
-        replace_child(parent.snowflake_plan.source_plan, old_node, new_node)
+        replace_child(parent.snowflake_plan.source_plan, old_child, new_child)
         return
 
     if isinstance(parent, (UnaryNode, Limit, CopyIntoLocationNode)):
-        parent.children = [new_node]
-        parent.child = new_node
+        parent.children = [new_child]
+        parent.child = new_child
         return
 
     if isinstance(parent, BinaryNode):
         parent.children = [
-            node if node != old_node else new_node for node in parent.children
+            node if node != old_child else new_child for node in parent.children
         ]
-        if parent.left == old_node:
-            parent.left = new_node
-        else:
-            parent.right = new_node
+        if parent.left == old_child:
+            parent.left = new_child
+        if parent.right == old_child:
+            parent.right = new_child
         return
 
     if isinstance(parent, SnowflakeCreateTable):
-        parent.children = [new_node]
-        parent.query = new_node
+        parent.children = [new_child]
+        parent.query = new_child
         return
 
     if isinstance(parent, LogicalPlan):
         parent.children = [
-            node if node != old_node else new_node for node in parent.children
+            node if node != old_child else new_child for node in parent.children
         ]
         return
 

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -16,7 +16,6 @@ from snowflake.snowpark._internal.analyzer.select_statement import (
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     CopyIntoLocationNode,
-    LeafNode,
     Limit,
     LogicalPlan,
     SnowflakeCreateTable,
@@ -60,7 +59,10 @@ def create_query_generator(plan: SnowflakePlan) -> QueryGenerator:
 
 
 def replace_child(
-    parent: LogicalPlan, old_child: LogicalPlan, new_child: LeafNode, analyzer: Analyzer
+    parent: LogicalPlan,
+    old_child: LogicalPlan,
+    new_child: LogicalPlan,
+    analyzer: Analyzer,
 ) -> None:
     """
     Helper function to replace the child node in the plan with a new child.
@@ -82,10 +84,6 @@ def replace_child(
 
     if old_child not in getattr(parent, "children_plan_nodes", parent.children):
         raise ValueError(f"old_child {old_child} is not a child of parent {parent}.")
-
-    assert isinstance(
-        new_child, LeafNode
-    ), f"expecting new_child to be LeafNode, got {type(new_child)}"
 
     if isinstance(parent, SnowflakePlan):
         assert parent.source_plan is not None

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -90,7 +90,7 @@ def replace_child(
 
     if isinstance(parent, SnowflakePlan):
         assert parent.source_plan is not None
-        replace_child(parent.source_plan, old_child, new_child)
+        replace_child(parent.source_plan, old_child, new_child, analyzer)
         return
 
     if isinstance(parent, SelectStatement):
@@ -113,7 +113,7 @@ def replace_child(
 
     if isinstance(parent, Selectable):
         assert parent.snowflake_plan.source_plan is not None
-        replace_child(parent.snowflake_plan.source_plan, old_child, new_child)
+        replace_child(parent.snowflake_plan.source_plan, old_child, new_child, analyzer)
         return
 
     if isinstance(parent, (UnaryNode, Limit, CopyIntoLocationNode)):

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -3,16 +3,28 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Optional
+from typing import Optional, Union
 
+from snowflake.snowpark._internal.analyzer.binary_plan_node import BinaryNode
+from snowflake.snowpark._internal.analyzer.select_statement import (
+    Selectable,
+    SelectStatement,
+    SetStatement,
+)
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    CopyIntoLocationNode,
+    Limit,
+    LogicalPlan,
     SnowflakeCreateTable,
 )
+from snowflake.snowpark._internal.analyzer.unary_plan_node import UnaryNode
 from snowflake.snowpark._internal.compiler.query_generator import (
     QueryGenerator,
     SnowflakeCreateTablePlanInfo,
 )
+
+PlanTreeNode = Union[SnowflakePlan, Selectable, LogicalPlan]
 
 
 def create_query_generator(plan: SnowflakePlan) -> QueryGenerator:
@@ -39,3 +51,64 @@ def create_query_generator(plan: SnowflakePlan) -> QueryGenerator:
         )
 
     return QueryGenerator(plan.session, snowflake_create_table_plan_info)
+
+
+def replace_child(
+    parent: PlanTreeNode, old_node: PlanTreeNode, new_node: Selectable
+) -> None:
+    """
+    Helper function to replace the child node in the plan.
+    """
+    if not parent._is_valid_for_replacement:
+        raise ValueError(f"node {parent} is not valid for replacement.")
+
+    if old_node not in getattr(parent, "children_plan_nodes", parent.children):
+        raise ValueError(f"old_node {old_node} is not a child of parent {parent}.")
+
+    if isinstance(parent, SnowflakePlan):
+        assert parent.source_plan is not None
+        replace_child(parent.source_plan, old_node, new_node)
+        return
+
+    if isinstance(parent, SelectStatement):
+        parent.from_ = new_node
+        return
+
+    if isinstance(parent, SetStatement):
+        parent._nodes = [
+            node if node != old_node else new_node for node in parent._nodes
+        ]
+        return
+
+    if isinstance(parent, Selectable):
+        assert parent.snowflake_plan.source_plan is not None
+        replace_child(parent.snowflake_plan.source_plan, old_node, new_node)
+        return
+
+    if isinstance(parent, (UnaryNode, Limit, CopyIntoLocationNode)):
+        parent.children = [new_node]
+        parent.child = new_node
+        return
+
+    if isinstance(parent, BinaryNode):
+        parent.children = [
+            node if node != old_node else new_node for node in parent.children
+        ]
+        if parent.left == old_node:
+            parent.left = new_node
+        else:
+            parent.right = new_node
+        return
+
+    if isinstance(parent, SnowflakeCreateTable):
+        parent.children = [new_node]
+        parent.query = new_node
+        return
+
+    if isinstance(parent, LogicalPlan):
+        parent.children = [
+            node if node != old_node else new_node for node in parent.children
+        ]
+        return
+
+    raise ValueError(f"parent type {type(parent)} not supported")

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -3,12 +3,13 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Optional, Union
+from typing import Optional
 
+from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.binary_plan_node import BinaryNode
 from snowflake.snowpark._internal.analyzer.select_statement import (
     Selectable,
-    SelectableEntity,
+    SelectSnowflakePlan,
     SelectStatement,
     SetOperand,
     SetStatement,
@@ -16,6 +17,7 @@ from snowflake.snowpark._internal.analyzer.select_statement import (
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     CopyIntoLocationNode,
+    LeafNode,
     Limit,
     LogicalPlan,
     SnowflakeCreateTable,
@@ -30,8 +32,6 @@ from snowflake.snowpark._internal.compiler.query_generator import (
     QueryGenerator,
     SnowflakeCreateTablePlanInfo,
 )
-
-PlanTreeNode = Union[SnowflakePlan, Selectable, LogicalPlan]
 
 
 def create_query_generator(plan: SnowflakePlan) -> QueryGenerator:
@@ -61,11 +61,23 @@ def create_query_generator(plan: SnowflakePlan) -> QueryGenerator:
 
 
 def replace_child(
-    parent: PlanTreeNode, old_child: PlanTreeNode, new_child: SelectableEntity
+    parent: LogicalPlan, old_child: LogicalPlan, new_child: LeafNode, analyzer: Analyzer
 ) -> None:
     """
-    Helper function to replace the child node in the plan with a new selectable entity.
+    Helper function to replace the child node in the plan with a new child.
+
+    Whenever necessary, we convert the new_child into a Selectable or SnowflakePlan
+    based on the parent node type.
     """
+
+    def to_selectable(plan: LogicalPlan, analyzer: Analyzer) -> Selectable:
+        """Given a LogicalPlan, convert it to a Selectable."""
+        if isinstance(plan, Selectable):
+            return plan
+
+        snowflake_plan = analyzer.resolve(plan)
+        return SelectSnowflakePlan(snowflake_plan, analyzer=analyzer)
+
     if not parent._is_valid_for_replacement:
         raise ValueError(f"parent node {parent} is not valid for replacement.")
 
@@ -73,8 +85,8 @@ def replace_child(
         raise ValueError(f"old_child {old_child} is not a child of parent {parent}.")
 
     assert isinstance(
-        new_child, SelectableEntity
-    ), f"expecting new_child to be SelectableEntity, got {type(new_child)}"
+        new_child, LeafNode
+    ), f"expecting new_child to be LeafNode, got {type(new_child)}"
 
     if isinstance(parent, SnowflakePlan):
         assert parent.source_plan is not None
@@ -82,17 +94,19 @@ def replace_child(
         return
 
     if isinstance(parent, SelectStatement):
-        parent.from_ = new_child
+        parent.from_ = to_selectable(new_child, analyzer)
         return
 
     if isinstance(parent, SetStatement):
+        new_child_as_selectable = to_selectable(new_child, analyzer)
         parent._nodes = [
-            node if node != old_child else new_child for node in parent._nodes
+            node if node != old_child else new_child_as_selectable
+            for node in parent._nodes
         ]
         parent.set_operands = tuple(
             operand
             if operand.selectable != old_child
-            else SetOperand(new_child, operand.operator)
+            else SetOperand(new_child_as_selectable, operand.operator)
             for operand in parent.set_operands
         )
         return
@@ -123,13 +137,13 @@ def replace_child(
         return
 
     if isinstance(parent, (TableUpdate, TableDelete)):
-        snowflake_plan = new_child.snowflake_plan
+        snowflake_plan = analyzer.resolve(new_child)
         parent.children = [snowflake_plan]
         parent.source_data = snowflake_plan
         return
 
     if isinstance(parent, TableMerge):
-        snowflake_plan = new_child.snowflake_plan
+        snowflake_plan = analyzer.resolve(new_child)
         parent.children = [snowflake_plan]
         parent.source = snowflake_plan
         return

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -84,12 +84,12 @@ def replace_child(
         parent._nodes = [
             node if node != old_child else new_child for node in parent._nodes
         ]
-        parent.set_operands = [
+        parent.set_operands = tuple(
             operand
             if operand.selectable != old_child
-            else SetOperand(operand.operator, new_child)
+            else SetOperand(new_child, operand.operator)
             for operand in parent.set_operands
-        ]
+        )
         return
 
     if isinstance(parent, Selectable):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from snowflake.connector import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
-from snowflake.snowpark._internal.analyzer.snowflake_plan import Query
+from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
 from snowflake.snowpark._internal.server_connection import ServerConnection
 from snowflake.snowpark.session import Session
 
@@ -27,8 +27,20 @@ def mock_server_connection() -> ServerConnection:
 
 
 @pytest.fixture(scope="module")
-def mock_analyzer() -> Analyzer:
+def mock_snowflake_plan() -> Analyzer:
+    fake_snowflake_plan = mock.create_autospec(SnowflakePlan)
+    fake_snowflake_plan._id = "dummy id"
+    return fake_snowflake_plan
+
+
+@pytest.fixture(scope="module")
+def mock_analyzer(mock_snowflake_plan) -> Analyzer:
+    def mock_resolve(x):
+        mock_snowflake_plan.source_plan = x
+        return mock_snowflake_plan
+
     fake_analyzer = mock.create_autospec(Analyzer)
+    fake_analyzer.resolve.side_effect = mock_resolve
     return fake_analyzer
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,9 +27,22 @@ def mock_server_connection() -> ServerConnection:
 
 
 @pytest.fixture(scope="module")
-def mock_snowflake_plan() -> Analyzer:
+def mock_query():
+    fake_query = mock.create_autospec(Query)
+    fake_query.sql = "dummy sql"
+    fake_query.params = "dummy params"
+    return fake_query
+
+
+@pytest.fixture(scope="module")
+def mock_snowflake_plan(mock_query) -> Analyzer:
     fake_snowflake_plan = mock.create_autospec(SnowflakePlan)
     fake_snowflake_plan._id = "dummy id"
+    fake_snowflake_plan.expr_to_alias = {}
+    fake_snowflake_plan.df_aliased_col_name_to_real_col_name = {}
+    fake_snowflake_plan.queries = [mock_query]
+    fake_snowflake_plan.post_actions = []
+    fake_snowflake_plan.api_calls = []
     return fake_snowflake_plan
 
 
@@ -50,11 +63,3 @@ def mock_session(mock_analyzer) -> Session:
     fake_session._analyzer = mock_analyzer
     mock_analyzer.session = fake_session
     return fake_session
-
-
-@pytest.fixture(scope="module")
-def mock_query():
-    fake_query = mock.create_autospec(Query)
-    fake_query.sql = "dummy sql"
-    fake_query.params = "dummy params"
-    return fake_query

--- a/tests/unit/test_replace_child.py
+++ b/tests/unit/test_replace_child.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+import copy
+
 import pytest
 
 from snowflake.snowpark._internal.analyzer.binary_plan_node import Inner, Join
@@ -32,27 +34,16 @@ def test_logical_plan(using_snowflake_plan, mock_query):
     get_children = (
         lambda plan: plan.children_plan_nodes if using_snowflake_plan else plan.children
     )
-    src_project_plan = Project([], old_plan)
+    project_plan = Project([], old_plan)
     src_join_plan = Join(
         left=old_plan,
-        right=src_project_plan,
+        right=project_plan,
         join_type=Inner,
         join_condition=None,
         match_condition=None,
     )
 
     if using_snowflake_plan:
-        project_plan = SnowflakePlan(
-            queries=[mock_query],
-            schema_query="",
-            post_actions=[],
-            expr_to_alias={},
-            source_plan=src_project_plan,
-            api_calls=None,
-            df_aliased_col_name_to_real_col_name=None,
-            placeholder_query=None,
-            session=None,
-        )
         join_plan = SnowflakePlan(
             queries=[mock_query],
             schema_query="",
@@ -65,28 +56,30 @@ def test_logical_plan(using_snowflake_plan, mock_query):
             session=None,
         )
     else:
-        project_plan = src_project_plan
         join_plan = src_join_plan
+
+    with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        join_plan.replace_child(irrelevant_plan, new_plan)
+
+    if using_snowflake_plan:
+        join_plan = copy.deepcopy(join_plan)
+    else:
+        join_plan = copy.deepcopy(src_join_plan)
+        join_plan._is_deep_copied = True
 
     with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
     ):
         join_plan.replace_child(irrelevant_plan, new_plan)
-    assert get_children(join_plan) == [old_plan, src_project_plan]
+    assert len(get_children(join_plan)) == 2
+    copied_old_plan, copied_project_plan = get_children(join_plan)
+    assert isinstance(copied_old_plan, LogicalPlan)
+    assert isinstance(copied_project_plan, Project)
 
-    with pytest.raises(
-        ValueError, match="old_node to be replaced is not found in the children nodes."
-    ):
-        project_plan.replace_child(irrelevant_plan, new_plan)
-    assert get_children(project_plan) == [old_plan]
-
-    assert get_children(join_plan) == [old_plan, src_project_plan]
-    join_plan.replace_child(old_plan, new_plan)
-    assert get_children(join_plan) == [new_plan, src_project_plan]
-
-    assert get_children(project_plan) == [old_plan]
-    project_plan.replace_child(old_plan, new_plan)
-    assert get_children(project_plan) == [new_plan]
+    join_plan.replace_child(copied_old_plan, new_plan)
+    assert get_children(join_plan) == [new_plan, copied_project_plan]
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
@@ -108,6 +101,12 @@ def test_selectable_entity(
             session=mock_session,
         )
     with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        selectable_entity.replace_child(irrelevant_plan, new_plan)
+    selectable_entity = copy.deepcopy(selectable_entity)
+
+    with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
     ):
         selectable_entity.replace_child(irrelevant_plan, new_plan)
@@ -119,6 +118,12 @@ def test_selectable_entity(
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
 def test_select_sql(using_snowflake_plan, mock_session, mock_analyzer):
     select_sql_plan = SelectSQL("FAKE QUERY", analyzer=mock_analyzer)
+    with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        select_sql_plan.replace_child(irrelevant_plan, new_plan)
+    select_sql_plan = copy.deepcopy(select_sql_plan)
+
     with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
     ):
@@ -173,14 +178,22 @@ def test_select_snowflake_plan(
             session=mock_session,
         )
 
-    assert select_snowflake_plan.children_plan_nodes == [old_plan]
+    with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        select_snowflake_plan.replace_child(irrelevant_plan, new_plan)
+    select_snowflake_plan = copy.deepcopy(select_snowflake_plan)
+
     with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
     ):
         select_snowflake_plan.replace_child(irrelevant_plan, new_plan)
-    assert select_snowflake_plan.children_plan_nodes == [old_plan]
+    assert len(select_snowflake_plan.children_plan_nodes) == 1
 
-    select_snowflake_plan.replace_child(old_plan, new_plan)
+    # deep copy created a copy of old_plan
+    copied_old_plan = select_snowflake_plan.children_plan_nodes[0]
+
+    select_snowflake_plan.replace_child(copied_old_plan, new_plan)
     assert select_snowflake_plan.children_plan_nodes == [new_plan]
 
 
@@ -216,6 +229,12 @@ def test_select_statement(
             placeholder_query=None,
             session=mock_session,
         )
+
+    with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        select_statement_plan.replace_child(irrelevant_plan, new_plan)
+    select_statement_plan = copy.deepcopy(select_statement_plan)
 
     with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
@@ -261,14 +280,22 @@ def test_select_table_function(
             session=mock_session,
         )
 
-    assert table_function_plan.children_plan_nodes == [old_plan]
+    with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        table_function_plan.replace_child(irrelevant_plan, new_plan)
+    table_function_plan = copy.deepcopy(table_function_plan)
+
     with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
     ):
         table_function_plan.replace_child(irrelevant_plan, new_plan)
-    assert table_function_plan.children_plan_nodes == [old_plan]
+    assert len(table_function_plan.children_plan_nodes) == 1
 
-    table_function_plan.replace_child(old_plan, new_plan)
+    # deep copy created a copy of old_plan
+    copied_old_plan = table_function_plan.children_plan_nodes[0]
+
+    table_function_plan.replace_child(copied_old_plan, new_plan)
     assert table_function_plan.children_plan_nodes == [new_plan]
 
 
@@ -296,7 +323,12 @@ def test_set_statement(using_snowflake_plan, mock_session, mock_analyzer, mock_q
             session=mock_session,
         )
 
-    assert set_statement_plan.children_plan_nodes == [selectable1, selectable2]
+    with pytest.raises(
+        ValueError, match="replace child can only be called on a deep copied plan node."
+    ):
+        set_statement_plan.replace_child(irrelevant_plan, new_plan)
+    set_statement_plan = copy.deepcopy(set_statement_plan)
+
     with pytest.raises(
         ValueError, match="old_node to be replaced is not found in the children nodes."
     ):

--- a/tests/unit/test_replace_child.py
+++ b/tests/unit/test_replace_child.py
@@ -1,0 +1,307 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+from snowflake.snowpark._internal.analyzer.binary_plan_node import Inner, Join
+from snowflake.snowpark._internal.analyzer.select_statement import (
+    SelectableEntity,
+    SelectSnowflakePlan,
+    SelectSQL,
+    SelectStatement,
+    SelectTableFunction,
+    SetOperand,
+    SetStatement,
+)
+from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    LogicalPlan,
+    SnowflakeTable,
+)
+from snowflake.snowpark._internal.analyzer.table_function import TableFunctionExpression
+from snowflake.snowpark._internal.analyzer.unary_plan_node import Project
+
+old_plan = LogicalPlan()
+new_plan = LogicalPlan()
+irrelevant_plan = LogicalPlan()
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_logical_plan(using_snowflake_plan, mock_query):
+    get_children = (
+        lambda plan: plan.children_plan_nodes if using_snowflake_plan else plan.children
+    )
+    src_project_plan = Project([], old_plan)
+    src_join_plan = Join(
+        left=old_plan,
+        right=src_project_plan,
+        join_type=Inner,
+        join_condition=None,
+        match_condition=None,
+    )
+
+    if using_snowflake_plan:
+        project_plan = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=src_project_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=None,
+        )
+        join_plan = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=src_join_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=None,
+        )
+    else:
+        project_plan = src_project_plan
+        join_plan = src_join_plan
+
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        join_plan.replace_child(irrelevant_plan, new_plan)
+    assert get_children(join_plan) == [old_plan, src_project_plan]
+
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        project_plan.replace_child(irrelevant_plan, new_plan)
+    assert get_children(project_plan) == [old_plan]
+
+    assert get_children(join_plan) == [old_plan, src_project_plan]
+    join_plan.replace_child(old_plan, new_plan)
+    assert get_children(join_plan) == [new_plan, src_project_plan]
+
+    assert get_children(project_plan) == [old_plan]
+    project_plan.replace_child(old_plan, new_plan)
+    assert get_children(project_plan) == [new_plan]
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_selectable_entity(
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+):
+    table = SnowflakeTable(name="table", session=mock_session)
+    selectable_entity = SelectableEntity(entity=table, analyzer=mock_analyzer)
+    if using_snowflake_plan:
+        selectable_entity = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=selectable_entity,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        )
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        selectable_entity.replace_child(irrelevant_plan, new_plan)
+
+    # SelectableEntity has no children
+    assert selectable_entity.children_plan_nodes == []
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_select_sql(using_snowflake_plan, mock_session, mock_analyzer):
+    select_sql_plan = SelectSQL("FAKE QUERY", analyzer=mock_analyzer)
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        select_sql_plan.replace_child(irrelevant_plan, new_plan)
+
+    if using_snowflake_plan:
+        select_sql_plan = SnowflakePlan(
+            queries=[Query("FAKE QUERY")],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=select_sql_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        )
+
+    # SelectSQL has no children
+    assert select_sql_plan.children_plan_nodes == []
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_select_snowflake_plan(
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+):
+    project_plan = Project([], old_plan)
+    snowflake_plan = SnowflakePlan(
+        queries=[mock_query],
+        schema_query="",
+        post_actions=[],
+        expr_to_alias={},
+        source_plan=project_plan,
+        api_calls=None,
+        df_aliased_col_name_to_real_col_name=None,
+        placeholder_query=None,
+        session=mock_session,
+    )
+
+    select_snowflake_plan = SelectSnowflakePlan(snowflake_plan, analyzer=mock_analyzer)
+
+    if using_snowflake_plan:
+        select_snowflake_plan = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=select_snowflake_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        )
+
+    assert select_snowflake_plan.children_plan_nodes == [old_plan]
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        select_snowflake_plan.replace_child(irrelevant_plan, new_plan)
+    assert select_snowflake_plan.children_plan_nodes == [old_plan]
+
+    select_snowflake_plan.replace_child(old_plan, new_plan)
+    assert select_snowflake_plan.children_plan_nodes == [new_plan]
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_select_statement(
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+):
+    from_ = SelectSnowflakePlan(
+        SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=None,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        ),
+        analyzer=mock_analyzer,
+    )
+    select_statement_plan = SelectStatement(from_=from_, analyzer=mock_analyzer)
+
+    if using_snowflake_plan:
+        select_statement_plan = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=select_statement_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        )
+
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        select_statement_plan.replace_child(irrelevant_plan, new_plan)
+    assert select_statement_plan.children_plan_nodes == [from_]
+
+    select_statement_plan.replace_child(from_, new_plan)
+    assert select_statement_plan.children_plan_nodes == [new_plan]
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_select_table_function(
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+):
+    project_plan = Project([], old_plan)
+    snowflake_plan = SnowflakePlan(
+        queries=[mock_query],
+        schema_query="",
+        post_actions=[],
+        expr_to_alias={},
+        source_plan=project_plan,
+        api_calls=None,
+        df_aliased_col_name_to_real_col_name=None,
+        placeholder_query=None,
+        session=mock_session,
+    )
+    table_function_plan = SelectTableFunction(
+        TableFunctionExpression("table_function"),
+        analyzer=mock_analyzer,
+        snowflake_plan=snowflake_plan,
+    )
+    if using_snowflake_plan:
+        table_function_plan = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=table_function_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        )
+
+    assert table_function_plan.children_plan_nodes == [old_plan]
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        table_function_plan.replace_child(irrelevant_plan, new_plan)
+    assert table_function_plan.children_plan_nodes == [old_plan]
+
+    table_function_plan.replace_child(old_plan, new_plan)
+    assert table_function_plan.children_plan_nodes == [new_plan]
+
+
+@pytest.mark.parametrize("using_snowflake_plan", [True, False])
+def test_set_statement(using_snowflake_plan, mock_session, mock_analyzer, mock_query):
+    selectable1 = SelectableEntity(
+        SnowflakeTable(name="table1", session=mock_session), analyzer=mock_analyzer
+    )
+    selectable2 = SelectSQL("SELECT * FROM table2", analyzer=mock_analyzer)
+    set_operand1 = SetOperand(selectable1, "UNION")
+    set_operand2 = SetOperand(selectable2, "UNION")
+    set_statement_plan = SetStatement(
+        set_operand1, set_operand2, analyzer=mock_analyzer
+    )
+    if using_snowflake_plan:
+        set_statement_plan = SnowflakePlan(
+            queries=[mock_query],
+            schema_query="",
+            post_actions=[],
+            expr_to_alias={},
+            source_plan=set_statement_plan,
+            api_calls=None,
+            df_aliased_col_name_to_real_col_name=None,
+            placeholder_query=None,
+            session=mock_session,
+        )
+
+    assert set_statement_plan.children_plan_nodes == [selectable1, selectable2]
+    with pytest.raises(
+        ValueError, match="old_node to be replaced is not found in the children nodes."
+    ):
+        set_statement_plan.replace_child(irrelevant_plan, new_plan)
+    assert set_statement_plan.children_plan_nodes == [selectable1, selectable2]
+
+    set_statement_plan.replace_child(selectable1, new_plan)
+    assert set_statement_plan.children_plan_nodes == [new_plan, selectable2]

--- a/tests/unit/test_replace_child.py
+++ b/tests/unit/test_replace_child.py
@@ -30,12 +30,18 @@ from snowflake.snowpark._internal.analyzer.unary_plan_node import Project, Sort
 from snowflake.snowpark._internal.compiler.utils import replace_child
 
 old_plan = LogicalPlan()
-new_plan = LogicalPlan()
 irrelevant_plan = LogicalPlan()
 
 
+@pytest.fixture(scope="module")
+def new_plan(mock_session, mock_analyzer):
+    yield SelectableEntity(
+        SnowflakeTable(name="table", session=mock_session), analyzer=mock_analyzer
+    )
+
+
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
-def test_logical_plan(using_snowflake_plan, mock_query):
+def test_logical_plan(using_snowflake_plan, mock_query, new_plan):
     def get_children(plan):
         if isinstance(plan, SnowflakePlan):
             return plan.children_plan_nodes
@@ -101,7 +107,7 @@ def test_logical_plan(using_snowflake_plan, mock_query):
         lambda x: CopyIntoLocationNode(x, "stage_location", copy_options={}),
     ],
 )
-def test_unary_plan(plan_initializer):
+def test_unary_plan(plan_initializer, new_plan):
     plan = plan_initializer(old_plan)
 
     assert plan.child == old_plan
@@ -120,7 +126,7 @@ def test_unary_plan(plan_initializer):
     assert plan.children == [new_plan]
 
 
-def test_binary_plan():
+def test_binary_plan(new_plan):
     left_plan = Project([], LogicalPlan())
     plan = Union(left=left_plan, right=old_plan, is_all=False)
 
@@ -141,7 +147,7 @@ def test_binary_plan():
     assert plan.children == [left_plan, new_plan]
 
 
-def test_snowflake_create_table():
+def test_snowflake_create_table(new_plan):
     plan = SnowflakeCreateTable(["temp_table"], None, "OVERWRITE", old_plan, "temp")
 
     assert plan.query == old_plan
@@ -162,7 +168,7 @@ def test_snowflake_create_table():
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
 def test_selectable_entity(
-    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query, new_plan
 ):
     table = SnowflakeTable(name="table", session=mock_session)
     selectable_entity = SelectableEntity(entity=table, analyzer=mock_analyzer)
@@ -190,7 +196,7 @@ def test_selectable_entity(
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
-def test_select_sql(using_snowflake_plan, mock_session, mock_analyzer):
+def test_select_sql(using_snowflake_plan, mock_session, mock_analyzer, new_plan):
     select_sql_plan = SelectSQL("FAKE QUERY", analyzer=mock_analyzer)
     with pytest.raises(ValueError, match="is not valid for replacement."):
         replace_child(select_sql_plan, irrelevant_plan, new_plan)
@@ -218,7 +224,7 @@ def test_select_sql(using_snowflake_plan, mock_session, mock_analyzer):
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
 def test_select_snowflake_plan(
-    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query, new_plan
 ):
     project_plan = Project([], old_plan)
     snowflake_plan = SnowflakePlan(
@@ -265,7 +271,7 @@ def test_select_snowflake_plan(
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
 def test_select_statement(
-    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query, new_plan
 ):
     from_ = SelectSnowflakePlan(
         SnowflakePlan(
@@ -310,7 +316,7 @@ def test_select_statement(
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
 def test_select_table_function(
-    using_snowflake_plan, mock_session, mock_analyzer, mock_query
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query, new_plan
 ):
     project_plan = Project([], old_plan)
     snowflake_plan = SnowflakePlan(
@@ -358,7 +364,9 @@ def test_select_table_function(
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
-def test_set_statement(using_snowflake_plan, mock_session, mock_analyzer, mock_query):
+def test_set_statement(
+    using_snowflake_plan, mock_session, mock_analyzer, mock_query, new_plan
+):
     selectable1 = SelectableEntity(
         SnowflakeTable(name="table1", session=mock_session), analyzer=mock_analyzer
     )
@@ -393,7 +401,7 @@ def test_set_statement(using_snowflake_plan, mock_session, mock_analyzer, mock_q
     assert set_statement_plan.children_plan_nodes == [new_plan, selectable2]
 
 
-def test_replace_child_negative():
+def test_replace_child_negative(new_plan):
     mock_parent = mock.Mock()
     mock_parent._is_valid_for_replacement = True
     mock_child = LogicalPlan()

--- a/tests/unit/test_replace_child.py
+++ b/tests/unit/test_replace_child.py
@@ -26,6 +26,11 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     SnowflakeTable,
 )
 from snowflake.snowpark._internal.analyzer.table_function import TableFunctionExpression
+from snowflake.snowpark._internal.analyzer.table_merge_expression import (
+    TableDelete,
+    TableMerge,
+    TableUpdate,
+)
 from snowflake.snowpark._internal.analyzer.unary_plan_node import Project, Sort
 from snowflake.snowpark._internal.compiler.utils import replace_child
 
@@ -38,6 +43,24 @@ def new_plan(mock_session, mock_analyzer):
     yield SelectableEntity(
         SnowflakeTable(name="table", session=mock_session), analyzer=mock_analyzer
     )
+
+
+def assert_precondition(plan, new_plan, using_deep_copy=False):
+    original_valid_for_replacement = plan._is_valid_for_replacement
+    try:
+        plan._is_valid_for_replacement = False
+        with pytest.raises(ValueError, match="is not valid for replacement."):
+            replace_child(plan, irrelevant_plan, new_plan)
+
+        if using_deep_copy:
+            plan = copy.deepcopy(plan)
+        else:
+            plan._is_valid_for_replacement = True
+
+        with pytest.raises(ValueError, match="is not a child of parent"):
+            replace_child(plan, irrelevant_plan, new_plan)
+    finally:
+        plan._is_valid_for_replacement = original_valid_for_replacement
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
@@ -71,20 +94,14 @@ def test_logical_plan(using_snowflake_plan, mock_query, new_plan):
     else:
         join_plan = src_join_plan
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(join_plan, irrelevant_plan, new_plan)
+    assert_precondition(join_plan, new_plan)
+    assert_precondition(project_plan, new_plan)
 
     if using_snowflake_plan:
         join_plan = copy.deepcopy(join_plan)
     else:
         join_plan._is_valid_for_replacement = True
     project_plan._is_valid_for_replacement = True
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(join_plan, irrelevant_plan, new_plan)
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(project_plan, irrelevant_plan, new_plan)
 
     assert len(get_children(join_plan)) == 2
     copied_old_plan, copied_project_plan = get_children(join_plan)
@@ -113,13 +130,8 @@ def test_unary_plan(plan_initializer, new_plan):
     assert plan.child == old_plan
     assert plan.children == [old_plan]
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(plan, irrelevant_plan, new_plan)
-
+    assert_precondition(plan, new_plan)
     plan._is_valid_for_replacement = True
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(plan, irrelevant_plan, new_plan)
 
     replace_child(plan, old_plan, new_plan)
     assert plan.child == new_plan
@@ -133,18 +145,41 @@ def test_binary_plan(new_plan):
     assert plan.left == left_plan
     assert plan.right == old_plan
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(plan, irrelevant_plan, new_plan)
-
+    assert_precondition(plan, new_plan)
     plan._is_valid_for_replacement = True
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(plan, irrelevant_plan, new_plan)
 
     replace_child(plan, old_plan, new_plan)
     assert plan.left == left_plan
     assert plan.right == new_plan
     assert plan.children == [left_plan, new_plan]
+
+
+@pytest.mark.parametrize(
+    "plan_initializer",
+    [
+        lambda x: TableDelete("table_name", None, x),
+        lambda x: TableUpdate("table_name", {}, None, x),
+    ],
+)
+def test_table_delete_update(plan_initializer, new_plan):
+    plan = plan_initializer(old_plan)
+    assert_precondition(plan, new_plan)
+    plan._is_valid_for_replacement = True
+
+    replace_child(plan, old_plan, new_plan)
+    assert plan.source_data == new_plan.snowflake_plan
+    assert plan.children == [new_plan.snowflake_plan]
+
+
+def test_table_merge(new_plan):
+    plan = TableMerge("table_name", old_plan, None, [])
+
+    assert_precondition(plan, new_plan)
+    plan._is_valid_for_replacement = True
+
+    replace_child(plan, old_plan, new_plan)
+    assert plan.source == new_plan.snowflake_plan
+    assert plan.children == [new_plan.snowflake_plan]
 
 
 def test_snowflake_create_table(new_plan):
@@ -153,13 +188,8 @@ def test_snowflake_create_table(new_plan):
     assert plan.query == old_plan
     assert plan.children == [old_plan]
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(plan, irrelevant_plan, new_plan)
-
+    assert_precondition(plan, new_plan)
     plan._is_valid_for_replacement = True
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(plan, irrelevant_plan, new_plan)
 
     replace_child(plan, old_plan, new_plan)
     assert plan.query == new_plan
@@ -171,55 +201,44 @@ def test_selectable_entity(
     using_snowflake_plan, mock_session, mock_analyzer, mock_query, new_plan
 ):
     table = SnowflakeTable(name="table", session=mock_session)
-    selectable_entity = SelectableEntity(entity=table, analyzer=mock_analyzer)
+    plan = SelectableEntity(entity=table, analyzer=mock_analyzer)
     if using_snowflake_plan:
-        selectable_entity = SnowflakePlan(
+        plan = SnowflakePlan(
             queries=[mock_query],
             schema_query="",
             post_actions=[],
             expr_to_alias={},
-            source_plan=selectable_entity,
+            source_plan=plan,
             api_calls=None,
             df_aliased_col_name_to_real_col_name=None,
             placeholder_query=None,
             session=mock_session,
         )
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(selectable_entity, irrelevant_plan, new_plan)
-    selectable_entity = copy.deepcopy(selectable_entity)
 
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(selectable_entity, irrelevant_plan, new_plan)
-
+    assert_precondition(plan, new_plan, using_deep_copy=True)
     # SelectableEntity has no children
-    assert selectable_entity.children_plan_nodes == []
+    assert plan.children_plan_nodes == []
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
 def test_select_sql(using_snowflake_plan, mock_session, mock_analyzer, new_plan):
-    select_sql_plan = SelectSQL("FAKE QUERY", analyzer=mock_analyzer)
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(select_sql_plan, irrelevant_plan, new_plan)
-    select_sql_plan = copy.deepcopy(select_sql_plan)
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(select_sql_plan, irrelevant_plan, new_plan)
-
+    plan = SelectSQL("FAKE QUERY", analyzer=mock_analyzer)
     if using_snowflake_plan:
-        select_sql_plan = SnowflakePlan(
+        plan = SnowflakePlan(
             queries=[Query("FAKE QUERY")],
             schema_query="",
             post_actions=[],
             expr_to_alias={},
-            source_plan=select_sql_plan,
+            source_plan=plan,
             api_calls=None,
             df_aliased_col_name_to_real_col_name=None,
             placeholder_query=None,
             session=mock_session,
         )
 
+    assert_precondition(plan, new_plan, using_deep_copy=True)
     # SelectSQL has no children
-    assert select_sql_plan.children_plan_nodes == []
+    assert plan.children_plan_nodes == []
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
@@ -239,34 +258,28 @@ def test_select_snowflake_plan(
         session=mock_session,
     )
 
-    select_snowflake_plan = SelectSnowflakePlan(snowflake_plan, analyzer=mock_analyzer)
+    plan = SelectSnowflakePlan(snowflake_plan, analyzer=mock_analyzer)
 
     if using_snowflake_plan:
-        select_snowflake_plan = SnowflakePlan(
+        plan = SnowflakePlan(
             queries=[mock_query],
             schema_query="",
             post_actions=[],
             expr_to_alias={},
-            source_plan=select_snowflake_plan,
+            source_plan=plan,
             api_calls=None,
             df_aliased_col_name_to_real_col_name=None,
             placeholder_query=None,
             session=mock_session,
         )
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(select_snowflake_plan, irrelevant_plan, new_plan)
-    select_snowflake_plan = copy.deepcopy(select_snowflake_plan)
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(select_snowflake_plan, irrelevant_plan, new_plan)
-    assert len(select_snowflake_plan.children_plan_nodes) == 1
-
+    assert_precondition(plan, new_plan, using_deep_copy=True)
+    plan = copy.deepcopy(plan)
     # deep copy created a copy of old_plan
-    copied_old_plan = select_snowflake_plan.children_plan_nodes[0]
+    copied_old_plan = plan.children_plan_nodes[0]
 
-    replace_child(select_snowflake_plan, copied_old_plan, new_plan)
-    assert select_snowflake_plan.children_plan_nodes == [new_plan]
+    replace_child(plan, copied_old_plan, new_plan)
+    assert plan.children_plan_nodes == [new_plan]
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
@@ -287,31 +300,25 @@ def test_select_statement(
         ),
         analyzer=mock_analyzer,
     )
-    select_statement_plan = SelectStatement(from_=from_, analyzer=mock_analyzer)
+    plan = SelectStatement(from_=from_, analyzer=mock_analyzer)
 
     if using_snowflake_plan:
-        select_statement_plan = SnowflakePlan(
+        plan = SnowflakePlan(
             queries=[mock_query],
             schema_query="",
             post_actions=[],
             expr_to_alias={},
-            source_plan=select_statement_plan,
+            source_plan=plan,
             api_calls=None,
             df_aliased_col_name_to_real_col_name=None,
             placeholder_query=None,
             session=mock_session,
         )
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(select_statement_plan, irrelevant_plan, new_plan)
-    select_statement_plan = copy.deepcopy(select_statement_plan)
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(select_statement_plan, irrelevant_plan, new_plan)
-    assert select_statement_plan.children_plan_nodes == [from_]
-
-    replace_child(select_statement_plan, from_, new_plan)
-    assert select_statement_plan.children_plan_nodes == [new_plan]
+    assert_precondition(plan, new_plan, using_deep_copy=True)
+    plan = copy.deepcopy(plan)
+    replace_child(plan, from_, new_plan)
+    assert plan.children_plan_nodes == [new_plan]
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
@@ -330,37 +337,32 @@ def test_select_table_function(
         placeholder_query=None,
         session=mock_session,
     )
-    table_function_plan = SelectTableFunction(
+    plan = SelectTableFunction(
         TableFunctionExpression("table_function"),
         analyzer=mock_analyzer,
         snowflake_plan=snowflake_plan,
     )
     if using_snowflake_plan:
-        table_function_plan = SnowflakePlan(
+        plan = SnowflakePlan(
             queries=[mock_query],
             schema_query="",
             post_actions=[],
             expr_to_alias={},
-            source_plan=table_function_plan,
+            source_plan=plan,
             api_calls=None,
             df_aliased_col_name_to_real_col_name=None,
             placeholder_query=None,
             session=mock_session,
         )
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(table_function_plan, irrelevant_plan, new_plan)
-    table_function_plan = copy.deepcopy(table_function_plan)
-
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(table_function_plan, irrelevant_plan, new_plan)
-    assert len(table_function_plan.children_plan_nodes) == 1
+    assert_precondition(plan, new_plan, using_deep_copy=True)
+    plan = copy.deepcopy(plan)
 
     # deep copy created a copy of old_plan
-    copied_old_plan = table_function_plan.children_plan_nodes[0]
+    copied_old_plan = plan.children_plan_nodes[0]
 
-    replace_child(table_function_plan, copied_old_plan, new_plan)
-    assert table_function_plan.children_plan_nodes == [new_plan]
+    replace_child(plan, copied_old_plan, new_plan)
+    assert plan.children_plan_nodes == [new_plan]
 
 
 @pytest.mark.parametrize("using_snowflake_plan", [True, False])
@@ -373,32 +375,27 @@ def test_set_statement(
     selectable2 = SelectSQL("SELECT * FROM table2", analyzer=mock_analyzer)
     set_operand1 = SetOperand(selectable1, "UNION")
     set_operand2 = SetOperand(selectable2, "UNION")
-    set_statement_plan = SetStatement(
-        set_operand1, set_operand2, analyzer=mock_analyzer
-    )
+    plan = SetStatement(set_operand1, set_operand2, analyzer=mock_analyzer)
     if using_snowflake_plan:
-        set_statement_plan = SnowflakePlan(
+        plan = SnowflakePlan(
             queries=[mock_query],
             schema_query="",
             post_actions=[],
             expr_to_alias={},
-            source_plan=set_statement_plan,
+            source_plan=plan,
             api_calls=None,
             df_aliased_col_name_to_real_col_name=None,
             placeholder_query=None,
             session=mock_session,
         )
 
-    with pytest.raises(ValueError, match="is not valid for replacement."):
-        replace_child(set_statement_plan, irrelevant_plan, new_plan)
-    set_statement_plan = copy.deepcopy(set_statement_plan)
+    assert_precondition(plan, new_plan, using_deep_copy=True)
+    plan = copy.deepcopy(plan)
 
-    with pytest.raises(ValueError, match="is not a child of parent"):
-        replace_child(set_statement_plan, irrelevant_plan, new_plan)
-    assert set_statement_plan.children_plan_nodes == [selectable1, selectable2]
-
-    replace_child(set_statement_plan, selectable1, new_plan)
-    assert set_statement_plan.children_plan_nodes == [new_plan, selectable2]
+    replace_child(plan, selectable1, new_plan)
+    assert plan.children_plan_nodes == [new_plan, selectable2]
+    if not using_snowflake_plan:
+        assert plan.set_operands[0].selectable == new_plan
 
 
 def test_replace_child_negative(new_plan):

--- a/tests/unit/test_replace_child.py
+++ b/tests/unit/test_replace_child.py
@@ -159,26 +159,23 @@ def test_binary_plan(new_plan):
     [
         lambda x: TableDelete("table_name", None, x),
         lambda x: TableUpdate("table_name", {}, None, x),
+        lambda x: TableMerge("table_name", x, None, []),
     ],
 )
-def test_table_delete_update(plan_initializer, new_plan):
+def test_table_delete_update_merge(plan_initializer, new_plan):
+    def get_source(plan):
+        if hasattr(plan, "source_data"):
+            return plan.source_data
+        return plan.source
+
     plan = plan_initializer(old_plan)
+
+    assert get_source(plan) == old_plan
     assert_precondition(plan, new_plan)
     plan._is_valid_for_replacement = True
 
     replace_child(plan, old_plan, new_plan)
-    assert plan.source_data == new_plan.snowflake_plan
-    assert plan.children == [new_plan.snowflake_plan]
-
-
-def test_table_merge(new_plan):
-    plan = TableMerge("table_name", old_plan, None, [])
-
-    assert_precondition(plan, new_plan)
-    plan._is_valid_for_replacement = True
-
-    replace_child(plan, old_plan, new_plan)
-    assert plan.source == new_plan.snowflake_plan
+    assert get_source(plan) == new_plan.snowflake_plan
     assert plan.children == [new_plan.snowflake_plan]
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1557229

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   This PR add method `repalce_child` to `LogicalPlan`, `SnowflakePlan` and `Selectable` classes to replace and old child node with a new one. This method is used when rewriting plan tree during optimization stages.
