### PR TITLE
SNOW-1659478: Cherrypick telemetry fixes

### DIFF
--- a/src/snowflake/snowpark/modin/pandas/__init__.py
+++ b/src/snowflake/snowpark/modin/pandas/__init__.py
@@ -88,14 +88,13 @@ import modin.pandas
 
 # TODO: SNOW-851745 make sure add all Snowpark pandas API general functions
 from modin.pandas import plotting  # type: ignore[import]
-from modin.pandas.base import BasePandasDataset
-from modin.pandas.series import _SERIES_EXTENSIONS_, Series
+from modin.pandas.series import Series
 
 from snowflake.snowpark.modin.pandas.api.extensions import (
     register_dataframe_accessor,
     register_series_accessor,
 )
-from snowflake.snowpark.modin.pandas.dataframe import _DATAFRAME_EXTENSIONS_, DataFrame
+from snowflake.snowpark.modin.pandas.dataframe import DataFrame
 from snowflake.snowpark.modin.pandas.general import (
     bdate_range,
     concat,
@@ -149,6 +148,7 @@ from snowflake.snowpark.modin.pandas.io import (  # read_json is provided by ove
 )
 from snowflake.snowpark.modin.plugin._internal.session import SnowpandasSessionHolder
 from snowflake.snowpark.modin.plugin._internal.telemetry import (
+    TELEMETRY_PRIVATE_METHODS,
     try_add_telemetry_to_attribute,
 )
 from snowflake.snowpark.modin.plugin.utils.frontend_constants import _ATTRS_NO_LOOKUP
@@ -165,24 +165,6 @@ from snowflake.snowpark.modin.plugin.extensions.pd_overrides import (  # isort: 
     TimedeltaIndex,
     read_json,
 )
-
-# Record which attributes are defined on an upstream object, and which are defined on a vendored
-# object (currently just dataframe.py), and determine when adding telemetry is necessary.
-# This must be checked before overrides are applied.
-_attrs_defined_on_modin_series = set()
-for attr_name, attr_value in Series.__dict__.items():
-    base_value = BasePandasDataset.__dict__.get(attr_name, None)
-    if base_value is None or attr_value != base_value:
-        _attrs_defined_on_modin_series.add(attr_name)
-
-_attrs_defined_on_dataframe = (
-    set()
-)  # TODO: SNOW-1063346 revisit when dataframe.py is removed
-for attr_name, attr_value in DataFrame.__dict__.items():
-    base_value = BasePandasDataset.__dict__.get(attr_name, None)
-    if base_value is None or attr_value != base_value:
-        _attrs_defined_on_dataframe.add(attr_name)
-
 
 # base overrides occur before subclass overrides in case subclasses override a base method
 import snowflake.snowpark.modin.plugin.extensions.base_extensions  # isort: skip  # noqa: E402,F401
@@ -203,48 +185,27 @@ modin.pandas.base._ATTRS_NO_LOOKUP.add("columns")
 modin.pandas.base._ATTRS_NO_LOOKUP.update(_ATTRS_NO_LOOKUP)
 
 
-# For any method defined on Series/DF, add telemetry to it if it meets all of the following conditions:
-# 1. The method was defined directly on an upstream class (_attrs_defined_on_modin_base, _attrs_defined_on_modin_series)
-#   1a. (DataFrame only): The method is not overridden by DataFrame (not applicable to Series, since we use the upstream version)
-# 2. The method is not overridden by an extensions module
-# 3. The method name does not start with an _
-_base_telemetry_added_attrs = set()
+# For any method defined on Series/DF, add telemetry to it if it:
+# 1. Is defined directly on an upstream class
+# 2. The method name does not start with an _, or is in TELEMETRY_PRIVATE_METHODS
 
-_series_ext = _SERIES_EXTENSIONS_.copy()
 for attr_name in dir(Series):
     # Since Series is defined in upstream Modin, all of its members were either defined upstream
     # or overridden by extension.
-    if attr_name not in _series_ext and not attr_name.startswith("_"):
+    if not attr_name.startswith("_") or attr_name in TELEMETRY_PRIVATE_METHODS:
         register_series_accessor(attr_name)(
             try_add_telemetry_to_attribute(attr_name, getattr(Series, attr_name))
         )
-        if attr_name not in _attrs_defined_on_modin_series:
-            # attribute was defined on BasePandasDataset and inherited, so don't override it again
-            # for DataFrame
-            _base_telemetry_added_attrs.add(attr_name)
 
 
 # TODO: SNOW-1063346
 # Since we still use the vendored version of DataFrame and the overrides for the top-level
 # namespace haven't been performed yet, we need to set properties on the vendored version
-_dataframe_ext = _DATAFRAME_EXTENSIONS_.copy()
 for attr_name in dir(DataFrame):
-    if (
-        attr_name not in _attrs_defined_on_dataframe
-        and attr_name not in _dataframe_ext
-        and not attr_name.startswith("_")
-    ):
-        # If this method was inherited from BasePandasDataset and telemetry was already added via
-        # Series, register the override but don't re-wrap the method in the telemetry annotation.
-        # If we don't do this check, we will end up double-reporting telemetry on some methods.
-        original_attr = getattr(DataFrame, attr_name)
-        new_attr = (
-            original_attr
-            if attr_name in _base_telemetry_added_attrs
-            else try_add_telemetry_to_attribute(attr_name, original_attr)
+    if not attr_name.startswith("_") or attr_name in TELEMETRY_PRIVATE_METHODS:
+        register_dataframe_accessor(attr_name)(
+            try_add_telemetry_to_attribute(attr_name, getattr(DataFrame, attr_name))
         )
-        register_dataframe_accessor(attr_name)(new_attr)
-        _base_telemetry_added_attrs.add(attr_name)
 
 
 def __getattr__(name: str) -> Any:

--- a/src/snowflake/snowpark/modin/pandas/dataframe.py
+++ b/src/snowflake/snowpark/modin/pandas/dataframe.py
@@ -91,7 +91,6 @@ from snowflake.snowpark.modin.pandas.utils import (
     replace_external_data_keys_with_empty_pandas_series,
     replace_external_data_keys_with_query_compiler,
 )
-from snowflake.snowpark.modin.plugin._internal.telemetry import TelemetryMeta
 from snowflake.snowpark.modin.plugin._internal.utils import is_repr_truncated
 from snowflake.snowpark.modin.plugin._typing import DropKeep, ListLike
 from snowflake.snowpark.modin.plugin.utils.error_message import (
@@ -138,7 +137,7 @@ _DATAFRAME_EXTENSIONS_ = {}
     ],
     apilink="pandas.DataFrame",
 )
-class DataFrame(BasePandasDataset, metaclass=TelemetryMeta):
+class DataFrame(BasePandasDataset):
     _pandas_class = pandas.DataFrame
 
     def __init__(

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -9,7 +9,6 @@ from contextlib import nullcontext
 from enum import Enum, unique
 from typing import Any, Callable, Optional, TypeVar, Union, cast
 
-import modin.pandas
 from typing_extensions import ParamSpec
 
 import snowflake.snowpark.session
@@ -543,8 +542,6 @@ class TelemetryMeta(type):
     def __new__(
         cls, name: str, bases: tuple, attrs: dict[str, Any]
     ) -> Union[
-        "modin.pandas.Series",
-        "snowflake.snowpark.modin.pandas.dataframe.DataFrame",
         "snowflake.snowpark.modin.pandas.groupby.DataFrameGroupBy",
         "snowflake.snowpark.modin.pandas.resample.Resampler",
         "snowflake.snowpark.modin.pandas.window.Window",
@@ -558,7 +555,6 @@ class TelemetryMeta(type):
         with ``snowpark_pandas_telemetry_api_usage`` telemetry decorator.
         Method arguments returned by _get_kwargs_telemetry are collected otherwise set telemetry_args=list().
         TelemetryMeta is only set as the metaclass of:
-         snowflake.snowpark.modin.pandas.dataframe.DataFrame,
          snowflake.snowpark.modin.pandas.groupby.DataFrameGroupBy,
          snowflake.snowpark.modin.pandas.resample.Resampler,
          snowflake.snowpark.modin.pandas.window.Window,

--- a/src/snowflake/snowpark/modin/plugin/extensions/base_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/base_extensions.py
@@ -6,15 +6,10 @@
 File containing BasePandasDataset APIs defined in Snowpark pandas but not the Modin API layer.
 """
 
-from snowflake.snowpark.modin.plugin._internal.telemetry import (
-    snowpark_pandas_telemetry_method_decorator,
-)
-
 from .base_overrides import register_base_override
 
 
 @register_base_override("__array_function__")
-@snowpark_pandas_telemetry_method_decorator
 def __array_function__(self, func: callable, types: tuple, args: tuple, kwargs: dict):
     """
     Apply the `func` to the `BasePandasDataset`.

--- a/src/snowflake/snowpark/modin/plugin/extensions/base_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/base_overrides.py
@@ -73,10 +73,6 @@ from snowflake.snowpark.modin.pandas.utils import (
     raise_if_native_pandas_objects,
     validate_and_try_convert_agg_func_arg_func_to_str,
 )
-from snowflake.snowpark.modin.plugin._internal.telemetry import (
-    snowpark_pandas_telemetry_method_decorator,
-    try_add_telemetry_to_attribute,
-)
 from snowflake.snowpark.modin.plugin._typing import ListLike
 from snowflake.snowpark.modin.plugin.utils.error_message import (
     ErrorMessage,
@@ -97,7 +93,6 @@ def register_base_override(method_name: str):
     """
 
     def decorator(base_method: Any):
-        base_method = try_add_telemetry_to_attribute(method_name, base_method)
         parent_method = getattr(BasePandasDataset, method_name, None)
         if isinstance(parent_method, property):
             parent_method = parent_method.fget
@@ -125,9 +120,7 @@ def register_base_override(method_name: str):
 
 def register_base_not_implemented():
     def decorator(base_method: Any):
-        func = snowpark_pandas_telemetry_method_decorator(
-            base_not_implemented()(base_method)
-        )
+        func = base_not_implemented()(base_method)
         register_series_accessor(base_method.__name__)(func)
         register_dataframe_accessor(base_method.__name__)(func)
         return func

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -16,9 +16,6 @@ from pandas._typing import IndexLabel
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
 from snowflake.snowpark.modin import pandas as pd  # noqa: F401
 from snowflake.snowpark.modin.pandas.api.extensions import register_dataframe_accessor
-from snowflake.snowpark.modin.plugin._internal.telemetry import (
-    snowpark_pandas_telemetry_method_decorator,
-)
 from snowflake.snowpark.modin.plugin.extensions.utils import add_cache_result_docstring
 
 
@@ -27,7 +24,6 @@ from snowflake.snowpark.modin.plugin.extensions.utils import add_cache_result_do
 # pandas DataFrame.
 # Implementation note: Arguments names and types are kept consistent with pandas.DataFrame.to_sql
 @register_dataframe_accessor("to_snowflake")
-@snowpark_pandas_telemetry_method_decorator
 def to_snowflake(
     self,
     name: Union[str, Iterable[str]],
@@ -67,7 +63,6 @@ def to_snowflake(
 
 
 @register_dataframe_accessor("to_snowpark")
-@snowpark_pandas_telemetry_method_decorator
 def to_snowpark(
     self, index: bool = True, index_label: Optional[IndexLabel] = None
 ) -> SnowparkDataFrame:
@@ -200,7 +195,6 @@ def to_snowpark(
 
 
 @register_dataframe_accessor("to_pandas")
-@snowpark_pandas_telemetry_method_decorator
 def to_pandas(
     self,
     *,
@@ -244,7 +238,6 @@ def to_pandas(
 
 @register_dataframe_accessor("cache_result")
 @add_cache_result_docstring
-@snowpark_pandas_telemetry_method_decorator
 def cache_result(self, inplace: bool = False) -> Optional[pd.DataFrame]:
     """
     Persists the current Snowpark pandas DataFrame to a temporary table that lasts the duration of the session.

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_overrides.py
@@ -18,9 +18,6 @@ from snowflake.snowpark.modin.pandas.api.extensions import register_dataframe_ac
 from snowflake.snowpark.modin.plugin._internal.aggregation_utils import (
     is_snowflake_agg_func,
 )
-from snowflake.snowpark.modin.plugin._internal.telemetry import (
-    snowpark_pandas_telemetry_method_decorator,
-)
 from snowflake.snowpark.modin.plugin.utils.error_message import ErrorMessage
 from snowflake.snowpark.modin.plugin.utils.warning_message import WarningMessage
 from snowflake.snowpark.modin.utils import _inherit_docstrings, validate_int_kwarg
@@ -28,7 +25,6 @@ from snowflake.snowpark.modin.utils import _inherit_docstrings, validate_int_kwa
 
 @_inherit_docstrings(native_pd.DataFrame.memory_usage, apilink="pandas.DataFrame")
 @register_dataframe_accessor("memory_usage")
-@snowpark_pandas_telemetry_method_decorator
 def memory_usage(self, index: bool = True, deep: bool = False) -> Any:
     """
     Memory Usage (Dummy Information)
@@ -68,7 +64,6 @@ def memory_usage(self, index: bool = True, deep: bool = False) -> Any:
 
 @register_dataframe_accessor("plot")
 @property
-@snowpark_pandas_telemetry_method_decorator
 def plot(
     self,
     x=None,
@@ -115,7 +110,6 @@ def plot(
 
 # Upstream modin defines sum differently for series/DF, but we use the same implementation for both.
 @register_dataframe_accessor("sum")
-@snowpark_pandas_telemetry_method_decorator
 def sum(
     self,
     axis: Union[Axis, None] = None,
@@ -137,7 +131,6 @@ def sum(
 
 
 @register_dataframe_accessor("transform")
-@snowpark_pandas_telemetry_method_decorator
 def transform(
     self, func: PythonFuncType, axis: Axis = 0, *args: Any, **kwargs: Any
 ) -> DataFrame:  # noqa: PR01, RT01, D200

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -16,14 +16,10 @@ from pandas._typing import IndexLabel
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
 from snowflake.snowpark.modin import pandas as pd  # noqa: F401
 from snowflake.snowpark.modin.pandas.api.extensions import register_series_accessor
-from snowflake.snowpark.modin.plugin._internal.telemetry import (
-    snowpark_pandas_telemetry_method_decorator,
-)
 from snowflake.snowpark.modin.plugin.extensions.utils import add_cache_result_docstring
 
 
 @register_series_accessor("to_snowflake")
-@snowpark_pandas_telemetry_method_decorator
 def to_snowflake(
     self,
     name: Union[str, Iterable[str]],
@@ -63,7 +59,6 @@ def to_snowflake(
 
 
 @register_series_accessor("to_snowpark")
-@snowpark_pandas_telemetry_method_decorator
 def to_snowpark(
     self, index: bool = True, index_label: Optional[IndexLabel] = None
 ) -> SnowparkDataFrame:
@@ -173,7 +168,6 @@ def to_snowpark(
 
 
 @register_series_accessor("to_pandas")
-@snowpark_pandas_telemetry_method_decorator
 def to_pandas(
     self,
     *,
@@ -208,7 +202,6 @@ def to_pandas(
 
 @register_series_accessor("cache_result")
 @add_cache_result_docstring
-@snowpark_pandas_telemetry_method_decorator
 def cache_result(self, inplace: bool = False) -> Optional[pd.Series]:
     """
     Persists the Snowpark pandas Series to a temporary table for the duration of the session.

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
@@ -55,10 +55,6 @@ from snowflake.snowpark.modin.pandas.utils import (
     is_scalar,
     try_convert_index_to_native,
 )
-from snowflake.snowpark.modin.plugin._internal.telemetry import (
-    snowpark_pandas_telemetry_method_decorator,
-    try_add_telemetry_to_attribute,
-)
 from snowflake.snowpark.modin.plugin._typing import DropKeep, ListLike
 from snowflake.snowpark.modin.plugin.utils.error_message import (
     ErrorMessage,
@@ -83,9 +79,7 @@ if TYPE_CHECKING:
 
 def register_series_not_implemented():
     def decorator(base_method: Any):
-        func = snowpark_pandas_telemetry_method_decorator(
-            series_not_implemented()(base_method)
-        )
+        func = series_not_implemented()(base_method)
         register_series_accessor(base_method.__name__)(func)
         return func
 
@@ -429,7 +423,6 @@ def __init__(
 # usage isn't meaningful and is set to always return 0.
 @_inherit_docstrings(native_pd.Series.memory_usage, apilink="pandas.Series")
 @register_series_accessor("memory_usage")
-@snowpark_pandas_telemetry_method_decorator
 def memory_usage(self, index: bool = True, deep: bool = False) -> int:
     """
     Return zero bytes for memory_usage
@@ -441,7 +434,6 @@ def memory_usage(self, index: bool = True, deep: bool = False) -> int:
 # Snowpark pandas has slightly different type validation from upstream modin.
 @_inherit_docstrings(native_pd.Series.isin, apilink="pandas.Series")
 @register_series_accessor("isin")
-@snowpark_pandas_telemetry_method_decorator
 def isin(self, values: set | ListLike) -> Series:
     """
     Whether elements in Series are contained in `values`.
@@ -529,7 +521,6 @@ def isin(self, values: set | ListLike) -> Series:
 # Snowpark pandas raises a warning before materializing data and passing to `plot`.
 @register_series_accessor("plot")
 @property
-@snowpark_pandas_telemetry_method_decorator
 def plot(
     self,
     kind="line",
@@ -570,7 +561,6 @@ def plot(
 # Upstream Modin has a bug binary operators (except add/radd, ) don't respect fill_value:
 # https://github.com/modin-project/modin/issues/7381
 @register_series_accessor("sub")
-@snowpark_pandas_telemetry_method_decorator
 def sub(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return subtraction of Series and `other`, element-wise (binary operator `sub`).
@@ -583,7 +573,6 @@ register_series_accessor("subtract")(sub)
 
 
 @register_series_accessor("rsub")
-@snowpark_pandas_telemetry_method_decorator
 def rsub(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return subtraction of series and `other`, element-wise (binary operator `rsub`).
@@ -595,7 +584,6 @@ def rsub(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01,
 
 
 @register_series_accessor("mul")
-@snowpark_pandas_telemetry_method_decorator
 def mul(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return multiplication of series and `other`, element-wise (binary operator `mul`).
@@ -608,7 +596,6 @@ register_series_accessor("multiply")(mul)
 
 
 @register_series_accessor("rmul")
-@snowpark_pandas_telemetry_method_decorator
 def rmul(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return multiplication of series and `other`, element-wise (binary operator `mul`).
@@ -620,7 +607,6 @@ def rmul(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01,
 
 
 @register_series_accessor("truediv")
-@snowpark_pandas_telemetry_method_decorator
 def truediv(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return floating division of series and `other`, element-wise (binary operator `truediv`).
@@ -636,7 +622,6 @@ register_series_accessor("divide")(truediv)
 
 
 @register_series_accessor("rtruediv")
-@snowpark_pandas_telemetry_method_decorator
 def rtruediv(
     self, other, level=None, fill_value=None, axis=0
 ):  # noqa: PR01, RT01, D200
@@ -653,7 +638,6 @@ register_series_accessor("rdiv")(rtruediv)
 
 
 @register_series_accessor("floordiv")
-@snowpark_pandas_telemetry_method_decorator
 def floordiv(
     self, other, level=None, fill_value=None, axis=0
 ):  # noqa: PR01, RT01, D200
@@ -667,7 +651,6 @@ def floordiv(
 
 
 @register_series_accessor("rfloordiv")
-@snowpark_pandas_telemetry_method_decorator
 def rfloordiv(
     self, other, level=None, fill_value=None, axis=0
 ):  # noqa: PR01, RT01, D200
@@ -681,7 +664,6 @@ def rfloordiv(
 
 
 @register_series_accessor("mod")
-@snowpark_pandas_telemetry_method_decorator
 def mod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return Modulo of series and `other`, element-wise (binary operator `mod`).
@@ -691,7 +673,6 @@ def mod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, 
 
 
 @register_series_accessor("rmod")
-@snowpark_pandas_telemetry_method_decorator
 def rmod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return modulo of series and `other`, element-wise (binary operator `rmod`).
@@ -703,7 +684,6 @@ def rmod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01,
 
 
 @register_series_accessor("pow")
-@snowpark_pandas_telemetry_method_decorator
 def pow(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return exponential power of series and `other`, element-wise (binary operator `pow`).
@@ -713,7 +693,6 @@ def pow(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, 
 
 
 @register_series_accessor("rpow")
-@snowpark_pandas_telemetry_method_decorator
 def rpow(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
     """
     Return exponential power of series and `other`, element-wise (binary operator `rpow`).
@@ -726,7 +705,6 @@ def rpow(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01,
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__add__")
-@snowpark_pandas_telemetry_method_decorator
 def __add__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.add(right)
@@ -734,7 +712,6 @@ def __add__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__radd__")
-@snowpark_pandas_telemetry_method_decorator
 def __radd__(self, left):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.radd(left)
@@ -742,7 +719,6 @@ def __radd__(self, left):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__and__")
-@snowpark_pandas_telemetry_method_decorator
 def __and__(self, other):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return super(Series, self).__and__(other)
@@ -750,7 +726,6 @@ def __and__(self, other):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rand__")
-@snowpark_pandas_telemetry_method_decorator
 def __rand__(self, other):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return super(Series, self).__rand__(other)
@@ -758,7 +733,6 @@ def __rand__(self, other):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__divmod__")
-@snowpark_pandas_telemetry_method_decorator
 def __divmod__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.divmod(right)
@@ -766,7 +740,6 @@ def __divmod__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rdivmod__")
-@snowpark_pandas_telemetry_method_decorator
 def __rdivmod__(self, left):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.rdivmod(left)
@@ -774,7 +747,6 @@ def __rdivmod__(self, left):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__floordiv__")
-@snowpark_pandas_telemetry_method_decorator
 def __floordiv__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.floordiv(right)
@@ -782,7 +754,6 @@ def __floordiv__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rfloordiv__")
-@snowpark_pandas_telemetry_method_decorator
 def __rfloordiv__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.rfloordiv(right)
@@ -790,7 +761,6 @@ def __rfloordiv__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__mod__")
-@snowpark_pandas_telemetry_method_decorator
 def __mod__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.mod(right)
@@ -798,7 +768,6 @@ def __mod__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rmod__")
-@snowpark_pandas_telemetry_method_decorator
 def __rmod__(self, left):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.rmod(left)
@@ -806,7 +775,6 @@ def __rmod__(self, left):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__mul__")
-@snowpark_pandas_telemetry_method_decorator
 def __mul__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.mul(right)
@@ -814,7 +782,6 @@ def __mul__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rmul__")
-@snowpark_pandas_telemetry_method_decorator
 def __rmul__(self, left):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.rmul(left)
@@ -822,7 +789,6 @@ def __rmul__(self, left):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__or__")
-@snowpark_pandas_telemetry_method_decorator
 def __or__(self, other):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return super(Series, self).__or__(other)
@@ -830,7 +796,6 @@ def __or__(self, other):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__ror__")
-@snowpark_pandas_telemetry_method_decorator
 def __ror__(self, other):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return super(Series, self).__ror__(other)
@@ -838,7 +803,6 @@ def __ror__(self, other):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__xor__")
-@snowpark_pandas_telemetry_method_decorator
 def __xor__(self, other):  # pragma: no cover
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return super(Series, self).__xor__(other)
@@ -846,7 +810,6 @@ def __xor__(self, other):  # pragma: no cover
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rxor__")
-@snowpark_pandas_telemetry_method_decorator
 def __rxor__(self, other):  # pragma: no cover
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return super(Series, self).__rxor__(other)
@@ -854,7 +817,6 @@ def __rxor__(self, other):  # pragma: no cover
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__pow__")
-@snowpark_pandas_telemetry_method_decorator
 def __pow__(self, right):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.pow(right)
@@ -862,7 +824,6 @@ def __pow__(self, right):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rpow__")
-@snowpark_pandas_telemetry_method_decorator
 def __rpow__(self, left):
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
     return self.rpow(left)
@@ -870,28 +831,24 @@ def __rpow__(self, left):
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__sub__")
-@snowpark_pandas_telemetry_method_decorator
 def __sub__(self, right):
     return self.sub(right)
 
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rsub__")
-@snowpark_pandas_telemetry_method_decorator
 def __rsub__(self, left):
     return self.rsub(left)
 
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__truediv__")
-@snowpark_pandas_telemetry_method_decorator
 def __truediv__(self, right):
     return self.truediv(right)
 
 
 # Modin defaults to pandas for binary operators against native pandas/list objects.
 @register_series_accessor("__rtruediv__")
-@snowpark_pandas_telemetry_method_decorator
 def __rtruediv__(self, left):
     return self.rtruediv(left)
 
@@ -906,7 +863,6 @@ register_series_accessor("__itruediv__")(__truediv__)
 
 # Upstream Modin does validation on func that Snowpark pandas does not.
 @register_series_accessor("aggregate")
-@snowpark_pandas_telemetry_method_decorator
 def aggregate(
     self, func: AggFuncType = None, axis: Axis = 0, *args: Any, **kwargs: Any
 ):
@@ -919,7 +875,6 @@ register_series_accessor("agg")(aggregate)
 
 # Upstream Modin does a significant amount of frontend manipulation and may default to pandas.
 @register_series_accessor("apply")
-@snowpark_pandas_telemetry_method_decorator
 def apply(
     self,
     func: AggFuncType,
@@ -947,7 +902,6 @@ def apply(
 
 # Upstream modin calls to_pandas on the series.
 @register_series_accessor("map")
-@snowpark_pandas_telemetry_method_decorator
 def map(
     self,
     arg: Callable | Mapping | Series,
@@ -962,7 +916,6 @@ def map(
 
 # Snowpark pandas does different validation than upstream Modin.
 @register_series_accessor("argmax")
-@snowpark_pandas_telemetry_method_decorator
 def argmax(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200
     """
     Return int position of the largest value in the Series.
@@ -983,7 +936,6 @@ def argmax(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, 
 
 # Snowpark pandas does different validation than upstream Modin.
 @register_series_accessor("argmin")
-@snowpark_pandas_telemetry_method_decorator
 def argmin(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200
     """
     Return int position of the smallest value in the Series.
@@ -1005,7 +957,6 @@ def argmin(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, 
 # Modin uses the same implementation as Snowpark pandas starting form 0.31.0.
 # Until then, upstream Modin does not convert arguments in the caselist into query compilers.
 @register_series_accessor("case_when")
-@snowpark_pandas_telemetry_method_decorator
 def case_when(self, caselist) -> Series:  # noqa: PR01, RT01, D200
     """
     Replace values where the conditions are True.
@@ -1026,7 +977,6 @@ def case_when(self, caselist) -> Series:  # noqa: PR01, RT01, D200
 # Upstream Modin has a bug:
 # https://github.com/modin-project/modin/issues/7334
 @register_series_accessor("compare")
-@snowpark_pandas_telemetry_method_decorator
 def compare(
     self,
     other: Series,
@@ -1073,7 +1023,6 @@ def compare(
 
 # Snowpark pandas does not respect `ignore_index`, and upstream Modin does not respect `how`.
 @register_series_accessor("dropna")
-@snowpark_pandas_telemetry_method_decorator
 def dropna(
     self,
     *,
@@ -1091,7 +1040,6 @@ def dropna(
 # Upstream Modin does not preserve the series name.
 # https://github.com/modin-project/modin/issues/7375
 @register_series_accessor("duplicated")
-@snowpark_pandas_telemetry_method_decorator
 def duplicated(self, keep: DropKeep = "first"):
     """
     Indicate duplicate Series values.
@@ -1109,7 +1057,6 @@ def duplicated(self, keep: DropKeep = "first"):
 # Modin has a separate definition in both series.py and base.py. In general, we cannot force base_overrides
 # to override both methods in case the series.py version calls the superclass method.
 @register_series_accessor("sum")
-@snowpark_pandas_telemetry_method_decorator
 def sum(
     self,
     axis: Axis | None = None,
@@ -1132,7 +1079,6 @@ def sum(
 
 # Snowpark pandas handles kwargs differently than modin.
 @register_series_accessor("std")
-@snowpark_pandas_telemetry_method_decorator
 def std(
     self,
     axis: Axis | None = None,
@@ -1157,7 +1103,6 @@ def std(
 
 # Snowpark pandas handles kwargs differently than modin.
 @register_series_accessor("var")
-@snowpark_pandas_telemetry_method_decorator
 def var(
     self,
     axis: Axis | None = None,
@@ -1233,7 +1178,6 @@ class CategoryMethods:
 
 @register_series_accessor("cat")
 @property
-@snowpark_pandas_telemetry_method_decorator
 def cat(self) -> CategoryMethods:
     return CategoryMethods(self)
 
@@ -1241,7 +1185,6 @@ def cat(self) -> CategoryMethods:
 # Snowpark pandas performs type validation that Modin does not.
 @register_series_accessor("dt")
 @property
-@snowpark_pandas_telemetry_method_decorator
 def dt(self):  # noqa: RT01, D200
     """
     Accessor object for datetimelike properties of the Series values.
@@ -1262,7 +1205,6 @@ def dt(self):  # noqa: RT01, D200
 # Avoid naming the object "str" to avoid overwriting Python built-in "str".
 @register_series_accessor("str")
 @property
-@snowpark_pandas_telemetry_method_decorator
 def _str(self):  # noqa: RT01, D200
     """
     Vectorized string functions for Series and Index.
@@ -1297,25 +1239,18 @@ def _set_name(self, name):
     self._update_inplace(new_query_compiler=self._query_compiler.set_columns(columns))
 
 
-register_series_accessor("name")(
-    try_add_telemetry_to_attribute(
-        "name",
-        property(Series._get_name, _set_name),
-    )
-)
+register_series_accessor("name")(property(Series._get_name, _set_name))
 
 
 # Modin uses len(self.index) instead of len(self), which may incur an extra query.
 @register_series_accessor("empty")
 @property
-@snowpark_pandas_telemetry_method_decorator
 def empty(self) -> bool:
     return len(self) == 0
 
 
 # Upstream modin uses squeeze_self instead of self_is_series.
 @register_series_accessor("fillna")
-@snowpark_pandas_telemetry_method_decorator
 def fillna(
     self,
     value: Hashable | Mapping | Series = None,
@@ -1345,7 +1280,6 @@ def fillna(
 
 # Snowpark pandas defines a custom GroupBy object
 @register_series_accessor("groupby")
-@snowpark_pandas_telemetry_method_decorator
 def groupby(
     self,
     by=None,
@@ -1389,7 +1323,6 @@ def groupby(
 # Snowpark pandas should avoid defaulting to pandas (the current Modin upstream version needs
 # Index._is_memory_usage_qualified to be implemented).
 @register_series_accessor("info")
-@snowpark_pandas_telemetry_method_decorator
 def info(
     self,
     verbose: bool | None = None,
@@ -1429,7 +1362,6 @@ def _qcut(
 
 # Snowpark pandas ignores `inplace` (possibly an error?) and performs additional validation.
 @register_series_accessor("replace")
-@snowpark_pandas_telemetry_method_decorator
 def replace(
     self,
     to_replace=None,
@@ -1463,7 +1395,6 @@ def replace(
 
 # Upstream Modin reset_index produces an extra query and performs a relative import of DataFrame.
 @register_series_accessor("reset_index")
-@snowpark_pandas_telemetry_method_decorator
 def reset_index(
     self,
     level=None,
@@ -1501,7 +1432,6 @@ def reset_index(
 
 # Snowpark pandas performs additional type validation.
 @register_series_accessor("set_axis")
-@snowpark_pandas_telemetry_method_decorator
 def set_axis(
     self,
     labels: IndexLabel,
@@ -1525,7 +1455,6 @@ def set_axis(
 # Modin does a relative import (from .dataframe import DataFrame). We should revisit this once
 # our vendored copy of DataFrame is removed.
 @register_series_accessor("rename")
-@snowpark_pandas_telemetry_method_decorator
 def rename(
     self,
     index: Renamer | Hashable | None = None,
@@ -1578,7 +1507,6 @@ def rename(
 # Modin does a relative import (from .dataframe import DataFrame). We should revisit this once
 # our vendored copy of DataFrame is removed.
 @register_series_accessor("sort_values")
-@snowpark_pandas_telemetry_method_decorator
 def sort_values(
     self,
     axis: Axis = 0,
@@ -1627,7 +1555,6 @@ def sort_values(
 # our vendored copy of DataFrame is removed.
 # Modin also defaults to pandas for some arguments for unstack
 @register_series_accessor("unstack")
-@snowpark_pandas_telemetry_method_decorator
 def unstack(
     self,
     level: int | str | list = -1,
@@ -1657,7 +1584,6 @@ def unstack(
 
 # Upstream Modin defaults at the frontend layer.
 @register_series_accessor("where")
-@snowpark_pandas_telemetry_method_decorator
 def where(
     self,
     cond: DataFrame | Series | Callable | AnyArrayLike,
@@ -1681,7 +1607,6 @@ def where(
 
 # Upstream modin defaults to pandas for some arguments.
 @register_series_accessor("value_counts")
-@snowpark_pandas_telemetry_method_decorator
 def value_counts(
     self,
     normalize: bool = False,
@@ -1711,7 +1636,6 @@ def value_counts(
 # https://github.com/pandas-dev/pandas/issues/54806
 # The parameter is ignored in upstream modin, but Snowpark pandas wants to error if the parameter is given.
 @register_series_accessor("shift")
-@snowpark_pandas_telemetry_method_decorator
 def shift(
     self,
     periods: int | Sequence[int] = 1,
@@ -1733,7 +1657,6 @@ def shift(
 
 # Snowpark pandas uses len(self) instead of len(index), saving a query in some cases.
 @register_series_accessor("squeeze")
-@snowpark_pandas_telemetry_method_decorator
 def squeeze(self, axis: Axis | None = None):
     """
     Squeeze 1 dimensional axis objects into scalars.
@@ -1784,7 +1707,6 @@ def _to_datetime(self, **kwargs):
 
 # Modin uses the query compiler to_list method, which we should try to implement instead of calling self.values.
 @register_series_accessor("to_list")
-@snowpark_pandas_telemetry_method_decorator
 def to_list(self) -> list:
     """
     Return a list of the values.
@@ -1797,7 +1719,6 @@ register_series_accessor("tolist")(to_list)
 
 
 @register_series_accessor("to_dict")
-@snowpark_pandas_telemetry_method_decorator
 def to_dict(self, into: type[dict] = dict) -> dict:
     """
     Convert Series to {label -> value} dict or dict-like object.
@@ -1846,7 +1767,6 @@ def _create_or_update_from_compiler(self, new_query_compiler, inplace=False):
 # Modin does a relative import (from .dataframe import DataFrame), so until we stop using the vendored
 # version of DataFrame, we must keep this override.
 @register_series_accessor("to_frame")
-@snowpark_pandas_telemetry_method_decorator
 def to_frame(self, name: Hashable = no_default) -> DataFrame:  # noqa: PR01, RT01, D200
     """
     Convert Series to {label -> value} dict or dict-like object.
@@ -1865,7 +1785,6 @@ def to_frame(self, name: Hashable = no_default) -> DataFrame:  # noqa: PR01, RT0
 
 
 @register_series_accessor("to_numpy")
-@snowpark_pandas_telemetry_method_decorator
 def to_numpy(
     self,
     dtype: npt.DTypeLike | None = None,
@@ -1891,7 +1810,6 @@ def to_numpy(
 
 # Snowpark pandas has the extra `statement_params` argument.
 @register_series_accessor("_to_pandas")
-@snowpark_pandas_telemetry_method_decorator
 def _to_pandas(
     self,
     *,
@@ -1922,7 +1840,6 @@ def _to_pandas(
 
 # Snowpark pandas does more validation and error checking than upstream Modin.
 @register_series_accessor("__setitem__")
-@snowpark_pandas_telemetry_method_decorator
 def __setitem__(self, key, value):
     """
     Set `value` identified by `key` in the Series.
@@ -2070,7 +1987,6 @@ def __setitem__(self, key, value):
 # Snowpark pandas uses the query compiler build_repr_df method to minimize queries, while upstream
 # modin calls BasePandasDataset.build_repr_df
 @register_series_accessor("__repr__")
-@snowpark_pandas_telemetry_method_decorator
 def __repr__(self):
     """
     Return a string representation for a particular Series.

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -594,3 +594,35 @@ def test_telemetry_series_isin():
         {"name": "Series.property.name_set"},
         {"name": "Series.isin"},
     ]
+
+
+@sql_count_checker(query_count=0)
+def test_telemetry_quantile():
+    # quantile is overridden in base_overrides.py
+    s = pd.Series([1, 2, 3, 4])
+    result_s = s.quantile(q=[0.1, 0.2])
+    assert result_s._query_compiler.snowpark_pandas_api_calls == [
+        {"name": "Series.property.name_set"},
+        {"argument": ["q"], "name": "Series.Series.quantile"},
+    ]
+    df = pd.DataFrame([1, 2, 3, 4])
+    result_df = df.quantile(q=[0.1, 0.2])
+    assert result_df._query_compiler.snowpark_pandas_api_calls == [
+        {"argument": ["q"], "name": "DataFrame.DataFrame.quantile"},
+    ]
+
+
+@sql_count_checker(query_count=2)
+def test_telemetry_to_pandas():
+    # to_pandas exists only in Snowpark pandas (modin uses _to_pandas instead)
+    s = pd.Series([1, 2, 3, 4])
+    result_s = s.to_pandas()
+    assert result_s._query_compiler.snowpark_pandas_api_calls == [
+        {"name": "Series.property.name_set"},
+        {"name": "Series.to_pandas"},
+    ]
+    df = pd.DataFrame([1, 2, 3, 4])
+    result_df = df.to_pandas()
+    assert result_df._query_compiler.snowpark_pandas_api_calls == [
+        {"name": "DataFrame.to_pandas"},
+    ]

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -613,16 +613,16 @@ def test_telemetry_quantile():
 
 
 @sql_count_checker(query_count=2)
-def test_telemetry_to_pandas():
-    # to_pandas exists only in Snowpark pandas (modin uses _to_pandas instead)
+def test_telemetry_cache_result():
+    # cache_result exists only in Snowpark pandas
     s = pd.Series([1, 2, 3, 4])
-    result_s = s.to_pandas()
+    result_s = s.cache_result()
     assert result_s._query_compiler.snowpark_pandas_api_calls == [
         {"name": "Series.property.name_set"},
-        {"name": "Series.to_pandas"},
+        {"name": "Series.cache_result"},
     ]
     df = pd.DataFrame([1, 2, 3, 4])
-    result_df = df.to_pandas()
+    result_df = df.cache_result()
     assert result_df._query_compiler.snowpark_pandas_api_calls == [
-        {"name": "DataFrame.to_pandas"},
+        {"name": "DataFrame.cache_result"},
     ]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1659478

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Previous code to de-duplicate telemetry entries was incorrect, and would not apply telemetry to methods defined on `dataframe.py` (currently still vendored) but inherited from upstream `base.py`, such as `DataFrame.copy`. This PR automatically applies telemetry annotations to Series + DataFrame inside `pandas/__init__.py` via the extensions module, meaning the `TelemetryMeta` class, and all annotations in extensions/overrides, should no longer be used.