### PR TITLE
SNOW-1637932 Refactor quoted_identifier_to_snowflake_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 - Added support for `Index.is_boolean`, `Index.is_integer`, `Index.is_floating`, `Index.is_numeric`, and `Index.is_object`.
 - Added support for `DatetimeIndex.round`, `DatetimeIndex.floor` and `DatetimeIndex.ceil`.
 
+#### Improvements
+
+- Refactored `quoted_identifier_to_snowflake_type` to avoid making metadata queries if the types have been cached locally.
+
 #### Bug Fixes
 
 - Stopped ignoring nanoseconds in `pd.Timedelta` scalars.

--- a/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py
@@ -1041,10 +1041,6 @@ def generate_column_agg_info(
         List[Hashable]
             The new index data column index names for the dataframe after aggregation
     """
-
-    quoted_identifier_to_snowflake_type: dict[
-        str, DataType
-    ] = internal_frame.quoted_identifier_to_snowflake_type()
     num_levels: int = internal_frame.num_index_levels(axis=1)
     # reserve all index column name and ordering column names
     identifiers_to_exclude: list[str] = (
@@ -1066,6 +1062,10 @@ def generate_column_agg_info(
     )
     pandas_label_level_included = (
         not agg_func_level_included or not include_agg_func_only_in_result_label
+    )
+
+    identifier_to_snowflake_type = internal_frame.quoted_identifier_to_snowflake_type(
+        [pair.snowflake_quoted_identifier for pair in column_to_agg_func.keys()]
     )
 
     for pandas_label_to_identifier, agg_func in column_to_agg_func.items():
@@ -1106,7 +1106,7 @@ def generate_column_agg_info(
             column_agg_ops.append(
                 AggregateColumnOpParameters(
                     snowflake_quoted_identifier=agg_func_col,
-                    data_type=quoted_identifier_to_snowflake_type[quoted_identifier],
+                    data_type=identifier_to_snowflake_type[quoted_identifier],
                     agg_pandas_label=label,
                     agg_snowflake_quoted_identifier=identifier,
                     snowflake_agg_func=snowflake_agg_func,

--- a/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
@@ -628,7 +628,7 @@ def prepare_binop_pairs_between_dataframe_and_dataframe(
         List of BinaryOperationPair.
     """
     # construct list of pairs which label belongs to which quoted identifier
-    type_map = aligned_rhs_and_lhs.result_frame.quoted_identifier_to_snowflake_type()
+    type_map = aligned_rhs_and_lhs.result_frame.get_snowflake_type
     left_right_pairs = []
     for label in combined_data_labels:
         left_identifier, right_identifier = None, None
@@ -646,7 +646,7 @@ def prepare_binop_pairs_between_dataframe_and_dataframe(
             left = col(left_identifier)
             # To avoid referencing always the last right_identifier in the loop, use functools.partial
             left_typer = functools.partial(
-                lambda identifier: type_map[identifier], left_identifier
+                lambda identifier: type_map(identifier), left_identifier
             )  # noqa: E731
         except ValueError:
             # lhs label not in list.
@@ -668,7 +668,7 @@ def prepare_binop_pairs_between_dataframe_and_dataframe(
             right = col(right_identifier)
             # To avoid referencing always the last right_identifier in the loop, use functools.partial
             right_typer = functools.partial(
-                lambda identifier: type_map[identifier], right_identifier
+                lambda identifier: type_map(identifier), right_identifier
             )  # noqa: E731
         except ValueError:
             # rhs label not in list

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -357,18 +357,64 @@ class InternalFrame:
             ]
         ]
 
-    def quoted_identifier_to_snowflake_type(self) -> dict[str, DataType]:
-        identifier_to_type = {}
-        for f in self.ordered_dataframe.schema.fields:
+    def get_snowflake_type(
+        self, identifier: Union[str, list[str]]
+    ) -> Union[DataType, list[DataType]]:
+        """
+        Get the Snowflake type.
+
+        Args:
+            identifier: one or a list of Snowflake quoted identifiers
+
+        Returns:
+             The one or a list of Snowflake types.
+
+        """
+        if isinstance(identifier, list):
+            return list(self.quoted_identifier_to_snowflake_type(identifier).values())
+        return list(self.quoted_identifier_to_snowflake_type([identifier]).values())[0]
+
+    def quoted_identifier_to_snowflake_type(
+        self, identifiers: Optional[list[str]] = None
+    ) -> dict[str, DataType]:
+        """
+        Get a map from Snowflake quoted identifier to Snowflake types.
+
+        Args:
+            identifiers: if identifiers is given, only return the mapping for those inputs. Otherwise, the map will
+            include all identifiers in the frame.
+
+        Return:
+            A mapping from Snowflake quoted identifier to Snowflake types.
+        """
+        snowpark_pandas_type_mapping = (
+            self.snowflake_quoted_identifier_to_snowpark_pandas_type
+        )
+        if identifiers is not None:
             # ordered dataframe may include columns that are not index or data
             # columns of this InternalFrame, so don't assume that each
             # identifier is in snowflake_quoted_identifier_to_snowflake_type.
-            cached_type = self.snowflake_quoted_identifier_to_snowpark_pandas_type.get(
-                f.column_identifier.quoted_name, None
-            )
-            identifier_to_type[f.column_identifier.quoted_name] = (
-                cached_type if cached_type is not None else f.datatype
-            )
+            cached_types = {
+                id: snowpark_pandas_type_mapping.get(id, None) for id in identifiers
+            }
+            if None not in cached_types.values():
+                # if all types are cached, then we don't need to call schema
+                return cached_types
+
+        all_identifier_to_type = {}
+
+        for f in self.ordered_dataframe.schema.fields:
+            id = f.column_identifier.quoted_name
+            cached_type = snowpark_pandas_type_mapping.get(id, None)
+            all_identifier_to_type[id] = cached_type or f.datatype
+
+        if identifiers is not None:
+            # Python dict's keys and values are iterated over in insertion order. This make sense result dict
+            # `identifier_to_type`'s order matches with the input `identifier`
+            identifier_to_type = {id: all_identifier_to_type[id] for id in identifiers}
+        else:
+            identifier_to_type = all_identifier_to_type
+
         return identifier_to_type
 
     @property
@@ -515,9 +561,7 @@ class InternalFrame:
         else:
             # We have one index column. Fill in the type correctly.
             index_identifier = self.index_column_snowflake_quoted_identifiers[0]
-            index_type = TypeMapper.to_pandas(
-                self.quoted_identifier_to_snowflake_type()[index_identifier]
-            )
+            index_type = TypeMapper.to_pandas(self.get_snowflake_type(index_identifier))
             ret = native_pd.Index(
                 [row[0] for row in index_values],
                 name=self.index_column_pandas_labels[0],

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -383,9 +383,9 @@ def get_frame_by_row_pos_frame(
         The selected frame
     """
     # check data type
-    key_datatype = key.quoted_identifier_to_snowflake_type()[
+    key_datatype = key.get_snowflake_type(
         key.data_column_snowflake_quoted_identifiers[0]
-    ]
+    )
     # implicitly allow float types to be compatible with pandas
     assert isinstance(
         key_datatype, NUMERIC_SNOWFLAKE_TYPES_TUPLE
@@ -1238,9 +1238,9 @@ def get_frame_by_row_label(
     ), f"frontend should convert key to the supported types but got {type(key)}"
 
     # check data type
-    key_datatype = key.quoted_identifier_to_snowflake_type()[
+    key_datatype = key.get_snowflake_type(
         key.data_column_snowflake_quoted_identifiers[0]
-    ]
+    )
 
     # boolean indexer
     if isinstance(key_datatype, BooleanType):
@@ -1652,9 +1652,7 @@ def _get_frame_by_row_label_non_boolean_frame(
         # Otherwise, when key value is not array type, loc does prefix match, i.e., match the top level only
         # e.g., if the internal frame has multiindex ["foo", "bar"]
         if isinstance(
-            key.quoted_identifier_to_snowflake_type()[
-                key.data_column_snowflake_quoted_identifiers[0]
-            ],
+            key.get_snowflake_type(key.data_column_snowflake_quoted_identifiers[0]),
             ArrayType,
         ):
             # if the key is array type, pandas performs exact match, so the value in the array needs to be exact
@@ -1739,10 +1737,10 @@ def _get_frame_by_row_series_bool(
     # e.g. `df = pd.DataFrame({'val': range(3)}, index=['2023-01-01', '2023-01-02', '2023-01-03', ])
     # bool_series = pd.Series([False, False, True, ],index=pd.date_range('2023-01-01', periods=3, freq='D'))
     # `df.loc[bool_series]` should return a dataframe with the third row from df
-    key_index_type = key.quoted_identifier_to_snowflake_type()[key_index_identifier]
-    df_index_type = internal_frame.quoted_identifier_to_snowflake_type()[
+    key_index_type = key.get_snowflake_type(key_index_identifier)
+    df_index_type = internal_frame.get_snowflake_type(
         internal_frame.index_column_snowflake_quoted_identifiers[0]
-    ]
+    )
     if (
         not (
             is_numeric_snowpark_type(key_index_type)
@@ -2679,9 +2677,9 @@ def set_frame_2d_positional(
     -------
     The result is a frame that has the indexed row and columns replaced with item values.
     """
-    index_data_type = index.quoted_identifier_to_snowflake_type()[
+    index_data_type = index.get_snowflake_type(
         index.data_column_snowflake_quoted_identifiers[0]
-    ]
+    )
 
     # If index is a bool_indexer then convert to same-sized position index, False values will be null.
     if isinstance(index_data_type, BooleanType):

--- a/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
@@ -1067,8 +1067,8 @@ def convert_incompatible_types_to_variant(
     """
     assert len(left_ids) == len(right_ids)
 
-    left_id_to_type_map = left.quoted_identifier_to_snowflake_type()
-    right_id_to_type_map = right.quoted_identifier_to_snowflake_type()
+    left_id_to_type_map = left.quoted_identifier_to_snowflake_type(left_ids)
+    right_id_to_type_map = right.quoted_identifier_to_snowflake_type(right_ids)
 
     left_to_variant = {}
     right_to_variant = {}

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -292,7 +292,7 @@ def get_snowflake_quoted_identifier_for_resample_index_col(frame: InternalFrame)
         )
 
     index_col = index_cols[0]
-    sf_type = frame.quoted_identifier_to_snowflake_type()[index_col]
+    sf_type = frame.get_snowflake_type(index_col)
 
     if not isinstance(sf_type, (TimestampType, DateType)):
         raise TypeError("Only valid with DatetimeIndex.")

--- a/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
@@ -323,11 +323,11 @@ def _prepare_unpivot_internal(
 
     # If the original frame had *all* the same data types, then we can preserve this here otherwise
     # we need to default to variant.
-    frame_data_type_map = original_frame.quoted_identifier_to_snowflake_type()
-    original_data_types = {
-        frame_data_type_map.get(snowflake_quoted_identifier)
-        for snowflake_quoted_identifier in original_frame.data_column_snowflake_quoted_identifiers
-    }
+    original_data_types = set(
+        original_frame.get_snowflake_type(
+            original_frame.data_column_snowflake_quoted_identifiers
+        )
+    )
     output_data_type = (
         original_data_types.pop() if len(original_data_types) == 1 else VariantType()
     )

--- a/src/snowflake/snowpark/modin/plugin/_internal/where_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/where_utils.py
@@ -16,17 +16,13 @@ def validate_expected_boolean_data_columns(frame: InternalFrame) -> None:
     Returns:
         None
     """
-    frame_snowflake_identifier_to_data_type_map = (
-        frame.quoted_identifier_to_snowflake_type()
-    )
-
     if not all(
         isinstance(
-            frame_snowflake_identifier_to_data_type_map.get(
-                snowflake_quoted_identifier
-            ),
+            type,
             BooleanType,
         )
-        for snowflake_quoted_identifier in frame.data_column_snowflake_quoted_identifiers
+        for type in frame.get_snowflake_type(
+            frame.data_column_snowflake_quoted_identifiers
+        )
     ):
         raise ValueError("Boolean array expected for the condition, not object")

--- a/src/snowflake/snowpark/modin/plugin/_internal/where_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/where_utils.py
@@ -18,10 +18,10 @@ def validate_expected_boolean_data_columns(frame: InternalFrame) -> None:
     """
     if not all(
         isinstance(
-            type,
+            t,
             BooleanType,
         )
-        for type in frame.get_snowflake_type(
+        for t in frame.get_snowflake_type(
             frame.data_column_snowflake_quoted_identifiers
         )
     ):

--- a/src/snowflake/snowpark/modin/plugin/extensions/index.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/index.py
@@ -1664,15 +1664,14 @@ class Index(metaclass=TelemetryMeta):
             "_is_index": True,
         }
 
-        internal_data_types = (
-            self._query_compiler._modin_frame.quoted_identifier_to_snowflake_type()
-        )
         internal_index_column = (
             self._query_compiler._modin_frame.index_column_snowflake_quoted_identifiers[
                 0
             ]
         )
-        internal_index_type = internal_data_types[internal_index_column]
+        internal_index_type = self._query_compiler._modin_frame.get_snowflake_type(
+            internal_index_column
+        )
         if isinstance(internal_index_type, ArrayType):
             raise NotImplementedError(
                 "Snowpark pandas does not support `reindex` with tuple-like Index values."

--- a/tests/integ/modin/frame/test_dtypes.py
+++ b/tests/integ/modin/frame/test_dtypes.py
@@ -31,11 +31,9 @@ from tests.integ.modin.utils import (
 
 def validate_series_snowpark_dtype(series: pd.Series, snowpark_type: DataType) -> None:
     internal_frame = series._query_compiler._modin_frame
-    snowpark_type_map = internal_frame.quoted_identifier_to_snowflake_type()
-    snowpark_dtypes = [
-        snowpark_type_map[quoted_identifier]
-        for quoted_identifier in internal_frame.data_column_snowflake_quoted_identifiers
-    ]
+    snowpark_dtypes = internal_frame.get_snowflake_type(
+        internal_frame.data_column_snowflake_quoted_identifiers
+    )
     assert len(snowpark_dtypes) == 1
     assert snowpark_dtypes[0] == snowpark_type
 

--- a/tests/unit/modin/conftest.py
+++ b/tests/unit/modin/conftest.py
@@ -13,6 +13,7 @@ from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
     SnowflakeQueryCompiler,
 )
+from snowflake.snowpark.types import StringType
 
 
 @pytest.fixture(scope="function")
@@ -23,6 +24,8 @@ def mock_single_col_query_compiler() -> SnowflakeQueryCompiler:
     mock_internal_frame.snowflake_quoted_identifier_to_snowpark_pandas_type = {
         '"A"': None
     }
+    mock_internal_frame.get_snowflake_type.return_value = [StringType()]
+
     fake_query_compiler = SnowflakeQueryCompiler(mock_internal_frame)
 
     return fake_query_compiler

--- a/tests/unit/modin/test_series_dt.py
+++ b/tests/unit/modin/test_series_dt.py
@@ -21,9 +21,7 @@ def mock_query_compiler_for_dt_series() -> SnowflakeQueryCompiler:
     mock_internal_frame = mock.create_autospec(InternalFrame)
     mock_internal_frame.data_columns_index = native_pd.Index(["A"], name="B")
     mock_internal_frame.data_column_snowflake_quoted_identifiers = ['"A"']
-    mock_internal_frame.quoted_identifier_to_snowflake_type.return_value = {
-        '"A"': TimestampType()
-    }
+    mock_internal_frame.get_snowflake_type.return_value = [TimestampType()]
     fake_query_compiler = SnowflakeQueryCompiler(mock_internal_frame)
 
     return fake_query_compiler


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1637932

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

The main purpose for this refactoring is to avoid calling schema when cached type is available, e.g., avoid calling schema when we know the type is Timedelta in binary ops.

This pull request includes several changes to the Snowflake Snowpark Modin plugin, focusing on refactoring the way Snowflake types are retrieved and used. The main changes involve replacing the `quoted_identifier_to_snowflake_type` method with a new `get_snowflake_type` method, which simplifies type retrieval by allowing it to accept a single identifier or a list of identifiers.

### Refactoring Type Retrieval

* [`src/snowflake/snowpark/modin/plugin/_internal/aggregation_utils.py`](diffhunk://#diff-036a8cce05771914c03d260ad7fb1ab74a1578b353ff5156a65fbe546788872cL1044-L1047): Updated `generate_column_agg_info` to use `get_snowflake_type` instead of `quoted_identifier_to_snowflake_type` for retrieving Snowflake types. [[1]](diffhunk://#diff-036a8cce05771914c03d260ad7fb1ab74a1578b353ff5156a65fbe546788872cL1044-L1047) [[2]](diffhunk://#diff-036a8cce05771914c03d260ad7fb1ab74a1578b353ff5156a65fbe546788872cR1067-R1070) [[3]](diffhunk://#diff-036a8cce05771914c03d260ad7fb1ab74a1578b353ff5156a65fbe546788872cL1109-R1109)

* [`src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py`](diffhunk://#diff-dd6dcb779b1e636fa0bc9541f9c0f8f0e18227367ef40a779146c5a6108676ebL631-R631): Modified `prepare_binop_pairs_between_dataframe_and_dataframe` to use `get_snowflake_type` for type mapping. [[1]](diffhunk://#diff-dd6dcb779b1e636fa0bc9541f9c0f8f0e18227367ef40a779146c5a6108676ebL631-R631) [[2]](diffhunk://#diff-dd6dcb779b1e636fa0bc9541f9c0f8f0e18227367ef40a779146c5a6108676ebL649-R649) [[3]](diffhunk://#diff-dd6dcb779b1e636fa0bc9541f9c0f8f0e18227367ef40a779146c5a6108676ebL671-R671)

* [`src/snowflake/snowpark/modin/plugin/_internal/frame.py`](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL360-R417): Added `get_snowflake_type` method and updated existing methods to use it. [[1]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL360-R417) [[2]](diffhunk://#diff-dc59d6fb5be73824e72c1e84ca671739e68c28f651a164e96af7f19a3f732edeL518-R564)

### Updating Indexing Utilities

* [`src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py`](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL386-R388): Replaced `quoted_identifier_to_snowflake_type` with `get_snowflake_type` in multiple functions for checking data types. [[1]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL386-R388) [[2]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL1241-R1243) [[3]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL1655-R1655) [[4]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL1742-R1743) [[5]](diffhunk://#diff-524607b71f519819352dae1467474661e35164db39180ad106e30e7bf2e3265eL2682-R2682)

### Enhancing Join and Where Utilities

* [`src/snowflake/snowpark/modin/plugin/_internal/join_utils.py`](diffhunk://#diff-67e1df8ec1e45b14cf51e35c6f67ac04982e41f85580cdfff391e35e025546d0L1070-R1071): Updated `convert_incompatible_types_to_variant` to use `get_snowflake_type` for type mapping.

* [`src/snowflake/snowpark/modin/plugin/_internal/where_utils.py`](diffhunk://#diff-ddf55ef822ec0c6f0e5406f498175dce3ae3a2177c036884d7356961d5b15015L19-R26): Refactored `validate_expected_boolean_data_columns` to use `get_snowflake_type` for type validation.

### Compiler Adjustments

* [`src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py`](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L473-R477): Refactored several methods to use `get_snowflake_type` for type retrieval and mapping. [[1]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L473-R477) [[2]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L497-R502) [[3]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1500) [[4]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1545-R1546) [[5]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1710-R1711) [[6]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1870-R1877) [[7]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1924)