### PR TITLE
[SNOW-1632895] Add derive_dependent_columns_with_duplication capability

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/binary_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/binary_expression.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from functools import cached_property
 from typing import AbstractSet, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import (
@@ -31,7 +30,6 @@ class BinaryExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.left, self.right)
 
-    @cached_property
     def dependent_column_names_with_duplication(self) -> list[str]:
         return derive_dependent_columns_with_duplication(self.left, self.right)
 

--- a/src/snowflake/snowpark/_internal/analyzer/binary_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/binary_expression.py
@@ -2,11 +2,13 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+from functools import cached_property
 from typing import AbstractSet, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
     derive_dependent_columns,
+    derive_dependent_columns_with_duplication,
 )
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanNodeCategory,
@@ -28,6 +30,10 @@ class BinaryExpression(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.left, self.right)
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.left, self.right)
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:

--- a/src/snowflake/snowpark/_internal/analyzer/binary_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/binary_expression.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import AbstractSet, Optional
+from typing import AbstractSet, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
@@ -30,7 +30,7 @@ class BinaryExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.left, self.right)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.left, self.right)
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -169,7 +169,7 @@ class ScalarSubquery(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return COLUMN_DEPENDENCY_DOLLAR
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return list(COLUMN_DEPENDENCY_DOLLAR)
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -57,7 +57,7 @@ def derive_dependent_columns(
 
 def derive_dependent_columns_with_duplication(
     *expressions: "Optional[Expression]",
-) -> list[str]:
+) -> List[str]:
     """
     Given set of expressions, derive the list of columns that the expression dependents on.
 
@@ -65,7 +65,7 @@ def derive_dependent_columns_with_duplication(
     the given expression. For example, concat(col1, upper(co1), upper(col2)) will have result
     [col1, col1, col2], where col1 occurred twice in the result.
     """
-    result: List[str] = []
+    result = []
     for exp in expressions:
         result.extend(exp.dependent_column_names_with_duplication())
     return result
@@ -91,7 +91,7 @@ class Expression:
         # TODO: consider adding it to __init__ or use cached_property.
         return COLUMN_DEPENDENCY_EMPTY
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return []
 
     @property
@@ -185,7 +185,7 @@ class MultipleExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.expressions)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(*self.expressions)
 
     @property
@@ -204,7 +204,7 @@ class InExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.columns, *self.values)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.columns, *self.values)
 
     @property
@@ -247,7 +247,7 @@ class Attribute(Expression, NamedExpression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return {self.name}
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return [self.name]
 
     @property
@@ -273,7 +273,7 @@ class Star(Expression):
             else COLUMN_DEPENDENCY_ALL
         )
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return (
             derive_dependent_columns_with_duplication(*self.expressions)
             if self.expressions
@@ -323,7 +323,7 @@ class UnresolvedAttribute(Expression, NamedExpression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return self._dependent_column_names
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return (
             []
             if self._dependent_column_names == COLUMN_DEPENDENCY_ALL
@@ -423,7 +423,7 @@ class Like(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, self.pattern)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr, self.pattern)
 
     @property
@@ -455,7 +455,7 @@ class RegExp(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, self.pattern)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr, self.pattern)
 
     @property
@@ -481,7 +481,7 @@ class Collate(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr)
 
     @property
@@ -505,7 +505,7 @@ class SubfieldString(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr)
 
     @property
@@ -530,7 +530,7 @@ class SubfieldInt(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr)
 
     @property
@@ -577,7 +577,7 @@ class FunctionExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.children)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(*self.children)
 
     @property
@@ -595,7 +595,7 @@ class WithinGroup(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, *self.order_by_cols)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr, *self.order_by_cols)
 
     @property
@@ -623,7 +623,7 @@ class CaseWhen(Expression):
         self.else_value = else_value
 
     @property
-    def _child_expressions(self) -> list[Expression]:
+    def _child_expressions(self) -> List[Expression]:
         exps = []
         for exp_tuple in self.branches:
             exps.extend(exp_tuple)
@@ -635,7 +635,7 @@ class CaseWhen(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self._child_expressions)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(*self._child_expressions)
 
     @property
@@ -683,7 +683,7 @@ class SnowflakeUDF(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.children)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(*self.children)
 
     @property
@@ -701,7 +701,7 @@ class ListAgg(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.col)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.col)
 
     @property
@@ -723,7 +723,7 @@ class ColumnSum(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.exprs)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(*self.exprs)
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -328,6 +328,10 @@ class UnresolvedAttribute(Expression, NamedExpression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return self._dependent_column_names
 
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return [] if self._dependent_column_names == COLUMN_DEPENDENCY_ALL else list(self._dependent_column_names)
+
     @property
     def plan_node_category(self) -> PlanNodeCategory:
         return PlanNodeCategory.COLUMN
@@ -421,6 +425,10 @@ class Like(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, self.pattern)
 
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.expr, self.pattern)
+
     @property
     def plan_node_category(self) -> PlanNodeCategory:
         # expr LIKE pattern
@@ -450,6 +458,10 @@ class RegExp(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, self.pattern)
 
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.expr, self.pattern)
+
     @property
     def plan_node_category(self) -> PlanNodeCategory:
         # expr REG_EXP pattern
@@ -472,6 +484,10 @@ class Collate(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr)
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.expr)
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -4,6 +4,7 @@
 
 import copy
 import uuid
+from functools import cached_property
 from typing import TYPE_CHECKING, AbstractSet, Any, Dict, List, Optional, Tuple
 
 import snowflake.snowpark._internal.utils
@@ -35,6 +36,13 @@ COLUMN_DEPENDENCY_EMPTY: AbstractSet[str] = frozenset()  # depend on no columns.
 def derive_dependent_columns(
     *expressions: "Optional[Expression]",
 ) -> Optional[AbstractSet[str]]:
+    """
+    Given set of expressions, derive the set of columns that the expressions dependents on.
+
+    Note, the returned dependent columns is a set without duplication. For example, given expression
+    concat(col1, upper(co1), upper(col2)), the result will be {col1, col2} even if col1 has
+    occurred in the given expression twice.
+    """
     result = set()
     for exp in expressions:
         if exp is not None:
@@ -45,6 +53,20 @@ def derive_dependent_columns(
                 return COLUMN_DEPENDENCY_ALL
             assert child_dependency is not None
             result.update(child_dependency)
+    return result
+
+
+def derive_dependent_columns_with_duplication(*expressions: "Optional[Expression]") -> list[str]:
+    """
+    Given set of expressions, derive the list of columns that the expression dependents on.
+
+    Note, the returned columns will have duplication if the column occurred more than once in
+    the given expression. For example, concat(col1, upper(co1), upper(col2)) will have result
+    [col1, col1, col2], where col1 occurred twice in the result.
+    """
+    result: List[str] = []
+    for exp in expressions:
+        result.extend(exp.dependent_column_names_with_duplication)
     return result
 
 
@@ -67,6 +89,10 @@ class Expression:
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         # TODO: consider adding it to __init__ or use cached_property.
         return COLUMN_DEPENDENCY_EMPTY
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return []
 
     @property
     def pretty_name(self) -> str:
@@ -143,6 +169,10 @@ class ScalarSubquery(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return COLUMN_DEPENDENCY_DOLLAR
 
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return list(COLUMN_DEPENDENCY_DOLLAR)
+
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:
         return self.plan.cumulative_node_complexity
@@ -155,6 +185,10 @@ class MultipleExpression(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.expressions)
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(*self.expressions)
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:
@@ -171,6 +205,10 @@ class InExpression(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.columns, *self.values)
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.columns, *self.values)
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:
@@ -212,6 +250,10 @@ class Attribute(Expression, NamedExpression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return {self.name}
 
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return [self.name]
+
     @property
     def plan_node_category(self) -> PlanNodeCategory:
         return PlanNodeCategory.COLUMN
@@ -233,6 +275,14 @@ class Star(Expression):
             derive_dependent_columns(*self.expressions)
             if self.expressions
             else COLUMN_DEPENDENCY_ALL
+        )
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return (
+            derive_dependent_columns_with_duplication(*self.expressions)
+            if self.expressions
+            else []         # we currently do not handle * dependency
         )
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -67,7 +67,8 @@ def derive_dependent_columns_with_duplication(
     """
     result = []
     for exp in expressions:
-        result.extend(exp.dependent_column_names_with_duplication())
+        if exp is not None:
+            result.extend(exp.dependent_column_names_with_duplication())
     return result
 
 
@@ -326,7 +327,8 @@ class UnresolvedAttribute(Expression, NamedExpression):
     def dependent_column_names_with_duplication(self) -> List[str]:
         return (
             []
-            if self._dependent_column_names == COLUMN_DEPENDENCY_ALL
+            if (self._dependent_column_names == COLUMN_DEPENDENCY_ALL)
+            or (self._dependent_column_names is None)
             else list(self._dependent_column_names)
         )
 

--- a/src/snowflake/snowpark/_internal/analyzer/grouping_set.py
+++ b/src/snowflake/snowpark/_internal/analyzer/grouping_set.py
@@ -24,7 +24,7 @@ class GroupingSet(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.group_by_exprs)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(*self.group_by_exprs)
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/grouping_set.py
+++ b/src/snowflake/snowpark/_internal/analyzer/grouping_set.py
@@ -49,7 +49,7 @@ class GroupingSetsExpression(Expression):
         flattened_args = [exp for sublist in self.args for exp in sublist]
         return derive_dependent_columns(*flattened_args)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         flattened_args = [exp for sublist in self.args for exp in sublist]
         return derive_dependent_columns_with_duplication(*flattened_args)
 

--- a/src/snowflake/snowpark/_internal/analyzer/grouping_set.py
+++ b/src/snowflake/snowpark/_internal/analyzer/grouping_set.py
@@ -7,6 +7,7 @@ from typing import AbstractSet, Dict, List, Optional
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
     derive_dependent_columns,
+    derive_dependent_columns_with_duplication,
 )
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanNodeCategory,
@@ -22,6 +23,9 @@ class GroupingSet(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(*self.group_by_exprs)
+
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(*self.group_by_exprs)
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:
@@ -44,6 +48,10 @@ class GroupingSetsExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         flattened_args = [exp for sublist in self.args for exp in sublist]
         return derive_dependent_columns(*flattened_args)
+
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        flattened_args = [exp for sublist in self.args for exp in sublist]
+        return derive_dependent_columns_with_duplication(*flattened_args)
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:

--- a/src/snowflake/snowpark/_internal/analyzer/sort_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/sort_expression.py
@@ -7,6 +7,7 @@ from typing import AbstractSet, Optional, Type
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
     derive_dependent_columns,
+    derive_dependent_columns_with_duplication,
 )
 
 
@@ -55,3 +56,6 @@ class SortOrder(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.child)
+
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.child)

--- a/src/snowflake/snowpark/_internal/analyzer/sort_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/sort_expression.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import AbstractSet, Optional, Type
+from typing import AbstractSet, List, Optional, Type
 
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
@@ -57,5 +57,5 @@ class SortOrder(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.child)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.child)

--- a/src/snowflake/snowpark/_internal/analyzer/unary_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/unary_expression.py
@@ -2,12 +2,14 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+from functools import cached_property
 from typing import AbstractSet, Dict, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
     NamedExpression,
     derive_dependent_columns,
+    derive_dependent_columns_with_duplication,
 )
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanNodeCategory,
@@ -35,6 +37,10 @@ class UnaryExpression(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.child)
+
+    @cached_property
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.child)
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:

--- a/src/snowflake/snowpark/_internal/analyzer/unary_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/unary_expression.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from functools import cached_property
 from typing import AbstractSet, Dict, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import (
@@ -38,7 +37,6 @@ class UnaryExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.child)
 
-    @cached_property
     def dependent_column_names_with_duplication(self) -> list[str]:
         return derive_dependent_columns_with_duplication(self.child)
 

--- a/src/snowflake/snowpark/_internal/analyzer/unary_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/unary_expression.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import AbstractSet, Dict, Optional
+from typing import AbstractSet, Dict, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
@@ -37,7 +37,7 @@ class UnaryExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.child)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.child)
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/window_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/window_expression.py
@@ -7,6 +7,7 @@ from typing import AbstractSet, Dict, List, Optional
 from snowflake.snowpark._internal.analyzer.expression import (
     Expression,
     derive_dependent_columns,
+    derive_dependent_columns_with_duplication,
 )
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanNodeCategory,
@@ -71,6 +72,9 @@ class SpecifiedWindowFrame(WindowFrame):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.lower, self.upper)
 
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.lower, self.upper)
+
     @property
     def plan_node_category(self) -> PlanNodeCategory:
         return PlanNodeCategory.LOW_IMPACT
@@ -99,6 +103,11 @@ class WindowSpecDefinition(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(
+            *self.partition_spec, *self.order_spec, self.frame_spec
+        )
+
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(
             *self.partition_spec, *self.order_spec, self.frame_spec
         )
 
@@ -138,6 +147,9 @@ class WindowExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.window_function, self.window_spec)
 
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.window_function, self.window_spec)
+
     @property
     def plan_node_category(self) -> PlanNodeCategory:
         return PlanNodeCategory.WINDOW
@@ -170,6 +182,9 @@ class RankRelatedFunctionExpression(Expression):
 
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, self.default)
+
+    def dependent_column_names_with_duplication(self) -> list[str]:
+        return derive_dependent_columns_with_duplication(self.expr, self.default)
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:

--- a/src/snowflake/snowpark/_internal/analyzer/window_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/window_expression.py
@@ -148,7 +148,9 @@ class WindowExpression(Expression):
         return derive_dependent_columns(self.window_function, self.window_spec)
 
     def dependent_column_names_with_duplication(self) -> list[str]:
-        return derive_dependent_columns_with_duplication(self.window_function, self.window_spec)
+        return derive_dependent_columns_with_duplication(
+            self.window_function, self.window_spec
+        )
 
     @property
     def plan_node_category(self) -> PlanNodeCategory:

--- a/src/snowflake/snowpark/_internal/analyzer/window_expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/window_expression.py
@@ -72,7 +72,7 @@ class SpecifiedWindowFrame(WindowFrame):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.lower, self.upper)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.lower, self.upper)
 
     @property
@@ -106,7 +106,7 @@ class WindowSpecDefinition(Expression):
             *self.partition_spec, *self.order_spec, self.frame_spec
         )
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(
             *self.partition_spec, *self.order_spec, self.frame_spec
         )
@@ -147,7 +147,7 @@ class WindowExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.window_function, self.window_spec)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(
             self.window_function, self.window_spec
         )
@@ -185,7 +185,7 @@ class RankRelatedFunctionExpression(Expression):
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return derive_dependent_columns(self.expr, self.default)
 
-    def dependent_column_names_with_duplication(self) -> list[str]:
+    def dependent_column_names_with_duplication(self) -> List[str]:
         return derive_dependent_columns_with_duplication(self.expr, self.default)
 
     @property

--- a/tests/unit/test_expression_dependent_columns.py
+++ b/tests/unit/test_expression_dependent_columns.py
@@ -242,7 +242,9 @@ def test_within_group():
     assert a.dependent_column_names() == set("abcde")
     assert a.dependent_column_names_with_duplication() == list("eabcd")
 
-    b = WithinGroup(UnresolvedAttribute("e"), [UnresolvedAttribute(x) for x in "abcdea"])
+    b = WithinGroup(
+        UnresolvedAttribute("e"), [UnresolvedAttribute(x) for x in "abcdea"]
+    )
     assert b.dependent_column_names() == set("abcde")
     assert b.dependent_column_names_with_duplication() == list("eabcdea")
 
@@ -309,7 +311,11 @@ def test_binary_expression(expression_class):
     # hierarchical expressions with duplication
     hierarchical_binary_expression = expression_class(expression_class(a, b), b)
     assert hierarchical_binary_expression.dependent_column_names() == {"A", "B"}
-    assert hierarchical_binary_expression.dependent_column_names_with_duplication() == ["A", "B", "B"]
+    assert hierarchical_binary_expression.dependent_column_names_with_duplication() == [
+        "A",
+        "B",
+        "B",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -412,6 +418,22 @@ def test_window_expression():
     a = WindowExpression(UnresolvedAttribute("x"), window_spec_definition)
     assert a.dependent_column_names() == set("abcdefx")
     assert a.dependent_column_names_with_duplication() == list("xabcdef")
+
+
+def test_window_expression_with_duplication_columns():
+    window_spec_definition = WindowSpecDefinition(
+        [UnresolvedAttribute("a"), UnresolvedAttribute("b")],
+        [
+            SortOrder(UnresolvedAttribute("c"), Ascending()),
+            SortOrder(UnresolvedAttribute("a"), Ascending()),
+        ],
+        SpecifiedWindowFrame(
+            RowFrame(), UnresolvedAttribute("e"), UnresolvedAttribute("f")
+        ),
+    )
+    a = WindowExpression(UnresolvedAttribute("e"), window_spec_definition)
+    assert a.dependent_column_names() == set("abcef")
+    assert a.dependent_column_names_with_duplication() == list("eabcaef")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_expression_dependent_columns.py
+++ b/tests/unit/test_expression_dependent_columns.py
@@ -87,30 +87,37 @@ from snowflake.snowpark.types import IntegerType
 def test_expression():
     a = Expression()
     assert a.dependent_column_names() == COLUMN_DEPENDENCY_EMPTY
+    assert a.dependent_column_names_with_duplication() == []
     b = Expression(child=UnresolvedAttribute("a"))
     assert b.dependent_column_names() == COLUMN_DEPENDENCY_EMPTY
+    assert b.dependent_column_names_with_duplication() == []
     # root class Expression always returns empty dependency
 
 
 def test_literal():
     a = Literal(5)
     assert a.dependent_column_names() == COLUMN_DEPENDENCY_EMPTY
+    assert a.dependent_column_names_with_duplication() == []
 
 
 def test_attribute():
     a = Attribute("A", IntegerType())
     assert a.dependent_column_names() == {"A"}
+    assert a.dependent_column_names_with_duplication() == ["A"]
 
 
 def test_unresolved_attribute():
     a = UnresolvedAttribute("A")
     assert a.dependent_column_names() == {"A"}
+    assert a.dependent_column_names_with_duplication() == ["A"]
 
     b = UnresolvedAttribute("a > 1", is_sql_text=True)
     assert b.dependent_column_names() == COLUMN_DEPENDENCY_ALL
+    assert b.dependent_column_names_with_duplication() == []
 
     c = UnresolvedAttribute("$1 > 1", is_sql_text=True)
     assert c.dependent_column_names() == COLUMN_DEPENDENCY_DOLLAR
+    assert c.dependent_column_names_with_duplication() == ['$']
 
 
 def test_case_when():
@@ -118,46 +125,56 @@ def test_case_when():
     b = Column("b")
     z = when(a > b, col("c")).when(a < b, col("d")).else_(col("e"))
     assert z._expression.dependent_column_names() == {'"A"', '"B"', '"C"', '"D"', '"E"'}
+    # verify column '"A"', '"B"' occurred twice in the dependency columns
+    assert z._expression.dependent_column_names_with_duplication() == ['"A"', '"B"', '"C"', '"A"', '"B"', '"D"', '"E"']
 
 
 def test_collate():
     a = Collate(UnresolvedAttribute("a"), "spec")
     assert a.dependent_column_names() == {"a"}
+    assert a.dependent_column_names_with_duplication() == ["a"]
 
 
 def test_function_expression():
     a = FunctionExpression("test_func", [UnresolvedAttribute(x) for x in "abcd"], False)
     assert a.dependent_column_names() == set("abcd")
+    assert a.dependent_column_names_with_duplication() == list("abcd")
 
 
 def test_in_expression():
     a = InExpression(UnresolvedAttribute("e"), [UnresolvedAttribute(x) for x in "abcd"])
     assert a.dependent_column_names() == set("abcde")
+    assert a.dependent_column_names_with_duplication() == list("eabcd")
 
 
 def test_like():
     a = Like(UnresolvedAttribute("a"), UnresolvedAttribute("b"))
     assert a.dependent_column_names() == {"a", "b"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b"]
 
 
 def test_list_agg():
     a = ListAgg(UnresolvedAttribute("a"), ",", True)
     assert a.dependent_column_names() == {"a"}
+    assert a.dependent_column_names_with_duplication() == ["a"]
 
 
 def test_multiple_expression():
     a = MultipleExpression([UnresolvedAttribute(x) for x in "abcd"])
     assert a.dependent_column_names() == set("abcd")
+    assert a.dependent_column_names_with_duplication() == list("abcd")
 
 
 def test_reg_exp():
     a = RegExp(UnresolvedAttribute("a"), UnresolvedAttribute("b"))
     assert a.dependent_column_names() == {"a", "b"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b"]
 
 
 def test_scalar_subquery():
     a = ScalarSubquery(None)
     assert a.dependent_column_names() == COLUMN_DEPENDENCY_DOLLAR
+    assert a.dependent_column_names_with_duplication() == list(COLUMN_DEPENDENCY_DOLLAR)
 
 
 def test_snowflake_udf():
@@ -165,21 +182,25 @@ def test_snowflake_udf():
         "udf_name", [UnresolvedAttribute(x) for x in "abcd"], IntegerType()
     )
     assert a.dependent_column_names() == set("abcd")
+    assert a.dependent_column_names_with_duplication() == list("abcd")
 
 
 def test_star():
     a = Star([Attribute(x, IntegerType()) for x in "abcd"])
     assert a.dependent_column_names() == set("abcd")
+    assert a.dependent_column_names_with_duplication() == list("abcd")
 
 
 def test_subfield_string():
     a = SubfieldString(UnresolvedAttribute("a"), "field")
     assert a.dependent_column_names() == {"a"}
+    assert a.dependent_column_names_with_duplication() == ["a"]
 
 
 def test_within_group():
     a = WithinGroup(UnresolvedAttribute("e"), [UnresolvedAttribute(x) for x in "abcd"])
     assert a.dependent_column_names() == set("abcde")
+    assert a.dependent_column_names_with_duplication() == list("eabcd")
 
 
 @pytest.mark.parametrize(
@@ -189,16 +210,19 @@ def test_within_group():
 def test_unary_expression(expression_class):
     a = expression_class(child=UnresolvedAttribute("a"))
     assert a.dependent_column_names() == {"a"}
+    assert a.dependent_column_names_with_duplication() == ["a"]
 
 
 def test_alias():
     a = Alias(child=Add(UnresolvedAttribute("a"), UnresolvedAttribute("b")), name="c")
     assert a.dependent_column_names() == {"a", "b"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b"]
 
 
 def test_cast():
     a = Cast(UnresolvedAttribute("a"), IntegerType())
     assert a.dependent_column_names() == {"a"}
+    assert a.dependent_column_names_with_duplication() == ["a"]
 
 
 @pytest.mark.parametrize(
@@ -234,6 +258,10 @@ def test_binary_expression(expression_class):
     assert b.dependent_column_names() == {"B"}
     assert binary_expression.dependent_column_names() == {"A", "B"}
 
+    assert a.dependent_column_names_with_duplication() == ["A"]
+    assert b.dependent_column_names_with_duplication() == ["B"]
+    assert binary_expression.dependent_column_names_with_duplication() == ["A", "B"]
+
 
 @pytest.mark.parametrize(
     "expression_class",
@@ -253,6 +281,7 @@ def test_grouping_set(expression_class):
         ]
     )
     assert a.dependent_column_names() == {"a", "b", "c", "d"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b", "c", "d"]
 
 
 def test_grouping_sets_expression():
@@ -263,11 +292,13 @@ def test_grouping_sets_expression():
         ]
     )
     assert a.dependent_column_names() == {"a", "b", "c", "d"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b", "c", "d"]
 
 
 def test_sort_order():
     a = SortOrder(UnresolvedAttribute("a"), Ascending())
     assert a.dependent_column_names() == {"a"}
+    assert a.dependent_column_names_with_duplication() == ["a"]
 
 
 def test_specified_window_frame():
@@ -275,12 +306,14 @@ def test_specified_window_frame():
         RowFrame(), UnresolvedAttribute("a"), UnresolvedAttribute("b")
     )
     assert a.dependent_column_names() == {"a", "b"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b"]
 
 
 @pytest.mark.parametrize("expression_class", [RankRelatedFunctionExpression, Lag, Lead])
 def test_rank_related_function_expression(expression_class):
     a = expression_class(UnresolvedAttribute("a"), 1, UnresolvedAttribute("b"), False)
     assert a.dependent_column_names() == {"a", "b"}
+    assert a.dependent_column_names_with_duplication() == ["a", "b"]
 
 
 def test_window_spec_definition():
@@ -295,6 +328,7 @@ def test_window_spec_definition():
         ),
     )
     assert a.dependent_column_names() == set("abcdef")
+    assert a.dependent_column_names_with_duplication() == list("abcdef")
 
 
 def test_window_expression():
@@ -310,6 +344,7 @@ def test_window_expression():
     )
     a = WindowExpression(UnresolvedAttribute("x"), window_spec_definition)
     assert a.dependent_column_names() == set("abcdefx")
+    assert a.dependent_column_names_with_duplication() == list("xabcdef")
 
 
 @pytest.mark.parametrize(
@@ -325,3 +360,4 @@ def test_window_expression():
 def test_other_window_expressions(expression_class):
     a = expression_class()
     assert a.dependent_column_names() == COLUMN_DEPENDENCY_EMPTY
+    assert a.dependent_column_names_with_duplication() == []


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1632895

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

in order to handle nested select with column dependency (not handled by sql simplifier) complexity calculation, added a utility support for deriving all column depenencies with duplication, for example, col('a') + col('b') + 3*('a'), should return dependency ['a', 'b', 'a'] this provides both information about the columns it dependents on and also the number of times/
