### PR TITLE
SNOW-1625830: Fix circular import when calling `to_snowpark_pandas` without initializing Snowpark pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Fixed a bug in `DataFrame.lineage.trace` to split the quoted feature view's name and version correctly.
 - Fixed a bug in `Column.isin` that caused invalid sql generation when passed an empty list.
 - Fixed a bug that fails to raise NotImplementedError while setting cell with list like item.
+- Fixed a bug where calling `DataFrame.to_snowpark_pandas_dataframe` without explicitly initializing the Snowpark pandas plugin caused an error.
 
 ### Snowpark Local Testing Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed a bug in `session.read.csv` that caused an error when setting `PARSE_HEADER = True` in an externally defined file format.
 - Fixed a bug in query generation from set operations that allowed generation of duplicate queries when children have common subqueries.
 - Fixed a bug in `session.get_session_stage` that referenced a non-existing stage after switching database or schema.
+- Fixed a bug where calling `DataFrame.to_snowpark_pandas_dataframe` without explicitly initializing the Snowpark pandas plugin caused an error.
 
 ### Snowpark Local Testing Updates
 
@@ -98,7 +99,6 @@
 - Fixed a bug in `DataFrame.lineage.trace` to split the quoted feature view's name and version correctly.
 - Fixed a bug in `Column.isin` that caused invalid sql generation when passed an empty list.
 - Fixed a bug that fails to raise NotImplementedError while setting cell with list like item.
-- Fixed a bug where calling `DataFrame.to_snowpark_pandas_dataframe` without explicitly initializing the Snowpark pandas plugin caused an error.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1007,8 +1007,12 @@ class DataFrame:
             B A
             2 1  1  3  1
         """
-        import snowflake.snowpark.modin.pandas as pd  # pragma: no cover
-
+        # black and isort disagree on how to format this section with isort: skip
+        # fmt: off
+        import snowflake.snowpark.modin.plugin  # isort: skip  # noqa: F401
+        # If snowflake.snowpark.modin.plugin was successfully imported, then modin.pandas is available
+        import modin.pandas as pd  # isort: skip
+        # fmt: on
         # create a temporary table out of the current snowpark dataframe
         temporary_table_name = random_name_for_temp_object(
             TempObjectType.TABLE

--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -40,13 +40,7 @@ def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
     # Check if modin is installed (if so, we're running in Snowpark pandas; if not, we're just in Snowpark Python)
     try:
         import modin  # noqa: F401
-
-        modin_installed = True
     except ModuleNotFoundError:
-        modin_installed = False
-    if modin_installed:
-        snowpark_df.to_snowpark_pandas()  # should have no errors
-    else:
         # Current Snowpark Python installs pandas==2.2.2, but Snowpark pandas depends on modin
         # 0.28.1, which needs pandas==2.2.1. The pandas version check is currently performed
         # before Snowpark pandas checks whether modin is installed.
@@ -58,3 +52,5 @@ def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
             match="does not match the supported pandas version in Snowpark pandas",
         ):
             snowpark_df.to_snowpark_pandas()
+    else:
+        snowpark_df.to_snowpark_pandas()  # should have no errors

--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -44,7 +44,7 @@ def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
         snowpark_df.to_snowpark_pandas()  # should have no errors
     except ModuleNotFoundError:
         with pytest.raises(
-            ModuleNotFoundError,
-            match=r"(Modin is not installed)|(does not match the supported pandas version in Modin)",
+            (ModuleNotFoundError, RuntimeError),
+            match=r"(Modin is not installed)|(does not match the supported pandas version in Snowpark pandas)",
         ):
             snowpark_df.to_snowpark_pandas()

--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+# Tests behavior of to_snowpark_pandas() without explicitly initializing Snowpark pandas.
+
+import pytest
+
+from snowflake.snowpark._internal.utils import TempObjectType
+from tests.utils import Utils
+
+
+@pytest.fixture(scope="module")
+def tmp_table_basic(session):
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    Utils.create_table(
+        session, table_name, "id integer, foot_size float, shoe_model varchar"
+    )
+    session.sql(f"insert into {table_name} values (1, 32.0, 'medium')").collect()
+    session.sql(f"insert into {table_name} values (2, 27.0, 'small')").collect()
+    session.sql(f"insert into {table_name} values (3, 40.0, 'large')").collect()
+
+    try:
+        yield table_name
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
+    snowpark_df = session.table(tmp_table_basic)
+    # Check if modin is installed
+    try:
+        import modin  # noqa: F401
+
+        snowpark_df.to_snowpark_pandas()  # should have no errors
+    except ModuleNotFoundError:
+        with pytest.raises(ModuleNotFoundError, match="Modin is not installed."):
+            snowpark_df.to_snowpark_pandas()

--- a/tox.ini
+++ b/tox.ini
@@ -96,11 +96,11 @@ commands =
     local: {env:SNOWFLAKE_PYTEST_CMD} --local_testing_mode -m "integ or unit or mock" {posargs:} tests
     dailynotdoctest: {env:SNOWFLAKE_PYTEST_DAILY_CMD} -m "{env:SNOWFLAKE_TEST_TYPE} or udf" {posargs:} tests
     # Snowpark pandas commands:
-    snowparkpandasnotdoctest: {env:MODIN_PYTEST_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin
+    snowparkpandasnotdoctest: {env:MODIN_PYTEST_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin tests/integ/test_df_to_snowpark_pandas.py
     # This one only run doctest but we still need to include the tests folder to let tests/conftest.py to mark the doctest files for us
     snowparkpandasdoctest: {env:MODIN_PYTEST_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} src/snowflake/snowpark/modin/ tests/unit/modin
     # This one is used by daily_modin_precommit.yml
-    snowparkpandasdailynotdoctest: {env:MODIN_PYTEST_DAILY_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin
+    snowparkpandasdailynotdoctest: {env:MODIN_PYTEST_DAILY_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin tests/integ/test_df_to_snowpark_pandas.py
     # This one is only called by jenkins job and the only difference from `snowparkpandasnotdoctest` is that it uses
     # MODIN_PYTEST_NO_COV_CMD instead of MODIN_PYTEST_CMD
     snowparkpandasjenkins: {env:MODIN_PYTEST_NO_COV_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1625830

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Calling `to_snowpark_pandas` on a Snowpark Python DataFrame without first performing `import snowflake.snowpark.modin.plugin` currently raises an error (see attached JIRA for exact reproduction). This was not the case in previous releases, and this PR fixes internal imports such that performing this operation implicitly initializes Snowpark pandas.

After this PR, when `to_snowpark_pandas` is called without explicitly initializing Snowpark pandas, one of two things happens:
1. If modin is not installed, Snowpark pandas will surface the following error:
```
ModuleNotFoundError: Modin is not installed. Run `pip install "snowflake-snowpark-python[modin]"` to resolve.
```
This is the same error as if the user had tried to `import snowflake.snowpark.modin.plugin` without installing the modin dependency.

2. If modin is installed, Snowpark pandas will implicitly initialize Snowpark pandas by internally running `import snowflake.snowpark.modin.plugin`. If the user performs `import modin.pandas as pd` afterwards, the modin namespace will be set up with Snowpark pandas behavior.