### PR TITLE
SNOW-1618623 lazy index: refactor qc as input for index constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 
 ### Behavior change
 - `Dataframe.columns` now returns native pandas Index object instead of Snowpark Index object.
+- Refactor and introduce `query_compiler` argument in `Index` constructor to create `Index` from query compiler.
 
 ## 1.20.0 (2024-07-17)
 

--- a/src/snowflake/snowpark/modin/pandas/base.py
+++ b/src/snowflake/snowpark/modin/pandas/base.py
@@ -670,8 +670,12 @@ class BasePandasDataset(metaclass=TelemetryMeta):
         from snowflake.snowpark.modin.plugin.extensions.index import Index
 
         if self._query_compiler.is_multiindex():
+            # Lazy multiindex is not supported
             return self._query_compiler.index
-        return Index(data=self)
+
+        idx = Index(query_compiler=self._query_compiler)
+        idx._parent = self
+        return idx
 
     index = property(_get_index, _set_index)
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1585,6 +1585,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             The index (row labels) of the DataFrame.
         """
         if self.is_multiindex():
+            # Lazy multiindex is not supported
             return self._modin_frame.index_columns_pandas_index()
         else:
             return pd.Index(query_compiler=self)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1578,8 +1578,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
     @property
     def index(self) -> Union["pd.Index", native_pd.MultiIndex]:
         """
-        Get index. If MultiIndex, the method eagerly pulls the values from Snowflake because index requires the values to be
-        filled and returns a pandas MultiIndex. If not MultiIndex, create a modin index and pass it self
+        Get index. If MultiIndex, the method eagerly pulls the values from Snowflake because index requires the values
+        to be filled and returns a pandas MultiIndex. If not MultiIndex, create a modin index and pass itself
 
         Returns:
             The index (row labels) of the DataFrame.
@@ -1587,7 +1587,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if self.is_multiindex():
             return self._modin_frame.index_columns_pandas_index()
         else:
-            return pd.Index(self)
+            return pd.Index(query_compiler=self)
 
     def _is_scalar_in_index(self, scalar: Union[Scalar, tuple]) -> bool:
         """

--- a/tests/integ/modin/index/test_datetime_index_methods.py
+++ b/tests/integ/modin/index/test_datetime_index_methods.py
@@ -46,7 +46,7 @@ def test_datetime_index_construction_negative():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     msg = "DatetimeIndex can only be created from a query compiler with TimestampType"
     with pytest.raises(ValueError, match=msg):
-        pd.DatetimeIndex(df._query_compiler)
+        pd.DatetimeIndex(query_compiler=df._query_compiler)
 
 
 @sql_count_checker(query_count=0)
@@ -72,7 +72,7 @@ def test_non_default_args(kwargs):
     value = list(kwargs.values())[0]
     msg = f"Non-default argument '{name}={value}' when constructing Index with query compiler"
     with pytest.raises(AssertionError, match=msg):
-        pd.DatetimeIndex(data=idx._query_compiler, **kwargs)
+        pd.DatetimeIndex(query_compiler=idx._query_compiler, **kwargs)
 
 
 @sql_count_checker(query_count=6)

--- a/tests/integ/modin/index/test_index_methods.py
+++ b/tests/integ/modin/index/test_index_methods.py
@@ -382,4 +382,21 @@ def test_non_default_args(kwargs):
     value = list(kwargs.values())[0]
     msg = f"Non-default argument '{name}={value}' when constructing Index with query compiler"
     with pytest.raises(AssertionError, match=msg):
-        pd.Index(data=idx._query_compiler, **kwargs)
+        pd.Index(query_compiler=idx._query_compiler, **kwargs)
+
+
+@sql_count_checker(query_count=2)
+def test_create_index_from_series():
+    idx = pd.Index(pd.Series([5, 6]))
+    assert_index_equal(idx, native_pd.Index([5, 6]))
+
+    idx = pd.Index(pd.Series([5, 6], name="abc"))
+    assert_index_equal(idx, native_pd.Index([5, 6], name="abc"))
+
+
+@sql_count_checker(query_count=0)
+def test_create_index_from_df_negative():
+    with pytest.raises(ValueError):
+        pd.Index(pd.DataFrame([[1, 2], [3, 4]]))
+    with pytest.raises(ValueError):
+        pd.DatetimeIndex(pd.DataFrame([[1, 2], [3, 4]]))


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1618623

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

lazy index: 

- refactor qc as input for index constructor and make it consistent with other init methos like dataframe and series.
- raise ValueError for `pd.Index(df)`