### PR TITLE
Always run tests in the America/New_York time zone

### DIFF
--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -185,5 +185,7 @@ def test_ast(session, test_case):
 
 
 if __name__ == "__main__":
+    # Use any time zone other than America/Los_Angeles and UTC, to minimize the
+    # odds of tests passing by luck.
     os.environ["TZ"] = "America/New_York"
     pytest.main()

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -185,4 +185,5 @@ def test_ast(session, test_case):
 
 
 if __name__ == "__main__":
+    os.environ["TZ"] = "America/New_York"
     pytest.main()


### PR DESCRIPTION
Some of the column literal tests specify timestamps or datetime objects without a time zone. This is a good thing, as it's something client code can choose to do.

For these tests, the time zone defaults to the system time zone. This is a bad thing, as it renders the test sensitive to the current configured time zone.

Explicitly codify the time zone that is implicitly used in the existing expectation tests. Use any time zone *other* than `America/Los_Angeles` and `UTC`, to minimize the possibility that the test passes by chance.

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-0000000

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   The `col_literals.test` creates datetime and timestamp objects without an explicit time zone. This is a legitimate action that client code might perform.
   When the API caller does not supply an explicit time zone, the Python datetime module will use the system time zone. The system time zone might vary between development and test machines.
   Explicitly choose a time zone that allows `col_literals.test` to pass with the current expectations.