### PR TITLE
SNOW-1569842: Allow string literals in to_date fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added support for column lineage in the DataFrame.lineage.trace API.
 - Added support for passing `INFER_SCHEMA` options to `DataFrameReader` via `INFER_SCHEMA_OPTIONS`.
 - Added support for automatically cleaning up temporary tables created by `df.cache_result()` in the current session, when the DataFrame is no longer referenced (i.e., gets garbage collected). It is still an experimental feature not enabled by default, and can be enabled by setting `session.auto_clean_up_temp_table_enabled` to `True`.
+- Added support for string literals to the `fmt` parameter of `snowflake.snowpark.functions.to_date`.
 
 #### Bug Fixes
 

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1936,6 +1936,7 @@ def test_to_date(session):
             df.select(*[to_date(col(column)) for column in df.columns]), expected
         )
 
+    # with format column
     expected4 = [
         Row(date(2024, 4, 18)),
         Row(date(1999, 9, 1)),
@@ -1943,9 +1944,17 @@ def test_to_date(session):
         Row(date(2015, 5, 15)),
     ]
     df = TestData.date_primitives4(session)
-    Utils.check_answer(
-        df.select(to_date(*[col(column) for column in df.columns])), expected4
-    )
+    Utils.check_answer(df.select(to_date(df.a, df.b)), expected4)
+
+    # with string format column
+    data5 = ["1999-01-01", "2000-02-02", "2024-03-03"]
+    expected5 = [
+        Row(date(1999, 1, 1)),
+        Row(date(2000, 2, 2)),
+        Row(date(2024, 3, 3)),
+    ]
+    df = session.create_dataframe(data5).to_df(["a"])
+    Utils.check_answer(df.select(to_date(df.a, "YYYY-MM-DD")), expected5)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1569842

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   The typing for the fmt parameter of `to_date` is a little ambiguous in the [sql docs](https://docs.snowflake.com/en/sql-reference/functions/to_date#arguments). Spark and pandas both support string literals in their equivalent functions so I think it's worthwhile to add support for it here to.