### PR TITLE
SNOW-1573504: Fix session stage after switching database or schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed a bug in `session.read.csv` that caused an error when setting `PARSE_HEADER = True` in an externally defined file format.
 - Fixed a bug in query generation from set operations that allowed generation of duplicate queries when children have common subqueries.
+- Fixed a bug in `session.get_session_stage` that referenced a non-existing stage after switching database or schema.
 
 ### Snowpark Local Testing Updates
 

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -68,7 +68,6 @@ def setup(session, resources_path, local_testing_mode):
 @pytest.fixture(autouse=True)
 def clean_up(session):
     session._session_stage = Utils.random_stage_name()
-    session._stage_created = False
     session.clear_packages()
     session.clear_imports()
     session.custom_package_usage_config = {}

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -67,7 +67,7 @@ def setup(session, resources_path, local_testing_mode):
 
 @pytest.fixture(autouse=True)
 def clean_up(session):
-    session._session_stage = Utils.random_stage_name()
+    session._session_stage = None
     session.clear_packages()
     session.clear_imports()
     session.custom_package_usage_config = {}

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -745,6 +745,10 @@ def test_create_session_from_default_config_file(monkeypatch, db_parameters):
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="use schema is not allowed in stored proc (owner mode)"
 )
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="running sql query is not supported in local testing",
+)
 def test_get_session_stage(session):
     with session.query_history() as history:
         session_stage = session.get_session_stage()

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1952,7 +1952,18 @@ def test_stored_proc_register_with_module(session):
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="use schema is not allowed in stored proc (owner mode)"
 )
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="running sql query is not supported in local testing",
+)
 def test_register_sproc_after_switch_schema(session):
+    add_sp = session.sproc.register(
+        lambda session_, x, y: session_.create_dataframe([[x + y]]).collect()[0][0],
+        return_type=IntegerType(),
+        input_types=[IntegerType(), IntegerType()],
+    )
+    assert add_sp(1, 2) == 3
+
     current_schema = session.get_current_schema()
     current_database = session.get_current_database()
 

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1947,3 +1947,36 @@ def test_stored_proc_register_with_module(session):
         source_code_display=False,
         packages=packages,
     )
+
+
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC, reason="use schema is not allowed in stored proc (owner mode)"
+)
+def test_register_sproc_after_switch_schema(session):
+    current_schema = session.get_current_schema()
+    current_database = session.get_current_database()
+
+    databases = []
+    try:
+        for i in range(2):
+            new_database = f"db_{Utils.random_alphanumeric_str(10)}"
+            databases.append(new_database)
+            new_schema = f"{new_database}.test"
+
+            session._run_query(f"create database if not exists {new_database}")
+            session._run_query(f"create schema if not exists {new_schema}")
+            session._run_query(f"use schema {new_schema}")
+
+            add_sp = session.sproc.register(
+                lambda session_, x, y: session_.create_dataframe([[x + y]]).collect()[
+                    0
+                ][0],
+                return_type=IntegerType(),
+                input_types=[IntegerType(), IntegerType()],
+            )
+            assert add_sp(1, 2) == 3
+    finally:
+        for db in databases:
+            Utils.drop_database(session, db)
+        session.use_database(current_database)
+        session.use_schema(current_schema)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1573504

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Previously registering stored proc will fail after switching database or schema because session.get_session_stage will return a different stage.  
