### PR TITLE
SNOW-1320309: Remove unnecessary warning from sort_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Improved `to_pandas` to persist the original timezone offset for TIMESTAMP_TZ type.
 - Improved `dtype` results for TIMESTAMP_TZ type to show correct timezone offset.
 - Improved error message when passing non-bool value to `numeric_only` for groupby aggregations.
+- Removed unnecessary warning about sort algorithm in `sort_values`.
 
 #### New Features
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3355,7 +3355,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 # This error message is different from native pandas hence, hence it is kept here instead
                 # of moving this to frontend layer.
                 raise ValueError(f"sort kind must be 'stable' or None (got '{kind}')")
-            if kind != "stable":
+            # Do not show warning for 'quicksort' as this the default option.
+            if kind not in ("stable", "quicksort"):
                 logging.warning(
                     f"choice of sort algorithm '{kind}' is ignored. sort kind must be 'stable' or None"
                 )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3358,7 +3358,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # Do not show warning for 'quicksort' as this the default option.
             if kind not in ("stable", "quicksort"):
                 logging.warning(
-                    f"choice of sort algorithm '{kind}' is ignored. sort kind must be 'stable' or None"
+                    f"choice of sort algorithm '{kind}' is ignored. sort kind must be 'stable', 'quicksort', or None"
                 )
 
         matched_identifiers = (


### PR DESCRIPTION
Remove warning from sort_values when sort algorithm is 'quicksort'. We still raise warning if user passed a sort algorithm explicitly like `mergesort` for `quicksort` is default value so it doesn't make sense to raise this warning.