### PR TITLE
[SNOW-1645085] Always use SCOPED temp table for snowpark pandas generated api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Improved `dtype` results for TIMESTAMP_LTZ type to show correct timezone.
 - Improved error message when passing non-bool value to `numeric_only` for groupby aggregations.
 - Removed unnecessary warning about sort algorithm in `sort_values`.
+- Use SCOPED object for internal create temp tables.
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Improved `dtype` results for TIMESTAMP_LTZ type to show correct timezone.
 - Improved error message when passing non-bool value to `numeric_only` for groupby aggregations.
 - Removed unnecessary warning about sort algorithm in `sort_values`.
-- Use SCOPED object for internal create temp tables.
+- Use SCOPED object for internal create temp tables. The SCOPED objects will be stored sproc scoped if created within stored sproc, otherwise will be session scoped, and the object will be automatically cleaned at the end of the scope.
 
 #### New Features
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -285,7 +285,6 @@ def _create_read_only_table(
             else STATEMENT_PARAMS.UNKNOWN,
         }
         statement_params.update(new_params)
-        # TODO: use snowpark save_as_table when user facing scoped object is supported
         session.sql(
             f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=use_scoped_temp_table, is_generated=True)} TABLE {temp_table_name} AS {ctas_query}"
         ).collect(statement_params=statement_params)
@@ -300,7 +299,7 @@ def _create_read_only_table(
             STATEMENT_PARAMS.READONLY_TABLE_NAME: readonly_table_name,
         }
     )
-    # TODO: pushing read only table creation down to snowpark for general usage
+    # TODO (SNOW-1669224): pushing read only table creation down to snowpark for general usage
     session.sql(
         f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=use_scoped_temp_table, is_generated=True)} READ ONLY TABLE {readonly_table_name} CLONE {table_name}"
     ).collect(statement_params=statement_params)

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -261,7 +261,7 @@ def _create_read_only_table(
     readonly_table_name = (
         f"{random_name_for_temp_object(TempObjectType.TABLE)}{READ_ONLY_TABLE_SUFFIX}"
     )
-
+    use_scoped_temp_table = session._use_scoped_temp_objects
     # If we need to materialize into a temp table our create table expression
     # needs to be SELECT * FROM (object).
     if materialize_into_temp_table:
@@ -287,7 +287,7 @@ def _create_read_only_table(
         statement_params.update(new_params)
         # TODO: use snowpark save_as_table when user facing scoped object is supported
         session.sql(
-            f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=True, is_generated=True)} TABLE {temp_table_name} AS {ctas_query}"
+            f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=use_scoped_temp_table, is_generated=True)} TABLE {temp_table_name} AS {ctas_query}"
         ).collect(statement_params=statement_params)
         table_name = temp_table_name
 
@@ -302,7 +302,7 @@ def _create_read_only_table(
     )
     # TODO: pushing read only table creation down to snowpark for general usage
     session.sql(
-        f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=True, is_generated=True)} READ ONLY TABLE {readonly_table_name} CLONE {table_name}"
+        f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=use_scoped_temp_table, is_generated=True)} READ ONLY TABLE {readonly_table_name} CLONE {table_name}"
     ).collect(statement_params=statement_params)
 
     return readonly_table_name

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -28,6 +28,7 @@ from snowflake.snowpark._internal.utils import (
     TempObjectType,
     generate_random_alphanumeric,
     random_name_for_temp_object,
+    get_temp_type_for_object,
 )
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.exceptions import SnowparkSQLException
@@ -284,8 +285,9 @@ def _create_read_only_table(
             else STATEMENT_PARAMS.UNKNOWN,
         }
         statement_params.update(new_params)
+        # TODO: use snowpark save_as_table when user facing scoped object is supported
         session.sql(
-            f"CREATE OR REPLACE TEMPORARY TABLE {temp_table_name} AS {ctas_query}"
+            f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=True, is_generated=True)} TABLE {temp_table_name} AS {ctas_query}"
         ).collect(statement_params=statement_params)
         table_name = temp_table_name
 
@@ -298,8 +300,9 @@ def _create_read_only_table(
             STATEMENT_PARAMS.READONLY_TABLE_NAME: readonly_table_name,
         }
     )
+    # TODO: pushing read only table creation down to snowpark for general usage
     session.sql(
-        f"CREATE OR REPLACE TEMPORARY READ ONLY TABLE {readonly_table_name} CLONE {table_name}"
+        f"CREATE OR REPLACE {get_temp_type_for_object(use_scoped_temp_objects=True, is_generated=True)} READ ONLY TABLE {readonly_table_name} CLONE {table_name}"
     ).collect(statement_params=statement_params)
 
     return readonly_table_name

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -27,8 +27,8 @@ from snowflake.snowpark._internal.utils import (
     SNOWFLAKE_OBJECT_RE_PATTERN,
     TempObjectType,
     generate_random_alphanumeric,
-    random_name_for_temp_object,
     get_temp_type_for_object,
+    random_name_for_temp_object,
 )
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.exceptions import SnowparkSQLException

--- a/tests/integ/modin/io/test_read_snowflake.py
+++ b/tests/integ/modin/io/test_read_snowflake.py
@@ -138,7 +138,7 @@ def test_read_snowflake_semi_structured_types(
 
     # create snowpark pandas dataframe
     df = read_snowflake_and_verify_snapshot_creation(
-        session, table_name, as_query, verify_materialization=False
+        session, table_name, as_query, False
     )
 
     pdf = df.to_pandas()
@@ -179,7 +179,7 @@ def test_read_snowflake_column_names(session, col_name, as_query):
 
     # create snowpark pandas dataframe
     df = read_snowflake_and_verify_snapshot_creation(
-        session, table_name, as_query, verify_materialization=False
+        session, table_name, as_query, False
     )
 
     pdf = df.to_pandas()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1645085
Always use scoped temp table for internally created temp table during read_snowflake.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.
SCOPED temp object is feature introduced for snowpark internally created table, which is stored procedure scoped temp if the temp table is created within stored sproc, and session scoped if outside sored sproc.
Native app only allows usage of scoped object, similar as snowpark python, we always uses scoped object when enabled