### PR TITLE
SNOW-1628228: Fix bug in `groupby.first/last` with ordering columns in window expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Fixed a bug in `Index.to_frame` where the result frame's column name may be wrong where name is unspecified.  
 - Fixed a bug where some Index docstrings are ignored. 
 - Fixed a bug in `Series.reset_index(drop=True)` where the result name may be wrong.
+- Fixed a bug in `Groupby.first/last` ordering by the correct columns in the underlying window expression.
 
 ### Behavior change
 - `Dataframe.columns` now returns native pandas Index object instead of Snowpark Index object.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3826,14 +3826,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             func = first_value
             window_start = Window.CURRENT_ROW
             window_end = Window.UNBOUNDED_FOLLOWING
-
         return {
             snowflake_quoted_id: coalesce(
                 snowflake_quoted_id,
                 func(snowflake_quoted_id, ignore_nulls=True).over(
                     Window.partition_by(by_list)
                     .order_by(
-                        self._modin_frame.row_position_snowflake_quoted_identifier
+                        self._modin_frame.ordering_column_snowflake_quoted_identifiers
                     )
                     .rows_between(window_start, window_end)
                 ),

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3826,6 +3826,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             func = first_value
             window_start = Window.CURRENT_ROW
             window_end = Window.UNBOUNDED_FOLLOWING
+
         return {
             snowflake_quoted_id: coalesce(
                 snowflake_quoted_id,

--- a/tests/integ/modin/groupby/test_groupby_head_tail.py
+++ b/tests/integ/modin/groupby/test_groupby_head_tail.py
@@ -162,7 +162,7 @@ def test_df_groupby_head_tail_df_with_duplicate_columns(op_type, n):
 
 
 @sql_count_checker(query_count=1)
-def test_df_groupby_last_chained_pivot_table():
+def test_df_groupby_last_chained_pivot_table_SNOW_1628228():
     native_df = native_pd.DataFrame(
         data=native_pd.Series(
             native_pd.date_range(start="2024-01-01", freq="min", periods=10)

--- a/tests/integ/modin/groupby/test_groupby_head_tail.py
+++ b/tests/integ/modin/groupby/test_groupby_head_tail.py
@@ -1,7 +1,9 @@
 #
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
+import modin.pandas as pd
 import numpy as np
+import pandas as native_pd
 import pytest
 
 from tests.integ.modin.groupby.conftest import multiindex_data
@@ -156,4 +158,25 @@ def test_df_groupby_head_tail_df_with_duplicate_columns(op_type, n):
         ),
         lambda df: df.groupby(by="col1").__getattribute__(op_type)(n),
         check_index_type=False,
+    )
+
+
+@sql_count_checker(query_count=1)
+def test_df_groupby_last_chained_pivot_table():
+    native_df = native_pd.DataFrame(
+        data=native_pd.Series(
+            native_pd.date_range(start="2024-01-01", freq="min", periods=10)
+        ).values,
+        columns=["A"],
+    )
+    native_df["B"] = 2
+    native_df["C"] = 3
+    snow_df = pd.DataFrame(native_df)
+
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: df.pivot_table(index="A", values="C", aggfunc="mean")
+        .groupby("A")
+        .last(),
     )


### PR DESCRIPTION
Fixes SNOW-1628228

This PR fixes a bug in `groupby.last` by using the correct columns for the Order By as part of the Window Expression.
