### PR TITLE
[SNOW-1630273] Refactor compute_bin_indices to reuse asof join

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
@@ -218,6 +218,14 @@ def compute_bin_indices(
         ),
     )
 
+    bucket_frame = cuts_frame.append_columns(
+        ["b_data", "b_row_pos"],
+        [col(cuts_frame.data_column_snowflake_quoted_identifiers[0]), col(cuts_frame.row_position_snowflake_quoted_identifier)])
+
+    bucket_data_identifier = bucket_frame.data_column_snowflake_quoted_identifiers[-1]
+    bucket_row_position_identifier = bucket_frame.data_column_snowflake_quoted_identifiers[-2]
+    
+
     value_snowpark_frame = value_snowpark_frame.select(
         *tuple(value_index_identifiers),
         col(value_frame.data_column_snowflake_quoted_identifiers[0]).as_(
@@ -227,6 +235,7 @@ def compute_bin_indices(
             value_row_position_identifier
         ),
     )
+
 
     # Perform a left join. The idea is to find all values which fall into an interval
     # defined by the cuts/bins in the bucket frame. The closest can be then identified using the

--- a/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
@@ -185,30 +185,20 @@ def compute_bin_indices(
 
     cuts_frame = cuts_frame.ensure_row_position_column()
     # perform asof join to find the closet to the cut frame data.
-    if right:
-        asof_result = join(
-            values_frame,
-            cuts_frame,
-            how="asof",
-            left_on=[],
-            right_on=[],
-            left_match_col=values_frame.data_column_snowflake_quoted_identifiers[0],
-            right_match_col=cuts_frame.data_column_snowflake_quoted_identifiers[0],
-            match_comparator=MatchComparator.LESS_THAN_OR_EQUAL_TO,
-            sort=False,
-        )
-    else:
-        asof_result = join(
-            values_frame,
-            cuts_frame,
-            how="asof",
-            left_on=[],
-            right_on=[],
-            left_match_col=values_frame.data_column_snowflake_quoted_identifiers[0],
-            right_match_col=cuts_frame.data_column_snowflake_quoted_identifiers[0],
-            match_comparator=MatchComparator.GREATER_THAN_OR_EQUAL_TO,
-            sort=False,
-        )
+    asof_result = join(
+        values_frame,
+        cuts_frame,
+        how="asof",
+        left_on=[],
+        right_on=[],
+        left_match_col=values_frame.data_column_snowflake_quoted_identifiers[0],
+        right_match_col=cuts_frame.data_column_snowflake_quoted_identifiers[0],
+        match_comparator=MatchComparator.LESS_THAN_OR_EQUAL_TO
+        if right
+        else MatchComparator.GREATER_THAN_OR_EQUAL_TO,
+        sort=False,
+    )
+
     assert cuts_frame.row_position_snowflake_quoted_identifier is not None
     bin_index_col = col(
         asof_result.result_column_mapper.map_right_quoted_identifiers(

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -1050,21 +1050,26 @@ class InternalFrame:
         ]
 
         # Generate snowflake quoted identifier for new column to be added.
-        new_column_identifiers = self.ordered_dataframe.generate_snowflake_quoted_identifiers(pandas_labels=pandas_labels)
+        new_column_identifiers = (
+            self.ordered_dataframe.generate_snowflake_quoted_identifiers(
+                pandas_labels=pandas_labels
+            )
+        )
         new_ordered_dataframe = append_columns(
             self.ordered_dataframe, new_column_identifiers, values
         )
         return InternalFrame.create(
             ordered_dataframe=new_ordered_dataframe,
             data_column_pandas_labels=self.data_column_pandas_labels + pandas_labels,
-            data_column_snowflake_quoted_identifiers=self.data_column_snowflake_quoted_identifiers + new_column_identifiers,
+            data_column_snowflake_quoted_identifiers=self.data_column_snowflake_quoted_identifiers
+            + new_column_identifiers,
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
-            data_column_types=self.cached_data_column_snowpark_pandas_types + value_types,
+            data_column_types=self.cached_data_column_snowpark_pandas_types
+            + value_types,
             index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
-
 
     def project_columns(
         self,

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -1008,70 +1008,31 @@ class InternalFrame:
         # | . . .         | . . .         | . . .         | . . .         | . . .         |
         # +---------------+---------------+---------------+---------------+---------------+
 
-        return self.append_columns([pandas_label], [value], [value_type])
-
-    def append_columns(
-        self,
-        pandas_labels: list[Hashable],
-        values: list[SnowparkColumn],
-        value_types: Optional[list[Optional[SnowparkPandasType]]] = None,
-    ) -> "InternalFrame":
-        """
-        Append columns to this frame. The columns are added at the end. For a frame with multiindex column, it
-        automatically fills the missing levels with None. For example, in a table with MultiIndex columns like
-        ("A", "col1"), ("A", "col2"), ("B", "col1"), ("B", "col2"), appending a count column "cnt" will produce
-        a column labelled ("cnt", None).
-
-        Args:
-            pandas_labels: pandas labels for columns to be appended.
-            values: List[SnowparkColumn]. List of Snowpark columns used to produce the new columns to append.
-            value_types: The optional SnowparkPandasType for the new columns.
-
-        Returns:
-            A new InternalFrame with new columns appended at the end.
-        """
-        # +---------------+---------------+---------------+---------------+       +---------------+---------------+
-        # | ("A", "col1") | ("A", "col2") | ("B", "col1") | ("B", "col2") |       | "cnt1"        | "cnt2"        |
-        # +---------------+---------------+---------------+---------------+   +   +---------------+
-        # | . . .         | . . .         | . . .         | . . .         |       | . . .         | . . .         |
-        # +---------------+---------------+---------------+---------------+       +---------------+---------------
-        #
-        # Appending a column "cnt" to the table below will produce the following table:
-        # +---------------+---------------+---------------+---------------+---------------+---------------+
-        # | ("A", "col1") | ("A", "col2") | ("B", "col1") | ("B", "col2") | ("cnt1", None)|("cnt2", None) |
-        # +---------------+---------------+---------------+---------------+---------------+
-        # | . . .         | . . .         | . . .         | . . .         | . . .         |. . .         |
-        # +---------------+---------------+---------------+---------------+---------------+---------------+
-
         # Generate label for the column to be appended.
         nlevels = self.num_index_levels(axis=1)
-        pandas_labels = [
-            fill_missing_levels_for_pandas_label(pandas_label, nlevels, 0, None)
-            for pandas_label in pandas_labels
-        ]
+        pandas_label = fill_missing_levels_for_pandas_label(
+            pandas_label, nlevels, 0, None
+        )
 
         # Generate snowflake quoted identifier for new column to be added.
-        new_column_identifiers = (
+        new_column_identifier = (
             self.ordered_dataframe.generate_snowflake_quoted_identifiers(
-                pandas_labels=pandas_labels
-            )
+                pandas_labels=[pandas_label],
+            )[0]
         )
         new_ordered_dataframe = append_columns(
-            self.ordered_dataframe, new_column_identifiers, values
-        )
-        value_types = (
-            value_types if value_types is not None else [None] * len(pandas_labels)
+            self.ordered_dataframe, new_column_identifier, value
         )
         return InternalFrame.create(
             ordered_dataframe=new_ordered_dataframe,
-            data_column_pandas_labels=self.data_column_pandas_labels + pandas_labels,
+            data_column_pandas_labels=self.data_column_pandas_labels + [pandas_label],
             data_column_snowflake_quoted_identifiers=self.data_column_snowflake_quoted_identifiers
-            + new_column_identifiers,
+            + [new_column_identifier],
             data_column_pandas_index_names=self.data_column_pandas_index_names,
             index_column_pandas_labels=self.index_column_pandas_labels,
             index_column_snowflake_quoted_identifiers=self.index_column_snowflake_quoted_identifiers,
             data_column_types=self.cached_data_column_snowpark_pandas_types
-            + value_types,
+            + [value_type],
             index_column_types=self.cached_index_column_snowpark_pandas_types,
         )
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -1058,6 +1058,9 @@ class InternalFrame:
         new_ordered_dataframe = append_columns(
             self.ordered_dataframe, new_column_identifiers, values
         )
+        value_types = (
+            value_types if value_types is not None else [None] * len(pandas_labels)
+        )
         return InternalFrame.create(
             ordered_dataframe=new_ordered_dataframe,
             data_column_pandas_labels=self.data_column_pandas_labels + pandas_labels,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

  SNOW-1630273

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Refactored following parts:
1) compute_bin_indices requires asoj join, which wasn't available before, refactor the code to use asof join with join_utils
2) refactor the whole implementation to operate at internal frame level.