### PR TITLE
SNOW-1651296: Skip temp table cleanup flaky test

### DIFF
--- a/tests/integ/test_temp_table_cleanup.py
+++ b/tests/integ/test_temp_table_cleanup.py
@@ -17,9 +17,8 @@ from snowflake.snowpark.functions import col
 from tests.utils import IS_IN_STORED_PROC
 
 pytestmark = [
-    pytest.mark.skipif(
-        "config.getoption('local_testing_mode', default=False)",
-        reason="Temp table cleanup is not supported in Local Testing",
+    pytest.mark.skip(
+        reason="SNOW-1645523: Re-enable this test file after flaky test is fixed",
     ),
 ]
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1651296

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   The entire test suite is flaky because the drop table sql query might not finish when checking its existence. 
