### PR TITLE
SNOW-1638059: fix daily precommit failure test

### DIFF
--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -371,13 +371,6 @@ def test_async_is_running_and_cancel(session):
     assert async_job2.is_done()
 
 
-@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Requires large result")
-def test_async_place_holder(session):
-    exp = session.sql("show functions").where("1=1").collect()
-    async_job = session.sql("show functions").where("1=1").collect_nowait()
-    Utils.check_answer(async_job.result(), exp)
-
-
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is not available")
 @pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
 def test_create_async_job(session, create_async_job_from_query_id):

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -371,7 +371,6 @@ def test_table(session):
     [
         "select 1 as a, 2 as b",
         "show tables in schema limit 10",
-        "describe result last_query_id()",
     ],
 )
 def test_sql(session, query):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1638059

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

IMHO the two test cases are not be here, so removing them is the right approach here:

1. `test_async_place_holder`,  `show functions` causes flakiness because new functions can be created while the test is running, leading to chances of flakiness.
also we have a bunch of async tests, I don't think we need this place holder any more, deleting the test should not reduce test coverage

2. `test_sql `, sql `describe result last_query_id()` is not static, the result depends on the last executed query affected by the dataframe evaluation. 
see: https://github.com/snowflakedb/snowpark-python/actions/runs/10506040722/job/29104987419, if pandas is not installed, the last query will be the `df.count` but if pandas is installed, last query will be `df.to_pandas()`.

This leads to the test failure. I think using last query id is error-prone and we should remove it or replace it.
