### PR TITLE
SNOW-1649780: Bug fix Series.sort_values fails when name overlaps with index name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed a bug where an `Index` object created from a `Series`/`DataFrame` incorrectly updates the `Series`/`DataFrame`'s index name after an inplace update has been applied to the original `Series`/`DataFrame`.
 - Suppressed an unhelpful `SettingWithCopyWarning` that sometimes appeared when printing `Timedelta` columns.
 - Fixed `inplace` argument for `Series` objects derived from other `Series` objects.
+- Fixed a bug where `Series.sort_values` failed if series name overlapped with index column name.
 
 ## 1.22.1 (2024-09-11)
 This is a re-release of 1.22.0. Please refer to the 1.22.0 release notes for detailed release content.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3255,6 +3255,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ignore_index: bool,
         key: Optional[IndexKeyFunc] = None,
         include_indexer: bool = False,
+        include_index: bool = True,
     ) -> "SnowflakeQueryCompiler":
         """
         Reorder the rows based on the lexicographic order of the given columns.
@@ -3270,6 +3271,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             key: Apply the key function to the values before sorting.
             include_indexer: If True, add a data column with the original row numbers in the same order as
                 the index, i.e., add an indexer column. This is used with Index.sort_values.
+            include_index: If True, include index columns in the sort.
 
         Returns:
             A new SnowflakeQueryCompiler instance after applying the sort.
@@ -3297,7 +3299,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         matched_identifiers = (
             self._modin_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
-                columns
+                columns, include_index
             )
         )
 

--- a/tests/integ/modin/series/test_sort_values.py
+++ b/tests/integ/modin/series/test_sort_values.py
@@ -178,3 +178,13 @@ def test_sort_values_repeat(snow_series):
         snow_series.to_pandas(),
         lambda s: s.sort_values().sort_values(ascending=False),
     )
+
+
+@sql_count_checker(query_count=1)
+def test_sort_values_shared_name_with_index():
+    # Bug fix: SNOW-1649780
+    native_series = native_pd.Series(
+        [1, 3, 2], name="X", index=native_pd.Index([2, 1, 3], name="X")
+    )
+    snow_series = pd.Series(native_series)
+    eval_snowpark_pandas_result(snow_series, native_series, lambda s: s.sort_values())


### PR DESCRIPTION
In native pandas, calling sort_values where column name overlaps with index name raises error `ValueError: 'col' is both an index level and a column label, which is ambiguous`. But this works for series. 

In Snowpark pandas we were raising errors both the scenarios Dataframe (this is expected) and Series (this was bug).
**Root cause**: In modin frontend we to implement Series.sort_values we convert this to Dataframe and call sort_values on it. So this failed the validation above.
**Fix:** Instead of converting Series to Dataframe directly call `query_compiler.sort_rows_by_column_values`.
