### PR TITLE
[SNOW-1616087] Use copy instead of deepcopy during query generation

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -133,7 +133,7 @@ class QueryGenerator(Analyzer):
             )
 
             # update the resolved child
-            copied_resolved_child = copy.deepcopy(resolved_child)
+            copied_resolved_child = copy.copy(resolved_child)
             final_queries = get_snowflake_plan_queries(
                 copied_resolved_child, self.resolved_with_query_block
             )
@@ -173,7 +173,7 @@ class QueryGenerator(Analyzer):
             # the with definition must be generated before create, update, delete, merge and copy into
             # query.
             resolved_child = resolved_children[logical_plan.children[0]]
-            copied_resolved_child = copy.deepcopy(resolved_child)
+            copied_resolved_child = copy.copy(resolved_child)
             final_queries = get_snowflake_plan_queries(
                 copied_resolved_child, self.resolved_with_query_block
             )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

SNOW-1616087

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.
In query generator https://github.com/snowflakedb/snowpark-python/blob/main/src/snowflake/snowpark/_internal/compiler/query_generator.py#L136, we made deep copy of the resolved child to avoid messing up with the original snowflake plan node, because there is an update of queries field, however, there is no need for a deep copy here, a shallow copy should be enough.
