### PR TITLE
Fix error message in python 3.8 to_snowpark_pandas daily test

### DIFF
--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -51,7 +51,7 @@ def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
         # modin is not installed.
         match = (
             "Snowpark pandas does not support Python 3.8. Please update to Python 3.9 or later"
-            if sys.version_info == (3, 8)
+            if sys.version_info.major == 3 and sys.version_info.minor == 8
             else "does not match the supported pandas version in Snowpark pandas"
         )
         with pytest.raises(

--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -5,6 +5,8 @@
 
 # Tests behavior of to_snowpark_pandas() without explicitly initializing Snowpark pandas.
 
+import sys
+
 import pytest
 
 from snowflake.snowpark._internal.utils import TempObjectType
@@ -47,9 +49,14 @@ def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
         # TODO: SNOW-1552497: after upgrading to modin 0.30.1, Snowpark pandas will support
         # all pandas 2.2.x, and this function call will raise a ModuleNotFoundError since
         # modin is not installed.
+        match = (
+            "Snowpark pandas does not support Python 3.8. Please update to Python 3.9 or later"
+            if sys.version_info == (3, 8)
+            else "does not match the supported pandas version in Snowpark pandas"
+        )
         with pytest.raises(
             RuntimeError,
-            match="does not match the supported pandas version in Snowpark pandas",
+            match=match,
         ):
             snowpark_df.to_snowpark_pandas()
     else:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Updates the error message to check if we're on python 3.8 before checking the pandas version.