### PR TITLE
[SNOW-1556590] Enable test_sql with new compilation stage

### DIFF
--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -423,10 +423,6 @@ def test_table(session):
     assert count_number_of_ctes(df_result.queries["queries"][-1]) == 1
 
 
-@pytest.mark.skipif(
-    "config.getoption('disable_sql_simplifier', default=False)",
-    reason="TODO SNOW-1556590: Re-enable test_sql in test_cte.py when sql simplifier is disabled once new CTE implementation is completed",
-)
 @pytest.mark.parametrize(
     "query",
     [
@@ -435,6 +431,11 @@ def test_table(session):
     ],
 )
 def test_sql(session, query):
+    if not session._query_compilation_stage_enabled:
+        pytest.skip(
+            "CTE query generation without the new query generation doesn't work correctly"
+        )
+
     df = session.sql(query).filter(lit(True))
     df_result = df.union_all(df).select("*")
     check_result(session, df_result, expect_cte_optimized=True)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

  SNOW-1556590

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

The test was failing when sql simplification is off, this is fixed with the new query compilation stage, re-enable the test
