### PR TITLE
SNOW-1615695: Push empty all/any processing down to query compiler

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -925,7 +925,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
                 return data_for_compute.all(
                     axis=axis, bool_only=False, skipna=skipna, **kwargs
                 )
-            result = self._reduce_dimension(
+            return self._reduce_dimension(
                 self._query_compiler.all(
                     axis=axis, bool_only=bool_only, skipna=skipna, **kwargs
                 )
@@ -948,7 +948,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
                 return result.all(
                     axis=axis, bool_only=bool_only, skipna=skipna, **kwargs
                 )
-        return True if result is None else result
+            return result
 
     def any(self, axis=0, bool_only=None, skipna=True, **kwargs):
         """
@@ -969,7 +969,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
                 return data_for_compute.any(
                     axis=axis, bool_only=False, skipna=skipna, **kwargs
                 )
-            result = self._reduce_dimension(
+            return self._reduce_dimension(
                 self._query_compiler.any(
                     axis=axis, bool_only=bool_only, skipna=skipna, **kwargs
                 )
@@ -990,7 +990,7 @@ class BasePandasDataset(metaclass=TelemetryMeta):
                 return result.any(
                     axis=axis, bool_only=bool_only, skipna=skipna, **kwargs
                 )
-        return False if result is None else result
+            return result
 
     def apply(
         self,

--- a/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
@@ -480,7 +480,7 @@ def get_snowflake_agg_func(
             return lambda col: column_quantile(col, interpolation, q)
         elif agg_func in ("all", "any"):
             # If there are no rows in the input frame, the function will also return NULL, which should
-            # instead by TRUE for "all" and FALSE for "any"."
+            # instead by TRUE for "all" and FALSE for "any".
             # Need to wrap column name in IDENTIFIER, or else the agg function will treat the name
             # as a string literal.
             default_value = bool(agg_func == "all")

--- a/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
@@ -483,6 +483,10 @@ def get_snowflake_agg_func(
             # instead by TRUE for "all" and FALSE for "any".
             # Need to wrap column name in IDENTIFIER, or else the agg function will treat the name
             # as a string literal.
+            # The generated SQL expression for "all" is
+            #   IFNULL(BOOLAND_AGG(IDENTIFIER("column_name")), TRUE)
+            # The expression for "any" is
+            #   IFNULL(BOOLOR_AGG(IDENTIFIER("column_name")), FALSE)
             default_value = bool(agg_func == "all")
             return lambda col: builtin("ifnull")(
                 # mypy refuses to acknowledge snowflake_agg_func is non-NULL here

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -2129,22 +2129,21 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
         else:
             assert axis == 0
-            # The query compiler agg method complains if the resulting aggregation is empty, so we add a special check here
+            # The query compiler agg method complains if the resulting aggregation is empty, so we add a special check here.
             if empty_columns:
                 # The result should be an empty series of dtype bool, which is internally represented as an
                 # empty dataframe with only the MODIN_UNNAMED_SERIES_LABEL column
                 return SnowflakeQueryCompiler.from_pandas(
                     native_pd.DataFrame({MODIN_UNNAMED_SERIES_LABEL: []}, dtype=bool)
                 )
-
-            # The resulting DF is transposed so will have string 'NULL' as a column name,
-            # so we need to manually remove it
+            # If there are now rows (but there are columns), booland_agg/boolor_agg would return NULL.
+            # This behavior is handled within aggregation_utils to avoid an extra query.
             return self.agg(
                 agg_func,
                 axis=0,
                 args=[],
                 kwargs={"skipna": skipna},
-            ).set_columns([MODIN_UNNAMED_SERIES_LABEL])
+            )
 
     def all(
         self,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1615695

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Snowpark pandas implements `df.any/all(axis=0)` via the BOOLAND_AGG and BOOLOR_AGG SQL functions. These functions return a single row of NULL if there are no elements, while pandas produces a vacuous True/False value. In the fixes for SNOW-1458141, these cases are handled in the frontend, but since the frontend changes don't make sense for other modin backends, they should be pushed down to the query compiler or lower.

This PR adds an IFNULL statement to wrap the result of BOOLAND_AGG/BOOLOR_AGG to handle the empty-row case without any additional queries. This returns the frontend all/any functions to match the modin implementations.