### PR TITLE
SNOW-1418500: Refactor _resolve_packages to have no side-effects

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1062,7 +1062,7 @@ def resolve_imports_and_packages(
                 packages,
                 include_pandas=is_pandas_udf,
                 statement_params=statement_params,
-            )
+            )[0]
             if packages is not None
             else session._resolve_packages(
                 [],
@@ -1070,7 +1070,7 @@ def resolve_imports_and_packages(
                 validate_package=False,
                 include_pandas=is_pandas_udf,
                 statement_params=statement_params,
-            )
+            )[0]
         )
 
     if session is not None:

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -263,7 +263,7 @@ def test_add_packages(session, local_testing_mode):
     # add module objects
     # but we can't register a udf with these versions
     # because the server might not have them
-    resolved_packages = session._resolve_packages(
+    resolved_packages, _ = session._resolve_packages(
         [numpy, pandas, dateutil], validate_package=False
     )
     assert f"numpy=={numpy.__version__}" in resolved_packages


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1418500

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   This PR refactors `Session._resolve_packages` to not have any side-effects. In the old implementation, we relied on this function to make updates to `Session._packages` variable. Now we return the final resulting state after resolving packages and update `Session._packages` only in `Session.add_packages` making `Session._resolve_packages` have no side-effect.
