### PR TITLE
Fix query_generator for new compilation stage after optimization applied

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1608,7 +1608,9 @@ class SnowflakePlanBuilder:
 
         new_query = project_statement([], name)
 
-        queries = child.queries[:-1] + [Query(sql=new_query)]
+        queries = child.queries[:-1] + [
+            Query(sql=new_query, params=child.queries[-1].params)
+        ]
         # propagate the cte table
         referenced_ctes = {name}.union(child.referenced_ctes)
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1608,9 +1608,10 @@ class SnowflakePlanBuilder:
 
         new_query = project_statement([], name)
 
-        queries = child.queries[:-1] + [
-            Query(sql=new_query, params=child.queries[-1].params)
-        ]
+        # note we do not propagate the query parameter of the child here,
+        # the query parameter will be propagate along with the definition during
+        # query generation stage.
+        queries = child.queries[:-1] + [Query(sql=new_query)]
         # propagate the cte table
         referenced_ctes = {name}.union(child.referenced_ctes)
 

--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -64,7 +64,7 @@ class QueryGenerator(Analyzer):
         # NOTE: the dict used here is an ordered dict, all with query block definition is recorded in the
         # order of when the with query block is visited. The order is important to make sure the dependency
         # between the CTE definition is satisfied.
-        self.resolved_with_query_block: Dict[str, str] = {}
+        self.resolved_with_query_block: Dict[str, Query] = {}
 
     def generate_queries(
         self, logical_plans: List[LogicalPlan]
@@ -209,7 +209,7 @@ class QueryGenerator(Analyzer):
             if logical_plan.name not in self.resolved_with_query_block:
                 self.resolved_with_query_block[
                     logical_plan.name
-                ] = resolved_child.queries[-1].sql
+                ] = resolved_child.queries[-1]
 
             resolved_plan = self.plan_builder.with_query_block(
                 logical_plan.name,

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -269,16 +269,16 @@ def update_resolvable_node(
         assert node.snowflake_plan is not None
         update_resolvable_node(node.snowflake_plan, query_generator)
         node.analyzer = query_generator
-        node.expr_to_alias.update(node._snowflake_plan.expr_to_alias)
-        node.df_aliased_col_name_to_real_col_name.update(
-            node._snowflake_plan.df_aliased_col_name_to_real_col_name
-        )
 
         node.pre_actions = node._snowflake_plan.queries[:-1]
         node.post_actions = node._snowflake_plan.post_actions
         node._api_calls = node._snowflake_plan.api_calls
 
         if isinstance(node, SelectSnowflakePlan):
+            node.expr_to_alias.update(node._snowflake_plan.expr_to_alias)
+            node.df_aliased_col_name_to_real_col_name.update(
+                node._snowflake_plan.df_aliased_col_name_to_real_col_name
+            )
             node._query_params = []
             for query in node._snowflake_plan.queries:
                 if query.params:

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -227,6 +227,8 @@ def update_resolvable_node(
         # re-calculation of the sql query and snowflake plan
         node._sql_query = None
         node._snowflake_plan = None
+        # make sure we also clean up the cached _projection_in_str, so that
+        # the projection expression can be re-analyzed during code generation
         node._projection_in_str = None
         node.analyzer = query_generator
 

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -227,6 +227,7 @@ def update_resolvable_node(
         # re-calculation of the sql query and snowflake plan
         node._sql_query = None
         node._snowflake_plan = None
+        node._projection_in_str = None
         node.analyzer = query_generator
 
         # update the pre_actions and post_actions for the select statement
@@ -266,6 +267,20 @@ def update_resolvable_node(
         assert node.snowflake_plan is not None
         update_resolvable_node(node.snowflake_plan, query_generator)
         node.analyzer = query_generator
+        node.expr_to_alias.update(node._snowflake_plan.expr_to_alias)
+        node.df_aliased_col_name_to_real_col_name.update(
+            node._snowflake_plan.df_aliased_col_name_to_real_col_name
+        )
+
+        node.pre_actions = node._snowflake_plan.queries[:-1]
+        node.post_actions = node._snowflake_plan.post_actions
+        node._api_calls = node._snowflake_plan.api_calls
+
+        if isinstance(node, SelectSnowflakePlan):
+            node._query_params = []
+            for query in node._snowflake_plan.queries:
+                if query.params:
+                    node._query_params.extend(query.params)
 
     elif isinstance(node, Selectable):
         node.analyzer = query_generator

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -175,9 +175,8 @@ def test_execution_queries_and_post_actions(session):
             # the cte optimization is not kicking in when sql simplifier disabled, because
             # the cte_optimization_enabled is set to False when constructing the plan for df2,
             # and place_holder is not propogated.
-            # TODO (SNOW-1541096): revisit this test once the cte optimization is switched to the
-            #   new compilation infra.
-            cte_applied=session.sql_simplifier_enabled,
+            cte_applied=session.sql_simplifier_enabled
+            or session._query_compilation_stage_enabled,
             exec_queries=df2._plan.execution_queries,
         )
 

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -167,13 +167,20 @@ def test_variable_binding_multiple(session):
         "select $1 as a, $2 as b from values (?, ?), (?, ?)", params=[1, "c", 3, "d"]
     )
 
-    """
     df_res = df1.union(df1).union(df2)
     check_result(session, df_res, expect_cte_optimized=True)
     plan_queries = df_res._plan.execution_queries
 
-    assert plan_queries[PlanQueryType.QUERIES][-1].params == [1, "a", 2, "b", 1, "c", 3, "d"]
-    """
+    assert plan_queries[PlanQueryType.QUERIES][-1].params == [
+        1,
+        "a",
+        2,
+        "b",
+        1,
+        "c",
+        3,
+        "d",
+    ]
 
     df_res = df2.union(df1).union(df2).union(df1)
     check_result(session, df_res, expect_cte_optimized=True)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -10,6 +10,7 @@ import pytest
 from snowflake.connector.options import installed_pandas
 from snowflake.snowpark import Window
 from snowflake.snowpark._internal.analyzer import analyzer
+from snowflake.snowpark._internal.analyzer.snowflake_plan import PlanQueryType
 from snowflake.snowpark._internal.utils import (
     TEMP_OBJECT_NAME_PREFIX,
     TempObjectType,
@@ -33,6 +34,16 @@ pytestmark = [
         reason="CTE is a SQL feature",
         run=False,
     )
+]
+
+binary_operations = [
+    lambda x, y: x.union_all(y),
+    lambda x, y: x.select("a").union(y.select("a")),
+    lambda x, y: x.except_(y),
+    lambda x, y: x.select("a").intersect(y.select("a")),
+    lambda x, y: x.join(y.select("a", "b"), rsuffix="_y"),
+    lambda x, y: x.select("a").join(y, how="outer", rsuffix="_y"),
+    lambda x, y: x.join(y.select("a"), how="left", rsuffix="_y"),
 ]
 
 
@@ -104,18 +115,7 @@ def test_unary(session, action):
     check_result(session, df_action.union_all(df_action), expect_cte_optimized=True)
 
 
-@pytest.mark.parametrize(
-    "action",
-    [
-        lambda x, y: x.union_all(y),
-        lambda x, y: x.select("a").union(y.select("a")),
-        lambda x, y: x.except_(y),
-        lambda x, y: x.select("a").intersect(y.select("a")),
-        lambda x, y: x.join(y.select("a", "b"), rsuffix="_y"),
-        lambda x, y: x.select("a").join(y, how="outer", rsuffix="_y"),
-        lambda x, y: x.join(y.select("a"), how="left", rsuffix="_y"),
-    ],
-)
+@pytest.mark.parametrize("action", binary_operations)
 def test_binary(session, action):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     check_result(session, action(df, df), expect_cte_optimized=True)
@@ -136,6 +136,60 @@ def test_binary(session, action):
     # check the number of queries
     assert len(plan_queries["queries"]) == 3
     assert len(plan_queries["post_actions"]) == 1
+
+
+@pytest.mark.parametrize("action", binary_operations)
+def test_variable_binding_binary(session, action):
+    df1 = session.sql(
+        "select $1 as a, $2 as b from values (?, ?), (?, ?)", params=[1, "a", 2, "b"]
+    )
+    df2 = session.sql(
+        "select $1 as a, $2 as b from values (?, ?), (?, ?)", params=[1, "c", 3, "d"]
+    )
+    df3 = session.sql(
+        "select $1 as a, $2 as b from values (?, ?), (?, ?)", params=[1, "a", 2, "b"]
+    )
+
+    check_result(session, action(df1, df3), expect_cte_optimized=True)
+    check_result(session, action(df1, df2), expect_cte_optimized=False)
+
+
+def test_variable_binding_multiple(session):
+    if not session._query_compilation_stage_enabled:
+        pytest.skip(
+            "CTE query generation without the new query generation doesn't work correctly"
+        )
+
+    df1 = session.sql(
+        "select $1 as a, $2 as b from values (?, ?), (?, ?)", params=[1, "a", 2, "b"]
+    )
+    df2 = session.sql(
+        "select $1 as a, $2 as b from values (?, ?), (?, ?)", params=[1, "c", 3, "d"]
+    )
+
+    """
+    df_res = df1.union(df1).union(df2)
+    check_result(session, df_res, expect_cte_optimized=True)
+    plan_queries = df_res._plan.execution_queries
+
+    assert plan_queries[PlanQueryType.QUERIES][-1].params == [1, "a", 2, "b", 1, "c", 3, "d"]
+    """
+
+    df_res = df2.union(df1).union(df2).union(df1)
+    check_result(session, df_res, expect_cte_optimized=True)
+    plan_queries = df_res._plan.execution_queries
+
+    assert plan_queries[PlanQueryType.QUERIES][-1].params == [
+        1,
+        "a",
+        2,
+        "b",
+        1,
+        "c",
+        3,
+        "d",
+    ]
+    assert plan_queries[PlanQueryType.QUERIES][-1].sql.count(WITH) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
SNOW-1641324

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.
The test Enable CTE Optimization merge gate is currently failing because
1) the _projection_in_str for select statement is reset properly after updating, which causes the expr_alias is updated properly during query generation
2) query parameter is not propogated properly during query generation which causes variable binding query fail
