### PR TITLE
SNOW-1628925 Fix timedelta precision loss in to_pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 #### New Features
 
 - Added limited support for the `Timedelta` type, including the following features. Snowpark pandas will raise `NotImplementedError` for unsupported `Timedelta` use cases.
-  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `assign`, `bfill`, `ffill`, `fillna`, `compare`, `diff`, `drop`, `dropna`, `duplicated`, `empty`, `equals`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `mask`, `melt`, `merge`, `nlargest`, `nsmallest`.
+  - supporting tracking the Timedelta type through `copy`, `cache_result`, `shift`, `sort_index`, `assign`, `bfill`, `ffill`, `fillna`, `compare`, `diff`, `drop`, `dropna`, `duplicated`, `empty`, `equals`, `insert`, `isin`, `isna`, `items`, `iterrows`, `join`, `len`, `mask`, `melt`, `merge`, `nlargest`, `nsmallest`, `to_pandas`.
   - converting non-timedelta to timedelta via `astype`.
   - `NotImplementedError` will be raised for the rest of methods that do not support `Timedelta`.
   - support for subtracting two timestamps to get a Timedelta.

--- a/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
@@ -12,6 +12,7 @@ from pandas._typing import Callable, Scalar
 
 from snowflake.snowpark.column import Column as SnowparkColumn
 from snowflake.snowpark.functions import (
+    cast,
     ceil,
     col,
     concat,
@@ -39,6 +40,7 @@ from snowflake.snowpark.modin.plugin._internal.utils import pandas_lit
 from snowflake.snowpark.modin.plugin.utils.error_message import ErrorMessage
 from snowflake.snowpark.types import (
     DataType,
+    LongType,
     NullType,
     StringType,
     TimestampTimeZone,
@@ -443,7 +445,9 @@ def compute_binary_op_between_snowpark_columns(
     elif op == "mul" and (
         _op_is_between_timedelta_and_numeric(first_datatype, second_datatype)
     ):
-        binary_op_result_column = first_operand * second_operand
+        binary_op_result_column = cast(
+            floor(first_operand * second_operand), LongType()
+        )
         snowpark_pandas_type = TimedeltaType()
     # For `eq` and `ne`, note that Snowflake will consider 1 equal to
     # Timedelta(1) because those two have the same representation in Snowflake,
@@ -461,7 +465,9 @@ def compute_binary_op_between_snowpark_columns(
         and isinstance(first_datatype(), TimedeltaType)
         and _is_numeric_non_timedelta_type(second_datatype())
     ):
-        binary_op_result_column = floor(first_operand / second_operand)
+        binary_op_result_column = cast(
+            floor(first_operand / second_operand), LongType()
+        )
         snowpark_pandas_type = TimedeltaType()
     elif (
         op == "mod"

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, NamedTuple, Optional, Union
 
 import pandas as native_pd
 from pandas._typing import IndexLabel
-from pandas.core.dtypes.common import is_object_dtype
 
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
@@ -32,7 +31,6 @@ from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
 from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
     SnowparkPandasType,
 )
-from snowflake.snowpark.modin.plugin._internal.type_utils import TypeMapper
 from snowflake.snowpark.modin.plugin._internal.utils import (
     DEFAULT_DATA_COLUMN_LABEL,
     INDEX_LABEL,
@@ -546,37 +544,11 @@ class InternalFrame:
         Returns:
             The index (row labels) of the DataFrame.
         """
-        index_values = snowpark_to_pandas_helper(
-            self.ordered_dataframe.select(
-                self.index_column_snowflake_quoted_identifiers
-            ),
-            cached_snowpark_pandas_types=self.cached_index_column_snowpark_pandas_types,
+        return snowpark_to_pandas_helper(
+            self,
+            index_only=True,
             **kwargs,
-        ).values
-        if self.is_multiindex(axis=0):
-            value_tuples = [tuple(row) for row in index_values]
-            return native_pd.MultiIndex.from_tuples(
-                value_tuples, names=self.index_column_pandas_labels
-            )
-        else:
-            # We have one index column. Fill in the type correctly.
-            index_identifier = self.index_column_snowflake_quoted_identifiers[0]
-            index_type = TypeMapper.to_pandas(self.get_snowflake_type(index_identifier))
-            ret = native_pd.Index(
-                [row[0] for row in index_values],
-                name=self.index_column_pandas_labels[0],
-                # setting tupleize_cols=False to avoid creating a MultiIndex
-                # otherwise, when labels are tuples (e.g., [("A", "a"), ("B", "b")]),
-                # a MultiIndex will be created incorrectly
-                tupleize_cols=False,
-            )
-            # When pd.Index() failed to reduce dtype to a numpy or pandas extension type, it will be object type. For
-            # example, an empty dataframe will be object dtype by default, or a variant, or a timestamp column with
-            # multiple timezones. So here we cast the index to the index_type when ret = pd.Index(...) above cannot
-            # figure out a non-object dtype. Note that the index_type is a logical type may not be 100% accurate.
-            if is_object_dtype(ret.dtype) and not is_object_dtype(index_type):
-                ret = ret.astype(index_type)
-            return ret
+        )
 
     def get_snowflake_quoted_identifiers_group_by_pandas_labels(
         self,
@@ -887,36 +859,11 @@ class InternalFrame:
         pandas.DataFrame
             The InternalFrame converted to pandas.
         """
-        ordered_dataframe = self.ordered_dataframe.select(
-            self.index_column_snowflake_quoted_identifiers
-            + self.data_column_snowflake_quoted_identifiers
-        )
-
-        native_df = snowpark_to_pandas_helper(
-            ordered_dataframe,
+        return snowpark_to_pandas_helper(
+            self,
             statement_params=statement_params,
-            cached_snowpark_pandas_types=self.cached_index_column_snowpark_pandas_types
-            + self.cached_data_column_snowpark_pandas_types,
             **kwargs,
         )
-
-        # to_pandas() does not preserve the index information and will just return a
-        # RangeIndex. Therefore, we need to set the index column manually
-        native_df.set_index(
-            [
-                extract_pandas_label_from_snowflake_quoted_identifier(identifier)
-                for identifier in self.index_column_snowflake_quoted_identifiers
-            ],
-            inplace=True,
-        )
-        # set index name
-        native_df.index = native_df.index.set_names(self.index_column_pandas_labels)
-
-        from snowflake.snowpark.modin.pandas.utils import try_convert_index_to_native
-
-        # set column names and potential casting
-        native_df.columns = try_convert_index_to_native(self.data_columns_index)
-        return native_df
 
     ###########################################################################
     # START: Internal Frame mutation APIs.
@@ -1172,9 +1119,7 @@ class InternalFrame:
     def update_snowflake_quoted_identifiers_with_expressions(
         self,
         quoted_identifier_to_column_map: dict[str, SnowparkColumn],
-        data_column_snowpark_pandas_types: Optional[
-            list[Optional[SnowparkPandasType]]
-        ] = None,
+        snowpark_pandas_types: Optional[list[Optional[SnowparkPandasType]]] = None,
     ) -> UpdatedInternalFrameResult:
         """
         Points Snowflake quoted identifiers to column expression given by `quoted_identifier_to_column_map`.
@@ -1239,13 +1184,15 @@ class InternalFrame:
         new_type_mapping = dict(
             self.snowflake_quoted_identifier_to_snowpark_pandas_type
         )
-        if data_column_snowpark_pandas_types is None:
-            data_column_snowpark_pandas_types = [None] * len(
-                quoted_identifier_to_column_map
-            )
-        for ((existing_identifier, column_expression,), data_column_type) in zip(
-            quoted_identifier_to_column_map.items(), data_column_snowpark_pandas_types
-        ):
+        if snowpark_pandas_types is None:
+            snowpark_pandas_types = [None] * len(quoted_identifier_to_column_map)
+        for (
+            (
+                existing_identifier,
+                column_expression,
+            ),
+            data_column_type,
+        ) in zip(quoted_identifier_to_column_map.items(), snowpark_pandas_types):
             new_identifier = (
                 self.ordered_dataframe.generate_snowflake_quoted_identifiers(
                     pandas_labels=[

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Optional, Union
 import numpy as np
 import pandas as native_pd
 from pandas._typing import Scalar
-from pandas.core.dtypes.common import is_integer_dtype, is_scalar
+from pandas.core.dtypes.common import is_integer_dtype, is_object_dtype, is_scalar
 
 import snowflake.snowpark.modin.pandas as pd
 import snowflake.snowpark.modin.plugin._internal.statement_params_constants as STATEMENT_PARAMS
@@ -34,6 +34,7 @@ from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import (
     col,
     count,
+    floor,
     max as max_,
     mean,
     min as min_,
@@ -50,6 +51,7 @@ from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
 )
 from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
     SnowparkPandasType,
+    TimedeltaType,
     ensure_snowpark_python_type,
 )
 from snowflake.snowpark.modin.plugin._typing import LabelTuple
@@ -64,10 +66,13 @@ from snowflake.snowpark.modin.plugin.utils.warning_message import (
 from snowflake.snowpark.types import (
     ArrayType,
     DataType,
+    LongType,
     MapType,
+    StringType,
     StructField,
     StructType,
     VariantType,
+    _FractionalType,
 )
 
 ROW_POSITION_COLUMN_LABEL = "row_position"
@@ -1271,30 +1276,66 @@ def check_snowpark_pandas_object_in_arg(arg: Any) -> bool:
 
 
 def snowpark_to_pandas_helper(
-    ordered_dataframe: OrderedDataFrame,
-    cached_snowpark_pandas_types: list[SnowparkPandasType],
+    frame: "frame.InternalFrame",
     *,
+    index_only: bool = False,
     statement_params: Optional[dict[str, str]] = None,
     **kwargs: Any,
-) -> native_pd.DataFrame:
+) -> Union[native_pd.Index, native_pd.DataFrame]:
     """
     The helper function retrieves a pandas dataframe from an OrderedDataFrame. Performs necessary type
     conversions for variant types on the client. This function issues 2 queries, one metadata query
     to retrieve the schema and one query to retrieve the data values.
 
     Args:
-        ordered_dataframe: Ordered Dataframe abstraction to convert to pandas Dataframe
+        frame: The internal frame to convert to pandas Dataframe (or Index if index_only is true)
+        index_only: if true, only turn the index columns into a pandas Index
         statement_params: Dictionary of statement level parameters to be passed to conversion function of ordered dataframe abstraction.
-        cached_snowpark_pandas_types:
-            List of types for the ordered dataframe's projected columns. These
-            types override the types from Snowpark python.
         kwargs: Additional keyword-only args to pass to internal `to_pandas` conversion for orderded dataframe abstraction.
 
     Returns:
         pandas dataframe
     """
+    ids = frame.index_column_snowflake_quoted_identifiers
+    cached_snowpark_pandas_types = frame.cached_index_column_snowpark_pandas_types
 
-    # Step 1: Retrieve schema of Snowpark dataframe and
+    if not index_only:
+        ids += frame.data_column_snowflake_quoted_identifiers
+        cached_snowpark_pandas_types += frame.cached_data_column_snowpark_pandas_types
+
+    ordered_dataframe = frame.ordered_dataframe.select(*ids)
+    # Step 1: preprocessing on Snowpark pandas types
+    # Here we convert Timedelta to string before to_pandas to avoid precision loss.
+    if cached_snowpark_pandas_types is not None:
+        astype_mapping = {}
+        column_type_map = {
+            f.column_identifier.quoted_name: f.datatype
+            for f in ordered_dataframe.schema.fields
+        }
+        for col_id, snowpark_pandas_type in zip(ids, cached_snowpark_pandas_types):
+            if snowpark_pandas_type is not None:
+                if snowpark_pandas_type == TimedeltaType():
+                    timedelta_to_str_col = col(col_id)
+                    # Timedelta's underneath Snowflake type may not always be int after other operations, so explicitly
+                    # floor them to integer first before converting to string
+                    if isinstance(column_type_map[col_id], _FractionalType):
+                        timedelta_to_str_col = floor(timedelta_to_str_col).cast(
+                            LongType()
+                        )
+                    timedelta_to_str_col = timedelta_to_str_col.cast(StringType())
+                    astype_mapping[col_id] = timedelta_to_str_col
+        if astype_mapping:
+            (
+                frame,
+                old_to_new_id_mapping,
+            ) = frame.update_snowflake_quoted_identifiers_with_expressions(
+                quoted_identifier_to_column_map=astype_mapping,
+            )
+            ordered_dataframe = frame.ordered_dataframe.select(
+                [old_to_new_id_mapping.get(id, id) for id in ids]
+            )
+
+    # Step 2: Retrieve schema of Snowpark dataframe and
     # capture information about each quoted identifier and its corresponding datatype, store
     # as list to keep information about order of columns.
     columns_info = [
@@ -1309,7 +1350,7 @@ def snowpark_to_pandas_helper(
     )
     variant_type_identifiers = list(map(lambda t: t[0], variant_type_columns_info))
 
-    # Step 2: Create for each variant type column a separate type column (append at end), and retrieve data values
+    # Step 3: Create for each variant type column a separate type column (append at end), and retrieve data values
     # (and types for variant type columns).
     variant_type_typeof_identifiers = (
         ordered_dataframe.generate_snowflake_quoted_identifiers(
@@ -1335,7 +1376,7 @@ def snowpark_to_pandas_helper(
     ), "Snowpark DataFrame to convert must have unique column identifiers"
     pandas_df = ordered_dataframe.to_pandas(statement_params=statement_params, **kwargs)
 
-    # Step 3: perform post-processing
+    # Step 4: perform post-processing
     # If the dataframe has no rows, do not perform this. Using the result of the `apply` on
     # an empty frame would erroneously update the dtype of the column to be `float64` instead of `object`.
     # TODO SNOW-982779: verify correctness of this behavior
@@ -1383,21 +1424,79 @@ def snowpark_to_pandas_helper(
                         id_to_label_mapping[quoted_name]
                     ].apply(lambda value: None if value is None else json.loads(value))
 
-    # Return the original amount of columns by stripping any typeof(...) columns appended if
+    # Step 5. Return the original amount of columns by stripping any typeof(...) columns appended if
     # schema contained VariantType.
     downcast_pandas_df = pandas_df[pandas_df.columns[: len(columns_info)]]
 
+    # Step 6. postprocessing for Snowpark pandas types
     if cached_snowpark_pandas_types is not None:
+        timedelta_t = TimedeltaType()
+
+        def convert_str_to_timedelta(x: str) -> pd.Timedelta:
+            return (
+                x
+                if pd.isna(x)
+                else pd.NaT
+                if x == "NaN"
+                else timedelta_t.to_pandas(int(x))
+            )
+
         for pandas_label, snowpark_pandas_type in zip(
             downcast_pandas_df.columns, cached_snowpark_pandas_types
         ):
-            if snowpark_pandas_type is not None and isinstance(
-                snowpark_pandas_type, SnowparkPandasType
-            ):
+            if snowpark_pandas_type is not None and snowpark_pandas_type == timedelta_t:
                 downcast_pandas_df[pandas_label] = pandas_df[pandas_label].apply(
-                    snowpark_pandas_type.to_pandas
+                    convert_str_to_timedelta
                 )
 
+    # Step 7. postprocessing for return types
+    if index_only:
+        index_values = downcast_pandas_df.values
+        if frame.is_multiindex(axis=0):
+            value_tuples = [tuple(row) for row in index_values]
+            return native_pd.MultiIndex.from_tuples(
+                value_tuples, names=frame.index_column_pandas_labels
+            )
+        else:
+            # We have one index column. Fill in the type correctly.
+            index_identifier = frame.index_column_snowflake_quoted_identifiers[0]
+            from snowflake.snowpark.modin.plugin._internal.type_utils import TypeMapper
+
+            index_type = TypeMapper.to_pandas(
+                frame.get_snowflake_type(index_identifier)
+            )
+            ret = native_pd.Index(
+                [row[0] for row in index_values],
+                name=frame.index_column_pandas_labels[0],
+                # setting tupleize_cols=False to avoid creating a MultiIndex
+                # otherwise, when labels are tuples (e.g., [("A", "a"), ("B", "b")]),
+                # a MultiIndex will be created incorrectly
+                tupleize_cols=False,
+            )
+            # When pd.Index() failed to reduce dtype to a numpy or pandas extension type, it will be object type. For
+            # example, an empty dataframe will be object dtype by default, or a variant, or a timestamp column with
+            # multiple timezones. So here we cast the index to the index_type when ret = pd.Index(...) above cannot
+            # figure out a non-object dtype. Note that the index_type is a logical type may not be 100% accurate.
+            if is_object_dtype(ret.dtype) and not is_object_dtype(index_type):
+                ret = ret.astype(index_type)
+            return ret
+
+    # to_pandas() does not preserve the index information and will just return a
+    # RangeIndex. Therefore, we need to set the index column manually
+    downcast_pandas_df.set_index(
+        [
+            extract_pandas_label_from_snowflake_quoted_identifier(identifier)
+            for identifier in frame.index_column_snowflake_quoted_identifiers
+        ],
+        inplace=True,
+    )
+    # set index name
+    downcast_pandas_df.index = downcast_pandas_df.index.set_names(
+        frame.index_column_pandas_labels
+    )
+
+    # set column names and potential casting
+    downcast_pandas_df.columns = frame.data_columns_index
     return downcast_pandas_df
 
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1578,7 +1578,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             data_column_snowpark_pandas_types.append(snowpark_pandas_type)
         new_frame = frame.update_snowflake_quoted_identifiers_with_expressions(
             quoted_identifier_to_column_map=quoted_identifier_to_column_map,
-            data_column_snowpark_pandas_types=data_column_snowpark_pandas_types,
+            snowpark_pandas_types=data_column_snowpark_pandas_types,
         ).frame
 
         return self.__constructor__(new_frame)
@@ -1863,7 +1863,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         return SnowflakeQueryCompiler(
             self._modin_frame.update_snowflake_quoted_identifiers_with_expressions(
                 quoted_identifier_to_column_map=replace_mapping,
-                data_column_snowpark_pandas_types=data_column_snowpark_pandas_types,
+                snowpark_pandas_types=data_column_snowpark_pandas_types,
             ).frame
         )
 
@@ -4197,7 +4197,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     quoted_identifier_to_column_map=self._fill_null_values_in_groupby(
                         fillna_method, by_snowflake_quoted_identifiers_list
                     ),
-                    data_column_snowpark_pandas_types=self._modin_frame.cached_data_column_snowpark_pandas_types,
+                    snowpark_pandas_types=self._modin_frame.cached_data_column_snowpark_pandas_types,
                 ).frame
             )
         result = result.groupby_agg(
@@ -9196,7 +9196,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         return SnowflakeQueryCompiler(
             self._modin_frame.update_snowflake_quoted_identifiers_with_expressions(
                 quoted_identifier_to_column_map=astype_mapping,
-                data_column_snowpark_pandas_types=data_column_snowpark_pandas_types,
+                snowpark_pandas_types=data_column_snowpark_pandas_types,
             ).frame
         )
 
@@ -10635,7 +10635,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 quoted_identifier_to_column_map={
                     k: v.snowpark_column for k, v in diff_label_to_value_map.items()
                 },
-                data_column_snowpark_pandas_types=[
+                snowpark_pandas_types=[
                     a.snowpark_pandas_type for a in diff_label_to_value_map.values()
                 ],
             ).frame

--- a/tests/integ/modin/types/test_timedelta.py
+++ b/tests/integ/modin/types/test_timedelta.py
@@ -80,10 +80,8 @@ def test_timedelta_series_dtypes():
     )
 
 
-@pytest.mark.xfail(strict=True, raises=AssertionError)
-def test_timedelta_precision_insufficient_with_nulls_SNOW_1628925():
+def test_timedelta_precision_insufficient_with_nulls():
     # Storing this timedelta requires more than 15 digits of precision
-    # TODO(SNOW-1628925): Fix this bug.
     timedelta = pd.Timedelta(days=105, nanoseconds=1)
     eval_snowpark_pandas_result(
         pd, native_pd, lambda lib: lib.Series([None, timedelta])

--- a/tests/integ/modin/types/test_timedelta.py
+++ b/tests/integ/modin/types/test_timedelta.py
@@ -80,6 +80,7 @@ def test_timedelta_series_dtypes():
     )
 
 
+@sql_count_checker(query_count=1)
 def test_timedelta_precision_insufficient_with_nulls():
     # Storing this timedelta requires more than 15 digits of precision
     timedelta = pd.Timedelta(days=105, nanoseconds=1)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1628925

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

The main idea is to convert timedelta column to string before calling to_pandas, and then convert str back to timedelta to avoid precision loss.