### PR TITLE
[SNOW-1649147]: Fix `inplace` argument for Series objects derived from DataFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 
 - Stopped ignoring nanoseconds in `pd.Timedelta` scalars.
 - Fixed AssertionError in tree of binary operations.
+- Fixed `inplace` argument for Series objects derived from DataFrames.
 
 #### Behavior Change
 

--- a/src/snowflake/snowpark/modin/pandas/series.py
+++ b/src/snowflake/snowpark/modin/pandas/series.py
@@ -2752,8 +2752,6 @@ class Series(BasePandasDataset, metaclass=TelemetryMeta):
         # Propagate changes back to parent so that column in dataframe had the same contents
         if self._parent is not None:
             if self._parent_axis == 0:
-                self._parent.loc[self.name] = self
-            else:
                 self._parent[self.name] = self
 
     def _create_or_update_from_compiler(self, new_query_compiler, inplace=False):

--- a/tests/integ/modin/series/test_fillna.py
+++ b/tests/integ/modin/series/test_fillna.py
@@ -188,3 +188,16 @@ def test_argument_negative(test_fillna_series, test_fillna_df):
         expect_exception_type=TypeError,
         assert_exception_equal=False,
     )
+
+
+@sql_count_checker(query_count=1)
+def test_inplace_fillna_from_df():
+    def inplace_fillna(df):
+        df["B"].fillna(method="ffill", inplace=True)
+        return df
+
+    eval_snowpark_pandas_result(
+        pd.DataFrame([[1, 2, 3], [4, None, 6]], columns=list("ABC")),
+        native_pd.DataFrame([[1, 2, 3], [4, None, 6]], columns=list("ABC")),
+        inplace_fillna,
+    )


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1649147

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
