### PR TITLE
SNOW-1558347: Fix PARSE_HEADER bug in session.read.csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed a bug in `DataFrame.lineage.trace` to split the quoted feature view's name and version correctly.
 - Fixed a bug in `Column.isin` that caused invalid sql generation when passed an empty list.
 - Fixed a bug that fails to raise NotImplementedError while setting cell with list like item.
+- Fixed a bug in `session.read.csv` that caused an error when setting `PARSE_HEADER = True` in an externally defined file format.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -887,7 +887,10 @@ def create_file_format_statement(
     use_scoped_temp_objects: bool = False,
     is_generated: bool = False,
 ) -> str:
-    options_str = TYPE + EQUALS + file_type + SPACE + get_options_statement(options)
+    type_str = TYPE + EQUALS + file_type + SPACE
+    options_str = (
+        type_str if "TYPE" not in options else EMPTY_STRING
+    ) + get_options_statement(options)
     return (
         CREATE
         + (

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1126,13 +1126,13 @@ class SnowflakePlanBuilder:
         ).collect()
         for setting in file_format:
             if (
-                setting.property_value == setting.property_default
-                or setting.property in new_options
+                setting["property_value"] == setting["property_default"]
+                or setting["property"] in new_options
             ):
                 continue
-            new_options[setting.property] = type_map.get(setting.property_type, str)(
-                setting.property_value
-            )
+            new_options[str(setting["property"])] = type_map.get(
+                str(setting["property_type"]), str
+            )(setting["property_value"])
         return new_options
 
     def read_file(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1132,6 +1132,7 @@ class SnowflakePlanBuilder:
             "Boolean": bool,
         }
         new_options = {**file_format_options}
+        # SNOW-1628625: This query and subsequent merge operations should be done lazily
         file_format = self.session.sql(
             f"DESCRIBE FILE FORMAT {options['FORMAT_NAME']}"
         ).collect()

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -617,6 +617,7 @@ class DataFrameReader:
                 drop_tmp_file_format_if_exists_query = (
                     drop_file_format_if_exists_statement(file_format_name)
                 )
+            # SNOW-1628625: Schema inference should be done lazily
             results = self._session._conn.run_query(infer_schema_query)["data"]
             if len(results) == 0:
                 raise FileNotFoundError(

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -488,7 +488,7 @@ def test_csv_read_format_name(session, tmp_stage_name1):
     temp_file_fmt_name = Utils.random_name_for_temp_object(TempObjectType.FILE_FORMAT)
     session.sql(
         f"create temporary file format {temp_file_fmt_name} type = csv skip_header=1 "
-        "null_if = 'none';"
+        "null_if = ('none','NA');"
     ).collect()
     df = (
         session.read.schema(
@@ -564,7 +564,9 @@ def test_json_read_format_name(session, tmp_stage_name1):
     )
 
     assert any(
-        f"FILE_FORMAT  => '{file_fmt_name}'" in q for q in sf_df.queries["queries"]
+        "CREATE SCOPED TEMPORARY FILE  FORMAT" in q
+        and "TYPE = 'json' NULL_IF = '' COMPRESSION = 'gzip'" in q
+        for q in sf_df.queries["queries"]
     )
 
     df = sf_df.collect()

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -108,6 +108,9 @@ def test_copy_into_format_name_syntax(format_type, sql_simplifier_enabled):
     def query_result(*args, **kwargs):
         return [], [], [], None
 
+    def nop(name):
+        return name
+
     fake_session = mock.create_autospec(snowflake.snowpark.session.Session)
     fake_session.sql_simplifier_enabled = sql_simplifier_enabled
     fake_session._cte_optimization_enabled = False
@@ -115,6 +118,8 @@ def test_copy_into_format_name_syntax(format_type, sql_simplifier_enabled):
     fake_session._conn = mock.create_autospec(ServerConnection)
     fake_session._plan_builder = SnowflakePlanBuilder(fake_session)
     fake_session._analyzer = Analyzer(fake_session)
+    fake_session._use_scoped_temp_objects = True
+    fake_session.get_fully_qualified_name_if_possible = nop
     with mock.patch(
         "snowflake.snowpark.dataframe_reader.DataFrameReader._infer_schema_for_file_format",
         query_result,
@@ -122,7 +127,11 @@ def test_copy_into_format_name_syntax(format_type, sql_simplifier_enabled):
         df = getattr(
             DataFrameReader(fake_session).option("format_name", "TEST_FMT"), format_type
         )("@stage/file")
-    assert any("FILE_FORMAT  => 'TEST_FMT'" in q for q in df.queries["queries"])
+    assert any(
+        "CREATE SCOPED TEMPORARY FILE  FORMAT" in q
+        and f"TYPE  = {format_type.upper()}" in q
+        for q in df.queries["queries"]
+    )
 
 
 def test_select_bad_input():


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1558347

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Previously if a user specified `PARSE_HEADER = True` in an externally defined file format it would not be able to be used with `session.read.csv` without throwing an exception. This exception was caused due to how we infer csv schemas in the client. The client separates out csv loading into a schema inference step and a query step. Parsing the header is valid in the inference step, but should be skipped in the query step.

  This change modifies the logic to the read step so that a temporary file format is always created. The external file format is queried and merged with the local options giving the local options precedence. The local options are then modified as needed such as for the parse header issue above.

  I've added a test that provides a scenario that would have previously failed.

  These parts may be contentious:
  - `create_file_format_statement` is changed to only set the format if it wasn't specified in the options
  - `_merge_file_format_options` does some parsing of the options itself. I didn't see any other logic that currently handles that format. It should work for all currently existing formats, but it could break for future options if their formatting is significantly different.   
  - The new logic for `read_file` prefers the client specified options over the file_format options whereas previously the client format options would have been ignored. This is trivial to change, but I think the new style should make more sense to the user.