### PR TITLE
SNOW-1625379 Test coverage for timedelta under modin/integ/frame part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,7 @@
 #### New Features
 
 - Added limited support for the `Timedelta` type, including the following features. Snowpark pandas will raise `NotImplementedError` for unsupported `Timedelta` use cases.
-  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `fillna`, `diff`, `duplicated`, `empty`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `melt`, `nlargest`, `nsmallest`.
-  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`.
+  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `assign`, `bfill`, `ffill`, `fillna`, `compare`, `diff`, `drop`, `dropna`, `duplicated`, `empty`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `melt`, `merge`, `nlargest`, `nsmallest`.
   - converting non-timedelta to timedelta via `astype`.
   - `NotImplementedError` will be raised for the rest of methods that do not support `Timedelta`.
   - support for subtracting two timestamps to get a Timedelta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 #### New Features
 
 - Added limited support for the `Timedelta` type, including the following features. Snowpark pandas will raise `NotImplementedError` for unsupported `Timedelta` use cases.
-  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `assign`, `bfill`, `ffill`, `fillna`, `compare`, `diff`, `drop`, `dropna`, `duplicated`, `empty`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `melt`, `merge`, `nlargest`, `nsmallest`.
+  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `assign`, `bfill`, `ffill`, `fillna`, `compare`, `diff`, `drop`, `dropna`, `duplicated`, `empty`, `equals`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `mask`, `melt`, `merge`, `nlargest`, `nsmallest`.
   - converting non-timedelta to timedelta via `astype`.
   - `NotImplementedError` will be raised for the rest of methods that do not support `Timedelta`.
   - support for subtracting two timestamps to get a Timedelta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 #### New Features
 
 - Added limited support for the `Timedelta` type, including the following features. Snowpark pandas will raise `NotImplementedError` for unsupported `Timedelta` use cases.
+  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `fillna`, `diff`, `duplicated`, `empty`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `melt`, `nlargest`, `nsmallest`.
   - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`.
   - converting non-timedelta to timedelta via `astype`.
   - `NotImplementedError` will be raised for the rest of methods that do not support `Timedelta`.

--- a/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
@@ -512,10 +512,8 @@ def are_equal_types(type1: DataType, type2: DataType) -> bool:
     Returns:
         True if given types are equal, False otherwise.
     """
-    if isinstance(type1, TimedeltaType) and not isinstance(type2, TimedeltaType):
-        return False
-    if isinstance(type2, TimedeltaType) and not isinstance(type1, TimedeltaType):
-        return False
+    if isinstance(type1, TimedeltaType) or isinstance(type2, TimedeltaType):
+        return type1 == type2
     if isinstance(type1, _IntegralType) and isinstance(type2, _IntegralType):
         return True
     if isinstance(type1, _FractionalType) and isinstance(type2, _FractionalType):

--- a/src/snowflake/snowpark/modin/plugin/_internal/isin_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/isin_utils.py
@@ -14,6 +14,9 @@ from snowflake.snowpark.functions import (
 )
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.indexing_utils import set_frame_2d_labels
+from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
+    SnowparkPandasType,
+)
 from snowflake.snowpark.modin.plugin._internal.type_utils import infer_series_type
 from snowflake.snowpark.modin.plugin._internal.utils import (
     append_columns,
@@ -99,6 +102,13 @@ def scalar_isin_expression(
             pandas_lit(literal_expr._expression.value, VariantType())
             for literal_expr in values
         ]
+
+    # Case 4: If column's and values' data type differs and any of the type is SnowparkPandasType
+    elif values_dtype != column_dtype and (
+        isinstance(values_dtype, SnowparkPandasType)
+        or isinstance(column_dtype, SnowparkPandasType)
+    ):
+        return pandas_lit(False)
 
     values = array_construct(*values)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
@@ -173,7 +173,7 @@ def join(
     ), f"Invalid join type: {how}. Allowed values are {get_args(JoinTypeLit)}"
 
     def assert_snowpark_pandas_types_match() -> None:
-        """If Snowpark pandas types does not match, then a ValueError will be raised."""
+        """If Snowpark pandas types do not match, then a ValueError will be raised."""
         left_types = [
             left.snowflake_quoted_identifier_to_snowpark_pandas_type.get(id, None)
             for id in left_on

--- a/src/snowflake/snowpark/modin/plugin/_internal/snowpark_pandas_types.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/snowpark_pandas_types.py
@@ -118,7 +118,7 @@ class SnowparkPandasColumn(NamedTuple):
     snowpark_pandas_type: Optional[SnowparkPandasType]
 
 
-class TimedeltaType(SnowparkPandasType):
+class TimedeltaType(SnowparkPandasType, LongType):
     """
     Timedelta represents the difference between two times.
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/snowpark_pandas_types.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/snowpark_pandas_types.py
@@ -101,6 +101,13 @@ class SnowparkPandasType(DataType, metaclass=SnowparkPandasTypeMetaclass):
             return _type_to_snowpark_pandas_type[pandas_type]()
         return None
 
+    def type_match(self, value: Any) -> bool:
+        """Return True if the value's type matches self."""
+        val_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
+            type(value)
+        )
+        return self == val_type
+
 
 class SnowparkPandasColumn(NamedTuple):
     """A Snowpark Column that has an optional SnowparkPandasType."""
@@ -111,7 +118,7 @@ class SnowparkPandasColumn(NamedTuple):
     snowpark_pandas_type: Optional[SnowparkPandasType]
 
 
-class TimedeltaType(SnowparkPandasType, LongType):
+class TimedeltaType(SnowparkPandasType):
     """
     Timedelta represents the difference between two times.
 
@@ -132,6 +139,12 @@ class TimedeltaType(SnowparkPandasType, LongType):
         # Timedelta support.
         WarningMessage.single_warning(TIMEDELTA_WARNING_MESSAGE)
         super().__init__()
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
 
     @staticmethod
     def to_pandas(value: int) -> native_pd.Timedelta:

--- a/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
@@ -735,12 +735,16 @@ def _simple_unpivot(
     # create the initial set of columns to be retained as identifiers and those
     # which will be unpivoted. Collect data type information.
     unpivot_quoted_columns = []
+    unpivot_quoted_column_types = []
+
     ordering_decode_conditions = []
     id_col_names = []
     id_col_quoted_identifiers = []
-    for (pandas_label, snowflake_quoted_identifier) in zip(
+    id_col_types = []
+    for (pandas_label, snowflake_quoted_identifier, sp_pandas_type) in zip(
         frame.data_column_pandas_labels,
         frame.data_column_snowflake_quoted_identifiers,
+        frame.cached_data_column_snowpark_pandas_types,
     ):
         is_id_col = pandas_label in pandas_id_columns
         is_var_col = pandas_label in pandas_value_columns
@@ -752,9 +756,11 @@ def _simple_unpivot(
                 col(var_quoted) == pandas_lit(pandas_label)
             )
             unpivot_quoted_columns.append(snowflake_quoted_identifier)
+            unpivot_quoted_column_types.append(sp_pandas_type)
         if is_id_col:
             id_col_names.append(pandas_label)
             id_col_quoted_identifiers.append(snowflake_quoted_identifier)
+            id_col_types.append(sp_pandas_type)
 
     # create the case expressions used for the final result set ordering based
     # on the column position. This clause will be appled after the unpivot
@@ -787,7 +793,7 @@ def _simple_unpivot(
                 pandas_labels=[unquoted_col_name],
             )[0]
         )
-        # coalese the values to unpivot and preserve null values This code
+        # coalesce the values to unpivot and preserve null values This code
         # can be removed when UNPIVOT_INCLUDE_NULLS is enabled
         unpivot_columns_normalized_types.append(
             coalesce(to_variant(c), to_variant(pandas_lit(null_replace_value))).alias(
@@ -870,6 +876,13 @@ def _simple_unpivot(
         var_quoted,
         corrected_value_column_name,
     ]
+    corrected_value_column_type = None
+    if len(set(unpivot_quoted_column_types)) == 1:
+        corrected_value_column_type = unpivot_quoted_column_types[0]
+    final_snowflake_quoted_col_types = id_col_types + [
+        None,
+        corrected_value_column_type,
+    ]
 
     # Create the new frame and compiler
     return InternalFrame.create(
@@ -881,8 +894,8 @@ def _simple_unpivot(
         index_column_snowflake_quoted_identifiers=[
             ordered_dataframe.row_position_snowflake_quoted_identifier
         ],
-        data_column_types=None,
-        index_column_types=None,
+        data_column_types=final_snowflake_quoted_col_types,
+        index_column_types=[None],
     )
 
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1499,7 +1499,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         row_position_quoted_identifier = frame.row_position_snowflake_quoted_identifier
 
         fill_value_dtype = infer_object_type(fill_value)
-        fill_value = pandas_lit(fill_value) if fill_value is not None else None
+        fill_value = None if pd.isna(fill_value) else pandas_lit(fill_value)
 
         def shift_expression_and_type(
             quoted_identifier: str, dtype: DataType

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -5757,8 +5757,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             A new SnowflakeQueryCompiler instance with new column.
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         if not isinstance(value, SnowflakeQueryCompiler):
             # Scalar value
             new_internal_frame = self._modin_frame.append_column(
@@ -5848,7 +5846,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         data_column_snowflake_quoted_identifiers = (
             new_internal_frame.data_column_snowflake_quoted_identifiers
         )
+        data_column_types = new_internal_frame.cached_data_column_snowpark_pandas_types
         move_last_element(data_column_snowflake_quoted_identifiers, loc)
+        move_last_element(data_column_types, loc)
 
         new_internal_frame = InternalFrame.create(
             ordered_dataframe=new_internal_frame.ordered_dataframe,
@@ -5857,8 +5857,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             data_column_pandas_index_names=new_internal_frame.data_column_pandas_index_names,
             index_column_pandas_labels=new_internal_frame.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=new_internal_frame.index_column_snowflake_quoted_identifiers,
-            data_column_types=None,
-            index_column_types=None,
+            data_column_types=data_column_types,
+            index_column_types=new_internal_frame.cached_index_column_snowpark_pandas_types,
         )
         return SnowflakeQueryCompiler(new_internal_frame)
 
@@ -6645,8 +6645,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Notes:
             melt does not yet handle multiindex or ignore index
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         if col_level is not None:
             raise NotImplementedError(
                 "Snowpark Pandas doesn't support 'col_level' argument in melt API"
@@ -6749,8 +6747,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler instance with merged result.
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         if validate:
             ErrorMessage.not_implemented(
                 "Snowpark pandas merge API doesn't yet support 'validate' parameter"
@@ -9815,6 +9811,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         # case 2: fillna with a method
         if method is not None:
+            # no Snowpark pandas type change in this case
+            data_column_snowpark_pandas_types = (
+                self._modin_frame.cached_data_column_snowpark_pandas_types
+            )
             method = FillNAMethod.get_enum_for_string_method(method)
             method_is_ffill = method is FillNAMethod.FFILL_METHOD
             if axis == 0:
@@ -9921,6 +9921,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 include_index=False,
             )
             fillna_column_map = {}
+            data_column_snowpark_pandas_types = []
             if columns_mask is not None:
                 columns_to_ignore = itertools.compress(
                     self._modin_frame.data_column_pandas_labels,
@@ -9940,10 +9941,18 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                                 col(id),
                                 coalesce(id, pandas_lit(val)),
                             )
+                        col_type = self._modin_frame.get_snowflake_type(id)
+                        col_pandas_type = (
+                            col_type
+                            if isinstance(col_type, SnowparkPandasType)
+                            and col_type.type_match(val)
+                            else None
+                        )
+                        data_column_snowpark_pandas_types.append(col_pandas_type)
 
         return SnowflakeQueryCompiler(
             self._modin_frame.update_snowflake_quoted_identifiers_with_expressions(
-                fillna_column_map
+                fillna_column_map, data_column_snowpark_pandas_types
             ).frame
         )
 
@@ -10217,7 +10226,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         }
         return SnowflakeQueryCompiler(
             self._modin_frame.update_snowflake_quoted_identifiers_with_expressions(
-                diff_label_to_value_map
+                diff_label_to_value_map,
+                self._modin_frame.cached_data_column_snowpark_pandas_types,
             ).frame
         )
 

--- a/tests/integ/modin/data.py
+++ b/tests/integ/modin/data.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
+import pandas as native_pd
 
 RAW_NA_DF_DATA_TEST_CASES = [
     ({"A": [1, 2, 3], "B": [4, 5, 6]}, "numeric-no"),
@@ -16,9 +17,18 @@ RAW_NA_DF_DATA_TEST_CASES = [
     ({"A": [True, 1, "X"], "B": ["Y", 3.14, False]}, "mixed"),
     ({"A": [True, None, "X"], "B": [None, 3.14, None]}, "mixed-mixed-1"),
     ({"A": [None, 1, None], "B": ["Y", None, False]}, "mixed-mixed-2"),
+    (
+        {
+            "A": [None, native_pd.Timedelta(2), None],
+            "B": [native_pd.Timedelta(4), None, native_pd.Timedelta(6)],
+        },
+        "timedelta-mixed-1",
+    ),
 ]
 
 RAW_NA_DF_SERIES_TEST_CASES = [
     (list(df_data.values()), test_case)
-    for (df_data, test_case) in RAW_NA_DF_DATA_TEST_CASES
+    for (df_data, test_case) in RAW_NA_DF_DATA_TEST_CASES[
+        :1
+    ]  # "timedelta-mixed-1" is not json serializable
 ]

--- a/tests/integ/modin/frame/test_bfill_ffill.py
+++ b/tests/integ/modin/frame/test_bfill_ffill.py
@@ -14,7 +14,7 @@ from tests.integ.modin.utils import eval_snowpark_pandas_result
 
 @pytest.mark.parametrize("func", ["backfill", "bfill", "ffill", "pad"])
 @sql_count_checker(query_count=1)
-def test_df_func(func):
+def test_df_fill(func):
     native_df = native_pd.DataFrame(
         [
             [np.nan, 2, np.nan, 0],
@@ -25,6 +25,27 @@ def test_df_func(func):
         ],
         columns=list("ABCD"),
     )
+    snow_df = pd.DataFrame(native_df)
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: getattr(df, func)(),
+    )
+
+
+@pytest.mark.parametrize("func", ["backfill", "bfill", "ffill", "pad"])
+@sql_count_checker(query_count=1)
+def test_df_timedelta_fill(func):
+    native_df = native_pd.DataFrame(
+        [
+            [np.nan, 2, np.nan, 0],
+            [3, 4, np.nan, 1],
+            [np.nan, np.nan, np.nan, np.nan],
+            [np.nan, 3, np.nan, 4],
+            [3, np.nan, 4, np.nan],
+        ],
+        columns=list("ABCD"),
+    ).astype("timedelta64[ns]")
     snow_df = pd.DataFrame(native_df)
     eval_snowpark_pandas_result(
         snow_df,

--- a/tests/integ/modin/frame/test_compare.py
+++ b/tests/integ/modin/frame/test_compare.py
@@ -35,16 +35,10 @@ JOIN_COUNT_SINGLE_LEVEL_INDEX = 4
 def base_df() -> native_pd.DataFrame:
     return native_pd.DataFrame(
         [
-            [None, None, 3.1, pd.Timestamp("2024-01-01"), [130]],
-            [
-                "a",
-                1,
-                4.2,
-                pd.Timestamp("2024-02-01"),
-                [131],
-            ],
-            ["b", 2, 5.3, pd.Timestamp("2024-03-01"), [132]],
-            [None, 3, 6.4, pd.Timestamp("2024-04-01"), [133]],
+            [None, None, 3.1, pd.Timestamp("2024-01-01"), [130], pd.Timedelta(1)],
+            ["a", 1, 4.2, pd.Timestamp("2024-02-01"), [131], pd.Timedelta(11)],
+            ["b", 2, 5.3, pd.Timestamp("2024-03-01"), [132], pd.Timedelta(21)],
+            [None, 3, 6.4, pd.Timestamp("2024-04-01"), [133], pd.Timedelta(13)],
         ],
         index=pd.MultiIndex.from_tuples(
             [
@@ -64,6 +58,7 @@ def base_df() -> native_pd.DataFrame:
                 ("group_2", "float_col"),
                 ("group_2", "timestamp_col"),
                 ("group_2", "list_col"),
+                ("group_2", "timedelta_col"),
             ],
             names=["column_level1", "column_level2"],
         ),

--- a/tests/integ/modin/frame/test_diff.py
+++ b/tests/integ/modin/frame/test_diff.py
@@ -142,6 +142,20 @@ def test_df_diff_bool_df(periods):
 
 @sql_count_checker(query_count=1)
 @pytest.mark.parametrize("periods", [0, 1])
+def test_df_diff_timedelta_df(periods):
+    native_df = native_pd.DataFrame(
+        np.arange(NUM_ROWS_TALL_DF * NUM_COLS_TALL_DF).reshape(
+            (NUM_ROWS_TALL_DF, NUM_COLS_TALL_DF)
+        ),
+        columns=["A", "B", "C", "D"],
+    )
+    native_df = native_df.astype({"A": "timedelta64[ns]", "C": "timedelta64[ns]"})
+    snow_df = pd.DataFrame(native_df)
+    eval_snowpark_pandas_result(snow_df, native_df, lambda df: df.diff(periods=periods))
+
+
+@sql_count_checker(query_count=1)
+@pytest.mark.parametrize("periods", [0, 1])
 def test_df_diff_int_and_bool_df(periods):
     native_df = native_pd.DataFrame(
         np.arange(NUM_ROWS_TALL_DF * NUM_COLS_TALL_DF).reshape(

--- a/tests/integ/modin/frame/test_drop.py
+++ b/tests/integ/modin/frame/test_drop.py
@@ -71,6 +71,18 @@ def test_drop_list_like(native_df, labels):
 
 
 @pytest.mark.parametrize(
+    "labels", [Index(["red", "green"]), np.array(["red", "green"])]
+)
+@sql_count_checker(query_count=1)
+def test_drop_timedelta(native_df, labels):
+    native_df_dt = native_df.astype({"red": "timedelta64[ns]"})
+    snow_df = pd.DataFrame(native_df_dt)
+    eval_snowpark_pandas_result(
+        snow_df, native_df_dt, lambda df: df.drop(labels, axis=1)
+    )
+
+
+@pytest.mark.parametrize(
     "labels, axis, expected_query_count",
     [
         ([], 0, 1),

--- a/tests/integ/modin/frame/test_dropna.py
+++ b/tests/integ/modin/frame/test_dropna.py
@@ -19,6 +19,7 @@ def test_dropna_df():
             "name": ["Alfred", "Batman", "Catwoman"],
             "toy": [np.nan, "Batmobile", "Bullwhip"],
             "born": [pd.NaT, pd.Timestamp("1940-04-25"), pd.NaT],
+            "dt": [pd.NaT, pd.Timedelta(1), pd.NaT],
         }
     )
 

--- a/tests/integ/modin/frame/test_duplicated.py
+++ b/tests/integ/modin/frame/test_duplicated.py
@@ -53,11 +53,24 @@ def test_duplicated_with_misspelled_column_name_or_empty_subset(subset):
         (["A"], native_pd.Series([False, False, True, False, True])),
         (["B"], native_pd.Series([False, False, False, True, True])),
         (["A", "B"], native_pd.Series([False, False, False, False, True])),
+        ("C", native_pd.Series([False, False, True, False, True])),
     ],
 )
 @sql_count_checker(query_count=1, join_count=1)
 def test_duplicated_subset(subset, expected):
-    df = pd.DataFrame({"A": [0, 1, 1, 2, 0], "B": ["a", "b", "c", "b", "a"]})
+    df = pd.DataFrame(
+        {
+            "A": [0, 1, 1, 2, 0],
+            "B": ["a", "b", "c", "b", "a"],
+            "C": [
+                pd.Timedelta(1),
+                pd.Timedelta(10),
+                pd.Timedelta(1),
+                pd.Timedelta(0),
+                pd.Timedelta(10),
+            ],
+        }
+    )
 
     result = df.duplicated(subset=subset)
     assert_snowpark_pandas_equal_to_pandas(result, expected)

--- a/tests/integ/modin/frame/test_empty.py
+++ b/tests/integ/modin/frame/test_empty.py
@@ -16,7 +16,14 @@ from tests.integ.modin.utils import eval_snowpark_pandas_result
 @pytest.mark.parametrize(
     "dataframe_input, test_case_name",
     [
-        ({"A": [1, 2, 3], "B": [4, 5, 6]}, "simple non-empty"),
+        (
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+                "C": native_pd.timedelta_range(1, periods=3),
+            },
+            "simple non-empty",
+        ),
         ({"A": [], "B": []}, "empty column"),
         ({"A": [np.nan]}, "np nan column"),
     ],

--- a/tests/integ/modin/frame/test_equals.py
+++ b/tests/integ/modin/frame/test_equals.py
@@ -25,15 +25,10 @@ from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
         ([1, 2, None], [1, 2, None], True),  # nulls are considered equal
         ([1, 2, 3], [1.0, 2.0, 3.0], False),  # float and integer types are not equal
         ([1, 2, 3], ["1", "2", "3"], False),  # integer and string types are not equal
-        pytest.param(
+        (
             [1, 2, 3],
             pandas.timedelta_range(1, periods=3),
             False,  # timedelta and integer types are not equal
-            marks=pytest.mark.xfail(
-                strict=True,
-                raises=NotImplementedError,
-                reason="TODO(SNOW-1637101, SNOW-1637102): Support these cases.",
-            ),
         ),
     ],
 )

--- a/tests/integ/modin/frame/test_equals.py
+++ b/tests/integ/modin/frame/test_equals.py
@@ -25,8 +25,16 @@ from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
         ([1, 2, None], [1, 2, None], True),  # nulls are considered equal
         ([1, 2, 3], [1.0, 2.0, 3.0], False),  # float and integer types are not equal
         ([1, 2, 3], ["1", "2", "3"], False),  # integer and string types are not equal
-        # TODO(SNOW-1637101, SNOW-1637102): Support these cases.
-        # ([1, 2, 3], pandas.timedelta_range(1, periods=3), False),  # timedelta and integer types are not equal
+        pytest.param(
+            [1, 2, 3],
+            pandas.timedelta_range(1, periods=3),
+            False,  # timedelta and integer types are not equal
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=NotImplementedError,
+                reason="TODO(SNOW-1637101, SNOW-1637102): Support these cases.",
+            ),
+        ),
     ],
 )
 @sql_count_checker(query_count=2, join_count=2)

--- a/tests/integ/modin/frame/test_equals.py
+++ b/tests/integ/modin/frame/test_equals.py
@@ -25,6 +25,8 @@ from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
         ([1, 2, None], [1, 2, None], True),  # nulls are considered equal
         ([1, 2, 3], [1.0, 2.0, 3.0], False),  # float and integer types are not equal
         ([1, 2, 3], ["1", "2", "3"], False),  # integer and string types are not equal
+        # TODO(SNOW-1637101, SNOW-1637102): Support these cases.
+        # ([1, 2, 3], pandas.timedelta_range(1, periods=3), False),  # timedelta and integer types are not equal
     ],
 )
 @sql_count_checker(query_count=2, join_count=2)

--- a/tests/integ/modin/frame/test_fillna.py
+++ b/tests/integ/modin/frame/test_fillna.py
@@ -150,6 +150,23 @@ def test_value_scalar(test_fillna_df):
     )
 
 
+@sql_count_checker(query_count=2)
+def test_timedelta_value_scalar(test_fillna_df):
+    timedelta_df = test_fillna_df.astype("timedelta64[ns]")
+    eval_snowpark_pandas_result(
+        pd.DataFrame(timedelta_df),
+        timedelta_df,
+        lambda df: df.fillna(pd.Timedelta(1)),  # dtype keeps to be timedelta64[ns]
+    )
+
+    # Snowpark pandas dtype will be changed to int in this case
+    eval_snowpark_pandas_result(
+        pd.DataFrame(timedelta_df),
+        test_fillna_df,
+        lambda df: df.fillna(1),
+    )
+
+
 @sql_count_checker(query_count=1)
 def test_value_scalar_none_index(test_fillna_df_none_index):
     # note: none in index should not be filled

--- a/tests/integ/modin/frame/test_idxmax_idxmin.py
+++ b/tests/integ/modin/frame/test_idxmax_idxmin.py
@@ -197,6 +197,26 @@ def test_idxmax_idxmin_with_dates(func, axis):
 @sql_count_checker(query_count=1)
 @pytest.mark.parametrize("func", ["idxmax", "idxmin"])
 @pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.xfail(reason="SNOW-1625380 TODO")
+def test_idxmax_idxmin_with_timedelta(func, axis):
+    native_df = native_pd.DataFrame(
+        data={
+            "date_1": native_pd.timedelta_range(1, periods=3),
+            "date_2": [pd.Timedelta(1), pd.Timedelta(-1), pd.Timedelta(0)],
+        },
+        index=[10, 17, 12],
+    )
+    snow_df = pd.DataFrame(native_df)
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: getattr(df, func)(axis=axis),
+    )
+
+
+@sql_count_checker(query_count=1)
+@pytest.mark.parametrize("func", ["idxmax", "idxmin"])
+@pytest.mark.parametrize("axis", [0, 1])
 def test_idxmax_idxmin_with_strings(func, axis):
     eval_snowpark_pandas_result(
         *create_test_dfs(

--- a/tests/integ/modin/frame/test_insert.py
+++ b/tests/integ/modin/frame/test_insert.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
+import functools
+
 import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
@@ -768,3 +770,32 @@ def test_insert_with_unique_and_duplicate_index_values(
         expected_res = native_df1.join(native_df2["bar"], how="left", sort=False)
         expected_res = expected_res[["bar", "foo"]]
         assert_frame_equal(snow_res, expected_res, check_dtype=False)
+
+
+@sql_count_checker(query_count=4, join_count=6)
+def test_insert_timedelta():
+    native_df = native_pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    snow_df = pd.DataFrame(native_df)
+
+    def insert(column, vals, df):
+        if isinstance(df, pd.DataFrame) and isinstance(vals, native_pd.Series):
+            values = pd.Series(vals)
+        else:
+            values = vals
+        df.insert(1, column, values)
+        return df
+
+    vals = native_pd.timedelta_range(1, periods=2)
+    eval_snowpark_pandas_result(
+        snow_df, native_df, functools.partial(insert, "td", vals)
+    )
+
+    vals = native_pd.Series(native_pd.timedelta_range(1, periods=2))
+    eval_snowpark_pandas_result(
+        snow_df, native_df, functools.partial(insert, "td2", vals)
+    )
+
+    vals = native_pd.Series(native_pd.timedelta_range(1, periods=2), index=[0, 2])
+    eval_snowpark_pandas_result(
+        snow_df, native_df, functools.partial(insert, "td3", vals)
+    )

--- a/tests/integ/modin/frame/test_isin.py
+++ b/tests/integ/modin/frame/test_isin.py
@@ -260,7 +260,7 @@ def test_isin_dataframe_values_type_negative():
 )
 def test_isin_timedelta(values):
     native_df = native_pd.DataFrame({"a": [1, 2, 3], "b": [None, 4, 2]}).astype(
-        "timedelta64[ns]"
+        {"b": "timedelta64[ns]"}
     )
     snow_df = pd.DataFrame(native_df)
 

--- a/tests/integ/modin/frame/test_isin.py
+++ b/tests/integ/modin/frame/test_isin.py
@@ -250,8 +250,15 @@ def test_isin_dataframe_values_type_negative():
         df.isin(values="abcdef")
 
 
-@sql_count_checker(query_count=6)
-def test_isin_timedelta():
+@sql_count_checker(query_count=3)
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param([2, 3], id="integers"),
+        pytest.param([pd.Timedelta(2), pd.Timedelta(3)], id="timedeltas"),
+    ],
+)
+def test_isin_timedelta(values):
     native_df = native_pd.DataFrame({"a": [1, 2, 3], "b": [None, 4, 2]}).astype(
         "timedelta64[ns]"
     )
@@ -260,13 +267,5 @@ def test_isin_timedelta():
     eval_snowpark_pandas_result(
         snow_df,
         native_df,
-        lambda df: _test_isin_with_snowflake_logic(df, [2, 3], query_count=1),
-    )
-
-    eval_snowpark_pandas_result(
-        snow_df,
-        native_df,
-        lambda df: _test_isin_with_snowflake_logic(
-            df, [pd.Timedelta(2), pd.Timedelta(3)], query_count=1
-        ),
+        lambda df: _test_isin_with_snowflake_logic(df, values, query_count=1),
     )

--- a/tests/integ/modin/frame/test_isin.py
+++ b/tests/integ/modin/frame/test_isin.py
@@ -248,3 +248,25 @@ def test_isin_dataframe_values_type_negative():
     ):
         df = pd.DataFrame([1, 2, 3])
         df.isin(values="abcdef")
+
+
+@sql_count_checker(query_count=6)
+def test_isin_timedelta():
+    native_df = native_pd.DataFrame({"a": [1, 2, 3], "b": [None, 4, 2]}).astype(
+        "timedelta64[ns]"
+    )
+    snow_df = pd.DataFrame(native_df)
+
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: _test_isin_with_snowflake_logic(df, [2, 3], query_count=1),
+    )
+
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: _test_isin_with_snowflake_logic(
+            df, [pd.Timedelta(2), pd.Timedelta(3)], query_count=1
+        ),
+    )

--- a/tests/integ/modin/frame/test_items.py
+++ b/tests/integ/modin/frame/test_items.py
@@ -51,6 +51,7 @@ def assert_items_results_equal(snow_result, pandas_result) -> None:
         ),
         native_pd.DataFrame(index=["a"]),
         native_pd.DataFrame(columns=["a"]),
+        native_pd.DataFrame({"ts": native_pd.timedelta_range(10, periods=10)}),
     ],
 )
 def test_items(dataframe):

--- a/tests/integ/modin/frame/test_iterrows.py
+++ b/tests/integ/modin/frame/test_iterrows.py
@@ -53,6 +53,7 @@ def assert_iterators_equal(snowpark_iterator, native_iterator):
         ),
         # empty df
         native_pd.DataFrame([]),
+        native_pd.DataFrame({"ts": native_pd.timedelta_range(10, periods=10)}),
     ],
 )
 def test_df_iterrows(native_df):

--- a/tests/integ/modin/frame/test_iterrows.py
+++ b/tests/integ/modin/frame/test_iterrows.py
@@ -53,7 +53,7 @@ def assert_iterators_equal(snowpark_iterator, native_iterator):
         ),
         # empty df
         native_pd.DataFrame([]),
-        native_pd.DataFrame({"ts": native_pd.timedelta_range(10, periods=10)}),
+        native_pd.DataFrame({"ts": native_pd.timedelta_range(10, periods=4)}),
     ],
 )
 def test_df_iterrows(native_df):

--- a/tests/integ/modin/frame/test_itertuples.py
+++ b/tests/integ/modin/frame/test_itertuples.py
@@ -37,6 +37,7 @@ ITERTUPLES_DF_DATA = [
     native_pd.DataFrame([[1, 1.5], [2, 2.5], [3, 7.8]], columns=["i nt", "flo at"]),
     # empty df
     native_pd.DataFrame([]),
+    native_pd.DataFrame({"ts": native_pd.timedelta_range(10, periods=10)}),
 ]
 
 

--- a/tests/integ/modin/frame/test_join.py
+++ b/tests/integ/modin/frame/test_join.py
@@ -259,3 +259,23 @@ def test_join_validate_negative(lvalues, rvalues, validate):
     msg = "Snowpark pandas merge API doesn't yet support 'validate' parameter"
     with pytest.raises(NotImplementedError, match=msg):
         left.join(right, validate=validate)
+
+
+@sql_count_checker(query_count=6, join_count=2)
+def test_join_timedelta(left, right):
+    right = right.astype("timedelta64[ns]")
+    eval_snowpark_pandas_result(
+        left,
+        left.to_pandas(),
+        lambda df: df.join(
+            right if isinstance(df, pd.DataFrame) else right.to_pandas()
+        ),
+    )
+    left = left.astype("timedelta64[ns]")
+    eval_snowpark_pandas_result(
+        left,
+        left.to_pandas(),
+        lambda df: df.join(
+            right if isinstance(df, pd.DataFrame) else right.to_pandas()
+        ),
+    )

--- a/tests/integ/modin/frame/test_len.py
+++ b/tests/integ/modin/frame/test_len.py
@@ -16,6 +16,7 @@ from tests.integ.modin.sql_counter import sql_count_checker
         ({"a": []}, 0),
         ({"a": [1, 2]}, 2),
         ({"a": [1, 2], "b": [1, 2], "c": [1, 2]}, 2),
+        ({"td": native_pd.timedelta_range(1, periods=20)}, 20),
     ],
 )
 @sql_count_checker(query_count=1)

--- a/tests/integ/modin/frame/test_mask.py
+++ b/tests/integ/modin/frame/test_mask.py
@@ -954,3 +954,12 @@ def test_mask_series_other_axis_1(index, data):
         native_df,
         perform_mask,
     )
+
+
+@pytest.mark.xfail(reason="TODO(SNOW-1637101, SNOW-1637102): Support these cases.")
+def test_mask_timedelta(test_data):
+    native_df = native_pd.DataFrame(test_data, dtype="timedelta64[ns]")
+    snow_df = pd.DataFrame(native_df)
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: df.mask(df > pd.Timedelta(1))
+    )

--- a/tests/integ/modin/frame/test_mask.py
+++ b/tests/integ/modin/frame/test_mask.py
@@ -956,7 +956,7 @@ def test_mask_series_other_axis_1(index, data):
     )
 
 
-@pytest.mark.xfail(reason="TODO(SNOW-1637101, SNOW-1637102): Support these cases.")
+@sql_count_checker(query_count=1)
 def test_mask_timedelta(test_data):
     native_df = native_pd.DataFrame(test_data, dtype="timedelta64[ns]")
     snow_df = pd.DataFrame(native_df)

--- a/tests/integ/modin/frame/test_melt.py
+++ b/tests/integ/modin/frame/test_melt.py
@@ -303,3 +303,22 @@ def test_everything():
             value_name="dependent",
         ),
     )
+
+
+@sql_count_checker(query_count=2)
+def test_melt_timedelta():
+    native_df = npd.DataFrame(
+        {
+            "A": {0: "a", 1: "b", 2: "c"},
+            "B": {0: 1, 1: 3, 2: 5},
+            "C": {0: 2, 1: 4, 2: 6},
+        }
+    ).astype({"B": "timedelta64[ns]", "C": "timedelta64[ns]"})
+    snow_df = pd.DataFrame(native_df)
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: df.melt(id_vars=["A"], value_vars=["B"])
+    )
+
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: df.melt(id_vars=["A"], value_vars=["B", "C"])
+    )

--- a/tests/integ/modin/frame/test_melt.py
+++ b/tests/integ/modin/frame/test_melt.py
@@ -305,8 +305,9 @@ def test_everything():
     )
 
 
-@sql_count_checker(query_count=2)
-def test_melt_timedelta():
+@sql_count_checker(query_count=1)
+@pytest.mark.parametrize("value_vars", [["B"], ["B", "C"]])
+def test_melt_timedelta(value_vars):
     native_df = npd.DataFrame(
         {
             "A": {0: "a", 1: "b", 2: "c"},
@@ -316,9 +317,5 @@ def test_melt_timedelta():
     ).astype({"B": "timedelta64[ns]", "C": "timedelta64[ns]"})
     snow_df = pd.DataFrame(native_df)
     eval_snowpark_pandas_result(
-        snow_df, native_df, lambda df: df.melt(id_vars=["A"], value_vars=["B"])
-    )
-
-    eval_snowpark_pandas_result(
-        snow_df, native_df, lambda df: df.melt(id_vars=["A"], value_vars=["B", "C"])
+        snow_df, native_df, lambda df: df.melt(id_vars=["A"], value_vars=value_vars)
     )

--- a/tests/integ/modin/series/test_shift.py
+++ b/tests/integ/modin/series/test_shift.py
@@ -46,11 +46,7 @@ def test_series_with_values_shift(series, periods, fill_value):
         lambda s: s.shift(
             periods=periods,
             fill_value=pd.Timedelta(fill_value)
-            if isinstance(
-                s, native_pd.Series
-            )  # pandas does not support fill int to timedelta
-            and s.dtype == "timedelta64[ns]"
-            and fill_value is not no_default
+            if s.dtype == "timedelta64[ns]" and fill_value is not no_default
             else fill_value,
         ),
     )

--- a/tests/unit/modin/test_snowpark_pandas_types.py
+++ b/tests/unit/modin/test_snowpark_pandas_types.py
@@ -14,6 +14,7 @@ from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
     SnowparkPandasType,
     TimedeltaType,
 )
+from snowflake.snowpark.types import LongType
 
 
 def test_timedelta_type_is_immutable():
@@ -68,3 +69,9 @@ def test_get_snowpark_pandas_type_for_pandas_type(pandas_obj, snowpark_pandas_ty
 )
 def test_TimedeltaType_from_pandas(timedelta, snowpark_pandas_value):
     assert TimedeltaType.from_pandas(timedelta) == snowpark_pandas_value
+
+
+def test_equals():
+    assert TimedeltaType() == TimedeltaType()
+    assert TimedeltaType() != LongType()
+    assert LongType() != TimedeltaType()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1625379 Test coverage for timedelta under modin/integ/frame part 1

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

This pull request includes several changes to enhance support for the `Timedelta` type, improve type handling, and add new test cases. The most important changes include adding support for various `Timedelta` operations, enhancing type checking and handling, and introducing new test cases to ensure the robustness of these features.

### Enhancements to `Timedelta` Support:

* Added support for `Timedelta` type in various operations like `fillna`, `diff`, `duplicated`, `empty`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `melt`, `nlargest`, and `nsmallest` in the `CHANGELOG.md` file.
* Removed `NotImplementedError` for `Timedelta` in methods such as `insert`, `melt`, and `merge` in `snowflake_query_compiler.py`. [[1]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L5756-L5757) [[2]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L6631-L6632) [[3]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L6735-L6736)

### Improvements in Type Handling:

* Introduced `type_match` method in `SnowparkPandasType` class to check type compatibility.
* Enhanced the `_simple_unpivot` function to handle `SnowparkPandasType` correctly and added type information for unpivoted columns. [[1]](diffhunk://#diff-7cb97f6cd7fe8ccd13a0e4f482622edaf6d3e20a4289cef11c394cae56054198R738-R747) [[2]](diffhunk://#diff-7cb97f6cd7fe8ccd13a0e4f482622edaf6d3e20a4289cef11c394cae56054198R759-R763) [[3]](diffhunk://#diff-7cb97f6cd7fe8ccd13a0e4f482622edaf6d3e20a4289cef11c394cae56054198L790-R796) [[4]](diffhunk://#diff-7cb97f6cd7fe8ccd13a0e4f482622edaf6d3e20a4289cef11c394cae56054198R879-R885) [[5]](diffhunk://#diff-7cb97f6cd7fe8ccd13a0e4f482622edaf6d3e20a4289cef11c394cae56054198L884-R898)
* Updated `fillna` and `diff` methods to maintain `SnowparkPandasType` consistency after operations. [[1]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03R9789-R9792) [[2]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L10195-R10205)

### New Test Cases:

* Added test cases for `Timedelta` type in `assign`, `ffill`, `bfill`, and `diff` methods to ensure proper functionality. [[1]](diffhunk://#diff-ca5c04609726549052929ac53289f47c80b13355949ba45d714221b5e820b90bR241-R261) [[2]](diffhunk://#diff-adee223f3478e814786eb931d777565482438add6f27928a38cd03a570c1f847L17-R17) [[3]](diffhunk://#diff-adee223f3478e814786eb931d777565482438add6f27928a38cd03a570c1f847R34-R54) [[4]](diffhunk://#diff-61d2953e049081cd075fa2952a7910995e67980403a66f2806e4580f7b1c7defR143-R156)
* Introduced a new test case for `Timedelta` type in `test_compare.py` to validate comparison operations. [[1]](diffhunk://#diff-8d1c8c7ca2b331b0e3f36453255ba307ffd88e02a583d4cf2edeef39204ed3e0L28-R31) [[2]](diffhunk://#diff-8d1c8c7ca2b331b0e3f36453255ba307ffd88e02a583d4cf2edeef39204ed3e0R51)

These changes collectively improve the handling and support of the `Timedelta` type, ensuring more robust and comprehensive functionality across various operations.