### PR TITLE
SNOW-1625377 Raise NotImplementedError for timedelta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,10 @@
     `is_month_start`, `is_month_end`, `is_quarter_start`, `is_quarter_end`, `is_year_start`, `is_year_end`
     and `is_leap_year`.
 - Added support for `Resampler.fillna` and `Resampler.bfill`.
-- Added limited support for the `Timedelta` type, including creating `Timedelta` columns and `to_pandas`.
+- Added limited support for the `Timedelta` type, including
+  - support for creating `Timedelta` columns and `to_pandas`.
+  - support `copy`, `cache_result`, `shift`, `sort_index`.
+  - `NotImplementedError` will be raised for the rest of methods that do not support `Timedelta`.
 - Added support for `Index.argmax` and `Index.argmin`.
 - Added support for index's arithmetic and comparison operators.
 - Added support for `Series.dt.round`.

--- a/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
@@ -652,6 +652,12 @@ def drop_non_numeric_data_columns(
         col.snowflake_quoted_identifier for col in data_column_to_retain
     ]
 
+    new_data_column_types = [
+        type
+        for id, type in original_frame.snowflake_quoted_identifier_to_snowpark_pandas_type.items()
+        if id in new_data_column_snowflake_quoted_identifiers
+    ]
+
     return SnowflakeQueryCompiler(
         InternalFrame.create(
             ordered_dataframe=original_frame.ordered_dataframe,
@@ -660,6 +666,8 @@ def drop_non_numeric_data_columns(
             data_column_pandas_index_names=original_frame.data_column_pandas_index_names,
             index_column_pandas_labels=original_frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=original_frame.index_column_snowflake_quoted_identifiers,
+            data_column_types=new_data_column_types,
+            index_column_types=original_frame.cached_index_column_snowpark_pandas_types,
         )
     )
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -1257,6 +1257,8 @@ def groupby_apply_create_internal_frame_from_final_ordered_dataframe(
         + func_result_index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=group_quoted_identifiers
         + func_result_index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py
@@ -228,8 +228,8 @@ def union_all(
         data_column_pandas_index_names=frame1.data_column_pandas_index_names,
         index_column_pandas_labels=frame1.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame1.index_column_snowflake_quoted_identifiers,
-        data_column_types=frame1.cached_data_column_snowpark_pandas_types,
-        index_column_types=frame1.cached_index_column_snowpark_pandas_types,
+        data_column_types=None,
+        index_column_types=None,
     )
 
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py
@@ -98,6 +98,8 @@ def convert_to_single_level_index(frame: InternalFrame, axis: int) -> InternalFr
             data_column_pandas_index_names=[None],
             index_column_pandas_labels=frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+            data_column_types=frame.cached_data_column_snowpark_pandas_types,
+            index_column_types=frame.cached_index_column_snowpark_pandas_types,
         )
     else:
         WarningMessage.tuples_stored_as_array(
@@ -122,6 +124,8 @@ def convert_to_single_level_index(frame: InternalFrame, axis: int) -> InternalFr
             data_column_pandas_labels=frame.data_column_pandas_labels,
             data_column_snowflake_quoted_identifiers=frame.data_column_snowflake_quoted_identifiers,
             data_column_pandas_index_names=frame.data_column_pandas_index_names,
+            data_column_types=None,
+            index_column_types=None,
         )
 
 
@@ -224,6 +228,8 @@ def union_all(
         data_column_pandas_index_names=frame1.data_column_pandas_index_names,
         index_column_pandas_labels=frame1.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame1.index_column_snowflake_quoted_identifiers,
+        data_column_types=frame1.cached_data_column_snowpark_pandas_types,
+        index_column_types=frame1.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -262,6 +268,8 @@ def add_key_as_index_columns(frame: InternalFrame, key: Hashable) -> InternalFra
         data_column_pandas_index_names=frame.data_column_pandas_index_names,
         index_column_pandas_labels=index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
 
@@ -322,6 +330,8 @@ def _select_columns(
         data_column_pandas_index_names=frame.data_column_pandas_index_names,
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
 
@@ -360,4 +370,6 @@ def add_global_ordering_columns(frame: InternalFrame, position: int) -> Internal
         data_column_pandas_index_names=frame.data_column_pandas_index_names,
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=frame.cached_index_column_snowpark_pandas_types,
     )

--- a/src/snowflake/snowpark/modin/plugin/_internal/cumulative_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cumulative_utils.py
@@ -196,6 +196,8 @@ def get_groupby_cumagg_frame_axis0(
             index_column_pandas_labels=result_frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=result_frame.index_column_snowflake_quoted_identifiers,
             data_column_pandas_index_names=[None],
+            data_column_types=result_frame.cached_data_column_snowpark_pandas_types,
+            index_column_types=result_frame.cached_index_column_snowpark_pandas_types,
         )
     else:
         return result_frame

--- a/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
@@ -310,6 +310,8 @@ def compute_bin_indices(
         data_column_snowflake_quoted_identifiers=[new_data_identifier],
         index_column_pandas_labels=value_frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=value_index_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
     return new_frame

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -1098,11 +1098,11 @@ class InternalFrame:
                 self.data_column_snowflake_quoted_identifiers
             ),
             data_column_pandas_index_names=self.data_column_pandas_index_names,
-            data_column_types=self.cached_data_column_snowpark_pandas_types,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=get_updated_identifiers(
                 self.index_column_snowflake_quoted_identifiers
             ),
+            data_column_types=self.cached_data_column_snowpark_pandas_types,
             index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -83,9 +83,19 @@ def _create_snowflake_quoted_identifier_to_snowpark_pandas_type(
         dict mapping each column's Snowflake quoted identifier to the column's Snowpark pandas type.
     """
     if data_column_types is not None:
-        assert len(data_column_types) == len(data_column_snowflake_quoted_identifiers)
+        assert len(data_column_types) == len(
+            data_column_snowflake_quoted_identifiers
+        ), (
+            f"The length of data_column_types {data_column_types} is different from the length of "
+            f"data_column_snowflake_quoted_identifiers {data_column_snowflake_quoted_identifiers}"
+        )
     if index_column_types is not None:
-        assert len(index_column_types) == len(index_column_snowflake_quoted_identifiers)
+        assert len(index_column_types) == len(
+            index_column_snowflake_quoted_identifiers
+        ), (
+            f"The length of index_column_types {index_column_types} is different from the length of "
+            f"index_column_snowflake_quoted_identifiers {index_column_snowflake_quoted_identifiers}"
+        )
 
     return MappingProxyType(
         {
@@ -164,8 +174,8 @@ class InternalFrame:
         data_column_snowflake_quoted_identifiers: list[str],
         index_column_pandas_labels: list[Hashable],
         index_column_snowflake_quoted_identifiers: list[str],
-        data_column_types: Optional[list[Optional[SnowparkPandasType]]] = None,
-        index_column_types: Optional[list[Optional[SnowparkPandasType]]] = None,
+        data_column_types: Optional[list[Optional[SnowparkPandasType]]],
+        index_column_types: Optional[list[Optional[SnowparkPandasType]]],
     ) -> "InternalFrame":
         """
         Args:
@@ -630,7 +640,14 @@ class InternalFrame:
 
     def get_snowflake_identifiers_and_pandas_labels_from_levels(
         self, levels: list[int]
-    ) -> tuple[list[Hashable], list[str], list[Hashable], list[str]]:
+    ) -> tuple[
+        list[Hashable],
+        list[str],
+        list[Optional[SnowparkPandasType]],
+        list[Hashable],
+        list[str],
+        list[Optional[SnowparkPandasType]],
+    ]:
         """
         Selects snowflake identifiers and pandas labels from index columns in `levels`.
         Also returns snowflake identifiers and pandas labels not in `levels`.
@@ -639,36 +656,45 @@ class InternalFrame:
             levels: A list of integers represents levels in pandas Index.
 
         Returns:
-            A tuple contains 4 lists:
+            A tuple contains 6 lists:
             1. The first list contains snowflake identifiers of index columns in `levels`.
             2. The second list contains pandas labels of index columns in `levels`.
-            3. The third list contains snowflake identifiers of index columns not in `levels`.
-            4. The fourth list contains pandas labels of index columns not in `levels`.
+            3. The third list contains Snowpark pandas types of index columns in `levels`.
+            4. The fourth list contains snowflake identifiers of index columns not in `levels`.
+            5. The fifth list contains pandas labels of index columns not in `levels`.
+            6. The sixth list contains Snowpark pandas types of index columns not in `levels`.
         """
         index_column_pandas_labels_in_levels = []
         index_column_snowflake_quoted_identifiers_in_levels = []
+        index_column_types_in_levels = []
         index_column_pandas_labels_not_in_levels = []
         index_column_snowflake_quoted_identifiers_not_in_levels = []
-        for idx, (identifier, label) in enumerate(
+        index_column_types_not_in_levels = []
+        for idx, (identifier, label, type) in enumerate(
             zip(
                 self.index_column_snowflake_quoted_identifiers,
                 self.index_column_pandas_labels,
+                self.cached_index_column_snowpark_pandas_types,
             )
         ):
             if idx in levels:
                 index_column_pandas_labels_in_levels.append(label)
                 index_column_snowflake_quoted_identifiers_in_levels.append(identifier)
+                index_column_types_in_levels.append(type)
             else:
                 index_column_pandas_labels_not_in_levels.append(label)
                 index_column_snowflake_quoted_identifiers_not_in_levels.append(
                     identifier
                 )
+                index_column_types_not_in_levels.append(type)
 
         return (
             index_column_pandas_labels_in_levels,
             index_column_snowflake_quoted_identifiers_in_levels,
+            index_column_types_in_levels,
             index_column_pandas_labels_not_in_levels,
             index_column_snowflake_quoted_identifiers_not_in_levels,
+            index_column_types_not_in_levels,
         )
 
     @functools.cached_property
@@ -855,8 +881,10 @@ class InternalFrame:
             data_column_pandas_labels=self.data_column_pandas_labels,
             data_column_snowflake_quoted_identifiers=self.data_column_snowflake_quoted_identifiers,
             data_column_pandas_index_names=self.data_column_pandas_index_names,
+            data_column_types=self.cached_data_column_snowpark_pandas_types,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def ensure_row_count_column(self) -> "InternalFrame":
@@ -873,6 +901,8 @@ class InternalFrame:
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
+            data_column_types=self.cached_data_column_snowpark_pandas_types,
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def persist_to_temporary_table(self) -> "InternalFrame":
@@ -886,9 +916,11 @@ class InternalFrame:
             ordered_dataframe=cache_result(self.ordered_dataframe),
             data_column_pandas_labels=self.data_column_pandas_labels,
             data_column_snowflake_quoted_identifiers=self.data_column_snowflake_quoted_identifiers,
+            data_column_types=self.cached_data_column_snowpark_pandas_types,
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def append_column(
@@ -943,6 +975,8 @@ class InternalFrame:
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
+            data_column_types=self.cached_data_column_snowpark_pandas_types + [None],
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def project_columns(
@@ -981,6 +1015,8 @@ class InternalFrame:
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
+            data_column_types=None,
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def rename_snowflake_identifiers(
@@ -1080,7 +1116,7 @@ class InternalFrame:
         This function takes a mapping from existing snowflake quoted identifiers to
         new Snowpark column expressions and points the existing quoted identifiers to the
         column expressions provided by the mapping. For optimization purposes,
-        existing expressions are kept as columns. This does not change pandas labels.
+        existing expressions are kept as columns. This does not change pandas labels and cached Snwopark pandas types.
 
         The process involves the following steps:
 
@@ -1170,8 +1206,10 @@ class InternalFrame:
                 data_column_pandas_labels=self.data_column_pandas_labels,
                 data_column_snowflake_quoted_identifiers=new_data_column_snowflake_quoted_identifiers,
                 data_column_pandas_index_names=self.data_column_pandas_index_names,
+                data_column_types=self.cached_data_column_snowpark_pandas_types,
                 index_column_pandas_labels=self.index_column_pandas_labels,
                 index_column_snowflake_quoted_identifiers=new_index_column_snowflake_quoted_identifiers,
+                index_column_types=self.cached_index_column_snowpark_pandas_types,
             ),
             existing_id_to_new_id_mapping,
         )
@@ -1239,6 +1277,8 @@ class InternalFrame:
             data_column_pandas_labels=self.data_column_pandas_labels,
             data_column_snowflake_quoted_identifiers=self.data_column_snowflake_quoted_identifiers,
             data_column_pandas_index_names=self.data_column_pandas_index_names,
+            data_column_types=self.cached_data_column_snowpark_pandas_types,
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def strip_duplicates(
@@ -1305,6 +1345,8 @@ class InternalFrame:
             data_column_pandas_index_names=frame.data_column_pandas_index_names,
             index_column_pandas_labels=frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+            data_column_types=frame.cached_data_column_snowpark_pandas_types,
+            index_column_types=frame.cached_index_column_snowpark_pandas_types,
         )
 
     def filter(
@@ -1325,6 +1367,8 @@ class InternalFrame:
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
+            data_column_types=self.cached_data_column_snowpark_pandas_types,
+            index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 
     def normalize_snowflake_quoted_identifiers_with_pandas_label(

--- a/src/snowflake/snowpark/modin/plugin/_internal/generator_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/generator_utils.py
@@ -101,6 +101,8 @@ def _create_qc_from_snowpark_dataframe(
             index_column_snowflake_quoted_identifiers=[
                 odf.row_position_snowflake_quoted_identifier
             ],
+            data_column_types=None,
+            index_column_types=None,
         )
     )
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
@@ -386,6 +386,8 @@ def get_frame_with_groupby_columns_as_index(
             data_column_pandas_labels=internal_frame.data_column_pandas_labels,
             data_column_snowflake_quoted_identifiers=internal_frame.data_column_snowflake_quoted_identifiers,
             data_column_pandas_index_names=internal_frame.data_column_pandas_index_names,
+            data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+            index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
         )
     )
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -3163,8 +3163,16 @@ def get_row_position_index_from_bool_indexer(index: InternalFrame) -> InternalFr
         index_column_snowflake_quoted_identifiers=[
             index_column_snowflake_quoted_identifier
         ],
-        data_column_types=index.cached_data_column_snowpark_pandas_types,
-        index_column_types=index.cached_index_column_snowpark_pandas_types,
+        data_column_types=[
+            index.snowflake_quoted_identifier_to_snowpark_pandas_type.get(
+                data_column_snowflake_quoted_identifier, None
+            )
+        ],
+        index_column_types=[
+            index.snowflake_quoted_identifier_to_snowpark_pandas_type.get(
+                index_column_snowflake_quoted_identifier, None
+            )
+        ],
     )
     return index
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -406,6 +406,8 @@ def get_frame_by_row_pos_frame(
             data_column_pandas_index_names=key.data_column_pandas_index_names,
             index_column_snowflake_quoted_identifiers=key.index_column_snowflake_quoted_identifiers,
             index_column_pandas_labels=key.index_column_pandas_labels,
+            data_column_types=key.cached_data_column_snowpark_pandas_types[1:],
+            index_column_types=key.cached_index_column_snowpark_pandas_types,
         )
     return _get_frame_by_row_pos_int_frame(internal_frame, key)
 
@@ -453,6 +455,8 @@ def _get_frame_by_row_pos_boolean_frame(
         index_column_snowflake_quoted_identifiers=result_column_mapper.map_left_quoted_identifiers(
             internal_frame.index_column_snowflake_quoted_identifiers
         ),
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -500,6 +504,8 @@ def _get_frame_by_row_pos_int_frame(
         index_column_snowflake_quoted_identifiers=result_column_mapper.map_right_quoted_identifiers(
             internal_frame.index_column_snowflake_quoted_identifiers
         ),
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -553,6 +559,8 @@ def _get_adjusted_key_frame_by_row_pos_int_frame(
             count_ordered_dataframe.row_position_snowflake_quoted_identifier
         ],
         data_column_pandas_index_names=[None],
+        data_column_types=[None],
+        index_column_types=[None],
     )
 
     # cross join the count with the key to append the count column with the key frame. For example: if the
@@ -682,6 +690,8 @@ def get_frame_by_row_pos_slice_frame(
         data_column_snowflake_quoted_identifiers=internal_frame.data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=internal_frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=internal_frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -1013,6 +1023,8 @@ def get_frame_by_col_label(
             data_column_pandas_index_names=new_data_column_pandas_index_names,
             index_column_pandas_labels=result.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=result.index_column_snowflake_quoted_identifiers,
+            data_column_types=result.cached_data_column_snowpark_pandas_types,
+            index_column_types=result.cached_index_column_snowpark_pandas_types,
         )
     return result
 
@@ -1129,10 +1141,19 @@ def get_frame_by_col_pos(
     selected_columns: list[ColumnOrName] = []
     # the snowflake quoted identifiers for the selected Snowpark columns
     selected_columns_quoted_identifiers: list[str] = []
+    selected_columns_types = []
+
     for col_index in valid_indices:
         snowflake_quoted_identifier = frame_data_column_quoted_identifiers_list[
             col_index
         ]
+
+        selected_columns_types.append(
+            internal_frame.snowflake_quoted_identifier_to_snowpark_pandas_type[
+                snowflake_quoted_identifier
+            ]
+        )
+
         pandas_label = frame_data_column_pandas_labels_list[col_index]
         if snowflake_quoted_identifier in selected_columns_quoted_identifiers:
             # if the current column has already been selected, duplicate the column with
@@ -1161,6 +1182,8 @@ def get_frame_by_col_pos(
         data_column_snowflake_quoted_identifiers=selected_columns_quoted_identifiers,
         index_column_pandas_labels=internal_frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=internal_frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=selected_columns_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -1275,6 +1298,9 @@ def _get_frame_by_row_multiindex_label_tuple(
     new_index_column_snowflake_quoted_identifiers = (
         filtered_frame.index_column_snowflake_quoted_identifiers[levels_to_drop:]
     )
+    new_index_types = filtered_frame.cached_index_column_snowpark_pandas_types[
+        levels_to_drop:
+    ]
 
     return InternalFrame.create(
         ordered_dataframe=filtered_frame.ordered_dataframe,
@@ -1283,6 +1309,8 @@ def _get_frame_by_row_multiindex_label_tuple(
         data_column_pandas_index_names=filtered_frame.data_column_pandas_index_names,
         index_column_pandas_labels=new_index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=new_index_column_snowflake_quoted_identifiers,
+        data_column_types=filtered_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=new_index_types,
     )
 
 
@@ -1541,6 +1569,8 @@ def _get_frame_by_row_label_slice(
         data_column_snowflake_quoted_identifiers=internal_frame.data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=internal_frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=internal_frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -1590,6 +1620,8 @@ def _get_frame_by_row_label_boolean_frame(
         index_column_snowflake_quoted_identifiers=result_column_mapper.map_left_quoted_identifiers(
             internal_frame.index_column_snowflake_quoted_identifiers
         ),
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -1664,6 +1696,8 @@ def _get_frame_by_row_label_non_boolean_frame(
         index_column_snowflake_quoted_identifiers=result_column_mapper.map_right_quoted_identifiers(
             internal_frame.index_column_snowflake_quoted_identifiers
         ),
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -1724,6 +1758,8 @@ def _get_frame_by_row_series_bool(
         data_column_snowflake_quoted_identifiers=key.data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=key.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=key.index_column_snowflake_quoted_identifiers,
+        data_column_types=key.cached_data_column_snowpark_pandas_types,
+        index_column_types=key.cached_index_column_snowpark_pandas_types,
     )
 
     joined_frame, result_column_mapper = join(
@@ -1745,6 +1781,8 @@ def _get_frame_by_row_series_bool(
         index_column_snowflake_quoted_identifiers=result_column_mapper.map_right_quoted_identifiers(
             internal_frame.index_column_snowflake_quoted_identifiers
         ),
+        data_column_types=internal_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=internal_frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -2759,6 +2797,8 @@ def set_frame_2d_positional(
         data_column_snowflake_quoted_identifiers=new_data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -2909,6 +2949,8 @@ def get_kv_frame_from_index_and_item_frames(
         + new_item_data_column_snowflake_identifiers,
         index_column_pandas_labels=kv_frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=kv_frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=kv_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=kv_frame.cached_index_column_snowpark_pandas_types,
     )
 
     return new_kv_frame
@@ -2979,6 +3021,8 @@ def get_item_series_as_single_row_frame(
 
     item_series_snowflake_quoted_identifiers: list[str] = []
     item_series_column_exprs: list[Column] = []
+    item_series_data_column_types = []
+
     for row_position, pandas_label in enumerate(item_series_pandas_labels):
         new_snowflake_quoted_identifier = (
             item_frame.ordered_dataframe.generate_snowflake_quoted_identifiers(
@@ -2999,6 +3043,9 @@ def get_item_series_as_single_row_frame(
         )
         item_series_snowflake_quoted_identifiers.append(new_snowflake_quoted_identifier)
         item_series_column_exprs.append(new_column_expr)
+        item_series_data_column_types.append(
+            item.cached_data_column_snowpark_pandas_types[0]
+        )
 
     item_ordered_dataframe = append_columns(
         item_frame.ordered_dataframe,
@@ -3022,6 +3069,8 @@ def get_item_series_as_single_row_frame(
         index_column_snowflake_quoted_identifiers=item.index_column_snowflake_quoted_identifiers[
             :1
         ],
+        data_column_types=item_series_data_column_types,
+        index_column_types=item.cached_index_column_snowpark_pandas_types[:1],
     )
     return item
 
@@ -3114,6 +3163,8 @@ def get_row_position_index_from_bool_indexer(index: InternalFrame) -> InternalFr
         index_column_snowflake_quoted_identifiers=[
             index_column_snowflake_quoted_identifier
         ],
+        data_column_types=index.cached_data_column_snowpark_pandas_types,
+        index_column_types=index.cached_index_column_snowpark_pandas_types,
     )
     return index
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/isin_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/isin_utils.py
@@ -232,6 +232,8 @@ def compute_isin_with_dataframe(
         + new_identifiers,
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
     # local import to avoid circular import

--- a/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
@@ -370,6 +370,8 @@ def _create_internal_frame_with_join_or_align_result(
         index_column_pandas_labels=index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=index_column_snowflake_quoted_identifiers,
         data_column_pandas_index_names=data_column_pandas_index_names,
+        data_column_types=None,
+        index_column_types=None,
     )
     result_column_mapper = JoinOrAlignResultColumnMapper(
         left_quoted_identifiers_map,
@@ -886,6 +888,8 @@ def _reorder_index_columns(
             data_column_pandas_labels=frame.data_column_pandas_labels,
             data_column_snowflake_quoted_identifiers=frame.data_column_snowflake_quoted_identifiers,
             data_column_pandas_index_names=frame.data_column_pandas_index_names,
+            data_column_types=None,
+            index_column_types=None,
         )
     else:
         return frame

--- a/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
@@ -257,6 +257,8 @@ def pivot_helper(
             data_column_snowflake_quoted_identifiers=[],
             index_column_pandas_labels=index,
             index_column_snowflake_quoted_identifiers=groupby_snowflake_quoted_identifiers,
+            data_column_types=None,
+            index_column_types=None,
         )
     data_column_pandas_labels: list[Hashable] = []
     data_column_snowflake_quoted_identifiers: list[str] = []
@@ -482,6 +484,8 @@ def pivot_helper(
         data_column_snowflake_quoted_identifiers=data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=index,
         index_column_snowflake_quoted_identifiers=index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
 
@@ -1285,6 +1289,8 @@ def expand_pivot_result_with_pivot_table_margins_no_groupby_columns(
             data_column_snowflake_quoted_identifiers=margins_frame.data_column_snowflake_quoted_identifiers,
             index_column_pandas_labels=margins_frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=margins_frame.index_column_snowflake_quoted_identifiers,
+            data_column_types=margins_frame.cached_data_column_snowpark_pandas_types,
+            index_column_types=margins_frame.cached_index_column_snowpark_pandas_types,
         )
 
     # Need to create a QueryCompiler for the margins frame, but SnowflakeQueryCompiler is not present in this scope
@@ -1691,6 +1697,8 @@ def expand_pivot_result_with_pivot_table_margins(
         data_column_pandas_index_names=pivoted_frame.data_column_pandas_index_names,
         index_column_pandas_labels=pivoted_frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=pivoted_frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
     from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
@@ -1758,6 +1766,8 @@ def expand_pivot_result_with_pivot_table_margins(
         index_column_snowflake_quoted_identifiers=margin_row_df_identifiers[
             0 : len(groupby_snowflake_quoted_identifiers)
         ],
+        data_column_types=None,
+        index_column_types=None,
     )
     single_row_qc = SnowflakeQueryCompiler(margin_row_frame)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -511,6 +511,8 @@ def get_expected_resample_bins_frame(
         index_column_pandas_labels=[RESAMPLE_INDEX_LABEL],
         index_column_snowflake_quoted_identifiers=index_column_snowflake_quoted_identifiers,
         data_column_pandas_index_names=[None],
+        data_column_types=None,
+        index_column_types=None,
     )
 
 
@@ -615,6 +617,8 @@ def fill_missing_resample_bins_for_frame(
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=joined_frame.index_column_snowflake_quoted_identifiers,
         data_column_pandas_index_names=frame.data_column_pandas_index_names,
+        data_column_types=frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=frame.cached_index_column_snowpark_pandas_types,
     )
 
 
@@ -780,4 +784,6 @@ def perform_asof_join_on_frame(
             left_timecol_snowflake_quoted_identifier
         ],
         data_column_pandas_index_names=referenced_frame.data_column_pandas_index_names,
+        data_column_types=referenced_frame.cached_data_column_snowpark_pandas_types,
+        index_column_types=referenced_frame.cached_index_column_snowpark_pandas_types,
     )

--- a/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
@@ -284,6 +284,8 @@ def clean_up_transpose_result_index_and_labels(
         data_column_snowflake_quoted_identifiers=new_data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=new_index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=new_index_column_snowflake_quoted_identifiers,
+        data_column_types=None,
+        index_column_types=None,
     )
 
     # Rename the data column snowflake quoted identifiers to be closer to pandas labels, normalizing names

--- a/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
@@ -660,6 +660,8 @@ def clean_up_unpivot(
         data_column_snowflake_quoted_identifiers=final_snowflake_qouted_identfiers,
         index_column_pandas_labels=index_column_pandas_names,
         index_column_snowflake_quoted_identifiers=index_column_quoted_names,
+        data_column_types=None,
+        index_column_types=None,
     )
 
     # Rename the data column snowflake quoted identifiers to be closer to pandas labels, normalizing names
@@ -879,6 +881,8 @@ def _simple_unpivot(
         index_column_snowflake_quoted_identifiers=[
             ordered_dataframe.row_position_snowflake_quoted_identifier
         ],
+        data_column_types=None,
+        index_column_types=None,
     )
 
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1765,6 +1765,7 @@ def create_frame_with_data_columns(
 
     new_frame_data_column_pandas_labels = []
     new_frame_data_column_snowflake_quoted_identifier = []
+    new_frame_data_column_types = []
 
     data_column_label_to_snowflake_quoted_identifier = {
         data_column_pandas_label: data_column_snowflake_quoted_identifier
@@ -1786,6 +1787,11 @@ def create_frame_with_data_columns(
         new_frame_data_column_snowflake_quoted_identifier.append(
             snowflake_quoted_identifier
         )
+        new_frame_data_column_types.append(
+            frame.snowflake_quoted_identifier_to_snowpark_pandas_type.get(
+                snowflake_quoted_identifier, None
+            )
+        )
 
     return InternalFrame.create(
         ordered_dataframe=frame.ordered_dataframe,
@@ -1794,6 +1800,8 @@ def create_frame_with_data_columns(
         data_column_pandas_index_names=frame.data_column_pandas_index_names,
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+        data_column_types=new_frame_data_column_types,
+        index_column_types=frame.cached_index_column_snowpark_pandas_types,
     )
 
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -389,15 +389,21 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # Copying and modifying self.snowpark_pandas_api_calls is taken care of in telemetry decorators
         self.snowpark_pandas_api_calls: list = []
 
-    def _raise_not_implemented_error_for_timedelta(self, method: str) -> None:
+    def _raise_not_implemented_error_for_timedelta(self) -> None:
         """Raise NotImplementedError for SnowflakeQueryCompiler methods which does not support timedelta yet."""
         for (
             val
         ) in (
             self._modin_frame.snowflake_quoted_identifier_to_snowpark_pandas_type.values()
         ):
+            method = "Unknown method"
             if isinstance(val, TimedeltaType):
-                ErrorMessage.not_implemented_for_timedelta(method)
+                try:
+                    method = inspect.currentframe().f_back.f_back.f_code.co_name  # type: ignore[union-attr]
+                except Exception:
+                    pass
+                finally:
+                    ErrorMessage.not_implemented_for_timedelta(method)
 
     def snowpark_pandas_type_immutable_check(func: Callable) -> Any:
         """The decorator to check on SnowflakeQueryCompiler methods which return a new SnowflakeQueryCompiler.
@@ -1256,7 +1262,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Args:
             **kwargs: to_csv arguments.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # Raise not implemented error for unsupported parameters.
         unsupported_params = [
@@ -1313,7 +1319,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         index_label: Optional[IndexLabel] = None,
         table_type: Literal["", "temp", "temporary", "transient"] = "",
     ) -> None:
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if if_exists not in ("fail", "replace", "append"):
             # Same error message as native pandas.
@@ -1358,7 +1364,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         For details, please see comment in _to_snowpark_dataframe_of_pandas_dataframe.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._to_snowpark_dataframe_from_snowpark_pandas_dataframe(
             index, index_label
@@ -1429,9 +1435,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             data_column_pandas_labels=new_pandas_labels.tolist(),
             data_column_pandas_index_names=new_pandas_labels.names,
             data_column_snowflake_quoted_identifiers=new_data_column_snowflake_quoted_identifiers,
-            data_column_types=renamed_frame.cached_data_column_snowpark_pandas_types,
             index_column_pandas_labels=renamed_frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=renamed_frame.index_column_snowflake_quoted_identifiers,
+            data_column_types=renamed_frame.cached_data_column_snowpark_pandas_types,
             index_column_types=renamed_frame.cached_index_column_snowpark_pandas_types,
         )
         return SnowflakeQueryCompiler(new_internal_frame)
@@ -1740,7 +1746,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             The new SnowflakeQueryCompiler after the set_index operation
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         assert (
             len(key._modin_frame.data_column_pandas_labels) == 1
@@ -1863,7 +1869,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         """
         from snowflake.snowpark.modin.pandas.series import Series
 
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # Step 1: Convert other to a Series and join on the row position with self.
         other_qc = Series(other)._query_compiler
@@ -2010,7 +2016,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         from snowflake.snowpark.modin.pandas.series import Series
         from snowflake.snowpark.modin.pandas.utils import is_scalar
 
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # fail explicitly for unsupported scenarios
         if level is not None:
@@ -2285,7 +2291,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             and the Snowflake quoted identifiers for the monotonically increasing and monotonically
             decreasing columns (in that order).
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         modin_frame = self._modin_frame
         modin_frame = modin_frame.ensure_row_position_column()
@@ -2365,7 +2371,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         SnowflakeQueryCompiler
             QueryCompiler with aligned axis.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         new_index_qc = pd.Series(labels)._query_compiler
         new_index_modin_frame = new_index_qc._modin_frame
@@ -2645,7 +2651,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         SnowflakeQueryCompiler
             QueryCompiler with aligned axis.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         method = kwargs.get("method", None)
         level = kwargs.get("level", None)
@@ -3224,7 +3230,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             KeyError if a hashable label in by (groupby items) can not be found in the current dataframe
             ValueError if more than one column can be found for the groupby item
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         validate_groupby_columns(self, by, axis, level)
 
@@ -3234,7 +3240,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         axis: int,
         groupby_kwargs: dict[str, Any],
     ) -> int:
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         level = groupby_kwargs.get("level", None)
         dropna = groupby_kwargs.get("dropna", True)
@@ -3321,7 +3327,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         level = groupby_kwargs.get("level", None)
 
@@ -3602,7 +3608,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         -------
             A query compiler with the result.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         level = groupby_kwargs.get("level", None)
         if not check_is_groupby_supported_by_snowflake(by, level, axis):
@@ -4068,7 +4074,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: The result of groupby_first()
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._groupby_first_last(
             "first", by, axis, groupby_kwargs, agg_args, agg_kwargs, drop, **kwargs
@@ -4103,7 +4109,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: The result of groupby_last()
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._groupby_first_last(
             "last", by, axis, groupby_kwargs, agg_args, agg_kwargs, drop, **kwargs
@@ -4179,7 +4185,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         5      1
         6      2
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         level = groupby_kwargs.get("level", None)
         dropna = groupby_kwargs.get("dropna", True)
@@ -4353,7 +4359,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # TODO: handle cases where the fill_value has a different type from
         # the column. SNOW-990325 deals with fillna that has a similar problem.
@@ -4502,7 +4508,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: The result of groupby_get_group().
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         level = groupby_kwargs.get("level", None)
         is_supported = check_is_groupby_supported_by_snowflake(by, level, axis)
@@ -4571,7 +4577,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: The result of groupby_size()
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         level = groupby_kwargs.get("level", None)
         is_supported = check_is_groupby_supported_by_snowflake(by, level, axis)
@@ -4653,7 +4659,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         4    5        2                     4                     5
         0    8        9                     0                     8
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         original_index_names = self.get_index_names()
         frame = self._modin_frame
@@ -4762,7 +4768,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             dict: a map from group keys to row labels.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         frame = self._modin_frame.ensure_row_position_column()
         return dict(
@@ -4809,7 +4815,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return SnowflakeQueryCompiler(
             get_groupby_cumagg_frame_axis0(
@@ -4846,7 +4852,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return SnowflakeQueryCompiler(
             get_groupby_cumagg_frame_axis0(
@@ -4882,7 +4888,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return SnowflakeQueryCompiler(
             get_groupby_cumagg_frame_axis0(
@@ -4915,7 +4921,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return SnowflakeQueryCompiler(
             get_groupby_cumagg_frame_axis0(
@@ -4939,7 +4945,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler
@@ -4964,7 +4970,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler
@@ -4989,7 +4995,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler
@@ -5010,7 +5016,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         prefix: Hashable,
         prefix_sep: str,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         dummy_column_name = random_name_for_temp_object(TempObjectType.COLUMN)
         # We need to add a column that will help us differentiate between identical
@@ -5243,7 +5249,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         1  2       0       1       1       0       0
         2  3       1       0       0       0       1
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if dummy_na is True or drop_first is True or dtype is not None:
             ErrorMessage.not_implemented(
@@ -5313,7 +5319,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             args: the arguments passed for the aggregation
             kwargs: keyword arguments passed for the aggregation function.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         numeric_only = kwargs.get("numeric_only", False)
         # Call fallback if the aggregation function passed in the arg is currently not supported
@@ -5751,7 +5757,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             A new SnowflakeQueryCompiler instance with new column.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if not isinstance(value, SnowflakeQueryCompiler):
             # Scalar value
@@ -5880,7 +5886,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             A new QueryCompiler instance with updated index.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         index_column_pandas_labels = keys
         index_column_snowflake_quoted_identifiers = []
@@ -6335,7 +6341,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             NOTE: Original column level names are lost and result column index has only
             one level.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if levels is not None:
             raise NotImplementedError(
@@ -6526,7 +6532,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler instance with cumulative sum of Series or DataFrame.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if axis == 1:
             ErrorMessage.not_implemented("cumsum with axis=1 is not supported yet")
@@ -6555,7 +6561,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler instance with cumulative min of Series or DataFrame.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if axis == 1:
             ErrorMessage.not_implemented("cummin with axis=1 is not supported yet")
@@ -6584,7 +6590,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler instance with cumulative max of Series or DataFrame.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if axis == 1:
             ErrorMessage.not_implemented("cummax with axis=1 is not supported yet")
@@ -6625,7 +6631,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Notes:
             melt does not yet handle multiindex or ignore index
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if col_level is not None:
             raise NotImplementedError(
@@ -6729,7 +6735,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler instance with merged result.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if validate:
             ErrorMessage.not_implemented(
@@ -6961,7 +6967,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler which may be Series or DataFrame representing result of .apply(axis=1)
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # Process using general approach via UDTF + dynamic pivot to handle column expansion case.
 
@@ -7254,7 +7260,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler representing a Series holding the result of apply(func, axis=1).
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # extract index columns and types, which are passed as first columns to UDF.
         type_map = self._modin_frame.quoted_identifier_to_snowflake_type()
@@ -7372,7 +7378,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         **kwargs : dict
             Keyword arguments to pass to `func`.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # axis=0 is not supported, raise error.
         if axis == 0:
@@ -7466,7 +7472,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args : iterable
         **kwargs : dict
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # Currently, NULL values are always passed into the udtf even if strict=True,
         # which is a bug on the server side SNOW-880105.
@@ -7508,7 +7514,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         na_action: Optional[Literal["ignore"]] = None,
     ) -> "SnowflakeQueryCompiler":
         """This method will only be called from Series."""
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # TODO SNOW-801847: support series.map when arg is a dict/series
         # Currently, NULL values are always passed into the udtf even if strict=True,
@@ -7540,7 +7546,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         **kwargs : dict
             Keyword arguments to pass to `func`.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         assert self.is_series_like()
 
@@ -7596,7 +7602,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         -------
         SnowflakeQueryCompiler
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # Call pivot_table which is a more generalized version of pivot with `min` aggregation
         # Note we differ from pandas by not checking for duplicates and raising a ValueError as that would require an eager query
@@ -7626,7 +7632,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         observed: bool,
         sort: bool,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         """
         Create a spreadsheet-style pivot table from underlying data.
@@ -7977,7 +7983,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         BaseQueryCompiler
             New masked QueryCompiler.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # TODO: SNOW-884220 support multiindex
         # index can only be a query compiler or slice object
@@ -8297,7 +8303,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         -------
         SnowflakeQueryCompiler
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         if self._modin_frame.is_multiindex(axis=0) and (
             is_scalar(index) or isinstance(index, tuple)
@@ -8405,7 +8411,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             SnowflakeQueryCompiler
                 Transposed new QueryCompiler object.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         frame = self._modin_frame
 
@@ -8563,7 +8569,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # STEP 1) Construct a temporary index column that contains the original index with position.
         # STEP 2) Perform an unpivot which flattens the original data columns into a single name and value rows
         # grouped by the temporary transpose index column.
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         unpivot_result = prepare_and_unpivot_for_transpose(
             frame, self, is_single_row=False
@@ -11328,7 +11334,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             dropna : bool
                 Don't include counts of NaN.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         # validate whether by is valid (e.g., contains duplicates or non-existing labels)
         self.validate_groupby(by=by, axis=0, level=None)
@@ -11723,7 +11729,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         column would allow us to create an accurate row position column, but would require a
         potentially expensive JOIN operator afterwards to apply the correct index labels.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         assert len(self._modin_frame.data_column_pandas_labels) == 1
 
@@ -12473,7 +12479,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._window_agg(
             window_func=WindowFunction.ROLLING,
@@ -12492,7 +12498,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_sum", engine, engine_kwargs
@@ -12514,7 +12520,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_mean", engine, engine_kwargs
@@ -12548,7 +12554,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
@@ -12571,7 +12577,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
@@ -12593,7 +12599,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_min", engine, engine_kwargs
@@ -12615,7 +12621,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_max", engine, engine_kwargs
@@ -12712,7 +12718,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._window_agg(
             window_func=WindowFunction.ROLLING,
@@ -12858,7 +12864,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         expanding_kwargs: dict,
         numeric_only: bool = False,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._window_agg(
             window_func=WindowFunction.EXPANDING,
@@ -12875,7 +12881,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_sum", engine, engine_kwargs
@@ -12895,7 +12901,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_mean", engine, engine_kwargs
@@ -12926,7 +12932,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
@@ -12947,7 +12953,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_std", engine, engine_kwargs
@@ -12967,7 +12973,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_min", engine, engine_kwargs
@@ -12987,7 +12993,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_max", engine, engine_kwargs
@@ -13077,7 +13083,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ddof: int = 1,
         numeric_only: bool = False,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._window_agg(
             window_func=WindowFunction.EXPANDING,
@@ -13594,7 +13600,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler representing result of binary op operation.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         assert (
             other.is_series_like()
@@ -13773,7 +13779,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._idxmax_idxmin(
             func="idxmax", axis=axis, skipna=skipna, numeric_only=numeric_only
@@ -13799,7 +13805,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         return self._idxmax_idxmin(
             func="idxmin", axis=axis, skipna=skipna, numeric_only=numeric_only
@@ -15547,7 +15553,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             A SnowflakeQueryCompiler object representing a DataFrame.
         """
-        self._raise_not_implemented_error_for_timedelta(inspect.stack()[0][3])
+        self._raise_not_implemented_error_for_timedelta()
 
         original_frame = self._modin_frame
         ordered_dataframe = original_frame.ordered_dataframe
@@ -16991,7 +16997,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 data_column_snowflake_quoted_identifiers=frame.data_column_snowflake_quoted_identifiers,
                 index_column_pandas_labels=[None],
                 index_column_snowflake_quoted_identifiers=[index_quoted_identifier],
-                data_column_types=frame.cached_data_column_snowpark_pandas_types,
+                data_column_types=None,
                 index_column_types=[None],
             )
 

--- a/src/snowflake/snowpark/modin/plugin/utils/error_message.py
+++ b/src/snowflake/snowpark/modin/plugin/utils/error_message.py
@@ -158,6 +158,12 @@ class ErrorMessage:
         logger.debug(f"NotImplementedError: {message}")
         raise NotImplementedError(message)
 
+    @classmethod
+    def not_implemented_for_timedelta(cls, method: str) -> NoReturn:
+        ErrorMessage.not_implemented(
+            f"SnowflakeQueryCompiler::{method} is not yet implemented for Timedelta Type"
+        )
+
     @staticmethod
     def method_not_implemented_error(
         name: str, class_: str

--- a/tests/integ/modin/frame/test_reset_index.py
+++ b/tests/integ/modin/frame/test_reset_index.py
@@ -20,6 +20,11 @@ def native_df_simple():
         {
             "a": ["one", "two", "three"],
             "b": ["abc", "pqr", "xyz"],
+            "dt": [
+                native_pd.Timedelta("1 days"),
+                native_pd.Timedelta("2 days"),
+                native_pd.Timedelta("3 days"),
+            ],
         },
         index=native_pd.Index(["a", "b", "c"], name="c"),
     )
@@ -74,13 +79,13 @@ def test_reset_index_drop_false(native_df_simple):
     eval_snowpark_pandas_result(snow_df, native_df_simple, lambda df: df.reset_index())
 
     snow_df = snow_df.reset_index()
-    assert ["c", "a", "b"] == list(snow_df.columns)
+    assert ["c", "a", "b", "dt"] == list(snow_df.columns)
 
     snow_df = snow_df.reset_index()
-    assert ["index", "c", "a", "b"] == list(snow_df.columns)
+    assert ["index", "c", "a", "b", "dt"] == list(snow_df.columns)
 
     snow_df = snow_df.reset_index()
-    assert ["level_0", "index", "c", "a", "b"] == list(snow_df.columns)
+    assert ["level_0", "index", "c", "a", "b", "dt"] == list(snow_df.columns)
 
 
 @sql_count_checker(query_count=1)
@@ -168,7 +173,7 @@ def test_reset_index_allow_duplicates(native_df_simple):
     # Allow duplicates when provided name conflicts with existing data label.
     snow_df = pd.DataFrame(native_df_simple)
     snow_df = snow_df.reset_index(drop=False, allow_duplicates=True, names=["a"])
-    assert ["a", "a", "b"] == list(snow_df.columns)
+    assert ["a", "a", "b", "dt"] == list(snow_df.columns)
 
     # Verify even if allow_duplicates is True, "index" is not duplicated.
     snow_df = pd.DataFrame({"index": ["one", "two", "three"]})

--- a/tests/integ/modin/series/test_cache_result.py
+++ b/tests/integ/modin/series/test_cache_result.py
@@ -12,7 +12,7 @@ import pytest
 from pandas.testing import assert_series_equal
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.modin.sql_counter import SqlCounter
+from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
     create_test_series,
@@ -149,3 +149,15 @@ class TestCacheResultReducesQueryCount:
                 cached_snow_series,
                 native_series,
             )
+
+
+@sql_count_checker(query_count=1)
+def test_cacheresult_timedelta():
+    native_s = native_pd.Series(
+        [
+            native_pd.Timedelta("1 days"),
+            native_pd.Timedelta("2 days"),
+            native_pd.Timedelta("3 days"),
+        ]
+    )
+    assert "timedelta64[ns]" == pd.Series(native_s).cache_result().dtype

--- a/tests/integ/modin/series/test_copy.py
+++ b/tests/integ/modin/series/test_copy.py
@@ -2,11 +2,15 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 import modin.pandas as pd
+import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
-from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
+from tests.integ.modin.utils import (
+    assert_snowpark_pandas_equal_to_pandas,
+    eval_snowpark_pandas_result,
+)
 
 
 @pytest.fixture(scope="function")
@@ -77,3 +81,15 @@ def test_copy_inplace_operations_on_shallow_copy(snow_series, operation):
 
         # Verify that 'snow_series' is also changed.
         assert_snowpark_pandas_equal_to_pandas(snow_series, copy.to_pandas())
+
+
+@sql_count_checker(query_count=1)
+def test_copy_timedelta():
+    native_s = native_pd.Series(
+        [
+            native_pd.Timedelta("1 days"),
+            native_pd.Timedelta("2 days"),
+            native_pd.Timedelta("3 days"),
+        ]
+    )
+    eval_snowpark_pandas_result(pd.Series(native_s), native_s, lambda s: s.copy())

--- a/tests/integ/modin/series/test_shift.py
+++ b/tests/integ/modin/series/test_shift.py
@@ -17,6 +17,13 @@ TEST_SERIES = [
     native_pd.Series([1, 2, 3, 4]),
     native_pd.Series(["a", None, 1, 2, 4.5]),
     native_pd.Series([2.0, None, 3.6, -10], index=[1, 2, 3, 4]),
+    native_pd.Series(
+        [
+            native_pd.Timedelta("1 days"),
+            native_pd.Timedelta("2 days"),
+            native_pd.Timedelta("3 days"),
+        ],
+    ),
 ]
 
 
@@ -36,7 +43,16 @@ def test_series_with_values_shift(series, periods, fill_value):
     eval_snowpark_pandas_result(
         snow_series,
         native_series,
-        lambda s: s.shift(periods=periods, fill_value=fill_value),
+        lambda s: s.shift(
+            periods=periods,
+            fill_value=pd.Timedelta(fill_value)
+            if isinstance(
+                s, native_pd.Series
+            )  # pandas does not support fill int to timedelta
+            and s.dtype == "timedelta64[ns]"
+            and fill_value is not no_default
+            else fill_value,
+        ),
     )
 
 

--- a/tests/integ/modin/series/test_sort_index.py
+++ b/tests/integ/modin/series/test_sort_index.py
@@ -15,9 +15,21 @@ from tests.integ.modin.utils import eval_snowpark_pandas_result
 @pytest.mark.parametrize("na_position", ["first", "last"])
 @pytest.mark.parametrize("ignore_index", [True, False])
 @pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["a", "b", np.nan, "d"],
+        [
+            native_pd.Timedelta("1 days"),
+            native_pd.Timedelta("2 days"),
+            native_pd.Timedelta("3 days"),
+            native_pd.Timedelta(None),
+        ],
+    ],
+)
 @sql_count_checker(query_count=1)
-def test_sort_index_series(ascending, na_position, ignore_index, inplace):
-    native_series = native_pd.Series(["a", "b", np.nan, "d"], index=[3, 2, 1, np.nan])
+def test_sort_index_series(ascending, na_position, ignore_index, inplace, data):
+    native_series = native_pd.Series(data, index=[3, 2, 1, np.nan])
     snow_series = pd.Series(native_series)
     eval_snowpark_pandas_result(
         snow_series,

--- a/tests/integ/modin/types/test_timedelta.py
+++ b/tests/integ/modin/types/test_timedelta.py
@@ -94,3 +94,23 @@ def test_timedelta_precision_insufficient_with_nulls_SNOW_1628925():
     eval_snowpark_pandas_result(
         pd, native_pd, lambda lib: lib.Series([None, timedelta])
     )
+
+
+@sql_count_checker(query_count=0)
+def test_timedelta_not_supported():
+    df = pd.DataFrame(
+        {
+            "a": ["one", "two", "three"],
+            "b": ["abc", "pqr", "xyz"],
+            "dt": [
+                pd.Timedelta("1 days"),
+                pd.Timedelta("2 days"),
+                pd.Timedelta("3 days"),
+            ],
+        }
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="validate_groupby is not yet implemented for Timedelta Type",
+    ):
+        df.groupby("a").count()

--- a/tests/unit/modin/conftest.py
+++ b/tests/unit/modin/conftest.py
@@ -20,6 +20,9 @@ def mock_single_col_query_compiler() -> SnowflakeQueryCompiler:
     mock_internal_frame = mock.create_autospec(InternalFrame)
     mock_internal_frame.data_columns_index = native_pd.Index(["A"], name="B")
     mock_internal_frame.data_column_snowflake_quoted_identifiers = ['"A"']
+    mock_internal_frame.snowflake_quoted_identifier_to_snowpark_pandas_type = {
+        '"A"': None
+    }
     fake_query_compiler = SnowflakeQueryCompiler(mock_internal_frame)
 
     return fake_query_compiler

--- a/tests/unit/modin/test_internal_frame.py
+++ b/tests/unit/modin/test_internal_frame.py
@@ -73,6 +73,8 @@ def test_dataframes(mock_dataframe) -> TestDataFrames:
         data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"C"', '"d"'],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     return TestDataFrames(ordered_dataframe, internal_frame)
@@ -110,6 +112,8 @@ def test_dataframes_with_multiindex_on_column(mock_dataframe) -> TestDataFrames:
         data_column_snowflake_quoted_identifiers=["\"('a', 'C')\"", "\"('b', 'D')\""],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     return TestDataFrames(ordered_dataframe, internal_frame)
@@ -125,6 +129,8 @@ def test_snowflake_quoted_identifier_without_quote_negative(test_dataframes) -> 
             data_column_snowflake_quoted_identifiers=["a", "b", "c"],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=['"INDEX"'],
+            data_column_types=None,
+            index_column_types=None,
         )
 
     assert "Found not-quoted identifier for 'dataframe column':'a'" in str(exc.value)
@@ -143,6 +149,8 @@ def test_column_labels_and_quoted_identifiers_have_same_length_negative(
             data_column_snowflake_quoted_identifiers=['"a"'],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=['"INDEX"'],
+            data_column_types=None,
+            index_column_types=None,
         )
 
     # check index columns
@@ -154,6 +162,8 @@ def test_column_labels_and_quoted_identifiers_have_same_length_negative(
             data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"C"'],
             index_column_pandas_labels=[],
             index_column_snowflake_quoted_identifiers=['"INDEX"'],
+            data_column_types=None,
+            index_column_types=None,
         )
 
 
@@ -167,6 +177,8 @@ def test_internal_frame_missing_data_column_negative(test_dataframes):
             data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"D"'],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=['"INDEX"'],
+            data_column_types=None,
+            index_column_types=None,
         )
 
     assert 'dataframe column="D" not found in snowpark dataframe schema' in str(
@@ -184,6 +196,8 @@ def test_internal_frame_missing_index_column_negative(test_dataframes):
             data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"C"'],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=['"E"'],
+            data_column_types=None,
+            index_column_types=None,
         )
 
     assert 'dataframe column="E" not found in snowpark dataframe schema' in str(
@@ -230,6 +244,8 @@ def test_pandas_label_as_empty_and_none(test_dataframes) -> None:
         data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"C"'],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     assert internal_frame.data_column_pandas_labels == ["", "b", None]
@@ -286,6 +302,8 @@ def test_internal_frame_ordering_columns(test_dataframes) -> None:
         data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"C"'],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     assert internal_frame.ordering_column_snowflake_quoted_identifiers == [
@@ -306,6 +324,8 @@ def test_internal_frame_ordering_columns(test_dataframes) -> None:
         data_column_snowflake_quoted_identifiers=['"a"'],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     assert internal_frame.ordering_column_snowflake_quoted_identifiers == [
@@ -322,6 +342,8 @@ def test_internal_frame_ordering_columns(test_dataframes) -> None:
         data_column_snowflake_quoted_identifiers=['"a"', '"C"'],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     assert internal_frame.ordering_column_snowflake_quoted_identifiers == [
@@ -344,6 +366,8 @@ def test_data_column_pandas_index_names(pandas_label, test_dataframes) -> None:
         data_column_snowflake_quoted_identifiers=['"a"', '"C"'],
         index_column_pandas_labels=[None],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     assert internal_frame.data_column_pandas_index_names == [pandas_label]
@@ -417,6 +441,8 @@ def test_data_column_pandas_multiindex_negative(
             ],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=['"INDEX"'],
+            data_column_types=None,
+            index_column_types=None,
         )
 
 
@@ -443,6 +469,8 @@ def test_get_snowflake_quoted_identifiers_by_pandas_labels_empty_not_include_ind
         data_column_snowflake_quoted_identifiers=['"a"', '"b"', '"C"'],
         index_column_pandas_labels=["index"],
         index_column_snowflake_quoted_identifiers=['"INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     assert internal_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
@@ -625,6 +653,8 @@ def test_num_levels(mock_dataframe, level0, level1):
         data_column_snowflake_quoted_identifiers=['"x"', '"y"'],
         index_column_pandas_labels=[None] * level0,
         index_column_snowflake_quoted_identifiers=['"a"', '"b"'][:level0],
+        data_column_types=None,
+        index_column_types=None,
     )
     assert frame.num_index_levels(axis=0) == level0
     assert frame.num_index_levels(axis=1) == level1
@@ -704,6 +734,8 @@ def test_validation_duplicated_data_columns_for_labels(
         ],
         index_column_pandas_labels=["F"],
         index_column_snowflake_quoted_identifiers=['"F_INDEX"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     if expected_message is not None:

--- a/tests/unit/modin/test_snowflake_query_compiler.py
+++ b/tests/unit/modin/test_snowflake_query_compiler.py
@@ -41,6 +41,8 @@ def test_query_compiler(mock_dataframe) -> SnowflakeQueryCompiler:
         data_column_snowflake_quoted_identifiers=['"a"', '"B"'],
         index_column_pandas_labels=["INDEX", "C"],
         index_column_snowflake_quoted_identifiers=['"INDEX"', '"C"'],
+        data_column_types=None,
+        index_column_types=None,
     )
 
     return SnowflakeQueryCompiler(internal_frame)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1625377 Raise NotImplementedError for timedelta. This PR also supported SNOW-1620417 cache_result.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

## My Summary
The main goal for this PR is to make sure we raise `NotImplementedError` from a SnowflakeQueryCompiler's public method when a dataframe or series contain Timedelta columns call it and it hasn't fully supported Timedelta type. Then in the coming weeks, we can remove those errors once we have implemented and tested those methods. The steps I did in this PR are:

1. Change `data_column_types` and `index_column_types` from `Optional` to required in `InternalFrame.create` method, so all usage of this method should explicitly specify these two arguments. It will help us to avoid bugs. I updated all `InternalFrame.create` methods and make sure the arguments are correctly specified. For those I'm not sure or tracked in other jira (e.g., binary ops), I set them to 
  ```
  data_column_types=None,
  index_column_types=None,
  ```
  In the coming weeks, we should replace those to be the right values.

2. For the above under construction cases, I make sure add `_raise_not_implemented_error_for_timedelta` into the SnowflakeQueryCompiler's methods that call those cases. In the coming weeks, we can try to remove all `_raise_not_implemented_error_for_timedelta` by supporting timedelta there with good test coverage.

3. For the SnowflakeQueryCompiler's methods that won't change pandas types, I make sure the type has been persisted correctly. To achieve that, I add two assertions: 1) I added a check `@snowpark_pandas_type_immutable_check` as a decorator to them to validate the types are not changed; 2) improved the assertion message in frame.py to make sure we got sufficient error message if `data_column_types` and `index_column_types` is not valid.

4. Lastly, I added some test cases for Timedelta types as examples and show it works on some changes, e.g., `copy`, `cache_result`. 

Once this PR is in, our goal towards Timedelta GA become quite concrete:

- we should remove all `_raise_not_implemented_error_for_timedelta`
- we should update all:
 ```
  data_column_types=None,
  index_column_types=None,
  ```
Once those are done, we should be confident say Timedelta is supported in Snowpark pandas.



## Copilot Summary
This pull request includes changes to improve type handling for data and index columns across various utility functions and internal frame operations in the `snowflake/snowpark/modin/plugin` package. The most important changes include adding type information to various internal frame functions and ensuring consistency in type handling.

### Enhancements to type handling:

* Added `data_column_types` and `index_column_types` to the return values and parameters of several functions in `aggregation_utils.py`, `apply_utils.py`, `concat_utils.py`, and `cumulative_utils.py` to ensure type information is preserved. (`src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py` [[1]](diffhunk://#diff-036a8cce05771914c03d260ad7fb1ab74a1578b353ff5156a65fbe546788872cR655-R660) [[2]](diffhunk://#diff-036a8cce05771914c03d260ad7fb1ab74a1578b353ff5156a65fbe546788872cR669-R670); `src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py` [[3]](diffhunk://#diff-806595767d4b19aebb493cbcf557cc6c4c28d3fb36e9247251ba47df5af216cbR1260-R1261); `src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py` [[4]](diffhunk://#diff-4c52f8bc24c5a3be5c07ff28fb6ad1b88aeefd4f4bb3b05ea104ac05179d8effR101-R102) [[5]](diffhunk://#diff-4c52f8bc24c5a3be5c07ff28fb6ad1b88aeefd4f4bb3b05ea104ac05179d8effR127-R128) [[6]](diffhunk://#diff-4c52f8bc24c5a3be5c07ff28fb6ad1b88aeefd4f4bb3b05ea104ac05179d8effR231-R232) [[7]](diffhunk://#diff-4c52f8bc24c5a3be5c07ff28fb6ad1b88aeefd4f4bb3b05ea104ac05179d8effR271-R272) [[8]](diffhunk://#diff-4c52f8bc24c5a3be5c07ff28fb6ad1b88aeefd4f4bb3b05ea104ac05179d8effR333-R334) [[9]](diffhunk://#diff-4c52f8bc24c5a3be5c07ff28fb6ad1b88aeefd4f4bb3b05ea104ac05179d8effR373-R374); `src/snowflake/snowpark/modin/plugin/_internal/cumulative_utils.py` [[10]](diffhunk://#diff-982803d5d0ed44aae6516d738acf049feb2d91837d773a5982c85770a9ae4508R199-R200)

### Consistency improvements:

* Updated `frame.py` to include type information in various methods, ensuring that type consistency is maintained when manipulating internal frames. This includes the `create` method, `get_snowflake_identifiers_and_pandas_labels_from_levels`, and other internal frame methods. (`src/snowflake/snowpark/modin/plugin/_internal/frame.py` [[1]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL86-R98) [[2]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL167-R178) [[3]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL633-R650) [[4]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL642-R697) [[5]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR884-R887) [[6]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR904-R905) [[7]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR919-R923) [[8]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR978-R979) [[9]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR1018-R1019) [[10]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL1083-R1119) [[11]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR1209-R1212) [[12]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR1280-R1281) [[13]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR1348-R1349) [[14]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR1370-R1371)

### Assertion improvements:

* Enhanced assertions in `frame.py` to provide clearer error messages when the lengths of type lists do not match the lengths of corresponding identifier lists. (`src/snowflake/snowpark/modin/plugin/_internal/frame.py` [src/snowflake/snowpark/modin/plugin/_internal/frame.pyL86-R98](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL86-R98))

### Generator utilities update:

* Modified `generator_utils.py` to include type information when creating query compilers from Snowpark dataframes. (`src/snowflake/snowpark/modin/plugin/_internal/generator_utils.py` [src/snowflake/snowpark/modin/plugin/_internal/generator_utils.pyR104-R105](diffhunk://#diff-6db3f0697e5e39655c11ab2f980994d781cc61649c129b0f03b17dc5360fb5abR104-R105))