### PR TITLE
SNOW-1616989: Enable creation for DatetimeIndex with query_compiler numeric or str type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - Added support for `pd.bdate_range` and included business frequency support (B, BME, BMS, BQE, BQS, BYE, BYS) for both `pd.date_range` and `pd.bdate_range`.
 - Added support for lazy `Index` objects  as `labels` in `DataFrame.reindex` and `Series.reindex`.
 - Added support for `Series.dt.days`, `Series.dt.seconds`, `Series.dt.microseconds`, and `Series.dt.nanoseconds`.
+- Added support for creating a `DatetimeIndex` from an `Index` of numeric or string type.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -6643,6 +6643,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             if isinstance(sf_type, BooleanType):
                 # bool is not allowed in to_datetime (but note that bool is allowed by astype)
                 raise TypeError("dtype bool cannot be converted to datetime64[ns]")
+            elif isinstance(sf_type, TimedeltaType):
+                raise TypeError(
+                    "dtype timedelta64[ns] cannot be converted to datetime64[ns]"
+                )
 
             to_datetime_cols[col_id] = generate_timestamp_col(
                 col(col_id),


### PR DESCRIPTION
Fixes: SNOW-1616989
Allow creation of DatetimeIndex from other types of data. Internally use to_datetime for conversion.