### PR TITLE
Fix `Column.isin()`with empty list

### DIFF
--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -437,6 +437,16 @@ class Column:
             for ve in value_expressions:
                 validate_value(ve)
 
+        if len(value_expressions) == 0:
+            # If `InExpression()` gets passed an empty list as `value_expressions`, it
+            # produces an invalid (sub-)query with empty brackets, like:
+            #
+            #   `SELECT ... FROM ... WHERE <column> IN ()`
+            #
+            # To avoid this we take the shortcut and return a no-op in case of an empty
+            # list.
+            return Column(Literal(None))
+
         return Column(InExpression(self._expression, value_expressions))
 
     def between(

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -216,3 +216,15 @@ def test_column_with_builtins_that_shadow_functions(session):
     with pytest.raises(TypeError) as ex_info:
         TestData.double1(session).select(sum(col("a"))).collect()
     assert iter_error_msg_text in str(ex_info)
+
+
+def test_return_empty_set_for_empty_filter_isin(session):
+    """
+    Filtering a dataframe with `isin()` and an empty set should yield an empty
+    dataframe.
+
+    NOTE: In SQL an `IN` expression without at least one value is not valid at all.
+    """
+    df1 = session.create_dataframe([1, 2]).to_df("a")
+    assert df1.filter(df1["a"].isin(None)).collect() == []
+    assert df1.filter(df1["a"].isin([])).collect() == []

--- a/tests/mock/test_filter.py
+++ b/tests/mock/test_filter.py
@@ -148,6 +148,15 @@ def test_null_nan_filter(session):
     assert res[1] == Row(1.0, 1.0)
     assert res[2] == Row(None, None)
 
+    # Check `in` expression with empty sets
+    origin_df: DataFrame = session.create_dataframe([[1], [2]], schema=["a"])
+
+    res = origin_df.filter(origin_df["a"].isin(None)).collect()
+    assert res == []
+
+    res = origin_df.filter(origin_df["a"].isin([])).collect()
+    assert res == []
+
 
 def test_chain_filter(session):
     origin_df: DataFrame = session.create_dataframe(


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1565789

   Github Issue #1999

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   This PR solves the problem that an incorrect SQL query gets generated if `Column.isin()` get called with an empty list (not `None`).

   I'm not sure if the place for handling this is chosen wisely. I've tried several other locations, e.g. handling empty lists or Nones in `InExpression`, but there are a few places that rely on `InExpression.values` being an iterable, so I picked `Column.isin()` which seems the place with the minimum impact.

   I've assumed that the expected result of an empty `isin()` would be an empty dataframe, following the logic that an intersection of any set with the empty set is again the empty set.
   But since an SQL IN expression requires at least one value and is invalid otherwise, the result is maybe not (well) defined at all.

   I'd be glad if parts of this PR might be helpful, but I'm also aware that this could be a tricky issue, so take whatever is useful, no hard feelings.