### PR TITLE
SNOW-1649392: Fix bug in `Series.dt.isocalendar` using a named Series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 
 - Stopped ignoring nanoseconds in `pd.Timedelta` scalars.
 - Fixed AssertionError in tree of binary operations.
+- Fixed bug in `Series.dt.isocalendar` using a named Series
 
 #### Behavior Change
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -10790,14 +10790,15 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         return self.dt_property("dayofweek")
 
     def dt_isocalendar(self) -> "SnowflakeQueryCompiler":
+        col_name = self.columns[0]
         year_col = self.dt_property("yearofweekiso").rename(
-            columns_renamer={MODIN_UNNAMED_SERIES_LABEL: "year"}
+            columns_renamer={col_name: "year"}
         )
         week_col = self.dt_property("weekiso").rename(
-            columns_renamer={MODIN_UNNAMED_SERIES_LABEL: "week"}
+            columns_renamer={col_name: "week"}
         )
         day_col = self.dt_property("dayofweekiso").rename(
-            columns_renamer={MODIN_UNNAMED_SERIES_LABEL: "day"}
+            columns_renamer={col_name: "day"}
         )
         return year_col.concat(axis=1, other=[week_col, day_col])
 

--- a/tests/integ/modin/series/test_dt_accessor.py
+++ b/tests/integ/modin/series/test_dt_accessor.py
@@ -183,7 +183,9 @@ def test_isocalendar():
             snow_ser, native_ser, lambda ser: ser.dt.isocalendar()
         )
     with SqlCounter(query_count=1):
-        native_ser = native_pd.to_datetime(native_pd.Series(["2010-01-01", None]))
+        native_ser = native_pd.to_datetime(
+            native_pd.Series(["2010-01-01", None], name="hello")
+        )
         snow_ser = pd.Series(native_ser)
         eval_snowpark_pandas_result(
             snow_ser, native_ser, lambda ser: ser.dt.isocalendar()


### PR DESCRIPTION
SNOW-1649392

Bug fix to rename the columns in `Series.dt.isocalendar` using the existing Series name instead of assuming `MODIN_UNNAMED_SERIES_LABEL`