### PR TITLE
SNOW-1625468 SNOW-1634393 Support indexing with Timedelta data columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Added limited support for the `Timedelta` type, including
   - support `copy`, `cache_result`, `shift`, `sort_index`.
   - `NotImplementedError` will be raised for the rest of methods that do not support `Timedelta`.
+  - support for subtracting two timestamps to get a Timedelta.
+  - support indexing with Timedelta data columns. 
 - Added support for index's arithmetic and comparison operators.
 - Added support for `Series.dt.round`.
 - Added documentation pages for `DatetimeIndex`.
@@ -35,7 +37,6 @@
 - Added support for `Index.__repr__`.
 - Added support for `DatetimeIndex.month_name` and `DatetimeIndex.day_name`.
 - Added support for `Series.dt.weekday`, `Series.dt.time`, and `DatetimeIndex.time`.
-- Added support for subtracting two timestamps to get a Timedelta.
 - Added support for `Index.min` and `Index.max`.
 
 #### Bug Fixes

--- a/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
@@ -272,7 +272,7 @@ def compute_binary_op_between_snowpark_columns(
             first_datatype,
         )
 
-    binary_op_result_column, snowpark_pandas_result_type = None, None
+    binary_op_result_column = None
 
     # some operators and the data types have to be handled specially to align with pandas
     # However, it is difficult to fail early if the arithmetic operator is not compatible
@@ -335,7 +335,6 @@ def compute_binary_op_between_snowpark_columns(
     ):
         # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
         # but it's valid in pandas and returns NULL.
-        snowpark_pandas_result_type = None
         binary_op_result_column = pandas_lit(None)
     elif (
         op == "sub"
@@ -344,7 +343,6 @@ def compute_binary_op_between_snowpark_columns(
     ):
         # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
         # but it's valid in pandas and returns NULL.
-        snowpark_pandas_result_type = None
         binary_op_result_column = pandas_lit(None)
     elif (
         op == "sub"
@@ -365,7 +363,7 @@ def compute_binary_op_between_snowpark_columns(
 
     return SnowparkPandasColumn(
         snowpark_column=binary_op_result_column,
-        snowpark_pandas_type=snowpark_pandas_result_type,
+        snowpark_pandas_type=None,
     )
 
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
@@ -335,7 +335,7 @@ def compute_binary_op_between_snowpark_columns(
     ):
         # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
         # but it's valid in pandas and returns NULL.
-        snowpark_pandas_result_type = NullType()
+        snowpark_pandas_result_type = None
         binary_op_result_column = pandas_lit(None)
     elif (
         op == "sub"
@@ -344,7 +344,7 @@ def compute_binary_op_between_snowpark_columns(
     ):
         # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
         # but it's valid in pandas and returns NULL.
-        snowpark_pandas_result_type = NullType()
+        snowpark_pandas_result_type = None
         binary_op_result_column = pandas_lit(None)
     elif (
         op == "sub"

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -2525,7 +2525,6 @@ def set_frame_2d_labels(
         Returns:
             The new SnowparkPandasColumn
         """
-        col_obj_type = None
         if item_is_scalar:
             new_column = pandas_lit(item)
             col_obj_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
@@ -2552,7 +2551,7 @@ def set_frame_2d_labels(
             )
             col_obj_type = result_frame.cached_data_column_snowpark_pandas_types[offset]
         else:
-            return SnowparkPandasColumn(pandas_lit(None))
+            return SnowparkPandasColumn(pandas_lit(None), None)
         if index_is_scalar:
             new_column = iff(
                 result_frame_index_col.equal_null(pandas_lit(index)),

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -46,6 +46,10 @@ from snowflake.snowpark.modin.plugin._internal.join_utils import (
     join,
 )
 from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import OrderingColumn
+from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
+    SnowparkPandasColumn,
+    SnowparkPandasType,
+)
 from snowflake.snowpark.modin.plugin._internal.type_utils import (
     NUMERIC_SNOWFLAKE_TYPES_TUPLE,
     is_numeric_snowpark_type,
@@ -2436,16 +2440,17 @@ def set_frame_2d_labels(
     )
 
     def generate_updated_expr_for_existing_col(
-        col_pos: int,
-    ) -> Column:
+        col_pos: int, origin_col_type: Optional[SnowparkPandasType]
+    ) -> SnowparkPandasColumn:
         """
         Helper function to generate the updated existing column based on the item value.
 
         Args:
             col_pos: the existing column position from internal_frame
+            origin_col_type: the original column type
 
         Returns:
-            The updated column
+            The updated SnowparkPandasColumn
         """
         original_col = col(
             result_frame.data_column_snowflake_quoted_identifiers[col_pos]
@@ -2453,15 +2458,21 @@ def set_frame_2d_labels(
         # col_pos can be any column in the original frame, i.e., internal_frame. So if it is not in
         # existing_column_positions, we can just return the original column
         if col_pos not in col_info.existing_column_positions:
-            return original_col
+            return SnowparkPandasColumn(original_col, origin_col_type)
 
         col_label = result_frame.data_column_pandas_labels[col_pos]
         # col will be updated
+        col_obj_type = None
         if item_is_scalar:
             col_obj = pandas_lit(item)
+            col_obj_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+                type(item)
+            )
         elif item_column_values:
-            col_obj = pandas_lit(
-                item_column_values[item_data_col_label_to_pos_map[col_label]]
+            item_val = item_column_values[item_data_col_label_to_pos_map[col_label]]
+            col_obj = pandas_lit(item_val)
+            col_obj_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+                type(item_val)
             )
         elif not matching_item_columns_by_label:
             # columns in item is matched by position not label here. E.g., assuming df as A, B, C three columns,
@@ -2469,25 +2480,23 @@ def set_frame_2d_labels(
             # df[["B", "A"]] = item will treat the first item's column as B and the second as A. Also, if column key
             # contains duplicates, e.g, df[["A", "A"]] = item, then only the right index matters, i.e., the second
             # column will be treated as A.
-            col_obj = col(
-                result_frame.data_column_snowflake_quoted_identifiers[
-                    item_data_col_offset
-                    + rindex(col_info.existing_column_positions, col_pos)
-                ]
+            offset = item_data_col_offset + rindex(
+                col_info.existing_column_positions, col_pos
             )
+            col_obj = col(result_frame.data_column_snowflake_quoted_identifiers[offset])
+            col_obj_type = result_frame.cached_data_column_snowpark_pandas_types[offset]
         elif (
             matching_item_columns_by_label
             and col_label in item_data_col_label_to_pos_map
         ):
             # col may have value in item, e.g., column "X"
-            col_obj = col(
-                result_frame.data_column_snowflake_quoted_identifiers[
-                    item_data_col_offset + item_data_col_label_to_pos_map[col_label]
-                ]
-            )
+            offset = item_data_col_offset + item_data_col_label_to_pos_map[col_label]
+            col_obj = col(result_frame.data_column_snowflake_quoted_identifiers[offset])
+            col_obj_type = result_frame.cached_data_column_snowpark_pandas_types[offset]
         else:
             # e.g., columns "E", i.e., column exists in the column key but not in item
             col_obj = pandas_lit(None)
+
         if index_is_scalar:
             col_obj = iff(
                 result_frame_index_col.equal_null(pandas_lit(index)),
@@ -2499,9 +2508,14 @@ def set_frame_2d_labels(
             col_obj = iff(index_data_col, col_obj, original_col)
         elif index_is_frame:
             col_obj = iff(index_data_col.is_null(), original_col, col_obj)
-        return col_obj
 
-    def generate_updated_expr_for_new_col(col_label: Hashable) -> Column:
+        col_obj_type = col_obj_type if col_obj_type == origin_col_type else None
+
+        return SnowparkPandasColumn(col_obj, col_obj_type)
+
+    def generate_updated_expr_for_new_col(
+        col_label: Hashable,
+    ) -> SnowparkPandasColumn:
         """
         Helper function to generate the newly added column.
 
@@ -2509,29 +2523,36 @@ def set_frame_2d_labels(
             col_label: the label of the new column
 
         Returns:
-            The new column
+            The new SnowparkPandasColumn
         """
+        col_obj_type = None
         if item_is_scalar:
             new_column = pandas_lit(item)
+            col_obj_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+                type(item)
+            )
         elif item_column_values:
             new_column = item_column_values[item_data_col_label_to_pos_map[col_label]]
-        elif not matching_item_columns_by_label:
-            new_column = col(
-                result_frame.data_column_snowflake_quoted_identifiers[
-                    item_data_col_offset + item_data_col_label_to_pos_map[col_label]
-                ]
+            col_obj_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+                type(new_column)
             )
+        elif not matching_item_columns_by_label:
+            offset = item_data_col_offset + item_data_col_label_to_pos_map[col_label]
+            new_column = col(
+                result_frame.data_column_snowflake_quoted_identifiers[offset]
+            )
+            col_obj_type = result_frame.cached_data_column_snowpark_pandas_types[offset]
         elif (
             matching_item_columns_by_label
             and col_label in item_data_col_label_to_pos_map
         ):
+            offset = item_data_col_offset + item_data_col_label_to_pos_map[col_label]
             new_column = col(
-                result_frame.data_column_snowflake_quoted_identifiers[
-                    item_data_col_offset + item_data_col_label_to_pos_map[col_label]
-                ]
+                result_frame.data_column_snowflake_quoted_identifiers[offset]
             )
+            col_obj_type = result_frame.cached_data_column_snowpark_pandas_types[offset]
         else:
-            return pandas_lit(None)
+            return SnowparkPandasColumn(pandas_lit(None))
         if index_is_scalar:
             new_column = iff(
                 result_frame_index_col.equal_null(pandas_lit(index)),
@@ -2543,14 +2564,14 @@ def set_frame_2d_labels(
             new_column = iff(index_data_col, new_column, pandas_lit(None))
         elif index_is_frame:
             new_column = iff(index_data_col.is_null(), pandas_lit(None), new_column)
-        return new_column
+        return SnowparkPandasColumn(new_column, col_obj_type)
 
     # The rest of code is to generate the list of project columns and labels for a loc set operation that can involve
     # replacing existing column values as well as adding new columns. The caller must provide the callables to select
     # the appropriate column replacement or new column logic.
     #
     # We use project_columns methods to handle all columns in one go
-    project_labels, project_columns = [], []
+    project_labels, project_columns, project_column_types = [], [], []
 
     num_data_columns = len(internal_frame.data_column_pandas_labels)
     duplicate_data_column_pos_to_count_map = (
@@ -2573,23 +2594,31 @@ def set_frame_2d_labels(
     for col_pos in range(num_data_columns):
         col_label = result_frame.data_column_pandas_labels[col_pos]
         project_labels.append(col_label)
-        col_obj = generate_updated_expr_for_existing_col(col_pos)
-        project_columns.append(col_obj)
+        origin_col_type = result_frame.cached_data_column_snowpark_pandas_types[col_pos]
+        snowpark_pandas_col = generate_updated_expr_for_existing_col(
+            col_pos, origin_col_type
+        )
+        project_columns.append(snowpark_pandas_col.snowpark_column)
+        project_column_types.append(snowpark_pandas_col.snowpark_pandas_type)
 
         # When duplicate is needed, pandas will duplicate the column right after the original columns.
         if col_pos in duplicate_data_column_pos_to_count_map:
             cnt = duplicate_data_column_pos_to_count_map[col_pos]
             project_labels += [col_label] * cnt
-            project_columns += [col_obj] * cnt
+            project_columns += [snowpark_pandas_col.snowpark_column] * cnt
+            project_column_types += [snowpark_pandas_col.snowpark_pandas_type] * cnt
 
     # Last, append new columns
     for col_label in new_data_column_pandas_labels_to_append:
-        new_column = generate_updated_expr_for_new_col(col_label)
+        new_snowpark_pandas_column = generate_updated_expr_for_new_col(col_label)
         project_labels.append(col_label)
-        project_columns.append(new_column)
+        project_columns.append(new_snowpark_pandas_column.snowpark_column)
+        project_column_types.append(new_snowpark_pandas_column.snowpark_pandas_type)
 
     return result_frame.project_columns(
-        pandas_labels=project_labels, column_objects=project_columns
+        pandas_labels=project_labels,
+        column_objects=project_columns,
+        column_types=project_column_types,
     )
 
 
@@ -2674,7 +2703,10 @@ def set_frame_2d_positional(
         kv_frame = get_kv_frame_from_index_and_item_frames(index, item)
         item_data_columns_len = len(item.data_column_snowflake_quoted_identifiers)
     else:
-        kv_frame = index.append_column(ITEM_VALUE_LABEL, pandas_lit(item))
+        item_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+            type(item)
+        )
+        kv_frame = index.append_column(ITEM_VALUE_LABEL, pandas_lit(item), item_type)
         item_data_columns_len = 1
 
     # Next we join the key-value frame with the original frame based on row_position and row key
@@ -2693,6 +2725,7 @@ def set_frame_2d_positional(
 
     frame = internal_frame.ensure_row_position_column()
     kv_frame = kv_frame.ensure_row_position_column()
+    item_type = kv_frame.cached_data_column_snowpark_pandas_types[-1]
 
     # To match the columns of the original dataframe (see [df] above) and the item values (see [item] above) we
     # use the "columns" containing the column position indices.  For example, if columns=[0, 2, 3] this would
@@ -2739,6 +2772,7 @@ def set_frame_2d_positional(
 
     df_kv_frame = df_kv_frame.ensure_row_position_column()
 
+    new_data_column_types = []
     for col_pos, snowflake_quoted_identifier_pair in enumerate(
         zip(
             frame.data_column_snowflake_quoted_identifiers,
@@ -2781,11 +2815,25 @@ def set_frame_2d_positional(
                     df_snowflake_quoted_identifier,
                 ).as_(new_snowflake_quoted_identifier)
             )
+            if (
+                frame.snowflake_quoted_identifier_to_snowpark_pandas_type[
+                    original_snowflake_quoted_identifier
+                ]
+                == item_type
+            ):
+                new_data_column_types.append(item_type)
+            else:
+                new_data_column_types.append(None)
         else:
             select_list.append(
                 col(original_snowflake_quoted_identifier).as_(
                     new_snowflake_quoted_identifier
                 )
+            )
+            new_data_column_types.append(
+                frame.snowflake_quoted_identifier_to_snowpark_pandas_type[
+                    original_snowflake_quoted_identifier
+                ]
             )
 
     select_list.append(df_kv_frame.row_position_snowflake_quoted_identifier)
@@ -2797,7 +2845,7 @@ def set_frame_2d_positional(
         data_column_snowflake_quoted_identifiers=new_data_column_snowflake_quoted_identifiers,
         index_column_pandas_labels=frame.index_column_pandas_labels,
         index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
-        data_column_types=frame.cached_data_column_snowpark_pandas_types,
+        data_column_types=new_data_column_types,
         index_column_types=frame.cached_index_column_snowpark_pandas_types,
     )
 
@@ -3014,6 +3062,7 @@ def get_item_series_as_single_row_frame(
         last_value(col(item.data_column_snowflake_quoted_identifiers[0])).over(
             Window.order_by(col(item.row_position_snowflake_quoted_identifier))
         ),
+        item.cached_data_column_snowpark_pandas_types[0],
     )
     last_value_snowflake_quoted_identifier = (
         item_frame.data_column_snowflake_quoted_identifiers[-1]

--- a/src/snowflake/snowpark/modin/plugin/_internal/snowpark_pandas_types.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/snowpark_pandas_types.py
@@ -19,11 +19,11 @@ TIMEDELTA_WARNING_MESSAGE = (
     "Snowpark pandas support for Timedelta is not currently available."
 )
 
-
-_python_type_to_from_pandas: dict[type, Callable[[Any], Any]] = {}
 """Map Python type to its from_pandas method"""
-_type_to_snowpark_pandas_type: dict[Union[type, np.dtype], type] = {}
+_python_type_to_from_pandas: dict[type, Callable[[Any], Any]] = {}
+
 """Map Python type and pandas dtype to Snowpark pandas type"""
+_type_to_snowpark_pandas_type: dict[Union[type, np.dtype], type] = {}
 
 
 class SnowparkPandasTypeMetaclass(
@@ -73,7 +73,7 @@ class SnowparkPandasTypeMetaclass(
         return new_snowpark_python_type
 
 
-class SnowparkPandasType(metaclass=SnowparkPandasTypeMetaclass):
+class SnowparkPandasType(DataType, metaclass=SnowparkPandasTypeMetaclass):
     """Abstract class for Snowpark pandas types."""
 
     @staticmethod

--- a/src/snowflake/snowpark/modin/plugin/_internal/type_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/type_utils.py
@@ -224,7 +224,7 @@ class TypeMapper:
     @classmethod
     def to_snowflake(
         cls, p: Union[np.dtype, ExtensionDtype, native_pd.Timestamp]
-    ) -> Union[DataType, SnowparkPandasType]:
+    ) -> DataType:
         """
         map a pandas or numpy type to snowpark data type.
         """

--- a/src/snowflake/snowpark/modin/plugin/_internal/type_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/type_utils.py
@@ -224,7 +224,7 @@ class TypeMapper:
     @classmethod
     def to_snowflake(
         cls, p: Union[np.dtype, ExtensionDtype, native_pd.Timestamp]
-    ) -> DataType:
+    ) -> Union[DataType, SnowparkPandasType]:
         """
         map a pandas or numpy type to snowpark data type.
         """
@@ -248,7 +248,7 @@ class TypeMapper:
             SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(p)
         )
         if snowpark_pandas_type is not None:
-            return snowpark_pandas_type()
+            return snowpark_pandas_type
 
         try:
             return PANDAS_TO_SNOWFLAKE_MAP[p]

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1524,6 +1524,12 @@ def pandas_lit(value: Any, datatype: Optional[DataType] = None) -> Column:
             Column(Literal(str(value)))
         )
 
+    snowpark_pandas_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+        type(value)
+    )
+    if snowpark_pandas_type:
+        return Column(Literal(type(snowpark_pandas_type).from_pandas(value)))
+
     value = (
         convert_numpy_pandas_scalar_to_snowpark_literal(value)
         if is_scalar(value)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -8014,8 +8014,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         BaseQueryCompiler
             New masked QueryCompiler.
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         # TODO: SNOW-884220 support multiindex
         # index can only be a query compiler or slice object
         assert isinstance(index, (SnowflakeQueryCompiler, slice))
@@ -8334,8 +8332,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         -------
         SnowflakeQueryCompiler
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         if self._modin_frame.is_multiindex(axis=0) and (
             is_scalar(index) or isinstance(index, tuple)
         ):
@@ -8600,8 +8596,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # STEP 1) Construct a temporary index column that contains the original index with position.
         # STEP 2) Perform an unpivot which flattens the original data columns into a single name and value rows
         # grouped by the temporary transpose index column.
-        self._raise_not_implemented_error_for_timedelta()
-
         unpivot_result = prepare_and_unpivot_for_transpose(
             frame, self, is_single_row=False
         )

--- a/src/snowflake/snowpark/modin/plugin/utils/warning_message.py
+++ b/src/snowflake/snowpark/modin/plugin/utils/warning_message.py
@@ -111,3 +111,9 @@ class WarningMessage:
                 "engine_kwargs",
                 engine_parameter_ignored_message,
             )
+
+    @classmethod
+    def lost_type_warning(cls, operation: str, type: str) -> None:
+        cls.single_warning(
+            f"`{type}` may be lost in `{operation}`'s result, please use `astype` to convert the result type back."
+        )

--- a/tests/integ/modin/types/test_timedelta_indexing.py
+++ b/tests/integ/modin/types/test_timedelta_indexing.py
@@ -111,7 +111,7 @@ def test_df_indexing_get_timedelta(
             if is_scalar(key[0]) and is_scalar(key[1]):
                 assert api(snow_td) == api(td)
             else:
-                native_td = td if type_preserved else td.astype(int)
+                native_td = td if type_preserved else td.astype("int64")
                 eval_snowpark_pandas_result(snow_td, native_td, api)
             if type_preserved:
                 assert expected_warning_msg not in caplog.text
@@ -257,7 +257,7 @@ def test_df_indexing_set_timedelta():
         # single value
         key = (1, 1)
         td_int = td.copy()
-        td_int["b"] = td_int["b"].astype(int)
+        td_int["b"] = td_int["b"].astype("int64")
         # timedelta type is not preserved in this case
         run_test(key, item, natvie_df=td_int)
 
@@ -322,7 +322,7 @@ def test_df_indexing_set_timedelta():
         # single value
         key = (1, "b")
         td_int = td.copy()
-        td_int["b"] = td_int["b"].astype(int)
+        td_int["b"] = td_int["b"].astype("int64")
         # timedelta type is not preserved in this case
         run_test(key, item, natvie_df=td_int, api=loc_set)
 

--- a/tests/integ/modin/types/test_timedelta_indexing.py
+++ b/tests/integ/modin/types/test_timedelta_indexing.py
@@ -1,0 +1,391 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+import functools
+import logging
+
+import modin.pandas as pd
+import pandas as native_pd
+import pytest
+from modin.pandas.utils import is_scalar
+
+from snowflake.snowpark.exceptions import SnowparkSQLException
+from tests.integ.modin.sql_counter import SqlCounter
+from tests.integ.modin.utils import assert_series_equal, eval_snowpark_pandas_result
+
+
+@pytest.mark.parametrize(
+    "key, iloc_join_count, loc_query_count, loc_join_count",
+    [
+        [2, 2, 2, 2],
+        [[2, 1], 2, 1, 1],
+        [slice(1, None), 0, 1, 0],
+        [[True, False, False, True], 1, 1, 1],
+    ],
+)
+def test_series_indexing_get_timedelta(
+    key, iloc_join_count, loc_query_count, loc_join_count
+):
+    # This test only verify indexing return timedelta results correctly
+    td_s = native_pd.Series(
+        [
+            native_pd.Timedelta("1 days 1 hour"),
+            native_pd.Timedelta("2 days 1 minute"),
+            native_pd.Timedelta("3 days 1 nanoseconds"),
+            native_pd.Timedelta("100 nanoseconds"),
+        ]
+    )
+    snow_td_s = pd.Series(td_s)
+
+    def run_test(api, query_count, join_count):
+        with SqlCounter(query_count=query_count, join_count=join_count):
+            if is_scalar(key):
+                assert api(snow_td_s) == api(td_s)
+            else:
+                eval_snowpark_pandas_result(snow_td_s, td_s, api)
+
+    run_test(lambda s: s.iloc[key], 1, iloc_join_count)
+    run_test(lambda s: s[key], loc_query_count, loc_join_count)
+    run_test(lambda s: s.loc[key], loc_query_count, loc_join_count)
+    if is_scalar(key):
+        run_test(lambda s: s.iat[key], 1, iloc_join_count)
+        run_test(lambda s: s.at[key], loc_query_count, loc_join_count)
+
+
+@pytest.mark.parametrize(
+    "key, query_count, join_count, type_preserved",
+    [
+        [(1, 1), 1, 2, True],
+        [(2, 2), 1, 2, True],
+        [([2, 1], 1), 1, 2, True],
+        [
+            (2, [1, 0]),
+            1,
+            4,
+            True,
+        ],  # require transpose and keep result column type as timedelta
+        [(2, ...), 1, 4, False],  # require transpose but lose the type
+        [(slice(1, None), 0), 1, 0, True],
+        [([True, False, False, True], 1), 1, 1, True],
+        [(1, "a"), 2, 2, True],
+        [(2, "b"), 2, 2, True],
+        [([2, 1], "a"), 1, 1, True],
+        [
+            (2, ["b", "a"]),
+            2,
+            3,
+            True,
+        ],  # require transpose and keep result column type as timedelta
+        [(2, ...), 1, 4, False],  # require transpose but lose the type
+        [(slice(1, None), "a"), 1, 0, True],
+        [([True, False, False, True], "b"), 1, 1, True],
+    ],
+)
+def test_df_indexing_get_timedelta(
+    key, query_count, join_count, type_preserved, caplog
+):
+    # This test only verify indexing return timedelta results correctly
+    td = native_pd.DataFrame(
+        {
+            "a": [
+                native_pd.Timedelta("1 days 1 hour"),
+                native_pd.Timedelta("2 days 1 minute"),
+                native_pd.Timedelta("3 days 1 nanoseconds"),
+                native_pd.Timedelta("100 nanoseconds"),
+            ],
+            "b": native_pd.timedelta_range("1 hour", "1 day", 4),
+            "c": [1, 2, 3, 4],
+        }
+    )
+    snow_td = pd.DataFrame(td)
+
+    expected_warning_msg = (
+        "`TimedeltaType` may be lost in `transpose`'s result, please use `astype` to convert the "
+        "result type back."
+    )
+
+    def run_test(api, query_count, join_count):
+        with SqlCounter(query_count=query_count, join_count=join_count):
+            caplog.clear()
+            if is_scalar(key[0]) and is_scalar(key[1]):
+                assert api(snow_td) == api(td)
+            else:
+                native_td = td if type_preserved else td.astype(int)
+                eval_snowpark_pandas_result(snow_td, native_td, api)
+            if type_preserved:
+                assert expected_warning_msg not in caplog.text
+            else:
+                assert expected_warning_msg in caplog.text
+
+    with caplog.at_level(logging.DEBUG):
+        if isinstance(key[1], str) or (
+            isinstance(key[1], list) and isinstance(key[1][0], str)
+        ):
+            api = lambda s: s.loc[key]  # noqa: E731
+        else:
+            api = lambda s: s.iloc[key]  # noqa: E731
+        run_test(api, query_count, join_count)
+        if is_scalar(key[0]) and is_scalar(key[1]):
+            if isinstance(key[1], str):
+                api = lambda s: s.at[key]  # noqa: E731
+            else:
+                api = lambda s: s.iat[key]  # noqa: E731
+            run_test(api, query_count, join_count)
+
+
+def test_df_getitem_timedelta():
+    td = native_pd.DataFrame(
+        {
+            "a": [
+                native_pd.Timedelta("1 days 1 hour"),
+                native_pd.Timedelta("2 days 1 minute"),
+                native_pd.Timedelta("3 days 1 nanoseconds"),
+                native_pd.Timedelta("100 nanoseconds"),
+            ],
+            "b": native_pd.timedelta_range("1 hour", "1 day", 4),
+            "c": [1, 2, 3, 4],
+        }
+    )
+    snow_td = pd.DataFrame(td)
+    with SqlCounter(query_count=1, join_count=0):
+        eval_snowpark_pandas_result(
+            snow_td.copy(),
+            td,
+            lambda df: df["b"],
+        )
+
+    with SqlCounter(query_count=1, join_count=1):
+        eval_snowpark_pandas_result(
+            snow_td.copy(),
+            td,
+            lambda df: df[[True, False, False, True]],
+        )
+
+
+def test_series_indexing_set_timedelta():
+    td_s = native_pd.Series(
+        [
+            native_pd.Timedelta("1 days 1 hour"),
+            native_pd.Timedelta("2 days 1 minute"),
+            native_pd.Timedelta("3 days 1 nanoseconds"),
+            native_pd.Timedelta("100 nanoseconds"),
+        ]
+    )
+    snow_td_s = pd.Series(td_s)
+
+    def iloc_set(key, item, s):
+        s.iloc[key] = item
+        return s
+
+    with SqlCounter(query_count=1, join_count=2):
+        # single value
+        eval_snowpark_pandas_result(
+            snow_td_s.copy(),
+            td_s,
+            functools.partial(iloc_set, 2, pd.Timedelta("2 days 2 hours")),
+        )
+
+    with SqlCounter(query_count=1, join_count=2):
+        # multi values
+        eval_snowpark_pandas_result(
+            snow_td_s.copy(),
+            td_s,
+            functools.partial(iloc_set, slice(2, None), pd.Timedelta("2 days 2 hours")),
+        )
+
+
+def test_df_indexing_set_timedelta():
+    td = native_pd.DataFrame(
+        {
+            "a": [
+                native_pd.Timedelta("1 days 1 hour"),
+                native_pd.Timedelta("2 days 1 minute"),
+                native_pd.Timedelta("3 days 1 nanoseconds"),
+                native_pd.Timedelta("100 nanoseconds"),
+            ],
+            "b": native_pd.timedelta_range("1 hour", "1 day", 4),
+            "c": [1, 2, 3, 4],
+        }
+    )
+    snow_td = pd.DataFrame(td)
+
+    def iloc_set(key, item, df):
+        df.iloc[key] = item
+        return df
+
+    def run_test(key, item, natvie_df=td, api=iloc_set):
+        eval_snowpark_pandas_result(
+            snow_td.copy(), natvie_df.copy(), functools.partial(api, key, item)
+        )
+
+    # Set timedelta value to timedelta columns
+    item = pd.Timedelta("2 days 2 hours")
+
+    with SqlCounter(query_count=1, join_count=2):
+        # single value
+        key = (1, 1)
+        run_test(key, item)
+
+    with SqlCounter(query_count=1, join_count=2):
+        # single column
+        key = (..., 0)
+        run_test(key, item)
+
+    with SqlCounter(query_count=1, join_count=2):
+        # multi columns
+        key = (..., [0, 1])
+        run_test(key, item)
+
+    with SqlCounter(query_count=1, join_count=3):
+        # multi columns with array
+        key = (..., [0, 1])
+        run_test(key, [item] * 2)
+
+    # Set other types to timedelta columns
+    item = "string"
+    with SqlCounter(query_count=0):
+        # single value
+        key = (1, 1)
+        with pytest.raises(
+            SnowparkSQLException, match="Numeric value 'string' is not recognized"
+        ):
+            run_test(key, item)
+
+    item = 1000
+    with SqlCounter(query_count=1, join_count=2):
+        # single value
+        key = (1, 1)
+        td_int = td.copy()
+        td_int["b"] = td_int["b"].astype(int)
+        # timedelta type is not preserved in this case
+        run_test(key, item, natvie_df=td_int)
+
+    def df_set(key, item, df):
+        df[key] = item
+        return df
+
+    # Set timedelta value to timedelta columns
+    item = pd.Timedelta("2 days 2 hours")
+
+    with SqlCounter(query_count=1, join_count=0):
+        # single column
+        key = "b"
+        run_test(key, item, api=df_set)
+
+    with SqlCounter(query_count=1, join_count=0):
+        # multi columns
+        key = ["a", "b"]
+        run_test(key, item, api=df_set)
+
+    with SqlCounter(query_count=1, join_count=0):
+        # multi columns with array
+        key = ["a", "b"]
+        run_test(key, [item] * 2, api=df_set)
+
+    def loc_set(key, item, df):
+        df.loc[key] = item
+        return df
+
+    with SqlCounter(query_count=1, join_count=1):
+        # single value
+        key = (1, "a")
+        run_test(key, item, api=loc_set)
+
+    with SqlCounter(query_count=1, join_count=0):
+        # single column
+        key = (slice(None, None, None), "a")
+        run_test(key, item, api=loc_set)
+
+    with SqlCounter(query_count=1, join_count=0):
+        # multi columns
+        key = (slice(None, None, None), ["a", "b"])
+        run_test(key, item, api=loc_set)
+
+    with SqlCounter(query_count=1, join_count=0):
+        # multi columns with array
+        key = (slice(None, None, None), ["a", "b"])
+        run_test(key, [item] * 2, api=loc_set)
+
+    # Set other types to timedelta columns
+    item = "string"
+    with SqlCounter(query_count=0):
+        # single value
+        key = (1, "a")
+        with pytest.raises(
+            SnowparkSQLException, match="Numeric value 'string' is not recognized"
+        ):
+            run_test(key, item, api=loc_set)
+
+    item = 1000
+    with SqlCounter(query_count=1, join_count=1):
+        # single value
+        key = (1, "b")
+        td_int = td.copy()
+        td_int["b"] = td_int["b"].astype(int)
+        # timedelta type is not preserved in this case
+        run_test(key, item, natvie_df=td_int, api=loc_set)
+
+
+def test_df_indexing_enlargement_timedelta():
+    td = native_pd.DataFrame(
+        {
+            "a": [
+                native_pd.Timedelta("1 days 1 hour"),
+                native_pd.Timedelta("2 days 1 minute"),
+                native_pd.Timedelta("3 days 1 nanoseconds"),
+                native_pd.Timedelta("100 nanoseconds"),
+            ],
+            "b": native_pd.timedelta_range("1 hour", "1 day", 4),
+            "c": [1, 2, 3, 4],
+        }
+    )
+    snow_td = pd.DataFrame(td)
+
+    def setitem_enlargement(key, item, df):
+        df[key] = item
+        return df
+
+    key = "x"
+    item = pd.Timedelta("2 hours")
+    with SqlCounter(query_count=1, join_count=0):
+        eval_snowpark_pandas_result(
+            snow_td.copy(), td.copy(), functools.partial(setitem_enlargement, key, item)
+        )
+
+    key = 10
+    with SqlCounter(query_count=1, join_count=1):
+        eval_snowpark_pandas_result(
+            snow_td["a"].copy(),
+            td["a"].copy(),
+            functools.partial(setitem_enlargement, key, item),
+        )
+
+    def loc_enlargement(key, item, df):
+        df.loc[key] = item
+        return df
+
+    key = (slice(None, None, None), "x")
+
+    with SqlCounter(query_count=1, join_count=0):
+        eval_snowpark_pandas_result(
+            snow_td.copy(), td.copy(), functools.partial(loc_enlargement, key, item)
+        )
+
+    key = 10
+    with SqlCounter(query_count=1, join_count=1):
+        eval_snowpark_pandas_result(
+            snow_td["a"].copy(),
+            td["a"].copy(),
+            functools.partial(loc_enlargement, key, item),
+        )
+
+    # single row
+    key = (10, slice(None, None, None))
+
+    with SqlCounter(query_count=1, join_count=1):
+        # dtypes does not change while in native pandas, col "c"'s type will change to object
+        assert_series_equal(
+            loc_enlargement(key, item, snow_td.copy()).to_pandas().dtypes,
+            snow_td.dtypes,
+        )

--- a/tests/unit/modin/test_snowpark_pandas_types.py
+++ b/tests/unit/modin/test_snowpark_pandas_types.py
@@ -2,12 +2,16 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+import datetime
 import re
 from dataclasses import FrozenInstanceError
 
+import numpy as np
+import pandas as native_pd
 import pytest
 
 from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
+    SnowparkPandasType,
     TimedeltaType,
 )
 
@@ -23,3 +27,44 @@ def test_timedelta_type_is_immutable():
         FrozenInstanceError, match=re.escape("cannot assign to field 'x'")
     ):
         TimedeltaType().x = 3
+
+
+@pytest.mark.parametrize(
+    "pandas_obj, snowpark_pandas_type",
+    [
+        [native_pd.Timedelta("1 day"), TimedeltaType],
+        [np.timedelta64(100, "ns"), TimedeltaType],
+        [np.timedelta64(100, "s"), TimedeltaType],
+        [
+            native_pd.Series(native_pd.Timedelta("1 day")).dtype,
+            TimedeltaType,
+        ],  # Note dtype is an object not a type
+        [datetime.timedelta(days=2), TimedeltaType],
+        [123, None],
+        ["string", None],
+        [native_pd.Interval(left=2, right=5, closed="both"), None],
+    ],
+)
+def test_get_snowpark_pandas_type_for_pandas_type(pandas_obj, snowpark_pandas_type):
+    pandas_type = pandas_obj if isinstance(pandas_obj, np.dtype) else type(pandas_obj)
+    res = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(pandas_type)
+    if snowpark_pandas_type:
+        assert isinstance(res, snowpark_pandas_type)
+    else:
+        assert res is None
+
+
+@pytest.mark.parametrize(
+    "timedelta, snowpark_pandas_value",
+    [
+        [native_pd.Timedelta("1 day"), 24 * 3600 * 10**9],
+        [np.timedelta64(100, "ns"), 100],
+        [np.timedelta64(100, "s"), 100 * 10**9],
+        [
+            native_pd.Series(native_pd.Timedelta("10000 day"))[0],
+            10000 * 24 * 3600 * 10**9,
+        ],
+    ],
+)
+def test_TimedeltaType_from_pandas(timedelta, snowpark_pandas_value):
+    assert TimedeltaType.from_pandas(timedelta) == snowpark_pandas_value


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   SNOW-1625468 Support indexing with Timedelta data columns

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Support indexing with Timedelta data columns:

- Added sufficient tests cases for indexing including get and set values with the same timedelta type or different types.
- To achieve this, I updated several util methods related to transpose, join too.
- Also, I need to refactor `SnowparkPandasType` since there are some confusing on `type` object and class there.

This pull request includes several changes to enhance support for `Timedelta` and improve type safety in the Snowflake Snowpark Modin plugin. The most important changes are summarized below:

### Enhancements to Timedelta Support:
* Added support for indexing with `Timedelta` data columns. (`CHANGELOG.md`: [CHANGELOG.mdR30-L37](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30-L37))

### Type Safety Improvements:
* Added assertions to check that `data_column_types` and `index_column_types` are instances of `SnowparkPandasType` in `_create_snowflake_quoted_identifier_to_snowpark_pandas_type`. (`src/snowflake/snowpark/modin/plugin/_internal/frame.py`: [src/snowflake/snowpark/modin/plugin/_internal/frame.pyR92-R106](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR92-R106))
* Updated `project_columns` to include an optional `column_types` parameter and ensure its length matches `pandas_labels`. (`src/snowflake/snowpark/modin/plugin/_internal/frame.py`: [[1]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR999) [[2]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeR1013-R1021) [[3]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL1023-R1037)
* Modified `set_frame_2d_labels` and `set_frame_2d_positional` to handle `SnowparkPandasColumn` and `SnowparkPandasType` correctly. (`src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py`: [[1]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL2439-R2499) [[2]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL2502-R2555) [[3]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL2677-R2709) [[4]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eR2775) [[5]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eR2818-R2837) [[6]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL2800-R2848)
* Updated `get_item_series_as_single_row_frame` to include `SnowparkPandasType`. (`src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py`: [src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.pyR3065](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eR3065))
* Enhanced `_create_internal_frame_with_join_or_align_result` to handle `data_column_types` and `index_column_types` during joins. (`src/snowflake/snowpark/modin/plugin/_internal/join_utils.py`: [[1]](diffhunk://#diff-67e1df8ec1e45b14cf51e35c6f67ac04982e41f85580cdfff391e35e025546d0R239-R246) [[2]](diffhunk://#diff-67e1df8ec1e45b14cf51e35c6f67ac04982e41f85580cdfff391e35e025546d0R265-R291) [[3]](diffhunk://#diff-67e1df8ec1e45b14cf51e35c6f67ac04982e41f85580cdfff391e35e025546d0R316-R327)