### PR TITLE
SNOW-1658008: Clean up Snowpark pandas documentation references

### DIFF
--- a/docs/source/modin/io.rst
+++ b/docs/source/modin/io.rst
@@ -20,6 +20,7 @@ Input/Output
     :toctree: pandas_api/
 
     read_snowflake
+    to_snowflake
     to_snowpark
 
 .. rubric:: pandas

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -168,6 +168,7 @@ else:
     from collections.abc import Iterable
 
 if TYPE_CHECKING:
+    import modin.pandas  # pragma: no cover
     from table import Table  # pragma: no cover
 
 _logger = getLogger(__name__)
@@ -938,7 +939,7 @@ class DataFrame:
         self,
         index_col: Optional[Union[str, List[str]]] = None,
         columns: Optional[List[str]] = None,
-    ) -> "snowflake.snowpark.modin.pandas.DataFrame":
+    ) -> "modin.pandas.DataFrame":
         """
         Convert the Snowpark DataFrame to Snowpark pandas DataFrame.
 
@@ -948,7 +949,7 @@ class DataFrame:
                 all columns except ones configured in index_col.
 
         Returns:
-            :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+            :class:`~modin.pandas.DataFrame`
                 A Snowpark pandas DataFrame contains index and data columns based on the snapshot of the current
                 Snowpark DataFrame, which triggers an eager evaluation.
 
@@ -964,12 +965,12 @@ class DataFrame:
         Note:
             Transformations performed on the returned Snowpark pandas Dataframe do not affect the Snowpark DataFrame
             from which it was created. Call
-            - :func:`snowflake.snowpark.modin.pandas.to_snowpark <snowflake.snowpark.modin.pandas.to_snowpark>`
+            - :func:`modin.pandas.to_snowpark <modin.pandas.to_snowpark>`
             to transform a Snowpark pandas DataFrame back to a Snowpark DataFrame.
 
             The column names used for columns or index_cols must be Normalized Snowflake Identifiers, and the
             Normalized Snowflake Identifiers of a Snowpark DataFrame can be displayed by calling df.show().
-            For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.read_snowflake`
+            For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~modin.pandas.read_snowflake`
 
             `to_snowpark_pandas` works only when the environment is set up correctly for Snowpark pandas. This environment
             may require version of Python and pandas different from what Snowpark Python uses If the environment is setup
@@ -980,9 +981,9 @@ class DataFrame:
             - the installation section https://docs.snowflake.com/en/developer-guide/snowpark/python/snowpark-pandas#installing-the-snowpark-pandas-api
 
         See also:
-            - :func:`snowflake.snowpark.modin.pandas.to_snowpark <snowflake.snowpark.modin.pandas.to_snowpark>`
-            - :func:`snowflake.snowpark.modin.pandas.DataFrame.to_snowpark <snowflake.snowpark.modin.pandas.DataFrame.to_snowpark>`
-            - :func:`snowflake.snowpark.modin.pandas.Series.to_snowpark <snowflake.snowpark.modin.pandas.Series.to_snowpark>`
+            - :func:`modin.pandas.to_snowpark <modin.pandas.to_snowpark>`
+            - :func:`modin.pandas.DataFrame.to_snowpark <modin.pandas.DataFrame.to_snowpark>`
+            - :func:`modin.pandas.Series.to_snowpark <modin.pandas.Series.to_snowpark>`
 
         Example::
             >>> df = session.create_dataframe([[1, 2, 3]], schema=["a", "b", "c"])

--- a/src/snowflake/snowpark/modin/pandas/general.py
+++ b/src/snowflake/snowpark/modin/pandas/general.py
@@ -90,7 +90,7 @@ from snowflake.snowpark.modin.utils import _inherit_docstrings, to_pandas
 if TYPE_CHECKING:
     # To prevent cross-reference warnings when building documentation and prevent erroneously
     # linking to `snowflake.snowpark.DataFrame`, we need to explicitly
-    # qualify return types in this file with `snowflake.snowpark.modin.pandas.DataFrame`.
+    # qualify return types in this file with `modin.pandas.DataFrame`.
     # SNOW-1233342: investigate how to fix these links without using absolute paths
     from modin.core.storage_formats import BaseQueryCompiler  # pragma: no cover
 
@@ -172,8 +172,8 @@ def merge(
 
     Parameters
     ----------
-    left : :class:`~snowflake.snowpark.modin.pandas.DataFrame` or named Series
-    right : :class:`~snowflake.snowpark.modin.pandas.DataFrame` or named Series
+    left : :class:`~modin.pandas.DataFrame` or named Series
+    right : :class:`~modin.pandas.DataFrame` or named Series
         Object to merge with.
     how : {'left', 'right', 'outer', 'inner', 'cross'}, default 'inner'
         Type of merge to be performed.
@@ -234,7 +234,7 @@ def merge(
 
     Returns
     -------
-    :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    :class:`~modin.pandas.DataFrame`
         A DataFrame of the two merged objects.
 
     See Also
@@ -429,8 +429,8 @@ def merge_asof(
 
     Parameters
     ----------
-    left : :class:`~snowflake.snowpark.modin.pandas.DataFrame` or named :class:`~snowflake.snowpark.modin.pandas.Series`.
-    right : :class:`~snowflake.snowpark.modin.pandas.DataFrame` or named :class:`~snowflake.snowpark.modin.pandas.Series`.
+    left : :class:`~modin.pandas.DataFrame` or named :class:`~modin.pandas.Series`.
+    right : :class:`~modin.pandas.DataFrame` or named :class:`~modin.pandas.Series`.
     on : label
         Field name to join on. Must be found in both DataFrames. The data MUST be ordered.
         Furthermore, this must be a numeric column such as datetimelike, integer, or float.
@@ -461,7 +461,7 @@ def merge_asof(
 
     Returns
     -------
-    Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    Snowpark pandas :class:`~modin.pandas.DataFrame`
 
     Examples
     --------
@@ -678,7 +678,7 @@ def pivot_table(
 
     Returns
     -------
-    Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    Snowpark pandas :class:`~modin.pandas.DataFrame`
         An Excel style pivot table.
 
     Notes
@@ -808,7 +808,7 @@ def pivot(data, index=None, columns=None, values=None):  # noqa: PR01, RT01, D20
 
     Parameters
     ----------
-    data : :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    data : :class:`~modin.pandas.DataFrame`
     columns : str or object or a list of str
         Column to use to make new frame’s columns.
     index : str or object or a list of str, optional
@@ -819,7 +819,7 @@ def pivot(data, index=None, columns=None, values=None):  # noqa: PR01, RT01, D20
 
     Returns
     -------
-    :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    :class:`~modin.pandas.DataFrame`
 
     Notes
     -----
@@ -1166,11 +1166,11 @@ def concat(
     Returns
     -------
     object, type of objs
-        When concatenating all Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` along the index (axis=0),
-        a Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` is returned. When ``objs`` contains at least
-        one Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`,
-        a Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` is returned. When concatenating along
-        the columns (axis=1), a Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` is returned.
+        When concatenating all Snowpark pandas :class:`~modin.pandas.Series` along the index (axis=0),
+        a Snowpark pandas :class:`~modin.pandas.Series` is returned. When ``objs`` contains at least
+        one Snowpark pandas :class:`~modin.pandas.DataFrame`,
+        a Snowpark pandas :class:`~modin.pandas.DataFrame` is returned. When concatenating along
+        the columns (axis=1), a Snowpark pandas :class:`~modin.pandas.DataFrame` is returned.
 
     See Also
     --------
@@ -1506,13 +1506,13 @@ def to_datetime(
     """
     Convert argument to datetime.
 
-    This function converts a scalar, array-like, :class:`~snowflake.snowpark.modin.pandas.Series` or
-    :class:`~snowflake.snowpark.modin.pandas.DataFrame`/dict-like to a pandas datetime object.
+    This function converts a scalar, array-like, :class:`~modin.pandas.Series` or
+    :class:`~modin.pandas.DataFrame`/dict-like to a pandas datetime object.
 
     Parameters
     ----------
-    arg : int, float, str, datetime, list, tuple, 1-d array, Series, :class:`~snowflake.snowpark.modin.pandas.DataFrame`/dict-like
-        The object to convert to a datetime. If a :class:`~snowflake.snowpark.modin.pandas.DataFrame` is provided, the
+    arg : int, float, str, datetime, list, tuple, 1-d array, Series, :class:`~modin.pandas.DataFrame`/dict-like
+        The object to convert to a datetime. If a :class:`~modin.pandas.DataFrame` is provided, the
         method expects minimally the following columns: :const:`"year"`,
         :const:`"month"`, :const:`"day"`.
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
@@ -1548,7 +1548,7 @@ def to_datetime(
         Control timezone-related parsing, localization and conversion.
 
         - If :const:`True`, the function *always* returns a timezone-aware
-          UTC-localized :class:`Timestamp`, :class:`~snowflake.snowpark.modin.pandas.Series` or
+          UTC-localized :class:`Timestamp`, :class:`~modin.pandas.Series` or
           :class:`DatetimeIndex`. To do this, timezone-naive inputs are
           *localized* as UTC, while timezone-aware inputs are *converted* to UTC.
 
@@ -1609,14 +1609,14 @@ def to_datetime(
         parsing):
 
         - scalar: :class:`Timestamp` (or :class:`datetime.datetime`)
-        - array-like: :class:`~snowflake.snowpark.modin.pandas.DatetimeIndex` (or
-          :class: :class:`~snowflake.snowpark.modin.pandas.Series` of :class:`object` dtype containing
+        - array-like: :class:`~modin.pandas.DatetimeIndex` (or
+          :class: :class:`~modin.pandas.Series` of :class:`object` dtype containing
           :class:`datetime.datetime`)
-        - Series: :class:`~snowflake.snowpark.modin.pandas.Series` of :class:`datetime64` dtype (or
-          :class: :class:`~snowflake.snowpark.modin.pandas.Series` of :class:`object` dtype containing
+        - Series: :class:`~modin.pandas.Series` of :class:`datetime64` dtype (or
+          :class: :class:`~modin.pandas.Series` of :class:`object` dtype containing
           :class:`datetime.datetime`)
-        - DataFrame: :class:`~snowflake.snowpark.modin.pandas.Series` of :class:`datetime64` dtype (or
-          :class:`~snowflake.snowpark.modin.pandas.Series` of :class:`object` dtype containing
+        - DataFrame: :class:`~modin.pandas.Series` of :class:`datetime64` dtype (or
+          :class:`~modin.pandas.Series` of :class:`object` dtype containing
           :class:`datetime.datetime`)
 
     Raises
@@ -1625,7 +1625,7 @@ def to_datetime(
         When parsing a date from string fails.
     ValueError
         When another datetime conversion error happens. For example when one
-        of 'year', 'month', day' columns is missing in a :class:`~snowflake.snowpark.modin.pandas.DataFrame`, or
+        of 'year', 'month', day' columns is missing in a :class:`~modin.pandas.DataFrame`, or
         when a Timezone-aware :class:`datetime.datetime` is found in an array-like
         of mixed time offsets, and ``utc=False``.
 
@@ -1651,21 +1651,21 @@ def to_datetime(
       :class:`datetime.datetime`. None/NaN/null entries are converted to
       :const:`NaT` in both cases.
 
-    - **Series** are converted to :class:`~snowflake.snowpark.modin.pandas.Series` with :class:`datetime64`
-      dtype when possible, otherwise they are converted to :class:`~snowflake.snowpark.modin.pandas.Series` with
+    - **Series** are converted to :class:`~modin.pandas.Series` with :class:`datetime64`
+      dtype when possible, otherwise they are converted to :class:`~modin.pandas.Series` with
       :class:`object` dtype, containing :class:`datetime.datetime`. None/NaN/null
       entries are converted to :const:`NaT` in both cases.
 
-    - **DataFrame/dict-like** are converted to :class:`~snowflake.snowpark.modin.pandas.Series` with
+    - **DataFrame/dict-like** are converted to :class:`~modin.pandas.Series` with
       :class:`datetime64` dtype. For each row a datetime is created from assembling
       the various dataframe columns. Column keys can be common abbreviations
       like [‘year’, ‘month’, ‘day’, ‘minute’, ‘second’, ‘ms’, ‘us’, ‘ns’]) or
       plurals of the same.
 
     The following causes are responsible for :class:`datetime.datetime` objects
-    being returned (possibly inside an :class:`Index` or a :class:`~snowflake.snowpark.modin.pandas.Series` with
+    being returned (possibly inside an :class:`Index` or a :class:`~modin.pandas.Series` with
     :class:`object` dtype) instead of a proper pandas designated type
-    (:class:`Timestamp` or :class:`~snowflake.snowpark.modin.pandas.Series` with :class:`datetime64` dtype):
+    (:class:`Timestamp` or :class:`~modin.pandas.Series` with :class:`datetime64` dtype):
 
     - when any input element is before :const:`Timestamp.min` or after
       :const:`Timestamp.max`, see `timestamp limitations
@@ -1673,7 +1673,7 @@ def to_datetime(
       #timeseries-timestamp-limits>`_.
 
     - when ``utc=False`` (default) and the input is an array-like or
-      :class:`~snowflake.snowpark.modin.pandas.Series` containing mixed naive/aware datetime, or aware with mixed
+      :class:`~modin.pandas.Series` containing mixed naive/aware datetime, or aware with mixed
       time offsets. Note that this happens in the (quite frequent) situation when
       the timezone has a daylight savings policy. In that case you may wish to
       use ``utc=True``.
@@ -1683,7 +1683,7 @@ def to_datetime(
 
     **Handling various input formats**
 
-    Assembling a datetime from multiple columns of a :class:`~snowflake.snowpark.modin.pandas.DataFrame`. The keys
+    Assembling a datetime from multiple columns of a :class:`~modin.pandas.DataFrame`. The keys
     can be common abbreviations like ['year', 'month', 'day', 'minute', 'second',
     'ms', 'us', 'ns']) or plurals of the same
 
@@ -1744,7 +1744,7 @@ def to_datetime(
 
     The default behaviour (``utc=False``) is as follows:
 
-    - Timezone-naive inputs are kept as timezone-naive :class:`~snowflake.snowpark.modin.pandas.DatetimeIndex`:
+    - Timezone-naive inputs are kept as timezone-naive :class:`~modin.pandas.DatetimeIndex`:
 
     >>> pd.to_datetime(['2018-10-26 12:00:00', '2018-10-26 13:00:15'])
     DatetimeIndex(['2018-10-26 12:00:00', '2018-10-26 13:00:15'], dtype='datetime64[ns]', freq=None)
@@ -1844,7 +1844,7 @@ def get_dummies(
 
     Parameters
     ----------
-    data : array-like, Series, or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    data : array-like, Series, or :class:`~modin.pandas.DataFrame`
         Data of which to get dummy indicators.
     prefix : str, list of str, or dict of str, default None
         String to append DataFrame column names.
@@ -1873,7 +1873,7 @@ def get_dummies(
 
     Returns
     -------
-    :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    :class:`~modin.pandas.DataFrame`
         Dummy-coded data.
 
     Examples
@@ -1942,7 +1942,7 @@ def melt(
 
     Returns
     -------
-    :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    :class:`~modin.pandas.DataFrame`
         unpivoted on the value columns
 
     Examples
@@ -2034,7 +2034,7 @@ def crosstab(
 
     Returns
     -------
-    Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+    Snowpark pandas :class:`~modin.pandas.DataFrame`
         Cross tabulation of the data.
 
     Notes

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -517,7 +517,7 @@ class BasePandasDataset:
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series`
+        Snowpark pandas :class:`~modin.pandas.DataFrame` or Snowpark pandas :class:`~modin.pandas.Series`
 
         Notes
         -----
@@ -585,7 +585,7 @@ class BasePandasDataset:
 
         Returns
         -------
-        same type as caller (Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series`)
+        same type as caller (Snowpark pandas :class:`~modin.pandas.DataFrame` or Snowpark pandas :class:`~modin.pandas.Series`)
 
         Examples
         --------
@@ -695,7 +695,7 @@ class BasePandasDataset:
 
         Returns
         -------
-        copy : Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        copy : Snowpark pandas :class:`~modin.pandas.Series` or Snowpark pandas :class:`~modin.pandas.DataFrame`
             Object type matches caller.
 
         Examples
@@ -753,7 +753,7 @@ class BasePandasDataset:
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series`
+        Snowpark pandas :class:`~modin.pandas.Series`
             For each column/row the number of non-NA/null entries.
 
         See Also

--- a/src/snowflake/snowpark/modin/plugin/docstrings/base.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/base.py
@@ -1511,8 +1511,6 @@ class BasePandasDataset:
         >>> df.iloc[[0]]
            a  b  c  d
         0  1  2  3  4
-        >>> type(df.iloc[[0]])
-        <class 'snowflake.snowpark.modin.pandas.dataframe.DataFrame'>
 
         >>> df.iloc[[0, 1]]
              a    b    c    d

--- a/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/dataframe.py
@@ -626,9 +626,9 @@ class DataFrame(BasePandasDataset):
 
         See Also
         --------
-        :func:`Series.apply <snowflake.snowpark.modin.pandas.Series.apply>` : For applying more complex functions on a Series.
+        :func:`Series.apply <modin.pandas.Series.apply>` : For applying more complex functions on a Series.
 
-        :func:`DataFrame.apply <snowflake.snowpark.modin.pandas.DataFrame.apply>` : Apply a function row-/column-wise.
+        :func:`DataFrame.apply <modin.pandas.DataFrame.apply>` : Apply a function row-/column-wise.
 
         Examples
         --------
@@ -775,9 +775,9 @@ class DataFrame(BasePandasDataset):
 
         See Also
         --------
-        :func:`Series.apply <snowflake.snowpark.modin.pandas.Series.apply>` : For applying more complex functions on a Series.
+        :func:`Series.apply <modin.pandas.Series.apply>` : For applying more complex functions on a Series.
 
-        :func:`DataFrame.applymap <snowflake.snowpark.modin.pandas.DataFrame.applymap>` : Apply a function elementwise on a whole DataFrame.
+        :func:`DataFrame.applymap <modin.pandas.DataFrame.applymap>` : Apply a function elementwise on a whole DataFrame.
 
         Notes
         -----
@@ -1307,7 +1307,7 @@ class DataFrame(BasePandasDataset):
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.DataFrame`
             The result of the comparison.
 
 
@@ -2679,7 +2679,7 @@ class DataFrame(BasePandasDataset):
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.DataFrame`
 
         Notes
         -----
@@ -4458,7 +4458,7 @@ class DataFrame(BasePandasDataset):
 
         See Also
         --------
-        :func:`Series.value_counts <snowflake.snowpark.modin.pandas.Series.value_counts>` : Equivalent method on Series.
+        :func:`Series.value_counts <modin.pandas.Series.value_counts>` : Equivalent method on Series.
 
         Notes
         -----

--- a/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
@@ -40,7 +40,7 @@ engine_kwargs : dict, default None {ek}
 
 Returns
 -------
-:class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+:class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
     Computed {fname} of values within each group.
 
 Examples
@@ -232,7 +232,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Series if the groupby as_index is True, otherwise DataFrame.
 
         Notes
@@ -333,7 +333,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
 
         Examples
         --------
@@ -707,7 +707,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Object shifted within each group.
 
         Examples
@@ -762,7 +762,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
 
         See also
         --------
@@ -857,7 +857,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
 
         See also
         --------
@@ -935,7 +935,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
 
         See Also
         --------
@@ -1034,7 +1034,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
 
         See also
         --------
@@ -1120,7 +1120,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Standard deviation of values within each group.
 
         Examples
@@ -1241,7 +1241,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame` with ranking of values within each group
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame` with ranking of values within each group
 
         Examples
         --------
@@ -1343,7 +1343,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Variance of values within each group.
 
         Examples
@@ -1651,7 +1651,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Median of values within each group.
 
         Examples
@@ -1709,7 +1709,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Subset of the original Series or DataFrame as determined by n.
 
         See also
@@ -1893,7 +1893,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Count of values within each group.
 
         Examples
@@ -2002,7 +2002,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Subset of the original Series or DataFrame as determined by n.
 
         See also
@@ -2092,7 +2092,7 @@ class DataFrameGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Return type determined by caller of GroupBy object.
         """
 
@@ -2244,5 +2244,5 @@ class SeriesGroupBy:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series`
+        :class:`~modin.pandas.Series`
         """

--- a/src/snowflake/snowpark/modin/plugin/docstrings/resample.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/resample.py
@@ -170,7 +170,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             A DataFrame with values forward filled for missing resample bins.
 
         Examples
@@ -300,7 +300,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             An upsampled Series or DataFrame with backward filled NaN values.
 
         Examples
@@ -357,7 +357,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             An upsampled Series or DataFrame with missing values filled.
 
         Examples
@@ -417,7 +417,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed count of values within each resample bin.
 
         Examples
@@ -494,7 +494,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             First values within each group.
 
         Examples
@@ -568,7 +568,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Last values within each group.
 
         Examples
@@ -643,7 +643,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed maximum of values within each resample bin.
 
         Examples
@@ -729,7 +729,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed mean of values within each resample bin.
 
         Examples
@@ -822,7 +822,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed median of values within each resample bin.
 
         Examples
@@ -897,7 +897,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed minimum of values within each resample bin.
 
         Examples
@@ -967,7 +967,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Number of rows in each group as a Series if ``as_index`` is True or a DataFrame if ``as_index`` is False.
 
         Examples
@@ -1049,7 +1049,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed standard deviation of values within each resample bin.
 
         Examples
@@ -1124,7 +1124,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed sum of values within each resample bin.
 
         Examples
@@ -1203,7 +1203,7 @@ class Resampler:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed variance of values within each resample bin.
 
         Examples

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -558,7 +558,7 @@ class Series(BasePandasDataset):
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or None
+        Snowpark pandas :class:`~modin.pandas.Series` or None
             Series with specified index labels removed or None if ``inplace=True``.
 
         Raises
@@ -672,17 +672,17 @@ class Series(BasePandasDataset):
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        Snowpark pandas :class:`~modin.pandas.Series` or Snowpark pandas :class:`~modin.pandas.DataFrame`
             If func returns a Series object the result will be a DataFrame.
 
 
         See Also
         --------
-        :func:`Series.map <snowflake.snowpark.modin.pandas.Series.map>` : For applying more complex functions on a Series.
+        :func:`Series.map <modin.pandas.Series.map>` : For applying more complex functions on a Series.
 
-        :func:`DataFrame.apply <snowflake.snowpark.modin.pandas.DataFrame.apply>` : Apply a function row-/column-wise.
+        :func:`DataFrame.apply <modin.pandas.DataFrame.apply>` : Apply a function row-/column-wise.
 
-        :func:`DataFrame.applymap <snowflake.snowpark.modin.pandas.DataFrame.applymap>` : Apply a function elementwise on a whole DataFrame.
+        :func:`DataFrame.applymap <modin.pandas.DataFrame.applymap>` : Apply a function elementwise on a whole DataFrame.
 
         Notes
         -----
@@ -702,7 +702,7 @@ class Series(BasePandasDataset):
         When no type annotation is provided and Variant data is returned, Python ``None`` is translated to
         JSON NULL, and all other pandas missing values (np.nan, pd.NA, pd.NaT) are translated to SQL NULL.
 
-        4. For working with 3rd-party-packages see :func:`DataFrame.apply <snowflake.snowpark.modin.pandas.DataFrame.apply>`.
+        4. For working with 3rd-party-packages see :func:`DataFrame.apply <modin.pandas.DataFrame.apply>`.
         """
 
     def argmax():
@@ -840,7 +840,7 @@ class Series(BasePandasDataset):
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or Snowpark pandas :class:`~modin.pandas.DataFrame`
             If axis is 0 or 'index' the result will be a Series.
             The resulting index will be a MultiIndex with 'self' and 'other'
             stacked alternately at the inner level.
@@ -967,8 +967,8 @@ class Series(BasePandasDataset):
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series`
-            Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` with the first differences of the Series.
+        Snowpark pandas :class:`~modin.pandas.Series`
+            Snowpark pandas :class:`~modin.pandas.Series` with the first differences of the Series.
 
         Notes
         -----
@@ -1101,7 +1101,7 @@ class Series(BasePandasDataset):
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or None
+        Snowpark pandas :class:`~modin.pandas.Series` or None
             Series with NA entries dropped from it or None if ``inplace=True``.
 
         See Also
@@ -1177,7 +1177,7 @@ class Series(BasePandasDataset):
         Returns
         -------
         Snowpark pandas Series[bool]
-            Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` indicating whether each value has occurred
+            Snowpark pandas :class:`~modin.pandas.Series` indicating whether each value has occurred
             in the preceding values.
 
         See Also
@@ -1776,11 +1776,11 @@ class Series(BasePandasDataset):
 
         See Also
         --------
-        :func:`Series.apply <snowflake.snowpark.modin.pandas.Series.apply>` : For applying more complex functions on a Series.
+        :func:`Series.apply <modin.pandas.Series.apply>` : For applying more complex functions on a Series.
 
-        :func:`DataFrame.apply <snowflake.snowpark.modin.pandas.DataFrame.apply>` : Apply a function row-/column-wise.
+        :func:`DataFrame.apply <modin.pandas.DataFrame.apply>` : Apply a function row-/column-wise.
 
-        :func:`DataFrame.applymap <snowflake.snowpark.modin.pandas.DataFrame.applymap>` : Apply a function elementwise on a whole DataFrame.
+        :func:`DataFrame.applymap <modin.pandas.DataFrame.applymap>` : Apply a function elementwise on a whole DataFrame.
 
         Notes
         -----
@@ -2180,7 +2180,7 @@ class Series(BasePandasDataset):
 
         Returns
         -------
-        Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        Snowpark pandas :class:`~modin.pandas.DataFrame`
 
         Notes
         -----

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py
@@ -38,7 +38,7 @@ class StringMethods:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series`, Index, :class:`~snowflake.snowpark.modin.pandas.DataFrame` or MultiIndex
+        :class:`~modin.pandas.Series`, Index, :class:`~modin.pandas.DataFrame` or MultiIndex
             Type matches caller unless expand=True (see Notes).
 
         See also
@@ -1527,7 +1527,7 @@ class CombinedDatetimelikeProperties:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.DataFrame`
             With columns year, week, and day.
 
         Examples

--- a/src/snowflake/snowpark/modin/plugin/docstrings/shared_docs.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/shared_docs.py
@@ -38,15 +38,15 @@ func : function, str, list or dict
 
 Returns
 -------
-scalar, Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+scalar, Snowpark pandas :class:`~modin.pandas.Series` or Snowpark pandas :class:`~modin.pandas.DataFrame`
 
     The return can be:
 
     * scalar : when Snowpark pandas Series.agg is called with single function
-    * Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` : when Snowpark pandas DataFrame.agg is called with a single function
-    * Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame` : when Snowpark pandas DataFrame.agg is called with several functions
+    * Snowpark pandas :class:`~modin.pandas.Series` : when Snowpark pandas DataFrame.agg is called with a single function
+    * Snowpark pandas :class:`~modin.pandas.DataFrame` : when Snowpark pandas DataFrame.agg is called with several functions
 
-    Return scalar, Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.Series` or Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`.
+    Return scalar, Snowpark pandas :class:`~modin.pandas.Series` or Snowpark pandas :class:`~modin.pandas.DataFrame`.
 
 Notes
 -----

--- a/src/snowflake/snowpark/modin/plugin/docstrings/window.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/window.py
@@ -39,7 +39,7 @@ engine_kwargs : dict, default None {ek}
 
 Returns
 -------
-:class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+:class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
     Computed {win_type} {fname} of values.
 
 Examples
@@ -70,9 +70,9 @@ Returns
 -------
 Scalar
     Case when `Series.agg` is called with a single function.
-:class:`~snowflake.snowpark.modin.pandas.Series`
+:class:`~modin.pandas.Series`
     Case when `DataFrame.agg` is called with a single function.
-:class:`~snowflake.snowpark.modin.pandas.DataFrame`
+:class:`~modin.pandas.DataFrame`
     Case when `DataFrame.agg` is called with several functions.
 
 {examples}
@@ -128,7 +128,7 @@ class Rolling:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed rolling count of values.
 
         Examples
@@ -540,7 +540,7 @@ class Rolling:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Return type is the same as the original object with np.float64 dtype.
 
         Examples
@@ -570,7 +570,7 @@ class Expanding:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Computed expanding count of values.
 
         Examples
@@ -827,7 +827,7 @@ class Expanding:
 
         Returns
         -------
-        :class:`~snowflake.snowpark.modin.pandas.Series` or :class:`~snowflake.snowpark.modin.pandas.DataFrame`
+        :class:`~modin.pandas.Series` or :class:`~modin.pandas.DataFrame`
             Return type is the same as the original object with np.float64 dtype.
 
         Examples

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -58,9 +58,9 @@ def to_snowflake(
             types `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
 
     See also:
-        - :func:`to_snowflake <modin.pandas.io.to_snowflake>`
+        - :func:`to_snowflake <snowflake.snowpark.modin.pandas.to_snowflake>`
         - :func:`Series.to_snowflake <modin.pandas.Series.to_snowflake>`
-        - :func:`read_snowflake <modin.pandas.io.read_snowflake>`
+        - :func:`read_snowflake <snowflake.snowpark.modin.pandas.read_snowflake>`
 
     """
     self._query_compiler.to_snowflake(name, if_exists, index, index_label, table_type)
@@ -97,13 +97,13 @@ def to_snowpark(
          ValueError if the label used for a index or data column is None.
 
     See also:
-        - :func:`to_snowpark <modin.pandas.io.to_snowpark>`
+        - :func:`to_snowpark <snowflake.snowpark.modin.pandas.to_snowpark>`
         - :func:`Series.to_snowpark <modin.pandas.Series.to_snowpark>`
 
     Note:
         The labels of the Snowpark pandas DataFrame or index_label provided will be used as Normalized Snowflake
         Identifiers of the Snowpark DataFrame.
-        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~modin.pandas.io.read_snowflake`
+        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.read_snowflake`
 
     Examples::
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -58,9 +58,9 @@ def to_snowflake(
             types `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
 
     See also:
-        - :func:`to_snowflake <snowflake.snowpark.modin.pandas.io.to_snowflake>`
-        - :func:`Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>`
-        - :func:`read_snowflake <snowflake.snowpark.modin.pandas.io.read_snowflake>`
+        - :func:`to_snowflake <modin.pandas.io.to_snowflake>`
+        - :func:`Series.to_snowflake <modin.pandas.Series.to_snowflake>`
+        - :func:`read_snowflake <modin.pandas.io.read_snowflake>`
 
     """
     self._query_compiler.to_snowflake(name, if_exists, index, index_label, table_type)
@@ -97,13 +97,13 @@ def to_snowpark(
          ValueError if the label used for a index or data column is None.
 
     See also:
-        - :func:`to_snowpark <snowflake.snowpark.modin.pandas.io.to_snowpark>`
-        - :func:`Series.to_snowpark <snowflake.snowpark.modin.pandas.Series.to_snowpark>`
+        - :func:`to_snowpark <modin.pandas.io.to_snowpark>`
+        - :func:`Series.to_snowpark <modin.pandas.Series.to_snowpark>`
 
     Note:
         The labels of the Snowpark pandas DataFrame or index_label provided will be used as Normalized Snowflake
         Identifiers of the Snowpark DataFrame.
-        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.io.read_snowflake`
+        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~modin.pandas.io.read_snowflake`
 
     Examples::
 
@@ -217,8 +217,8 @@ def to_pandas(
         pandas DataFrame
 
     See also:
-        - :func:`to_pandas <snowflake.snowpark.modin.pandas.io.to_pandas>`
-        - :func:`Series.to_pandas <snowflake.snowpark.modin.pandas.Series.to_pandas>`
+        - :func:`to_pandas <modin.pandas.io.to_pandas>`
+        - :func:`Series.to_pandas <modin.pandas.Series.to_pandas>`
 
     Examples:
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -41,12 +41,12 @@ def read_snowflake(
         columns: A list of column names to select from the table. If not specified, select all columns.
 
     See also:
-        - :func:`to_snowflake <snowflake.snowpark.modin.pandas.io.to_snowflake>`
+        - :func:`to_snowflake <snowflake.snowpark.modin.pandas.to_snowflake>`
 
     Notes:
         Transformations applied to the returned Snowpark pandas Dataframe do not affect the underlying Snowflake table
         (or object). Use
-        - :func:`snowflake.snowpark.modin.pandas.to_snowpark <snowflake.snowpark.modin.pandas.io.to_snowflake>`
+        - :func:`modin.pandas.to_snowpark <snowflake.snowpark.modin.pandas.to_snowpark>`
         to write the Snowpark pandas DataFrame back to a Snowpark table.
 
         This API supports table names, SELECT queries (including those that use CTEs), CTEs with anonymous stored procedures
@@ -398,9 +398,9 @@ def to_snowflake(
             types `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
 
     See also:
-        - :func:`DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>`
-        - :func:`Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>`
-        - :func:`read_snowflake <snowflake.snowpark.modin.pandas.io.read_snowflake>`
+        - :func:`DataFrame.to_snowflake <modin.pandas.DataFrame.to_snowflake>`
+        - :func:`Series.to_snowflake <modin.pandas.Series.to_snowflake>`
+        - :func:`read_snowflake <snowflake.snowpark.modin.pandas.read_snowflake>`
     """
     _snowpark_pandas_obj_check(obj)
 
@@ -444,13 +444,13 @@ def to_snowpark(
 
     See also:
         - :func:`Snowpark.DataFrame.to_snowpark_pandas <snowflake.snowpark.DataFrame.to_snowpark_pandas>`
-        - :func:`DataFrame.to_snowpark <snowflake.snowpark.modin.pandas.DataFrame.to_snowpark>`
-        - :func:`Series.to_snowpark <snowflake.snowpark.modin.pandas.Series.to_snowpark>`
+        - :func:`DataFrame.to_snowpark <modin.pandas.DataFrame.to_snowpark>`
+        - :func:`Series.to_snowpark <modin.pandas.Series.to_snowpark>`
 
     Note:
         The labels of the Snowpark pandas DataFrame or index_label provided will be used as Normalized Snowflake
         Identifiers of the Snowpark DataFrame.
-        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.io.read_snowflake`
+        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.read_snowflake`
 
     Examples::
 
@@ -578,8 +578,8 @@ def to_pandas(
         pandas DataFrame or Series
 
     See also:
-        - :func:`DataFrame.to_pandas <snowflake.snowpark.modin.pandas.DataFrame.to_pandas>`
-        - :func:`Series.to_pandas <snowflake.snowpark.modin.pandas.Series.to_pandas>`
+        - :func:`DataFrame.to_pandas <modin.pandas.DataFrame.to_pandas>`
+        - :func:`Series.to_pandas <modin.pandas.Series.to_pandas>`
 
     Examples:
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -54,10 +54,9 @@ def to_snowflake(
             types `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
 
     See Also:
-        - :func:`to_snowflake <snowflake.snowpark.modin.pandas.io.to_snowflake>`
-        - :func:`DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>`
-        - :func:`read_snowflake <snowflake.snowpark.modin.pandas.io.read_snowflake>`
-
+        - :func:`to_snowflake <snowflake.snowpark.modin.pandas.to_snowflake>`
+        - :func:`DataFrame.to_snowflake <modin.pandas.DataFrame.to_snowflake>`
+        - :func:`read_snowflake <snowflake.snowpark.modin.pandas.read_snowflake>`
     """
     self._query_compiler.to_snowflake(name, if_exists, index, index_label, table_type)
 
@@ -93,13 +92,13 @@ def to_snowpark(
          ValueError if the label used for a index or data column is None.
 
     See also:
-        - :func:`to_snowpark <snowflake.snowpark.modin.pandas.io.to_snowpark>`
-        - :func:`Series.to_snowpark <snowflake.snowpark.modin.pandas.Series.to_snowpark>`
+        - :func:`to_snowpark <modin.pandas.io.to_snowpark>`
+        - :func:`Series.to_snowpark <modin.pandas.Series.to_snowpark>`
 
     Note:
         The labels of the Snowpark pandas DataFrame or index_label provided will be used as Normalized Snowflake
         Identifiers of the Snowpark DataFrame.
-        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.io.read_snowflake`
+        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~modin.pandas.io.read_snowflake`
 
     Examples::
 
@@ -187,8 +186,8 @@ def to_pandas(
         statement_params: Dictionary of statement level parameters to be set while executing this action.
 
     See Also:
-        - :func:`to_pandas <snowflake.snowpark.modin.pandas.io.to_pandas>`
-        - :func:`DataFrame.to_pandas <snowflake.snowpark.modin.pandas.DataFrame.to_pandas>`
+        - :func:`to_pandas <snowflake.snowpark.modin.pandas.to_pandas>`
+        - :func:`DataFrame.to_pandas <modin.pandas.DataFrame.to_pandas>`
 
     Returns:
         pandas Series

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -92,13 +92,13 @@ def to_snowpark(
          ValueError if the label used for a index or data column is None.
 
     See also:
-        - :func:`to_snowpark <modin.pandas.io.to_snowpark>`
+        - :func:`to_snowpark <snowflake.snowpark.modin.pandas.to_snowpark>`
         - :func:`Series.to_snowpark <modin.pandas.Series.to_snowpark>`
 
     Note:
         The labels of the Snowpark pandas DataFrame or index_label provided will be used as Normalized Snowflake
         Identifiers of the Snowpark DataFrame.
-        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~modin.pandas.io.read_snowflake`
+        For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.read_snowflake`
 
     Examples::
 

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -233,7 +233,7 @@ class PandasOnSnowflakeIO(BaseIO):
         Note:
              The labels of the Snowpark pandas DataFrame/Series or index_label provided will be used as Normalized Snowflake
              Identifiers of the Snowpark DataFrame.
-             For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~snowflake.snowpark.modin.pandas.io.read_snowflake`
+             For details about Normalized Snowflake Identifiers, please refer to the Note in :func:`~modin.pandas.read_snowflake`
         """
         return cls.query_compiler_cls.to_snowpark(
             index, index_label

--- a/src/snowflake/snowpark/modin/utils.py
+++ b/src/snowflake/snowpark/modin/utils.py
@@ -1180,7 +1180,7 @@ def doc_replace_dataframe_with_link(_obj: Any, doc: str) -> str:
     """
     return re.sub(
         r"(?<=\s)DataFrame(?=[\s,])",
-        ":class:`~snowflake.snowpark.modin.pandas.DataFrame`",
+        ":class:`~modin.pandas.DataFrame`",
         doc,
     )
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -19,7 +19,18 @@ from functools import reduce
 from logging import getLogger
 from threading import RLock
 from types import ModuleType
-from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import cloudpickle
 import pkg_resources
@@ -174,6 +185,9 @@ from snowflake.snowpark.types import (
 from snowflake.snowpark.udaf import UDAFRegistration
 from snowflake.snowpark.udf import UDFRegistration
 from snowflake.snowpark.udtf import UDTFRegistration
+
+if TYPE_CHECKING:
+    import modin.pandas  # pragma: no cover
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
@@ -2300,8 +2314,8 @@ class Session:
     def _write_modin_pandas_helper(
         self,
         df: Union[
-            "snowflake.snowpark.modin.pandas.DataFrame",  # noqa: F821
-            "snowflake.snowpark.modin.pandas.Series",  # noqa: F821
+            "modin.pandas.DataFrame",  # noqa: F821
+            "modin.pandas.Series",  # noqa: F821
         ],
         table_name: str,
         location: str,
@@ -2315,8 +2329,8 @@ class Session:
         table_type: Literal["", "temp", "temporary", "transient"] = "",
     ) -> None:
         """A helper method used by `write_pandas` to write Snowpark pandas DataFrame or Series to a table by using
-        :func:`snowflake.snowpark.modin.pandas.DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>` or
-        :func:`snowflake.snowpark.modin.pandas.Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>` internally
+        :func:`modin.pandas.DataFrame.to_snowflake <modin.pandas.DataFrame.to_snowflake>` or
+        :func:`modin.pandas.Series.to_snowflake <modin.pandas.Series.to_snowflake>` internally
 
         Args:
             df: The Snowpark pandas DataFrame or Series we'd like to write back.
@@ -2377,8 +2391,8 @@ class Session:
         self,
         df: Union[
             "pandas.DataFrame",
-            "snowflake.snowpark.modin.pandas.DataFrame",  # noqa: F821
-            "snowflake.snowpark.modin.pandas.Series",  # noqa: F821
+            "modin.pandas.DataFrame",  # noqa: F821
+            "modin.pandas.Series",  # noqa: F821
         ],
         table_name: str,
         *,
@@ -2472,10 +2486,10 @@ class Session:
             your pandas DataFrame cannot be written to the specified table, an
             exception will be raised.
 
-            If the dataframe is Snowpark pandas :class:`~snowflake.snowpark.modin.pandas.DataFrame`
-            or :class:`~snowflake.snowpark.modin.pandas.Series`, it will call
-            :func:`modin.pandas.DataFrame.to_snowflake <snowflake.snowpark.modin.pandas.DataFrame.to_snowflake>`
-            or :func:`modin.pandas.Series.to_snowflake <snowflake.snowpark.modin.pandas.Series.to_snowflake>`
+            If the dataframe is Snowpark pandas :class:`~modin.pandas.DataFrame`
+            or :class:`~modin.pandas.Series`, it will call
+            :func:`modin.pandas.DataFrame.to_snowflake <modin.pandas.DataFrame.to_snowflake>`
+            or :func:`modin.pandas.Series.to_snowflake <modin.pandas.Series.to_snowflake>`
             internally to write a Snowpark pandas DataFrame into a Snowflake table.
         """
         if isinstance(self._conn, MockServerConnection):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1658008

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

This PR updates type annotation and documentation paths referencing Snowpark pandas objects. Notably, `snowflake.snowpark.modin.pandas.Series`/`DataFrame` are now referenced by `modin.pandas.Series`/`DataFrame`.

In Snowpark session + DataFrame objects: functions that reference Snowpark pandas objects now refer to `modin.pandas`, with the import guarded by the `TYPE_CHECKING` variable. This should not affect any Snowpark non-pandas users.

In Snowpark pandas, references to `snowflake.snowpark.modin.pandas.io.*` were not generating correctly; these have been edited to `snowflake.snowpark.modin.pandas.*`. Removing the `snowflake.snowpark` prefix from these does not currently work; I will investigate why after GA.