### PR TITLE
SNOW-1657460 Improved  results for TIMESTAMP_TZ type to show correct timezone offset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Improvements
 
 - Improved `to_pandas` to persist the original timezone offset for TIMESTAMP_TZ type.
+- Improved `dtype` results for TIMESTAMP_TZ type to show correct timezone offset.
 
 #### New Features
 

--- a/src/snowflake/snowpark/modin/pandas/indexing.py
+++ b/src/snowflake/snowpark/modin/pandas/indexing.py
@@ -51,11 +51,9 @@ from pandas._typing import AnyArrayLike, Scalar
 from pandas.api.types import is_bool, is_list_like
 from pandas.core.dtypes.common import (
     is_bool_dtype,
-    is_datetime64_any_dtype,
     is_integer,
     is_integer_dtype,
     is_numeric_dtype,
-    is_timedelta64_dtype,
     pandas_dtype,
 )
 from pandas.core.indexing import IndexingError
@@ -846,7 +844,7 @@ class _LocIndexer(_LocationIndexerBase):
             period = pd.Period(parsed, freq=reso.attr_abbrev)
 
             # partial string indexing only works for DatetimeIndex
-            if is_datetime64_any_dtype(self.df._query_compiler.index_dtypes[0]):
+            if self.df._query_compiler.is_datetime64_any_dtype(idx=0, is_index=True):
                 return slice(
                     pd.Timestamp(period.start_time, tzinfo=tzinfo),
                     pd.Timestamp(period.end_time, tzinfo=tzinfo),
@@ -927,7 +925,7 @@ class _LocIndexer(_LocationIndexerBase):
         row_loc = self._try_partial_string_indexing(row_loc)
 
         # Check if self or its index is a TimedeltaIndex. `index_dtypes` retrieves the dtypes of the index columns.
-        if is_timedelta64_dtype(self.df._query_compiler.index_dtypes[0]):
+        if self.df._query_compiler.is_timedelta64_dtype(idx=0, is_index=True):
             # Convert row_loc to timedelta format to perform exact matching for TimedeltaIndex.
             row_loc = self._convert_to_timedelta(row_loc)
 

--- a/src/snowflake/snowpark/modin/pandas/indexing.py
+++ b/src/snowflake/snowpark/modin/pandas/indexing.py
@@ -924,7 +924,7 @@ class _LocIndexer(_LocationIndexerBase):
         row_loc, col_loc = self._parse_get_row_and_column_locators(key)
         row_loc = self._try_partial_string_indexing(row_loc)
 
-        # Check if self or its index is a TimedeltaIndex. `index_dtypes` retrieves the dtypes of the index columns.
+        # Check if self or its index is a TimedeltaIndex.
         if self.df._query_compiler.is_timedelta64_dtype(idx=0, is_index=True):
             # Convert row_loc to timedelta format to perform exact matching for TimedeltaIndex.
             row_loc = self._convert_to_timedelta(row_loc)

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import Any, Callable, NamedTuple, Optional, Union
 
 import pandas as native_pd
+from pandas import DatetimeTZDtype
 from pandas._typing import IndexLabel
 
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
@@ -30,6 +31,9 @@ from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
 )
 from snowflake.snowpark.modin.plugin._internal.snowpark_pandas_types import (
     SnowparkPandasType,
+)
+from snowflake.snowpark.modin.plugin._internal.type_utils import (
+    _get_timezone_from_timestamp_tz,
 )
 from snowflake.snowpark.modin.plugin._internal.utils import (
     DEFAULT_DATA_COLUMN_LABEL,
@@ -1472,6 +1476,18 @@ class InternalFrame:
             )
         )
         return self.rename_snowflake_identifiers(renamed_quoted_identifier_mapping)
+
+    def get_datetime64tz_from_timestamp_tz(
+        self, timestamp_tz_snowfalke_quoted_identifier: str
+    ) -> DatetimeTZDtype:
+        """
+        map a snowpark timestamp type to datetime64 type.
+        """
+
+        return _get_timezone_from_timestamp_tz(
+            self.ordered_dataframe._dataframe_ref.snowpark_dataframe,
+            timestamp_tz_snowfalke_quoted_identifier,
+        )
 
     # END: Internal Frame mutation APIs.
     ###########################################################################

--- a/src/snowflake/snowpark/modin/plugin/_internal/type_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/type_utils.py
@@ -459,7 +459,7 @@ def _get_timezone_from_timestamp_tz(
         .select(to_char(col(snowflake_quoted_identifier), format="TZHTZM").as_("tz"))
         .group_by(["tz"])
         .agg()
-        .limit(2)
+        .limit(2)  # only need 2 to check whether it contains multiple timezones
         .to_pandas()
     )
     assert (

--- a/src/snowflake/snowpark/modin/plugin/extensions/datetime_index.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/datetime_index.py
@@ -41,7 +41,6 @@ from pandas._typing import (
     TimeAmbiguous,
     TimeNonexistent,
 )
-from pandas.core.dtypes.common import is_datetime64_any_dtype
 
 from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
     SnowflakeQueryCompiler,
@@ -136,8 +135,7 @@ class DatetimeIndex(Index):
         """
         if query_compiler:
             # Raise error if underlying type is not a TimestampType.
-            current_dtype = query_compiler.index_dtypes[0]
-            if not current_dtype == np.dtype("datetime64[ns]"):
+            if not query_compiler.is_datetime64_any_dtype(idx=0, is_index=True):
                 raise ValueError(
                     "DatetimeIndex can only be created from a query compiler with TimestampType."
                 )
@@ -158,7 +156,7 @@ class DatetimeIndex(Index):
             data, _CONSTRUCTOR_DEFAULTS, query_compiler, **kwargs
         )
         # Convert to datetime64 if not already.
-        if not is_datetime64_any_dtype(query_compiler.index_dtypes[0]):
+        if not query_compiler.is_datetime64_any_dtype(idx=0, is_index=True):
             query_compiler = query_compiler.series_to_datetime(include_index=True)
         index._query_compiler = query_compiler
         # `_parent` keeps track of any Series or DataFrame that this Index is a part of.

--- a/src/snowflake/snowpark/modin/plugin/extensions/index.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/index.py
@@ -45,7 +45,6 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_numeric_dtype,
     is_object_dtype,
-    is_timedelta64_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.inference import is_hashable
@@ -127,10 +126,9 @@ class Index(metaclass=TelemetryMeta):
         query_compiler = cls._init_query_compiler(
             data, _CONSTRUCTOR_DEFAULTS, query_compiler, **kwargs
         )
-        dtype = query_compiler.index_dtypes[0]
-        if is_datetime64_any_dtype(dtype):
+        if query_compiler.is_datetime64_any_dtype(idx=0, is_index=True):
             return DatetimeIndex(query_compiler=query_compiler)
-        if is_timedelta64_dtype(dtype):
+        if query_compiler.is_timedelta64_dtype(idx=0, is_index=True):
             return TimedeltaIndex(query_compiler=query_compiler)
         index = object.__new__(cls)
         # Initialize the Index

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
@@ -30,11 +30,6 @@ from pandas._typing import (
     Renamer,
     Scalar,
 )
-from pandas.api.types import (
-    is_datetime64_any_dtype,
-    is_string_dtype,
-    is_timedelta64_dtype,
-)
 from pandas.core.common import apply_if_callable, is_bool_indexer
 from pandas.core.dtypes.common import is_bool_dtype, is_dict_like, is_list_like
 from pandas.util._validators import validate_bool_kwarg
@@ -1163,10 +1158,9 @@ def dt(self):  # noqa: RT01, D200
     Accessor object for datetimelike properties of the Series values.
     """
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
-    current_dtype = self.dtype
-    if not is_datetime64_any_dtype(current_dtype) and not is_timedelta64_dtype(
-        current_dtype
-    ):
+    if not self._query_compiler.is_datetime64_any_dtype(
+        idx=0, is_index=False
+    ) and not self._query_compiler.is_timedelta64_dtype(idx=0, is_index=False):
         raise AttributeError("Can only use .dt accessor with datetimelike values")
 
     from modin.pandas.series_utils import DatetimeProperties
@@ -1183,8 +1177,7 @@ def _str(self):  # noqa: RT01, D200
     Vectorized string functions for Series and Index.
     """
     # TODO: SNOW-1063347: Modin upgrade - modin.pandas.Series functions
-    current_dtype = self.dtype
-    if not is_string_dtype(current_dtype):
+    if not self._query_compiler.is_string_dtype(idx=0, is_index=False):
         raise AttributeError("Can only use .str accessor with string values!")
 
     from modin.pandas.series_utils import StringMethods

--- a/tests/integ/modin/frame/test_dtypes.py
+++ b/tests/integ/modin/frame/test_dtypes.py
@@ -6,7 +6,7 @@ import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
-from pandas.core.dtypes.common import is_integer_dtype
+from pandas.core.dtypes.common import is_datetime64_any_dtype, is_integer_dtype
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.types import (
@@ -18,7 +18,7 @@ from snowflake.snowpark.types import (
     StringType,
     VariantType,
 )
-from tests.integ.modin.sql_counter import sql_count_checker
+from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_frame_equal,
     assert_series_equal,
@@ -352,7 +352,7 @@ def test_insert_multiindex_multi_label(label1, label2):
             ],
             "datetime64[ns, America/Los_Angeles]",
             "datetime64[ns, UTC-08:00]",
-            "datetime64[ns]",
+            "datetime64[ns, UTC-08:00]",
         ),
         (
             [
@@ -373,21 +373,27 @@ def test_insert_multiindex_multi_label(label1, label2):
             ],
             "object",
             "datetime64[ns, UTC-08:00]",
-            "datetime64[ns]",
+            "datetime64[ns, UTC-08:00]",
         ),
     ],
 )
-@sql_count_checker(query_count=1)
 def test_time(dataframe_input, input_dtype, expected_dtype, logical_dtype):
     expected = native_pd.Series(dataframe_input, dtype=expected_dtype)
-    created = pd.Series(dataframe_input, dtype=input_dtype)
-    # For snowpark pandas type mapping
-    assert created.dtype == logical_dtype
-    roundtripped = created.to_pandas()
-    assert_series_equal(
-        roundtripped, expected, check_dtype=False, check_index_type=False
+    qc = (
+        2
+        if is_datetime64_any_dtype(expected.dtype)
+        and getattr(expected.dtype, "tz", None) is not None
+        else 1
     )
-    assert roundtripped.dtype == expected.dtype
+    with SqlCounter(query_count=qc):
+        created = pd.Series(dataframe_input, dtype=input_dtype)
+        # For snowpark pandas type mapping
+        assert created.dtype == logical_dtype
+        roundtripped = created.to_pandas()
+        assert_series_equal(
+            roundtripped, expected, check_dtype=False, check_index_type=False
+        )
+        assert roundtripped.dtype == expected.dtype
 
 
 @pytest.mark.parametrize(
@@ -528,3 +534,33 @@ def test_str_float_type_with_nan(
     assert native_se.dtype == to_pandas_dtype
     expected = native_pd.Series(input_data, dtype=to_pandas_dtype)
     assert_series_equal(native_se, expected, check_index_type=False)
+
+
+@pytest.mark.parametrize(
+    "ts_data",
+    [
+        native_pd.date_range("2020-01-01", periods=10),
+        native_pd.date_range("2020-01-01", periods=10, tz="US/Pacific"),
+        native_pd.date_range("2020-01-01", periods=10, tz="UTC"),
+        native_pd.date_range("2020-01-01", periods=10, tz="Asia/Tokyo"),
+        native_pd.date_range("2020-01-01", periods=10, tz="UTC+1000"),
+        native_pd.date_range("2020-01-01", periods=10, tz="UTC+1000").append(
+            native_pd.date_range("2020-01-01", periods=10, tz="UTC")
+        ),
+    ],
+)
+def test_tz_dtype(ts_data):
+    with SqlCounter(
+        query_count=1
+        if is_datetime64_any_dtype(ts_data.dtype) and ts_data.tz is None
+        else 2
+    ):
+        s = pd.Series(ts_data)
+        assert s.dtype == s.to_pandas().dtype
+
+
+@sql_count_checker(query_count=1)
+def test_tz_dtype_cache():
+    s = pd.Series(native_pd.date_range("2020-10-01", periods=5, tz="UTC"))
+    for _ in range(50):
+        assert s.dtype == "datetime64[ns, UTC]"

--- a/tests/integ/modin/frame/test_dtypes.py
+++ b/tests/integ/modin/frame/test_dtypes.py
@@ -390,10 +390,7 @@ def test_time(dataframe_input, input_dtype, expected_dtype, logical_dtype):
         # For snowpark pandas type mapping
         assert created.dtype == logical_dtype
         roundtripped = created.to_pandas()
-        assert_series_equal(
-            roundtripped, expected, check_dtype=False, check_index_type=False
-        )
-        assert roundtripped.dtype == expected.dtype
+        assert_series_equal(roundtripped, expected, check_index_type=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/modin/index/test_index_methods.py
+++ b/tests/integ/modin/index/test_index_methods.py
@@ -347,14 +347,12 @@ def test_df_index_to_frame(native_df, index, name):
     )
 
 
-@sql_count_checker(query_count=0)
 @pytest.mark.parametrize("native_index", NATIVE_INDEX_TEST_DATA)
 def test_index_dtype(native_index):
-    snow_index = pd.Index(native_index)
-    if isinstance(native_index, native_pd.DatetimeIndex):
-        # Snowpark pandas does not include timezone info in dtype datetime64[ns],
-        assert snow_index.dtype == "datetime64[ns]"
-    else:
+    with SqlCounter(
+        query_count=1 if getattr(native_index.dtype, "tz", None) is not None else 0
+    ):
+        snow_index = pd.Index(native_index)
         assert snow_index.dtype == native_index.dtype
 
 

--- a/tests/integ/modin/series/test_astype.py
+++ b/tests/integ/modin/series/test_astype.py
@@ -221,8 +221,6 @@ def test_astype_to_DatetimeTZDtype(from_dtype, to_tz):
     else:
         with SqlCounter(query_count=2):
             s = pd.Series(seed, dtype=from_dtype).astype(to_dtype)
-            # Snowflake timestamp_tz column's metadata does not contain the tzinfo so it cannot provide dtype as
-            # datetime64[ns, UTC], so its dtype returns datetime64 or <M8[ns]
             assert s.dtype == DatetimeTZDtype(tz=offset_map[to_tz])
             #
             # native_pd.Series([0,1,2], dtype="float64").astype("datetime64[ns, Asia/Tokyo]")

--- a/tests/integ/modin/series/test_astype.py
+++ b/tests/integ/modin/series/test_astype.py
@@ -287,7 +287,7 @@ def test_astype_from_DatetimeTZDtype_to_datetime64(from_tz):
     native = native_pd.Series([0, 1, 2, 3], dtype=from_dtype)
     snow = pd.Series(native)
     expected_dtype = get_expected_dtype(to_dtype)
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=1):
         s = snow.astype(to_dtype)
         assert s.dtype == expected_dtype
         # Native pandas after 2.0 disallows using astype to convert from timzone-aware to timezone-naive

--- a/tests/integ/modin/series/test_dt_accessor.py
+++ b/tests/integ/modin/series/test_dt_accessor.py
@@ -222,7 +222,7 @@ def test_normalize():
     )
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 @timezones
 def test_tz_convert(tz):
     datetime_index = native_pd.DatetimeIndex(
@@ -236,7 +236,12 @@ def test_tz_convert(tz):
         tz="US/Eastern",
     )
     native_ser = native_pd.Series(datetime_index)
+    assert str(native_ser.dtype.tz) == "US/Eastern"
     snow_ser = pd.Series(native_ser)
+    # This is a great example to show the current limit of Snowpark pandas timezone, it only preserves the timezone
+    # offset and the timezone will be gone. So in this case, Snowpark pandas does not know the timezone is "US/Eastern"
+    # so it will treat it as a multi timezone offset column which results a dtype as "object".
+    assert snow_ser.dtype == "object"
     eval_snowpark_pandas_result(
         snow_ser,
         native_ser,

--- a/tests/integ/modin/test_from_pandas_to_pandas.py
+++ b/tests/integ/modin/test_from_pandas_to_pandas.py
@@ -308,7 +308,7 @@ def test_from_to_pandas_datetime64_support():
     )
 
 
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_rw_datetimeindex():
     test_datetime_index = native_pd.DatetimeIndex(
         ["2017-12-31 16:00:00", "2017-12-31 17:00:00", "2017-12-31 18:00:00"],
@@ -327,7 +327,9 @@ def test_rw_datetimeindex():
     df = pd.DataFrame({"ntz": test_datetime_index, "tz": test_datetime_index_tz})
     assert_series_equal(
         df.dtypes,
-        native_pd.Series(["datetime64[ns]", "datetime64[ns]"], index=["ntz", "tz"]),
+        native_pd.Series(
+            ["datetime64[ns]", "datetime64[ns, UTC-08:00]"], index=["ntz", "tz"]
+        ),
     )
     assert_series_equal(
         df.to_pandas().dtypes,

--- a/tests/unit/modin/conftest.py
+++ b/tests/unit/modin/conftest.py
@@ -25,7 +25,9 @@ def mock_single_col_query_compiler() -> SnowflakeQueryCompiler:
         '"A"': None
     }
     mock_internal_frame.get_snowflake_type.return_value = [StringType()]
-
+    mock_internal_frame.quoted_identifier_to_snowflake_type.return_value = {
+        '"A"': StringType()
+    }
     fake_query_compiler = SnowflakeQueryCompiler(mock_internal_frame)
 
     return fake_query_compiler

--- a/tests/unit/modin/test_series_dt.py
+++ b/tests/unit/modin/test_series_dt.py
@@ -22,6 +22,9 @@ def mock_query_compiler_for_dt_series() -> SnowflakeQueryCompiler:
     mock_internal_frame.data_columns_index = native_pd.Index(["A"], name="B")
     mock_internal_frame.data_column_snowflake_quoted_identifiers = ['"A"']
     mock_internal_frame.get_snowflake_type.return_value = [TimestampType()]
+    mock_internal_frame.quoted_identifier_to_snowflake_type.return_value = {
+        '"A"': TimestampType()
+    }
     fake_query_compiler = SnowflakeQueryCompiler(mock_internal_frame)
 
     return fake_query_compiler


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1657460

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Previously we use "datetime64[ns]" as the dtype for datetime with timezone which is missing the tz info. This change will extract the timezone from timestamp_tz column and show the timezone offset when calling dtypes.
