### PR TITLE
[SNOW-1570952] Remove unnecessary workaround for query comparison

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1564,6 +1564,7 @@ class Query:
             self.sql == other.sql
             and self.query_id_place_holder == other.query_id_place_holder
             and self.is_ddl_on_temp_object == other.is_ddl_on_temp_object
+            and self.params == other.params
         )
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -613,25 +613,6 @@ class SnowflakePlanBuilder:
         }
         api_calls = [*select_left.api_calls, *select_right.api_calls]
 
-        # This is a temporary workaround for query comparison. The query_id_place_holder
-        # field of Query be a random generated id if not provided, which could cause the
-        # comparison of two queries fail even if the sql and is_ddl_on_temp_object
-        # value is the same.
-        # TODO (SNOW-1570952): Find a uniform way for the query comparison
-        def _query_exists(current_query: Query, existing_queries: List[Query]) -> bool:
-            for existing_query in existing_queries:
-                if (
-                    (current_query.sql == existing_query.sql)
-                    and (
-                        current_query.is_ddl_on_temp_object
-                        == existing_query.is_ddl_on_temp_object
-                    )
-                    and (current_query.params == existing_query.params)
-                ):
-                    return True
-
-            return False
-
         referenced_ctes: Set[str] = set()
         if (
             self.session.cte_optimization_enabled
@@ -644,7 +625,7 @@ class SnowflakePlanBuilder:
             # Need to do a deduplication to avoid repeated query.
             merged_queries = select_left.queries[:-1].copy()
             for query in select_right.queries[:-1]:
-                if not _query_exists(query, merged_queries):
+                if query not in merged_queries:
                     merged_queries.append(copy.copy(query))
 
             referenced_ctes.update(select_left.referenced_ctes)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -38,7 +38,7 @@ pytestmark = [
 
 WITH = "WITH"
 
-paramList = [True, False]
+paramList = [False, True]
 
 
 @pytest.fixture(params=paramList, autouse=True)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -38,7 +38,7 @@ pytestmark = [
 
 WITH = "WITH"
 
-paramList = [False, True]
+paramList = [True, False]
 
 
 @pytest.fixture(params=paramList, autouse=True)
@@ -116,7 +116,7 @@ def test_unary(session, action):
         lambda x, y: x.join(y.select("a"), how="left", rsuffix="_y"),
     ],
 )
-def test_binary(session, action):
+def test_binary(session, action, sql_simplifier_enabled):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     check_result(session, action(df, df), expect_cte_optimized=True)
 
@@ -130,7 +130,23 @@ def test_binary(session, action):
         df2 = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     finally:
         analyzer.ARRAY_BIND_THRESHOLD = original_threshold
-    check_result(session, action(df2, df2), expect_cte_optimized=True)
+    df3 = action(df2, df2)
+    check_result(session, df3, expect_cte_optimized=True)
+    plan_queries = df3.queries
+    # check the number of queries
+    binary_build_used = (not sql_simplifier_enabled) or (
+        "JOIN" in plan_queries["queries"][-1]
+    )
+    # TODO (SNOW-1569005): Deduplicate queries during plan build for binary operators. This currently
+    #   is only fixed when _query_compilation_stage_enabled for build_binary.
+    if session._query_compilation_stage_enabled and binary_build_used:
+        num_queries = 3
+        num_post_actions = 1
+    else:
+        num_queries = 5
+        num_post_actions = 2
+    assert len(plan_queries["queries"]) == num_queries
+    assert len(plan_queries["post_actions"]) == num_post_actions
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
SNOW-1570952

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.
Previously, we put an function for deduplication of queries to allow deduplication of same query text but different place_holder_id. However, when propagating those query, the same query comes from the same node, they will also have the same placeholder id, therefore, there is no need for this extra comparison function.
