### PR TITLE
Fix pandas doc test failure after removing unncessary cast

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py
@@ -1340,7 +1340,7 @@ class CombinedDatetimelikeProperties:
         0    0
         1    1
         2    2
-        dtype: int64
+        dtype: int32
         """
 
     @property
@@ -1375,7 +1375,7 @@ class CombinedDatetimelikeProperties:
         6    4
         7    5
         8    6
-        dtype: int64
+        dtype: int16
         """
         pass
 


### PR DESCRIPTION
We are preparing to rollout optimization for eliminating unnecessary cast for numeric values PYTHON_SNOWPARK_ELIMINATE_NUMERIC_SQL_VALUE_CAST_ENABLED.
After turning the flag on for our testing account, the following doctest start failing due to type difference
1. snowpark.modin.plugin.docstrings.series_utils.CombinedDatetimelikeProperties.dayofweek
2. snowpark.modin.plugin.docstrings.series_utils.CombinedDatetimelikeProperties.nanosecond

The difference is caused due to the remove of extra cast expression in binary operations, for example
before the change, the generated column expression for dayofweek contains an extra cast the integer 1
dayofweekiso("__reduced__") - 1::INT
After we remove the cast,  the query will have no extra cast, and completely rely on snowflake engine for type decision
dayofweekiso("__reduced__") - 1


