### PR TITLE
Improve warning message for read_snowflake to include materialization reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,12 +109,14 @@
 
 #### Improvements
 
+- Improve concat, join performance when operations are performed on series coming from the same dataframe by avoiding unnecessary joins.
 - Refactored `quoted_identifier_to_snowflake_type` to avoid making metadata queries if the types have been cached locally.
 - Improved `pd.to_datetime` to handle all local input cases. 
 - Create a lazy index from another lazy index without pulling data to client.
 - Raised `NotImplementedError` for Index bitwise operators.
 - Display a clearer error message when `Index.names` is set to a non-like-like object.
 - Raise a warning whenever MultiIndex values are pulled in locally.
+- Improve warning message for `pd.read_snowflake` include the creation reason when temp table creation is triggered.
 
 #### Bug Fixes
 
@@ -129,9 +131,6 @@
 
 - When calling `DataFrame.set_index`, or setting `DataFrame.index` or `Series.index`, with a new index that does not match the current length of the `Series`/`DataFrame` object, a `ValueError` is no longer raised. When the `Series`/`DataFrame` object is longer than the new index, the `Series`/`DataFrame`'s new index is filled with `NaN` values for the "extra" elements. When the `Series`/`DataFrame` object is shorter than the new index, the extra values in the new index are ignored—`Series` and `DataFrame` stay the same length `n`, and use only the first `n` values of the new index.
 
-#### Improvements
-
-- Improve concat, join performance when operations are performed on series coming from the same dataframe by avoiding unnecessary joins.
 
 ## 1.21.0 (2024-08-19)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -265,8 +265,9 @@ def _create_read_only_table(
         temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
 
         _logger.warning(
-            f"Data from source table/view '{table_name}' is being copied into a new "
-            f"temporary table '{temp_table_name}'. DataFrame creation might take some time."
+            f"Snapshot source table/view '{table_name}' failed due to reason: `{materialization_reason}'. Data from "
+            f"source table/view '{table_name}' is being copied into a new "
+            f"temporary table '{temp_table_name}' for snapshotting. DataFrame creation might take some time."
         )
 
         statement_params = get_default_snowpark_pandas_statement_params()

--- a/tests/integ/modin/io/test_read_snowflake.py
+++ b/tests/integ/modin/io/test_read_snowflake.py
@@ -362,10 +362,12 @@ def test_read_snowflake_with_views(
             with caplog.at_level(logging.WARNING):
                 df = call_read_snowflake(table_name, as_query)
             assert df.columns.tolist() == ["COL1", "S"]
+            failing_reason = "SQL compilation error: Cannot clone from a view object"
             materialize_log = f"Data from source table/view '{table_name}' is being copied into a new temporary table"
             if table_type in ["view", "SECURE VIEW", "TEMP VIEW"]:
                 # verify temporary table is materialized for view, secure view and temp view
                 assert materialize_log in caplog.text
+                assert failing_reason in caplog.text
             else:
                 # verify no temporary table is materialized for regular table
                 assert not (materialize_log in caplog.text)


### PR DESCRIPTION
1. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

2. Please describe how your code solves the related issue.
read_snowflake will trigger table materialization under cases for hybrid table, iceberg table etc. include the reason inside the warning message to make the reason more clear to users