### PR TITLE
SNOW-1623450: fix flaky test by mocking datetime now

### DIFF
--- a/tests/integ/scala/test_update_delete_merge_suite.py
+++ b/tests/integ/scala/test_update_delete_merge_suite.py
@@ -5,7 +5,6 @@
 
 import copy
 import datetime
-from unittest.mock import patch
 
 import pytest
 
@@ -22,9 +21,6 @@ from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.exceptions import SnowparkTableException
 from snowflake.snowpark.functions import (
     col,
-    current_date,
-    current_time,
-    current_timestamp,
     max as max_,
     mean,
     min as min_,
@@ -345,10 +341,10 @@ def test_merge_with_insert_clause_only(session, local_testing_mode):
     ) == MergeResult(1, 0, 0)
     Utils.check_answer(target, [Row(10, "old"), Row(11, "new"), Row(12, "new")])
 
-    now_datetime = datetime.datetime(2024, 8, 13, 10, 1, 50)
-    fixed_date = datetime.datetime(2024, 7, 18, 12, 12, 12)
+    fixed_datetime = datetime.datetime(2024, 7, 18, 12, 12, 12)
+    insert_datetime = datetime.datetime(2024, 8, 13, 10, 1, 50)
     target_df = session.create_dataframe(
-        [("id1", fixed_date, fixed_date.date(), fixed_date.time())],
+        [("id1", fixed_datetime, fixed_datetime.date(), fixed_datetime.time())],
         schema=StructType(
             [
                 StructField("id", StringType()),
@@ -368,40 +364,29 @@ def test_merge_with_insert_clause_only(session, local_testing_mode):
         ],
         schema=StructType([StructField("id", StringType())]),
     )
-    with patch("snowflake.snowpark.mock._functions.datetime") as dt:
-        dt.datetime.now.return_value = now_datetime
-        assert target.merge(
-            source_df,
-            target["id"] == source_df["id"],
-            [
-                when_not_matched().insert(
-                    {
-                        "id": source_df["id"],
-                        "col_datetime": current_timestamp(),
-                        "col_date": current_date(),
-                        "col_time": current_time(),
-                    }
-                )
-            ],
-        ) == MergeResult(2, 0, 0)
-        res = target.collect()
-        assert (
-            len(res) == 3
-            and res[0][0] == "id1"
-            and res[0][1] == fixed_date
-            and res[0][2] == fixed_date.date()
-            and res[0][3] == fixed_date.time()
-        )
-        assert res[1][0] == "id2" and res[2][0] == "id3"
+    assert target.merge(
+        source_df,
+        target["id"] == source_df["id"],
+        [
+            when_not_matched().insert(
+                {
+                    "id": source_df["id"],
+                    "col_datetime": insert_datetime,
+                    "col_date": insert_datetime.date(),
+                    "col_time": insert_datetime.time(),
+                }
+            )
+        ],
+    ) == MergeResult(2, 0, 0)
 
-        if local_testing_mode:
-            assert res[1][1] == res[2][1] == now_datetime
-            assert res[1][2] == res[2][2] == now_datetime.date()
-            assert res[1][3] == res[2][3] == now_datetime.time()
-        else:
-            # in live connection time can differ because server timezone and test machine timezone differ
-            # so that we do not test exact time
-            assert len(res[1]) == len(res[2]) == 4
+    Utils.check_answer(
+        target,
+        [
+            Row("id1", fixed_datetime, fixed_datetime.date(), fixed_datetime.time()),
+            Row("id2", insert_datetime, insert_datetime.date(), insert_datetime.time()),
+            Row("id3", insert_datetime, insert_datetime.date(), insert_datetime.time()),
+        ],
+    )
 
 
 def test_merge_with_matched_and_not_matched_clauses(session):

--- a/tests/mock/test_functions.py
+++ b/tests/mock/test_functions.py
@@ -3,6 +3,7 @@
 #
 import datetime
 import math
+import unittest.mock
 
 import pytest
 
@@ -16,6 +17,9 @@ from snowflake.snowpark.functions import (  # count,; is_null,;
     col,
     contains,
     count,
+    current_date,
+    current_time,
+    current_timestamp,
     desc,
     is_null,
     lit,
@@ -327,3 +331,13 @@ def test_function_register_unregister(session):
     assert registry.get_function("abs") == mocked
     registry.unregister("abs")
     assert registry.get_function("abs") is None
+
+
+def test_current_time(session):
+    df = session.create_dataframe([1], schema=["a"])
+    now_datetime = datetime.datetime(2024, 8, 13, 10, 1, 50)
+    with unittest.mock.patch("snowflake.snowpark.mock._functions.datetime") as dt:
+        dt.datetime.now.return_value = now_datetime
+        assert df.select(
+            current_timestamp(), current_date(), current_time()
+        ).collect() == [Row(now_datetime, now_datetime.date(), now_datetime.time())]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1623450

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Fix flaky test due to the inherently unstable current time execution.
in this PR I decoupled the test:
1. add local testing current_timestamp/date/time test to use mock session only
2. update merge clause to be independent of current_timestamp/date/time