### PR TITLE
Update the analyzer to use a consistent way to get the resolved children

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1189,7 +1189,7 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                resolved_children[logical_plan.source_data],
+                resolved_children[logical_plan.children[0]],
                 logical_plan,
             )
 
@@ -1201,14 +1201,14 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                resolved_children[logical_plan.source_data],
+                resolved_children[logical_plan.children[0]],
                 logical_plan,
             )
 
         if isinstance(logical_plan, TableMerge):
             return self.plan_builder.merge(
                 logical_plan.table_name,
-                resolved_children[logical_plan.source],
+                resolved_children[logical_plan.children[0]],
                 self.analyze(
                     logical_plan.join_expr, df_aliased_col_name_to_real_col_name
                 ),

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1189,8 +1189,8 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                resolved_children[logical_plan.children[0]]
-                if len(logical_plan.children) > 0
+                resolved_children[logical_plan.source_data]
+                if logical_plan.source_data
                 else None,
                 logical_plan,
             )
@@ -1203,8 +1203,8 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                resolved_children[logical_plan.children[0]]
-                if len(logical_plan.children) > 0
+                resolved_children[logical_plan.source_data]
+                if logical_plan.source_data
                 else None,
                 logical_plan,
             )
@@ -1212,7 +1212,7 @@ class Analyzer:
         if isinstance(logical_plan, TableMerge):
             return self.plan_builder.merge(
                 logical_plan.table_name,
-                resolved_children[logical_plan.children[0]],
+                resolved_children[logical_plan.source] if logical_plan.source else logical_plan.source,
                 self.analyze(
                     logical_plan.join_expr, df_aliased_col_name_to_real_col_name
                 ),

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1212,9 +1212,7 @@ class Analyzer:
         if isinstance(logical_plan, TableMerge):
             return self.plan_builder.merge(
                 logical_plan.table_name,
-                resolved_children[logical_plan.children[0]]
-                if len(logical_plan.children) > 0
-                else None,
+                resolved_children[logical_plan.children[0]],
                 self.analyze(
                     logical_plan.join_expr, df_aliased_col_name_to_real_col_name
                 ),

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1189,7 +1189,9 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                resolved_children[logical_plan.children[0]],
+                resolved_children[logical_plan.children[0]]
+                if len(logical_plan.children) > 0
+                else None,
                 logical_plan,
             )
 
@@ -1201,14 +1203,18 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                resolved_children[logical_plan.children[0]],
+                resolved_children[logical_plan.children[0]]
+                if len(logical_plan.children) > 0
+                else None,
                 logical_plan,
             )
 
         if isinstance(logical_plan, TableMerge):
             return self.plan_builder.merge(
                 logical_plan.table_name,
-                resolved_children[logical_plan.children[0]],
+                resolved_children[logical_plan.children[0]]
+                if len(logical_plan.children) > 0
+                else None,
                 self.analyze(
                     logical_plan.join_expr, df_aliased_col_name_to_real_col_name
                 ),

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1189,7 +1189,7 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                logical_plan.source_data,
+                resolved_children[logical_plan.source_data],
                 logical_plan,
             )
 
@@ -1201,14 +1201,14 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
-                logical_plan.source_data,
+                resolved_children[logical_plan.source_data],
                 logical_plan,
             )
 
         if isinstance(logical_plan, TableMerge):
             return self.plan_builder.merge(
                 logical_plan.table_name,
-                logical_plan.source,
+                resolved_children[logical_plan.source],
                 self.analyze(
                     logical_plan.join_expr, df_aliased_col_name_to_real_col_name
                 ),

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1203,6 +1203,7 @@ class Analyzer:
                 )
                 if logical_plan.condition
                 else None,
+                # source_data is marked as child of the logical_plan
                 resolved_children[logical_plan.source_data]
                 if logical_plan.source_data
                 else None,
@@ -1212,7 +1213,9 @@ class Analyzer:
         if isinstance(logical_plan, TableMerge):
             return self.plan_builder.merge(
                 logical_plan.table_name,
-                resolved_children[logical_plan.source] if logical_plan.source else logical_plan.source,
+                resolved_children[logical_plan.source]
+                if logical_plan.source
+                else logical_plan.source,
                 self.analyze(
                     logical_plan.join_expr, df_aliased_col_name_to_real_col_name
                 ),

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -3,11 +3,11 @@
 #
 
 import sys
-from functools import cached_property
 from abc import ABC, abstractmethod
 from collections import UserDict, defaultdict
 from copy import copy, deepcopy
 from enum import Enum
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     AbstractSet,

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -3,6 +3,7 @@
 #
 
 import sys
+from functools import cached_property
 from abc import ABC, abstractmethod
 from collections import UserDict, defaultdict
 from copy import copy, deepcopy
@@ -252,7 +253,7 @@ class Selectable(LogicalPlan, ABC):
         """Returns the placeholder query of this Selectable logical plan."""
         pass
 
-    @property
+    @cached_property
     def _id(self) -> Optional[str]:
         """Returns the id of this Selectable logical plan."""
         return encode_id(self.sql_query, self.query_params)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.
This pr does the following small change that has no impact to users.
1) Update how TableUpdate, TableMerge and TableDelete  is handled in analyzer to use resolved children instead of the original one. This way it is consistent with how other nodes are handled in analyzer, and with the new compilation stage, the children may need to be re-resolved to get the final correct plan node.
2) update the _id to be a cached property, so that the id will not be updated once set.