### PR TITLE
SNOW-1552816 : Fix Session.lineage.trace API output for feature views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### Bug Fixes
 - Fixed a bug where SQL generated for selecting `*` column has an incorrect subquery.
 - Fixed a bug in `DataFrame.to_pandas_batches` where the iterator could throw an error if certain transformation is made to the pandas dataframe due to wrong isolation level.
+- Fixed a bug in `DataFrame.lineage.trace` to split the quoted feature view's name and version correctly.
 
 ### Snowpark Local Testing Updates
 #### New Features

--- a/src/snowflake/snowpark/lineage.py
+++ b/src/snowflake/snowpark/lineage.py
@@ -424,10 +424,14 @@ class Lineage:
         if user_domain in self._versioned_object_domains:
             if user_domain == _UserDomain.FEATURE_VIEW:
                 if "$" in name:
-                    parts = name.split("$")
+                    had_quotes = name.startswith('"') and name.endswith('"')
+                    parts = name.strip('"').split("$")
                     if len(parts) >= 2:
                         base_name = "$".join(parts[:-1])
                         version = parts[-1]
+                        if had_quotes:
+                            base_name = f'"{base_name}"'
+                            version = f'"{version}"'
                         return (f"{db}.{schema}.{base_name}", version)
                 else:
                     raise SnowparkClientExceptionMessages.SERVER_FAILED_FETCH_LINEAGE(

--- a/src/snowflake/snowpark/lineage.py
+++ b/src/snowflake/snowpark/lineage.py
@@ -431,7 +431,6 @@ class Lineage:
                         version = parts[-1]
                         if had_quotes:
                             base_name = f'"{base_name}"'
-                            version = f'"{version}"'
                         return (f"{db}.{schema}.{base_name}", version)
                 else:
                     raise SnowparkClientExceptionMessages.SERVER_FAILED_FETCH_LINEAGE(

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -71,6 +71,17 @@ def test_get_name_and_version():
         _ObjectField.DB: "db1",
         _ObjectField.SCHEMA: "schema1",
         _ObjectField.PROPERTIES: {_ObjectField.PARENT_NAME: "whatever"},
+        _ObjectField.NAME: '"name1$v1"',
+    }
+    name, version = Lineage(fake_session)._get_name_and_version(graph_entity)
+    assert name == 'db1.schema1."name1"'
+    assert version == '"v1"'
+
+    graph_entity = {
+        _ObjectField.USER_DOMAIN: _UserDomain.FEATURE_VIEW,
+        _ObjectField.DB: "db1",
+        _ObjectField.SCHEMA: "schema1",
+        _ObjectField.PROPERTIES: {_ObjectField.PARENT_NAME: "whatever"},
         _ObjectField.NAME: "name1$name2$v1",
     }
     name, version = Lineage(fake_session)._get_name_and_version(graph_entity)

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -75,7 +75,7 @@ def test_get_name_and_version():
     }
     name, version = Lineage(fake_session)._get_name_and_version(graph_entity)
     assert name == 'db1.schema1."name1"'
-    assert version == '"v1"'
+    assert version == "v1"
 
     graph_entity = {
         _ObjectField.USER_DOMAIN: _UserDomain.FEATURE_VIEW,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1552816 
Quoted Feature view names were not correctly split. This PR fixes that 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
