### PR TITLE
SNOW-1625380: Add support for basic GroupBy aggregations with Timedelta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
   - support for binary arithmetic between two `Timedelta` values.
   - support for lazy `TimedeltaIndex`.
   - support for `pd.to_timedelta`.
+  - support for `GroupBy` aggregations `min`, `max`, `mean`, `idxmax`, `idxmin`, `std`, `sum`, `median`, `count`, `any`, `all`, `size`, `nunique`.
 - Added support for index's arithmetic and comparison operators.
 - Added support for `Series.dt.round`.
 - Added documentation pages for `DatetimeIndex`.

--- a/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
@@ -41,6 +41,25 @@ BaseInternalKeyType = Union[
 ]
 
 NO_GROUPKEY_ERROR = ValueError("No group keys passed!")
+GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES = [
+    "min",
+    "max",
+    "sum",
+    "mean",
+    "median",
+    "std",
+    "first",
+    "last",
+]
+GROUPBY_AGG_DIFFERENT_INPUT_AND_OUTPUT_DATA_TYPES = [
+    "any",
+    "all",
+    "count",
+    "idxmax",
+    "idxmin",
+    "size",
+    "nunique",
+]
 
 
 def is_groupby_value_label_like(val: Any) -> bool:

--- a/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
@@ -41,7 +41,7 @@ BaseInternalKeyType = Union[
 ]
 
 NO_GROUPKEY_ERROR = ValueError("No group keys passed!")
-GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES = [
+GROUPBY_AGG_PRESERVES_SNOWPARK_PANDAS_TYPE = [
     "min",
     "max",
     "sum",
@@ -51,7 +51,7 @@ GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES = [
     "first",
     "last",
 ]
-GROUPBY_AGG_DIFFERENT_INPUT_AND_OUTPUT_DATA_TYPES = [
+GROUPBY_AGG_WITH_NONE_SNOWPARK_PANDAS_TYPES = [
     "any",
     "all",
     "count",

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -198,6 +198,8 @@ from snowflake.snowpark.modin.plugin._internal.cut_utils import (
 )
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.groupby_utils import (
+    GROUPBY_AGG_DIFFERENT_INPUT_AND_OUTPUT_DATA_TYPES,
+    GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES,
     check_is_groupby_supported_by_snowflake,
     extract_groupby_column_pandas_labels,
     get_frame_with_groupby_columns_as_index,
@@ -3426,30 +3428,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             new_data_column_quoted_identifiers.append(
                 col_agg_op.agg_snowflake_quoted_identifier
             )
-            if agg_func in (
-                "min",
-                "max",
-                "sum",
-                "mean",
-                "median",
-                "std",
-                "first",
-                "last",
-            ):
+            if agg_func in GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES:
                 new_data_column_snowpark_pandas_types.append(
                     col_agg_op.data_type
                     if isinstance(col_agg_op.data_type, SnowparkPandasType)
                     else None
                 )
-            elif agg_func in (
-                "any",
-                "all",
-                "count",
-                "idxmax",
-                "idxmin",
-                "size",
-                "nunique",
-            ):
+            elif agg_func in GROUPBY_AGG_DIFFERENT_INPUT_AND_OUTPUT_DATA_TYPES:
                 # In the case where the aggregation overrides the type of the output data column
                 # (e.g. any always returns boolean data columns), set the output Snowpark pandas type to None
                 new_data_column_snowpark_pandas_types = None  # type: ignore

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -198,8 +198,8 @@ from snowflake.snowpark.modin.plugin._internal.cut_utils import (
 )
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.groupby_utils import (
-    GROUPBY_AGG_DIFFERENT_INPUT_AND_OUTPUT_DATA_TYPES,
-    GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES,
+    GROUPBY_AGG_PRESERVES_SNOWPARK_PANDAS_TYPE,
+    GROUPBY_AGG_WITH_NONE_SNOWPARK_PANDAS_TYPES,
     check_is_groupby_supported_by_snowflake,
     extract_groupby_column_pandas_labels,
     get_frame_with_groupby_columns_as_index,
@@ -3428,13 +3428,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             new_data_column_quoted_identifiers.append(
                 col_agg_op.agg_snowflake_quoted_identifier
             )
-            if agg_func in GROUPBY_AGG_SAME_INPUT_AND_OUTPUT_DATA_TYPES:
+            if agg_func in GROUPBY_AGG_PRESERVES_SNOWPARK_PANDAS_TYPE:
                 new_data_column_snowpark_pandas_types.append(
                     col_agg_op.data_type
                     if isinstance(col_agg_op.data_type, SnowparkPandasType)
                     else None
                 )
-            elif agg_func in GROUPBY_AGG_DIFFERENT_INPUT_AND_OUTPUT_DATA_TYPES:
+            elif agg_func in GROUPBY_AGG_WITH_NONE_SNOWPARK_PANDAS_TYPES:
                 # In the case where the aggregation overrides the type of the output data column
                 # (e.g. any always returns boolean data columns), set the output Snowpark pandas type to None
                 new_data_column_snowpark_pandas_types = None  # type: ignore

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3231,8 +3231,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             KeyError if a hashable label in by (groupby items) can not be found in the current dataframe
             ValueError if more than one column can be found for the groupby item
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         validate_groupby_columns(self, by, axis, level)
 
     def groupby_ngroups(
@@ -3328,8 +3326,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: with a newly constructed internal dataframe
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         level = groupby_kwargs.get("level", None)
 
         if agg_func in ["head", "tail"]:
@@ -3422,12 +3418,44 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
         # the pandas label and quoted identifier generated for each result column
         # after aggregation will be used as new pandas label and quoted identifiers.
-        new_data_column_pandas_labels = [
-            col_agg_op.agg_pandas_label for col_agg_op in agg_col_ops
-        ]
-        new_data_column_quoted_identifier = [
-            col_agg_op.agg_snowflake_quoted_identifier for col_agg_op in agg_col_ops
-        ]
+        new_data_column_pandas_labels = []
+        new_data_column_quoted_identifiers = []
+        new_data_column_snowpark_pandas_types = []
+        for col_agg_op in agg_col_ops:
+            new_data_column_pandas_labels.append(col_agg_op.agg_pandas_label)
+            new_data_column_quoted_identifiers.append(
+                col_agg_op.agg_snowflake_quoted_identifier
+            )
+            if agg_func in (
+                "min",
+                "max",
+                "sum",
+                "mean",
+                "median",
+                "std",
+                "first",
+                "last",
+            ):
+                new_data_column_snowpark_pandas_types.append(
+                    col_agg_op.data_type
+                    if isinstance(col_agg_op.data_type, SnowparkPandasType)
+                    else None
+                )
+            elif agg_func in (
+                "any",
+                "all",
+                "count",
+                "idxmax",
+                "idxmin",
+                "size",
+                "nunique",
+            ):
+                # In the case where the aggregation overrides the type of the output data column
+                # (e.g. any always returns boolean data columns), set the output Snowpark pandas type to None
+                new_data_column_snowpark_pandas_types = None  # type: ignore
+            else:
+                self._raise_not_implemented_error_for_timedelta()
+                new_data_column_snowpark_pandas_types = None  # type: ignore
 
         # The ordering of the named aggregations is changed by us when we process
         # the agg_kwargs into the func dict (named aggregations on the same
@@ -3441,10 +3469,14 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 # and the new_data_column_quoted_identifier.
                 data_column_label_to_quoted_identifier = list(
                     zip(
-                        new_data_column_pandas_labels, new_data_column_quoted_identifier
+                        new_data_column_pandas_labels,
+                        new_data_column_quoted_identifiers,
                     )
                 )
-                new_data_column_pandas_labels, new_data_column_quoted_identifier = list(
+                (
+                    new_data_column_pandas_labels,
+                    new_data_column_quoted_identifiers,
+                ) = list(
                     zip(
                         *[
                             pair
@@ -3565,11 +3597,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 # original pandas label for data columns are still used as pandas labels
                 data_column_pandas_labels=new_data_column_pandas_labels,
                 data_column_pandas_index_names=new_data_column_index_names,
-                data_column_snowflake_quoted_identifiers=new_data_column_quoted_identifier,
+                data_column_snowflake_quoted_identifiers=new_data_column_quoted_identifiers,
                 index_column_pandas_labels=new_index_column_pandas_labels,
                 index_column_snowflake_quoted_identifiers=new_index_column_quoted_identifiers,
-                data_column_types=None,
-                index_column_types=None,
+                data_column_types=new_data_column_snowpark_pandas_types,
+                index_column_types=[
+                    internal_frame.snowflake_quoted_identifier_to_snowpark_pandas_type.get(
+                        identifier
+                    )
+                    for identifier in new_index_column_quoted_identifiers
+                ],
             )
         )
 
@@ -4578,8 +4615,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             SnowflakeQueryCompiler: The result of groupby_size()
         """
-        self._raise_not_implemented_error_for_timedelta()
-
         level = groupby_kwargs.get("level", None)
         is_supported = check_is_groupby_supported_by_snowflake(by, level, axis)
         if not is_supported:
@@ -4946,8 +4981,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler
         # does not have **kwargs.
@@ -4971,7 +5004,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
 
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler
@@ -4996,7 +5028,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
 
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler

--- a/tests/integ/modin/groupby/test_all_any.py
+++ b/tests/integ/modin/groupby/test_all_any.py
@@ -39,7 +39,7 @@ def test_all_any_basic(data):
 
 
 @pytest.mark.parametrize("agg_func", ["all", "any"])
-def test_groupby_all_any_timedelta(agg_func):
+def test_timedelta(agg_func):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(["1 days 06:05:01.00003", "15.5us", "10"]),

--- a/tests/integ/modin/groupby/test_groupby_basic_agg.py
+++ b/tests/integ/modin/groupby/test_groupby_basic_agg.py
@@ -1106,7 +1106,9 @@ def test_valid_func_valid_kwarg_should_work(basic_snowpark_pandas_df):
         "std",
     ],
 )
-def test_timedelta(agg_func):
+@pytest.mark.parametrize("by", ["A", "B"])
+@sql_count_checker(query_count=1)
+def test_timedelta(agg_func, by):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(
@@ -1117,11 +1119,6 @@ def test_timedelta(agg_func):
     )
     snow_df = pd.DataFrame(native_df)
 
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: getattr(df.groupby("A"), agg_func)()
-        )
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: getattr(df.groupby("B"), agg_func)()
-        )
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: getattr(df.groupby(by), agg_func)()
+    )

--- a/tests/integ/modin/groupby/test_groupby_basic_agg.py
+++ b/tests/integ/modin/groupby/test_groupby_basic_agg.py
@@ -1106,7 +1106,7 @@ def test_valid_func_valid_kwarg_should_work(basic_snowpark_pandas_df):
         "std",
     ],
 )
-def test_groupby_basic_agg_timedelta(agg_func):
+def test_timedelta(agg_func):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(

--- a/tests/integ/modin/groupby/test_groupby_basic_agg.py
+++ b/tests/integ/modin/groupby/test_groupby_basic_agg.py
@@ -1094,3 +1094,34 @@ def test_valid_func_valid_kwarg_should_work(basic_snowpark_pandas_df):
         basic_snowpark_pandas_df.groupby("col1").agg(max, min_count=2),
         basic_snowpark_pandas_df.to_pandas().groupby("col1").max(min_count=2),
     )
+
+
+@pytest.mark.parametrize(
+    "agg_func",
+    [
+        "count",
+        "sum",
+        "mean",
+        "median",
+        "std",
+    ],
+)
+def test_groupby_basic_agg_timedelta(agg_func):
+    native_df = native_pd.DataFrame(
+        {
+            "A": native_pd.to_timedelta(
+                ["1 days 06:05:01.00003", "15.5us", "nan", "16us"]
+            ),
+            "B": [8, 8, 12, 10],
+        }
+    )
+    snow_df = pd.DataFrame(native_df)
+
+    with SqlCounter(query_count=1):
+        eval_snowpark_pandas_result(
+            snow_df, native_df, lambda df: getattr(df.groupby("A"), agg_func)()
+        )
+    with SqlCounter(query_count=1):
+        eval_snowpark_pandas_result(
+            snow_df, native_df, lambda df: getattr(df.groupby("B"), agg_func)()
+        )

--- a/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
+++ b/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
@@ -8,7 +8,7 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.groupby.conftest import multiindex_data
-from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
+from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import (
     assert_frame_equal,
     create_test_dfs,
@@ -161,7 +161,9 @@ def test_df_groupby_idxmax_idxmin_on_groupby_axis_1_default_to_pandas(func):
 
 
 @pytest.mark.parametrize("agg_func", ["idxmin", "idxmax"])
-def test_timedelta(agg_func):
+@pytest.mark.parametrize("by", ["A", "B"])
+@sql_count_checker(query_count=1)
+def test_timedelta(agg_func, by):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(
@@ -172,11 +174,6 @@ def test_timedelta(agg_func):
     )
     snow_df = pd.DataFrame(native_df)
 
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: getattr(df.groupby("A"), agg_func)()
-        )
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: getattr(df.groupby("B"), agg_func)()
-        )
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: getattr(df.groupby(by), agg_func)()
+    )

--- a/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
+++ b/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
@@ -161,7 +161,7 @@ def test_df_groupby_idxmax_idxmin_on_groupby_axis_1_default_to_pandas(func):
 
 
 @pytest.mark.parametrize("agg_func", ["idxmin", "idxmax"])
-def test_groupby_idxmin_idxmax_timedelta(agg_func):
+def test_timedelta(agg_func):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(

--- a/tests/integ/modin/groupby/test_groupby_negative.py
+++ b/tests/integ/modin/groupby/test_groupby_negative.py
@@ -558,6 +558,7 @@ def test_groupby_agg_invalid_min_count(
         )
 
 
+@sql_count_checker(query_count=0)
 def test_groupby_negative_var():
     native_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/groupby/test_groupby_negative.py
+++ b/tests/integ/modin/groupby/test_groupby_negative.py
@@ -559,7 +559,7 @@ def test_groupby_agg_invalid_min_count(
 
 
 @sql_count_checker(query_count=0)
-def test_groupby_negative_var():
+def test_groupby_var_no_support_for_timedelta():
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(

--- a/tests/integ/modin/groupby/test_groupby_negative.py
+++ b/tests/integ/modin/groupby/test_groupby_negative.py
@@ -556,3 +556,22 @@ def test_groupby_agg_invalid_min_count(
         getattr(basic_snowpark_pandas_df.groupby("col1"), min_count_method)(
             min_count=min_count
         )
+
+
+def test_groupby_negative_var():
+    native_df = native_pd.DataFrame(
+        {
+            "A": native_pd.to_timedelta(
+                ["1 days 06:05:01.00003", "15.5us", "nan", "16us"]
+            ),
+            "B": [8, 8, 12, 10],
+        }
+    )
+    snow_df = pd.DataFrame(native_df)
+    with pytest.raises(
+        NotImplementedError,
+        match=re.escape(
+            "SnowflakeQueryCompiler::groupby_agg is not yet implemented for Timedelta Type"
+        ),
+    ):
+        snow_df.groupby("B").var()

--- a/tests/integ/modin/groupby/test_groupby_nunique.py
+++ b/tests/integ/modin/groupby/test_groupby_nunique.py
@@ -82,7 +82,7 @@ def test_groupby_nunique(df, groupby_columns, dropna):
         )
 
 
-def test_groupby_nunique_timedelta():
+def test_timedelta():
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(

--- a/tests/integ/modin/groupby/test_groupby_nunique.py
+++ b/tests/integ/modin/groupby/test_groupby_nunique.py
@@ -6,7 +6,7 @@ import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.pandas as pd
-from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
+from tests.integ.modin.sql_counter import sql_count_checker
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
     eval_snowpark_pandas_result,
@@ -82,7 +82,9 @@ def test_groupby_nunique(df, groupby_columns, dropna):
         )
 
 
-def test_timedelta():
+@pytest.mark.parametrize("by", ["A", "B", ["A", "B"]])
+@sql_count_checker(query_count=1)
+def test_timedelta(by):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(
@@ -94,17 +96,8 @@ def test_timedelta():
     )
     snow_df = pd.DataFrame(native_df)
 
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df,
-            native_df,
-            lambda df: df.groupby("A").nunique(),
-        )
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: df.groupby("A").nunique()
-        )
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: df.groupby(["A", "B"]).nunique()
-        )
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: df.groupby(by).nunique(),
+    )

--- a/tests/integ/modin/groupby/test_groupby_size.py
+++ b/tests/integ/modin/groupby/test_groupby_size.py
@@ -92,7 +92,9 @@ def test_error_checking():
         s.groupby(s).size()
 
 
-def test_timedelta():
+@pytest.mark.parametrize("by", ["A", "B"])
+@sql_count_checker(query_count=1)
+def test_timedelta(by):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(
@@ -104,17 +106,8 @@ def test_timedelta():
     )
     snow_df = pd.DataFrame(native_df)
 
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df,
-            native_df,
-            lambda df: df.groupby("A").size(),
-        )
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: df.groupby("A").size()
-        )
-    with SqlCounter(query_count=1):
-        eval_snowpark_pandas_result(
-            snow_df, native_df, lambda df: df.groupby(["A", "B"]).size()
-        )
+    eval_snowpark_pandas_result(
+        snow_df,
+        native_df,
+        lambda df: df.groupby(by).size(),
+    )

--- a/tests/integ/modin/groupby/test_groupby_size.py
+++ b/tests/integ/modin/groupby/test_groupby_size.py
@@ -92,7 +92,7 @@ def test_error_checking():
         s.groupby(s).size()
 
 
-def test_groupby_size_timedelta():
+def test_timedelta():
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(

--- a/tests/integ/modin/groupby/test_groupby_size.py
+++ b/tests/integ/modin/groupby/test_groupby_size.py
@@ -3,6 +3,7 @@
 #
 import modin.pandas as pd
 import numpy as np
+import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
@@ -89,3 +90,31 @@ def test_error_checking():
     s = pd.Series(list("abc") * 4)
     with pytest.raises(NotImplementedError):
         s.groupby(s).size()
+
+
+def test_groupby_size_timedelta():
+    native_df = native_pd.DataFrame(
+        {
+            "A": native_pd.to_timedelta(
+                ["1 days 06:05:01.00003", "15.5us", "nan", "16us"]
+            ),
+            "B": [8, 8, 12, 10],
+            "C": ["the", "name", "is", "bond"],
+        }
+    )
+    snow_df = pd.DataFrame(native_df)
+
+    with SqlCounter(query_count=1):
+        eval_snowpark_pandas_result(
+            snow_df,
+            native_df,
+            lambda df: df.groupby("A").size(),
+        )
+    with SqlCounter(query_count=1):
+        eval_snowpark_pandas_result(
+            snow_df, native_df, lambda df: df.groupby("A").size()
+        )
+    with SqlCounter(query_count=1):
+        eval_snowpark_pandas_result(
+            snow_df, native_df, lambda df: df.groupby(["A", "B"]).size()
+        )

--- a/tests/integ/modin/groupby/test_min_max.py
+++ b/tests/integ/modin/groupby/test_min_max.py
@@ -178,7 +178,7 @@ def test_min_max_with_mixed_str_numeric_type():
 
 
 @pytest.mark.parametrize("agg_func", ["min", "max"])
-def test_groupby_min_max_timedelta(agg_func):
+def test_timedelta(agg_func):
     native_df = native_pd.DataFrame(
         {
             "A": native_pd.to_timedelta(

--- a/tests/integ/modin/types/test_timedelta.py
+++ b/tests/integ/modin/types/test_timedelta.py
@@ -88,23 +88,3 @@ def test_timedelta_precision_insufficient_with_nulls_SNOW_1628925():
     eval_snowpark_pandas_result(
         pd, native_pd, lambda lib: lib.Series([None, timedelta])
     )
-
-
-@sql_count_checker(query_count=0)
-def test_timedelta_not_supported():
-    df = pd.DataFrame(
-        {
-            "a": ["one", "two", "three"],
-            "b": ["abc", "pqr", "xyz"],
-            "dt": [
-                pd.Timedelta("1 days"),
-                pd.Timedelta("2 days"),
-                pd.Timedelta("3 days"),
-            ],
-        }
-    )
-    with pytest.raises(
-        NotImplementedError,
-        match="validate_groupby is not yet implemented for Timedelta Type",
-    ):
-        df.groupby("a").count()

--- a/tests/integ/modin/types/test_timedelta.py
+++ b/tests/integ/modin/types/test_timedelta.py
@@ -88,3 +88,23 @@ def test_timedelta_precision_insufficient_with_nulls_SNOW_1628925():
     eval_snowpark_pandas_result(
         pd, native_pd, lambda lib: lib.Series([None, timedelta])
     )
+
+
+@sql_count_checker(query_count=0)
+def test_timedelta_not_supported():
+    df = pd.DataFrame(
+        {
+            "a": ["one", "two", "three"],
+            "b": ["abc", "pqr", "xyz"],
+            "dt": [
+                pd.Timedelta("1 days"),
+                pd.Timedelta("2 days"),
+                pd.Timedelta("3 days"),
+            ],
+        }
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="SnowflakeQueryCompiler::groupby_first is not yet implemented for Timedelta Type",
+    ):
+        df.groupby("a").first()


### PR DESCRIPTION
SNOW-1625380

This PR adds support for the following `GroupBy` aggregations with Timedelta columns: `min`, `max`, `mean`, `idxmax`, `idxmin`, `std`, `sum`, `median`, `count`, `any`, `all`, `size`, `nunique`
