### PR TITLE
SNOW-1641472 Refactor binary ops utility to improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,6 @@
 - Display a clearer error message when `Index.names` is set to a non-like-like object.
 - Raise a warning whenever MultiIndex values are pulled in locally.
 - Improve warning message for `pd.read_snowflake` include the creation reason when temp table creation is triggered.
-- Improved readability for binary operation utility code.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - Display a clearer error message when `Index.names` is set to a non-like-like object.
 - Raise a warning whenever MultiIndex values are pulled in locally.
 - Improve warning message for `pd.read_snowflake` include the creation reason when temp table creation is triggered.
+- Improved readability for binary operation utility code.
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/binary_op_utils.py
@@ -5,6 +5,7 @@ import functools
 from collections.abc import Hashable
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import Set, Type
 
 import numpy as np
 import pandas as native_pd
@@ -185,19 +186,6 @@ def compute_power_between_snowpark_columns(
     return result
 
 
-def is_binary_op_supported(op: str) -> bool:
-    """
-    check whether binary operation is mappable to Snowflake
-    Args
-        op: op as string
-
-    Returns:
-        True if binary operation can be mapped to Snowflake/Snowpark, else False
-    """
-
-    return op in SUPPORTED_BINARY_OPERATIONS
-
-
 def _compute_subtraction_between_snowpark_timestamp_columns(
     first_operand: SnowparkColumn,
     first_datatype: DataType,
@@ -312,314 +300,527 @@ def _op_is_between_timedelta_and_numeric(
     )
 
 
-def compute_binary_op_between_snowpark_columns(
-    op: str,
-    first_operand: SnowparkColumn,
-    first_datatype: DataTypeGetter,
-    second_operand: SnowparkColumn,
-    second_datatype: DataTypeGetter,
-) -> SnowparkPandasColumn:
-    """
-    Compute pandas binary operation for two SnowparkColumns
-    Args:
-        op: pandas operation
-        first_operand: SnowparkColumn for lhs
-        first_datatype: Callable for Snowpark Datatype for lhs
-        second_operand: SnowparkColumn for rhs
-        second_datatype: Callable for Snowpark DateType for rhs
-        it is not needed.
+class BinaryOp:
+    def __init__(
+        self,
+        op: str,
+        first_operand: SnowparkColumn,
+        first_datatype: DataTypeGetter,
+        second_operand: SnowparkColumn,
+        second_datatype: DataTypeGetter,
+    ) -> None:
+        self.op = op
+        self.first_operand = first_operand
+        self.first_datatype = first_datatype
+        self.second_operand = second_operand
+        self.second_datatype = second_datatype
+        self.result_column = None
+        self.result_snowpark_pandas_type = None
 
-    Returns:
-        SnowparkPandasColumn for translated pandas operation
-    """
-    if op in _RIGHT_BINARY_OP_TO_LEFT_BINARY_OP:
-        # Normalize right-sided binary operations to the equivalent left-sided
-        # operations with swapped operands. For example, rsub(col(a), col(b))
-        # becomes sub(col(b), col(a))
-        op, first_operand, first_datatype, second_operand, second_datatype = (
-            _RIGHT_BINARY_OP_TO_LEFT_BINARY_OP[op],
-            second_operand,
-            second_datatype,
-            first_operand,
-            first_datatype,
-        )
+    @staticmethod
+    def is_binary_op_supported(op: str) -> bool:
+        """
+        check whether binary operation is mappable to Snowflake
+        Args
+            op: op as string
 
-    binary_op_result_column = None
-    snowpark_pandas_type = None
+        Returns:
+            True if binary operation can be mapped to Snowflake/Snowpark, else False
+        """
 
-    # some operators and the data types have to be handled specially to align with pandas
-    # However, it is difficult to fail early if the arithmetic operator is not compatible
-    # with the data type, so we just let the server raise exception (e.g. a string minus a string).
-    if (
-        op == "add"
-        and isinstance(second_datatype(), TimedeltaType)
-        and isinstance(first_datatype(), TimestampType)
-    ):
-        binary_op_result_column = dateadd("ns", second_operand, first_operand)
-    elif (
-        op == "add"
-        and isinstance(first_datatype(), TimedeltaType)
-        and isinstance(second_datatype(), TimestampType)
-    ):
-        binary_op_result_column = dateadd("ns", first_operand, second_operand)
-    elif op in (
-        "add",
-        "sub",
-        "eq",
-        "ne",
-        "gt",
-        "ge",
-        "lt",
-        "le",
-        "floordiv",
-        "truediv",
-    ) and (
-        (
-            isinstance(first_datatype(), TimedeltaType)
-            and isinstance(second_datatype(), NullType)
-        )
-        or (
-            isinstance(second_datatype(), TimedeltaType)
-            and isinstance(first_datatype(), NullType)
-        )
-    ):
-        return SnowparkPandasColumn(pandas_lit(None), TimedeltaType())
-    elif (
-        op == "sub"
-        and isinstance(second_datatype(), TimedeltaType)
-        and isinstance(first_datatype(), TimestampType)
-    ):
-        binary_op_result_column = dateadd("ns", -1 * second_operand, first_operand)
-    elif (
-        op == "sub"
-        and isinstance(first_datatype(), TimedeltaType)
-        and isinstance(second_datatype(), TimestampType)
-    ):
-        # Timedelta - Timestamp doesn't make sense. Raise the same error
-        # message as pandas.
-        raise TypeError("bad operand type for unary -: 'DatetimeArray'")
-    elif op == "mod" and _op_is_between_two_timedeltas_or_timedelta_and_null(
-        first_datatype(), second_datatype()
-    ):
-        binary_op_result_column = compute_modulo_between_snowpark_columns(
-            first_operand, first_datatype(), second_operand, second_datatype()
-        )
-        snowpark_pandas_type = TimedeltaType()
-    elif op == "pow" and _op_is_between_two_timedeltas_or_timedelta_and_null(
-        first_datatype(), second_datatype()
-    ):
-        raise TypeError("unsupported operand type for **: Timedelta")
-    elif op == "__or__" and _op_is_between_two_timedeltas_or_timedelta_and_null(
-        first_datatype(), second_datatype()
-    ):
-        raise TypeError("unsupported operand type for |: Timedelta")
-    elif op == "__and__" and _op_is_between_two_timedeltas_or_timedelta_and_null(
-        first_datatype(), second_datatype()
-    ):
-        raise TypeError("unsupported operand type for &: Timedelta")
-    elif (
-        op in ("add", "sub")
-        and isinstance(first_datatype(), TimedeltaType)
-        and isinstance(second_datatype(), TimedeltaType)
-    ):
-        snowpark_pandas_type = TimedeltaType()
-    elif op == "mul" and _op_is_between_two_timedeltas_or_timedelta_and_null(
-        first_datatype(), second_datatype()
-    ):
-        raise np.core._exceptions._UFuncBinaryResolutionError(  # type: ignore[attr-defined]
-            np.multiply, (np.dtype("timedelta64[ns]"), np.dtype("timedelta64[ns]"))
-        )
-    elif op in (
-        "eq",
-        "ne",
-        "gt",
-        "ge",
-        "lt",
-        "le",
-    ) and _op_is_between_two_timedeltas_or_timedelta_and_null(
-        first_datatype(), second_datatype()
-    ):
-        # These operations, when done between timedeltas, work without any
-        # extra handling in `snowpark_pandas_type` or `binary_op_result_column`.
-        pass
-    elif op == "mul" and (
-        _op_is_between_timedelta_and_numeric(first_datatype, second_datatype)
-    ):
-        binary_op_result_column = cast(
-            floor(first_operand * second_operand), LongType()
-        )
-        snowpark_pandas_type = TimedeltaType()
-    # For `eq` and `ne`, note that Snowflake will consider 1 equal to
-    # Timedelta(1) because those two have the same representation in Snowflake,
-    # so we have to compare types in the client.
-    elif op == "eq" and (
-        _op_is_between_timedelta_and_numeric(first_datatype, second_datatype)
-    ):
-        binary_op_result_column = pandas_lit(False)
-    elif op == "ne" and _op_is_between_timedelta_and_numeric(
-        first_datatype, second_datatype
-    ):
-        binary_op_result_column = pandas_lit(True)
-    elif (
-        op in ("truediv", "floordiv")
-        and isinstance(first_datatype(), TimedeltaType)
-        and _is_numeric_non_timedelta_type(second_datatype())
-    ):
-        binary_op_result_column = cast(
-            floor(first_operand / second_operand), LongType()
-        )
-        snowpark_pandas_type = TimedeltaType()
-    elif (
-        op == "mod"
-        and isinstance(first_datatype(), TimedeltaType)
-        and _is_numeric_non_timedelta_type(second_datatype())
-    ):
-        binary_op_result_column = ceil(
-            compute_modulo_between_snowpark_columns(
-                first_operand, first_datatype(), second_operand, second_datatype()
+        return op in SUPPORTED_BINARY_OPERATIONS
+
+    @staticmethod
+    def create(
+        op: str,
+        first_operand: SnowparkColumn,
+        first_datatype: DataTypeGetter,
+        second_operand: SnowparkColumn,
+        second_datatype: DataTypeGetter,
+    ) -> "BinaryOp":
+        def snake_to_camel(snake_str: str) -> str:
+            """Converts a snake case string to camel case."""
+            components = snake_str.split("_")
+            return "".join(x.title() for x in components)
+
+        def get_all_subclasses(cls: Type[BinaryOp]) -> Set[Type[BinaryOp]]:
+            """Gets all subclasses of a given class."""
+            subclasses = set()
+            to_check = [cls]
+
+            while to_check:
+                parent = to_check.pop()
+                for child in parent.__subclasses__():
+                    if child not in subclasses:
+                        subclasses.add(child)
+                        to_check.append(child)
+
+            return subclasses
+
+        if op in _RIGHT_BINARY_OP_TO_LEFT_BINARY_OP:
+            # Normalize right-sided binary operations to the equivalent left-sided
+            # operations with swapped operands. For example, rsub(col(a), col(b))
+            # becomes sub(col(b), col(a))
+            op, first_operand, first_datatype, second_operand, second_datatype = (
+                _RIGHT_BINARY_OP_TO_LEFT_BINARY_OP[op],
+                second_operand,
+                second_datatype,
+                first_operand,
+                first_datatype,
             )
-        )
-        snowpark_pandas_type = TimedeltaType()
-    elif op in ("add", "sub") and (
-        (
-            isinstance(first_datatype(), TimedeltaType)
-            and _is_numeric_non_timedelta_type(second_datatype())
-        )
-        or (
-            _is_numeric_non_timedelta_type(first_datatype())
-            and isinstance(second_datatype(), TimedeltaType)
-        )
-    ):
-        raise TypeError(
-            "Snowpark pandas does not support addition or subtraction between timedelta values and numeric values."
-        )
-    elif op in ("truediv", "floordiv", "mod") and (
-        _is_numeric_non_timedelta_type(first_datatype())
-        and isinstance(second_datatype(), TimedeltaType)
-    ):
-        raise TypeError(
-            "Snowpark pandas does not support dividing numeric values by timedelta values with div (/), mod (%), or floordiv (//)."
-        )
-    elif op in (
-        "add",
-        "sub",
-        "truediv",
-        "floordiv",
-        "mod",
-        "gt",
-        "ge",
-        "lt",
-        "le",
-        "ne",
-        "eq",
-    ) and (
-        (
-            isinstance(first_datatype(), TimedeltaType)
-            and isinstance(second_datatype(), StringType)
-        )
-        or (
-            isinstance(second_datatype(), TimedeltaType)
-            and isinstance(first_datatype(), StringType)
-        )
-    ):
-        # TODO(SNOW-1646604): Support these cases.
-        ErrorMessage.not_implemented(
-            f"Snowpark pandas does not yet support the operation {op} between timedelta and string"
-        )
-    elif op in ("gt", "ge", "lt", "le", "pow", "__or__", "__and__") and (
-        _op_is_between_timedelta_and_numeric(first_datatype, second_datatype)
-    ):
-        raise TypeError(
-            f"Snowpark pandas does not support binary operation {op} between timedelta and a non-timedelta type."
-        )
-    elif op == "floordiv":
-        binary_op_result_column = floor(first_operand / second_operand)
-    elif op == "mod":
-        binary_op_result_column = compute_modulo_between_snowpark_columns(
-            first_operand, first_datatype(), second_operand, second_datatype()
-        )
-    elif op == "pow":
-        binary_op_result_column = compute_power_between_snowpark_columns(
-            first_operand, second_operand
-        )
-    elif op == "__or__":
-        binary_op_result_column = first_operand | second_operand
-    elif op == "__and__":
-        binary_op_result_column = first_operand & second_operand
-    elif (
-        op == "add"
-        and isinstance(second_datatype(), StringType)
-        and isinstance(first_datatype(), StringType)
-    ):
-        # string/string case (only for add)
-        binary_op_result_column = concat(first_operand, second_operand)
-    elif op == "mul" and (
-        (
-            isinstance(second_datatype(), _IntegralType)
-            and isinstance(first_datatype(), StringType)
-        )
-        or (
-            isinstance(second_datatype(), StringType)
-            and isinstance(first_datatype(), _IntegralType)
-        )
-    ):
-        # string/integer case (only for mul/rmul).
-        # swap first_operand with second_operand because
-        # REPEAT(<input>, <n>) expects <input> to be string
-        if isinstance(first_datatype(), _IntegralType):
-            first_operand, second_operand = second_operand, first_operand
 
-        binary_op_result_column = iff(
-            second_operand > pandas_lit(0),
-            repeat(first_operand, second_operand),
-            # Snowflake's repeat doesn't support negative number,
-            # but pandas will return an empty string
-            pandas_lit(""),
+        class_name = f"{snake_to_camel(op)}Op"
+        op_class = None
+        for subclass in get_all_subclasses(BinaryOp):
+            if subclass.__name__ == class_name:
+                op_class = subclass
+        if op_class is None:
+            op_class = BinaryOp
+        return op_class(
+            op, first_operand, first_datatype, second_operand, second_datatype
         )
-    elif op == "equal_null":
+
+    @staticmethod
+    def create_with_fill_value(
+        op: str,
+        lhs: SnowparkColumn,
+        lhs_datatype: DataTypeGetter,
+        rhs: SnowparkColumn,
+        rhs_datatype: DataTypeGetter,
+        fill_value: Scalar,
+    ) -> "BinaryOp":
+        """
+        Helper method for performing binary operations.
+        1. Fills NaN/None values in the lhs and rhs with the given fill_value.
+        2. Computes the binary operation expression for lhs <op> rhs.
+
+        fill_value replaces NaN/None values when only either lhs or rhs is NaN/None, not both lhs and rhs.
+        For instance, with fill_value = 100,
+        1. Given lhs = None and rhs = 10, lhs is replaced with fill_value.
+               result = lhs + rhs => None + 10 => 100 (replaced) + 10 = 110
+        2. Given lhs = 3 and rhs = None, rhs is replaced with fill_value.
+               result = lhs + rhs => 3 + None => 3 + 100 (replaced) = 103
+        3. Given lhs = None and rhs = None, neither lhs nor rhs is replaced since they both are None.
+               result = lhs + rhs => None + None => None.
+
+        Args:
+            op: pandas operation to perform between lhs and rhs
+            lhs: the lhs SnowparkColumn
+            lhs_datatype: Callable for Snowpark Datatype for lhs
+            rhs: the rhs SnowparkColumn
+            rhs_datatype: Callable for Snowpark Datatype for rhs
+            fill_value: Fill existing missing (NaN) values, and any new element needed for
+                successful DataFrame alignment, with this value before computation.
+
+        Returns:
+            SnowparkPandasColumn for translated pandas operation
+        """
+        lhs_cond, rhs_cond = lhs, rhs
+        if fill_value is not None:
+            fill_value_lit = pandas_lit(fill_value)
+            lhs_cond = iff(lhs.is_null() & ~rhs.is_null(), fill_value_lit, lhs)
+            rhs_cond = iff(rhs.is_null() & ~lhs.is_null(), fill_value_lit, rhs)
+
+        return BinaryOp.create(op, lhs_cond, lhs_datatype, rhs_cond, rhs_datatype)
+
+    @staticmethod
+    def create_with_rhs_scalar(
+        op: str,
+        first_operand: SnowparkColumn,
+        datatype: DataTypeGetter,
+        second_operand: Scalar,
+    ) -> "BinaryOp":
+        """
+        Compute the binary operation between a Snowpark column and a scalar.
+        Args:
+            op: the name of binary operation
+            first_operand: The SnowparkColumn for lhs
+            datatype: Callable for Snowpark data type
+            second_operand: Scalar value
+
+        Returns:
+            SnowparkPandasColumn for translated pandas operation
+        """
+
+        def second_datatype() -> DataType:
+            return infer_object_type(second_operand)
+
+        return BinaryOp.create(
+            op, first_operand, datatype, pandas_lit(second_operand), second_datatype
+        )
+
+    @staticmethod
+    def create_with_lhs_scalar(
+        op: str,
+        first_operand: Scalar,
+        second_operand: SnowparkColumn,
+        datatype: DataTypeGetter,
+    ) -> "BinaryOp":
+        """
+        Compute the binary operation between a scalar and a Snowpark column.
+        Args:
+            op: the name of binary operation
+            first_operand: Scalar value
+            second_operand: The SnowparkColumn for rhs
+            datatype: Callable for Snowpark data type
+            it is not needed.
+
+        Returns:
+            SnowparkPandasColumn for translated pandas operation
+        """
+
+        def first_datatype() -> DataType:
+            return infer_object_type(first_operand)
+
+        return BinaryOp.create(
+            op, pandas_lit(first_operand), first_datatype, second_operand, datatype
+        )
+
+    def _custom_compute(self) -> None:
+        """Implement custom compute method if needed."""
+        pass
+
+    def _get_result(self) -> SnowparkPandasColumn:
+        return SnowparkPandasColumn(
+            snowpark_column=self.result_column,
+            snowpark_pandas_type=self.result_snowpark_pandas_type,
+        )
+
+    def _check_timedelta_with_none(self) -> bool:
+        if self.op in (
+            "add",
+            "sub",
+            "eq",
+            "ne",
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "floordiv",
+            "truediv",
+        ) and (
+            (
+                isinstance(self.first_datatype(), TimedeltaType)
+                and isinstance(self.second_datatype(), NullType)
+            )
+            or (
+                isinstance(self.second_datatype(), TimedeltaType)
+                and isinstance(self.first_datatype(), NullType)
+            )
+        ):
+            self.result_column = pandas_lit(None)
+            self.result_snowpark_pandas_type = TimedeltaType()
+            return True
+        return False
+
+    def _check_error(self) -> None:
+        if (
+            self.op == "sub"
+            and isinstance(self.first_datatype(), TimedeltaType)
+            and isinstance(self.second_datatype(), TimestampType)
+        ):
+            # Timedelta - Timestamp doesn't make sense. Raise the same error
+            # message as pandas.
+            raise TypeError("bad operand type for unary -: 'DatetimeArray'")
+
+        elif self.op in "pow" and _op_is_between_two_timedeltas_or_timedelta_and_null(
+            self.first_datatype(), self.second_datatype()
+        ):
+            raise TypeError("unsupported operand type for **: Timedelta")
+        elif (
+            self.op == "__or__"
+            and _op_is_between_two_timedeltas_or_timedelta_and_null(
+                self.first_datatype(), self.second_datatype()
+            )
+        ):
+            raise TypeError("unsupported operand type for |: Timedelta")
+        elif (
+            self.op == "__and__"
+            and _op_is_between_two_timedeltas_or_timedelta_and_null(
+                self.first_datatype(), self.second_datatype()
+            )
+        ):
+            raise TypeError("unsupported operand type for &: Timedelta")
+        elif self.op == "mul" and _op_is_between_two_timedeltas_or_timedelta_and_null(
+            self.first_datatype(), self.second_datatype()
+        ):
+            raise np.core._exceptions._UFuncBinaryResolutionError(  # type: ignore[attr-defined]
+                np.multiply, (np.dtype("timedelta64[ns]"), np.dtype("timedelta64[ns]"))
+            )
+        elif self.op in ("add", "sub") and (
+            (
+                isinstance(self.first_datatype(), TimedeltaType)
+                and _is_numeric_non_timedelta_type(self.second_datatype())
+            )
+            or (
+                _is_numeric_non_timedelta_type(self.first_datatype())
+                and isinstance(self.second_datatype(), TimedeltaType)
+            )
+        ):
+            raise TypeError(
+                "Snowpark pandas does not support addition or subtraction between timedelta values and numeric values."
+            )
+        elif self.op in ("truediv", "floordiv", "mod") and (
+            _is_numeric_non_timedelta_type(self.first_datatype())
+            and isinstance(self.second_datatype(), TimedeltaType)
+        ):
+            raise TypeError(
+                "Snowpark pandas does not support dividing numeric values by timedelta values with div (/), mod (%), or floordiv (//)."
+            )
+        elif self.op in (
+            "add",
+            "sub",
+            "truediv",
+            "floordiv",
+            "mod",
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "ne",
+            "eq",
+        ) and (
+            (
+                isinstance(self.first_datatype(), TimedeltaType)
+                and isinstance(self.second_datatype(), StringType)
+            )
+            or (
+                isinstance(self.second_datatype(), TimedeltaType)
+                and isinstance(self.first_datatype(), StringType)
+            )
+        ):
+            # TODO(SNOW-1646604): Support these cases.
+            ErrorMessage.not_implemented(
+                f"Snowpark pandas does not yet support the operation {self.op} between timedelta and string"
+            )
+        elif self.op in ("gt", "ge", "lt", "le", "pow", "__or__", "__and__") and (
+            _op_is_between_timedelta_and_numeric(
+                self.first_datatype, self.second_datatype
+            )
+        ):
+            raise TypeError(
+                f"Snowpark pandas does not support binary operation {self.op} between timedelta and a non-timedelta type."
+            )
+
+    def compute(self) -> SnowparkPandasColumn:
+        self._check_error()
+
+        if self._check_timedelta_with_none():
+            return self._get_result()
+
+        # Generally, some operators and the data types have to be handled specially to align with pandas
+        # However, it is difficult to fail early if the arithmetic operator is not compatible
+        # with the data type, so we just let the server raise exception (e.g. a string minus a string).
+
+        self._custom_compute()
+        if self.result_column is None:
+            # If there is no special binary_op_result_column result, it means the operator and
+            # the data type of the column don't need special handling. Then we get the overloaded
+            # operator from Snowpark Column class, e.g., __add__ to perform binary operations.
+            self.result_column = getattr(self.first_operand, f"__{self.op}__")(
+                self.second_operand
+            )
+
+        return self._get_result()
+
+
+class AddOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        if isinstance(self.second_datatype(), TimedeltaType) and isinstance(
+            self.first_datatype(), TimestampType
+        ):
+            self.result_column = dateadd("ns", self.second_operand, self.first_operand)
+        elif isinstance(self.first_datatype(), TimedeltaType) and isinstance(
+            self.second_datatype(), TimestampType
+        ):
+            self.result_column = dateadd("ns", self.first_operand, self.second_operand)
+        elif isinstance(self.first_datatype(), TimedeltaType) and isinstance(
+            self.second_datatype(), TimedeltaType
+        ):
+            self.result_snowpark_pandas_type = TimedeltaType()
+        elif isinstance(self.second_datatype(), StringType) and isinstance(
+            self.first_datatype(), StringType
+        ):
+            # string/string case (only for add)
+            self.result_column = concat(self.first_operand, self.second_operand)
+
+
+class SubOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        if isinstance(self.second_datatype(), TimedeltaType) and isinstance(
+            self.first_datatype(), TimestampType
+        ):
+            self.result_column = dateadd(
+                "ns", -1 * self.second_operand, self.first_operand
+            )
+        elif isinstance(self.first_datatype(), TimedeltaType) and isinstance(
+            self.second_datatype(), TimedeltaType
+        ):
+            self.result_snowpark_pandas_type = TimedeltaType()
+        elif isinstance(self.first_datatype(), TimestampType) and isinstance(
+            self.second_datatype(), NullType
+        ):
+            # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
+            # but it's valid in pandas and returns NULL.
+            self.result_column = pandas_lit(None)
+        elif isinstance(self.first_datatype(), NullType) and isinstance(
+            self.second_datatype(), TimestampType
+        ):
+            # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
+            # but it's valid in pandas and returns NULL.
+            self.result_column = pandas_lit(None)
+        elif isinstance(self.first_datatype(), TimestampType) and isinstance(
+            self.second_datatype(), TimestampType
+        ):
+            (
+                self.result_column,
+                self.result_snowpark_pandas_type,
+            ) = _compute_subtraction_between_snowpark_timestamp_columns(
+                first_operand=self.first_operand,
+                first_datatype=self.first_datatype(),
+                second_operand=self.second_operand,
+                second_datatype=self.second_datatype(),
+            )
+
+
+class ModOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        self.result_column = compute_modulo_between_snowpark_columns(
+            self.first_operand,
+            self.first_datatype(),
+            self.second_operand,
+            self.second_datatype(),
+        )
+        if _op_is_between_two_timedeltas_or_timedelta_and_null(
+            self.first_datatype(), self.second_datatype()
+        ):
+            self.result_snowpark_pandas_type = TimedeltaType()
+        elif isinstance(
+            self.first_datatype(), TimedeltaType
+        ) and _is_numeric_non_timedelta_type(self.second_datatype()):
+            self.result_column = ceil(self.result_column)
+            self.result_snowpark_pandas_type = TimedeltaType()
+
+
+class MulOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        if _op_is_between_timedelta_and_numeric(
+            self.first_datatype, self.second_datatype
+        ):
+            self.result_column = cast(
+                floor(self.first_operand * self.second_operand), LongType()
+            )
+            self.result_snowpark_pandas_type = TimedeltaType()
+        elif (
+            isinstance(self.second_datatype(), _IntegralType)
+            and isinstance(self.first_datatype(), StringType)
+        ) or (
+            isinstance(self.second_datatype(), StringType)
+            and isinstance(self.first_datatype(), _IntegralType)
+        ):
+            # string/integer case (only for mul/rmul).
+            # swap first_operand with second_operand because
+            # REPEAT(<input>, <n>) expects <input> to be string
+            if isinstance(self.first_datatype(), _IntegralType):
+                self.first_operand, self.second_operand = (
+                    self.second_operand,
+                    self.first_operand,
+                )
+
+            self.result_column = iff(
+                self.second_operand > pandas_lit(0),
+                repeat(self.first_operand, self.second_operand),
+                # Snowflake's repeat doesn't support negative number,
+                # but pandas will return an empty string
+                pandas_lit(""),
+            )
+
+
+class EqOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        # some operators and the data types have to be handled specially to align with pandas
+        # However, it is difficult to fail early if the arithmetic operator is not compatible
+        # with the data type, so we just let the server raise exception (e.g. a string minus a string).
+
+        if _op_is_between_two_timedeltas_or_timedelta_and_null(
+            self.first_datatype(), self.second_datatype()
+        ):
+            return
+
+        # For `eq` and `ne`, note that Snowflake will consider 1 equal to
+        # Timedelta(1) because those two have the same representation in Snowflake,
+        # so we have to compare types in the client.
+        if _op_is_between_timedelta_and_numeric(
+            self.first_datatype, self.second_datatype
+        ):
+            self.result_column = pandas_lit(False)
+
+
+class NeOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        # some operators and the data types have to be handled specially to align with pandas
+        # However, it is difficult to fail early if the arithmetic operator is not compatible
+        # with the data type, so we just let the server raise exception (e.g. a string minus a string).
+
+        if _op_is_between_two_timedeltas_or_timedelta_and_null(
+            self.first_datatype(), self.second_datatype()
+        ):
+            return
+
+        # For `eq` and `ne`, note that Snowflake will consider 1 equal to
+        # Timedelta(1) because those two have the same representation in Snowflake,
+        # so we have to compare types in the client.
+        if _op_is_between_timedelta_and_numeric(
+            self.first_datatype, self.second_datatype
+        ):
+            self.result_column = pandas_lit(True)
+
+
+class FloordivOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        self.result_column = floor(self.first_operand / self.second_operand)
+        if isinstance(
+            self.first_datatype(), TimedeltaType
+        ) and _is_numeric_non_timedelta_type(self.second_datatype()):
+            self.result_column = cast(self.result_column, LongType())
+            self.result_snowpark_pandas_type = TimedeltaType()
+
+
+class TruedivOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        if isinstance(
+            self.first_datatype(), TimedeltaType
+        ) and _is_numeric_non_timedelta_type(self.second_datatype()):
+            self.result_column = floor(self.first_operand / self.second_operand)
+            self.result_column = cast(self.result_column, LongType())
+            self.result_snowpark_pandas_type = TimedeltaType()
+
+
+class PowOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        self.result_column = compute_power_between_snowpark_columns(
+            self.first_operand, self.second_operand
+        )
+
+
+class OrOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        self.result_column = self.first_operand | self.second_operand
+
+
+class AndOp(BinaryOp):
+    def _custom_compute(self) -> None:
+        self.result_column = self.first_operand & self.second_operand
+
+
+class EqualNullOp(BinaryOp):
+    def _custom_compute(self) -> None:
         # TODO(SNOW-1641716): In Snowpark pandas, generally use this equal_null
         # with type checking intead of snowflake.snowpark.functions.equal_null.
-        if not are_equal_types(first_datatype(), second_datatype()):
-            binary_op_result_column = pandas_lit(False)
+        if not are_equal_types(self.first_datatype(), self.second_datatype()):
+            self.result_column = pandas_lit(False)
         else:
-            binary_op_result_column = first_operand.equal_null(second_operand)
-    elif (
-        op == "sub"
-        and isinstance(first_datatype(), TimestampType)
-        and isinstance(second_datatype(), NullType)
-    ):
-        # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
-        # but it's valid in pandas and returns NULL.
-        binary_op_result_column = pandas_lit(None)
-    elif (
-        op == "sub"
-        and isinstance(first_datatype(), NullType)
-        and isinstance(second_datatype(), TimestampType)
-    ):
-        # Timestamp - NULL or NULL - Timestamp raises SQL compilation error,
-        # but it's valid in pandas and returns NULL.
-        binary_op_result_column = pandas_lit(None)
-    elif (
-        op == "sub"
-        and isinstance(first_datatype(), TimestampType)
-        and isinstance(second_datatype(), TimestampType)
-    ):
-        return _compute_subtraction_between_snowpark_timestamp_columns(
-            first_operand=first_operand,
-            first_datatype=first_datatype(),
-            second_operand=second_operand,
-            second_datatype=second_datatype(),
-        )
-    # If there is no special binary_op_result_column result, it means the operator and
-    # the data type of the column don't need special handling. Then we get the overloaded
-    # operator from Snowpark Column class, e.g., __add__ to perform binary operations.
-    if binary_op_result_column is None:
-        binary_op_result_column = getattr(first_operand, f"__{op}__")(second_operand)
-
-    return SnowparkPandasColumn(
-        snowpark_column=binary_op_result_column,
-        snowpark_pandas_type=snowpark_pandas_type,
-    )
+            self.result_column = self.first_operand.equal_null(self.second_operand)
 
 
 def are_equal_types(type1: DataType, type2: DataType) -> bool:
@@ -642,104 +843,6 @@ def are_equal_types(type1: DataType, type2: DataType) -> bool:
         return True
 
     return type1 == type2
-
-
-def compute_binary_op_between_snowpark_column_and_scalar(
-    op: str,
-    first_operand: SnowparkColumn,
-    datatype: DataTypeGetter,
-    second_operand: Scalar,
-) -> SnowparkPandasColumn:
-    """
-    Compute the binary operation between a Snowpark column and a scalar.
-    Args:
-        op: the name of binary operation
-        first_operand: The SnowparkColumn for lhs
-        datatype: Callable for Snowpark data type
-        second_operand: Scalar value
-
-    Returns:
-        SnowparkPandasColumn for translated pandas operation
-    """
-
-    def second_datatype() -> DataType:
-        return infer_object_type(second_operand)
-
-    return compute_binary_op_between_snowpark_columns(
-        op, first_operand, datatype, pandas_lit(second_operand), second_datatype
-    )
-
-
-def compute_binary_op_between_scalar_and_snowpark_column(
-    op: str,
-    first_operand: Scalar,
-    second_operand: SnowparkColumn,
-    datatype: DataTypeGetter,
-) -> SnowparkPandasColumn:
-    """
-    Compute the binary operation between a scalar and a Snowpark column.
-    Args:
-        op: the name of binary operation
-        first_operand: Scalar value
-        second_operand: The SnowparkColumn for rhs
-        datatype: Callable for Snowpark data type
-        it is not needed.
-
-    Returns:
-        SnowparkPandasColumn for translated pandas operation
-    """
-
-    def first_datatype() -> DataType:
-        return infer_object_type(first_operand)
-
-    return compute_binary_op_between_snowpark_columns(
-        op, pandas_lit(first_operand), first_datatype, second_operand, datatype
-    )
-
-
-def compute_binary_op_with_fill_value(
-    op: str,
-    lhs: SnowparkColumn,
-    lhs_datatype: DataTypeGetter,
-    rhs: SnowparkColumn,
-    rhs_datatype: DataTypeGetter,
-    fill_value: Scalar,
-) -> SnowparkPandasColumn:
-    """
-    Helper method for performing binary operations.
-    1. Fills NaN/None values in the lhs and rhs with the given fill_value.
-    2. Computes the binary operation expression for lhs <op> rhs.
-
-    fill_value replaces NaN/None values when only either lhs or rhs is NaN/None, not both lhs and rhs.
-    For instance, with fill_value = 100,
-    1. Given lhs = None and rhs = 10, lhs is replaced with fill_value.
-           result = lhs + rhs => None + 10 => 100 (replaced) + 10 = 110
-    2. Given lhs = 3 and rhs = None, rhs is replaced with fill_value.
-           result = lhs + rhs => 3 + None => 3 + 100 (replaced) = 103
-    3. Given lhs = None and rhs = None, neither lhs nor rhs is replaced since they both are None.
-           result = lhs + rhs => None + None => None.
-
-    Args:
-        op: pandas operation to perform between lhs and rhs
-        lhs: the lhs SnowparkColumn
-        lhs_datatype: Callable for Snowpark Datatype for lhs
-        rhs: the rhs SnowparkColumn
-        rhs_datatype: Callable for Snowpark Datatype for rhs
-        fill_value: Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-
-    Returns:
-        SnowparkPandasColumn for translated pandas operation
-    """
-    lhs_cond, rhs_cond = lhs, rhs
-    if fill_value is not None:
-        fill_value_lit = pandas_lit(fill_value)
-        lhs_cond = iff(lhs.is_null() & ~rhs.is_null(), fill_value_lit, lhs)
-        rhs_cond = iff(rhs.is_null() & ~lhs.is_null(), fill_value_lit, rhs)
-
-    return compute_binary_op_between_snowpark_columns(
-        op, lhs_cond, lhs_datatype, rhs_cond, rhs_datatype
-    )
 
 
 def merge_label_and_identifier_pairs(

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -184,11 +184,7 @@ from snowflake.snowpark.modin.plugin._internal.apply_utils import (
     sort_apply_udtf_result_columns_by_pandas_positions,
 )
 from snowflake.snowpark.modin.plugin._internal.binary_op_utils import (
-    compute_binary_op_between_scalar_and_snowpark_column,
-    compute_binary_op_between_snowpark_column_and_scalar,
-    compute_binary_op_between_snowpark_columns,
-    compute_binary_op_with_fill_value,
-    is_binary_op_supported,
+    BinaryOp,
     merge_label_and_identifier_pairs,
     prepare_binop_pairs_between_dataframe_and_dataframe,
 )
@@ -1854,7 +1850,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         replace_mapping = {}
         data_column_snowpark_pandas_types = []
         for identifier in self._modin_frame.data_column_snowflake_quoted_identifiers:
-            expression, snowpark_pandas_type = compute_binary_op_with_fill_value(
+            expression, snowpark_pandas_type = BinaryOp.create_with_fill_value(
                 op=op,
                 lhs=col(identifier),
                 lhs_datatype=lambda identifier=identifier: self._modin_frame.get_snowflake_type(
@@ -1863,7 +1859,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 rhs=pandas_lit(other),
                 rhs_datatype=lambda: infer_object_type(other),
                 fill_value=fill_value,
-            )
+            ).compute()
             replace_mapping[identifier] = expression
             data_column_snowpark_pandas_types.append(snowpark_pandas_type)
         return SnowflakeQueryCompiler(
@@ -1914,7 +1910,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         replace_mapping = {}
         snowpark_pandas_types = []
         for identifier in new_frame.data_column_snowflake_quoted_identifiers[:-1]:
-            expression, snowpark_pandas_type = compute_binary_op_with_fill_value(
+            expression, snowpark_pandas_type = BinaryOp.create_with_fill_value(
                 op=op,
                 lhs=col(identifier),
                 lhs_datatype=lambda identifier=identifier: new_frame.get_snowflake_type(
@@ -1923,7 +1919,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 rhs=col(other_identifier),
                 rhs_datatype=lambda: new_frame.get_snowflake_type(other_identifier),
                 fill_value=fill_value,
-            )
+            ).compute()
             replace_mapping[identifier] = expression
             snowpark_pandas_types.append(snowpark_pandas_type)
 
@@ -1986,7 +1982,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # rhs is not guaranteed to be a scalar value - it can be a list-like as well.
             # Convert all list-like objects to a list.
             rhs_lit = pandas_lit(rhs) if is_scalar(rhs) else pandas_lit(rhs.tolist())
-            expression, snowpark_pandas_type = compute_binary_op_with_fill_value(
+            expression, snowpark_pandas_type = BinaryOp.create_with_fill_value(
                 op,
                 lhs=lhs,
                 lhs_datatype=lambda identifier=identifier: self._modin_frame.get_snowflake_type(
@@ -1995,7 +1991,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 rhs=rhs_lit,
                 rhs_datatype=lambda rhs=rhs: infer_object_type(rhs),
                 fill_value=fill_value,
-            )
+            ).compute()
             replace_mapping[identifier] = expression
             snowpark_pandas_types.append(snowpark_pandas_type)
 
@@ -2056,7 +2052,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 # match pandas documentation; hence it is omitted in the Snowpark pandas implementation.
                 raise ValueError("Only scalars can be used as fill_value.")
 
-        if not is_binary_op_supported(op):
+        if not BinaryOp.is_binary_op_supported(op):
             ErrorMessage.not_implemented(
                 f"Snowpark pandas doesn't yet support '{op}' binary operation"
             )
@@ -2121,7 +2117,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )[0]
 
             # add new column with result as unnamed
-            new_column_expr, snowpark_pandas_type = compute_binary_op_with_fill_value(
+            new_column_expr, snowpark_pandas_type = BinaryOp.create_with_fill_value(
                 op=op,
                 lhs=col(lhs_quoted_identifier),
                 lhs_datatype=lambda: aligned_frame.get_snowflake_type(
@@ -2132,7 +2128,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     rhs_quoted_identifier
                 ),
                 fill_value=fill_value,
-            )
+            ).compute()
 
             # name is dropped when names of series differ. A dropped name is using unnamed series label.
             new_column_name = (
@@ -10548,7 +10544,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     snowpark_pandas_type=None,
                 )
             else:
-                return compute_binary_op_between_snowpark_columns(
+                return BinaryOp.create(
                     "sub",
                     col(snowflake_quoted_identifier),
                     lambda: column_datatype,
@@ -10560,7 +10556,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                         )
                     ),
                     lambda: column_datatype,
-                )
+                ).compute()
 
         else:
             # periods is the number of columns to *go back*.
@@ -10609,13 +10605,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                         col1 = cast(col1, IntegerType())
                     if isinstance(col2_dtype, BooleanType):
                         col2 = cast(col2, IntegerType())
-                    return compute_binary_op_between_snowpark_columns(
+                    return BinaryOp.create(
                         "sub",
                         col1,
                         lambda: col1_dtype,
                         col2,
                         lambda: col2_dtype,
-                    )
+                    ).compute()
 
     def diff(self, periods: int, axis: int) -> "SnowflakeQueryCompiler":
         """
@@ -14213,7 +14209,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
         )
 
-        # Lazify type map here for calling compute_binary_op_between_snowpark_columns.
+        # Lazify type map here for calling binaryOp.compute.
         def create_lazy_type_functions(
             identifiers: list[str],
         ) -> list[DataTypeGetter]:
@@ -14243,12 +14239,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         replace_mapping = {}
         snowpark_pandas_types = []
         for left, left_datatype in zip(left_result_data_identifiers, left_datatypes):
-            (
-                expression,
-                snowpark_pandas_type,
-            ) = compute_binary_op_between_snowpark_columns(
+            (expression, snowpark_pandas_type,) = BinaryOp.create(
                 op, col(left), left_datatype, col(right), right_datatype
-            )
+            ).compute()
             snowpark_pandas_types.append(snowpark_pandas_type)
             replace_mapping[left] = expression
         update_result = joined_frame.result_frame.update_snowflake_quoted_identifiers_with_expressions(
@@ -14507,14 +14500,14 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         replace_mapping = {}
         data_column_snowpark_pandas_types = []
         for p in left_right_pairs:
-            result_expression, snowpark_pandas_type = compute_binary_op_with_fill_value(
+            result_expression, snowpark_pandas_type = BinaryOp.create_with_fill_value(
                 op=op,
                 lhs=p.lhs,
                 lhs_datatype=p.lhs_datatype,
                 rhs=p.rhs,
                 rhs_datatype=p.rhs_datatype,
                 fill_value=fill_value,
-            )
+            ).compute()
             replace_mapping[p.identifier] = result_expression
             data_column_snowpark_pandas_types.append(snowpark_pandas_type)
         # Create restricted frame with only combined / replaced labels.
@@ -14781,19 +14774,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         snowpark_pandas_labels = []
         for label, identifier in overlapping_pairs:
             expression, new_type = (
-                compute_binary_op_between_scalar_and_snowpark_column(
+                BinaryOp.create_with_lhs_scalar(
                     op,
                     series.loc[label],
                     col(identifier),
                     datatype_getters[identifier],
-                )
+                ).compute()
                 if squeeze_self
-                else compute_binary_op_between_snowpark_column_and_scalar(
+                else BinaryOp.create_with_rhs_scalar(
                     op,
                     col(identifier),
                     datatype_getters[identifier],
                     series.loc[label],
-                )
+                ).compute()
             )
             snowpark_pandas_labels.append(new_type)
             replace_mapping[identifier] = expression
@@ -17246,9 +17239,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
         replace_mapping = {
-            p.identifier: compute_binary_op_between_snowpark_columns(
+            p.identifier: BinaryOp.create(
                 "equal_null", p.lhs, p.lhs_datatype, p.rhs, p.rhs_datatype
-            ).snowpark_column
+            )
+            .compute()
+            .snowpark_column
             for p in left_right_pairs
         }
 
@@ -17776,7 +17771,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             right_identifier = result_column_mapper.right_quoted_identifiers_map[
                 right_identifier
             ]
-            op_result = compute_binary_op_between_snowpark_columns(
+            op_result = BinaryOp.create(
                 op="equal_null",
                 first_operand=col(left_identifier),
                 first_datatype=functools.partial(
@@ -17786,7 +17781,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 second_datatype=functools.partial(
                     lambda col: result_frame.get_snowflake_type(col), right_identifier
                 ),
-            )
+            ).compute()
             binary_op_result = binary_op_result.append_column(
                 str(left_pandas_label) + "_comparison_result",
                 op_result.snowpark_column,
@@ -17897,19 +17892,23 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 right_identifier
             ]
 
-            cols_equal = compute_binary_op_between_snowpark_columns(
-                op="equal_null",
-                first_operand=col(left_mappped_identifier),
-                first_datatype=functools.partial(
-                    lambda col: result_frame.get_snowflake_type(col),
-                    left_mappped_identifier,
-                ),
-                second_operand=col(right_mapped_identifier),
-                second_datatype=functools.partial(
-                    lambda col: result_frame.get_snowflake_type(col),
-                    right_mapped_identifier,
-                ),
-            ).snowpark_column
+            cols_equal = (
+                BinaryOp.create(
+                    op="equal_null",
+                    first_operand=col(left_mappped_identifier),
+                    first_datatype=functools.partial(
+                        lambda col: result_frame.get_snowflake_type(col),
+                        left_mappped_identifier,
+                    ),
+                    second_operand=col(right_mapped_identifier),
+                    second_datatype=functools.partial(
+                        lambda col: result_frame.get_snowflake_type(col),
+                        right_mapped_identifier,
+                    ),
+                )
+                .compute()
+                .snowpark_column
+            )
 
             # Add a column containing the values from `self`, but replace
             # matching values with null.


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1641472

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Try to improve readability of binary ops by reorganize it as a `BinaryOp` class.
This pull request focuses on improving the readability and maintainability of the binary operation utility code within the Snowflake query compiler. The changes primarily involve refactoring the binary operation functions into a new `BinaryOp` class and updating the relevant method calls throughout the codebase.

### Refactoring binary operations:

* [`src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py`](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L187-R187): Replaced multiple function calls (`compute_binary_op_between_scalar_and_snowpark_column`, `compute_binary_op_between_snowpark_column_and_scalar`, `compute_binary_op_between_snowpark_columns`, `compute_binary_op_with_fill_value`, `is_binary_op_supported`) with the new `BinaryOp` class methods (`create`, `create_with_fill_value`, `create_with_lhs_scalar`, `create_with_rhs_scalar`, `is_binary_op_supported`). [[1]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L187-R187) [[2]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1857-R1853) [[3]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1866-R1862) [[4]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1917-R1913) [[5]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1926-R1922) [[6]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1989-R1985) [[7]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L1998-R1994) [[8]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L2059-R2055) [[9]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L2124-R2120) [[10]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L2135-R2131) [[11]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L10551-R10547) [[12]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L10563-R10559) [[13]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L10612-R10614) [[14]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L14216-R14212) [[15]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L14246-R14244) [[16]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L14510-R14510) [[17]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L14784-R14789) [[18]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L17249-R17246) [[19]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L17779-R17774) [[20]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L17789-R17784) [[21]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L17900-R17896) [[22]](diffhunk://#diff-834ee069919510e7e410c503a8afa455154c40e65389769c08d35b0ec3f8ec03L17912-R17911)

### Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR120): Added an entry to reflect the improved readability of the binary operation utility code.