### PR TITLE
SNOW-1640167: Test Timedelta input and output in apply-like methods.

### DIFF
--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -8,6 +8,7 @@ import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
+from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
@@ -23,6 +24,15 @@ from tests.integ.modin.utils import (
 # test data which has a python type as return type that is not a pandas Series/pandas DataFrame/tuple/list
 BASIC_DATA_FUNC_PYTHON_RETURN_TYPE_MAP = [
     [[[1.0, 2.2], [3, np.nan]], np.min, "float"],
+    param(
+        [[1.0, 2.2], [3, np.nan]],
+        lambda x: native_pd.Timedelta(1),
+        "native_pd.Timedelta",
+        id="return_timedelta_scalar",
+        marks=pytest.mark.xfail(
+            strict=True, raises=AssertionError, reason="SNOW-1619940"
+        ),
+    ),
     [[[1.1, 2.2], [3, np.nan]], lambda x: x.sum(), "float"],
     [[[1.1, 2.2], [3, np.nan]], lambda x: x.size, "int"],
     [[[1.1, 2.2], [3, np.nan]], lambda x: "0" if x.sum() > 1 else 0, "object"],
@@ -46,6 +56,16 @@ BASIC_DATA_FUNC_PYTHON_RETURN_TYPE_MAP = [
         [[{"a": "b"}, {"c": "d"}], [{"c": "b"}, {"a": "d"}]],
         lambda x: str(x[0]) + str(x[1]),
         "str",
+    ),
+    param(
+        [
+            [native_pd.Timedelta(1), native_pd.Timedelta(2)],
+            [native_pd.Timedelta(3), native_pd.Timedelta(4)],
+        ],
+        lambda column: column.sum().value,
+        "int",
+        id="apply_on_frame_with_timedelta_data_columns_returns_int",
+        marks=pytest.mark.xfail(strict=True, raises=NotImplementedError),
     ),
 ]
 
@@ -88,6 +108,17 @@ def test_axis_0_basic_types_with_type_hints(data, func, return_type):
         eval_snowpark_pandas_result(
             snow_df, native_df, lambda x: x.apply(func_with_type_hint, axis=0)
         )
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+@sql_count_checker(query_count=0)
+def test_frame_with_timedelta_index():
+    eval_snowpark_pandas_result(
+        *create_test_dfs(
+            native_pd.DataFrame([0], index=[native_pd.Timedelta(1)]),
+        ),
+        lambda df: df.apply(lambda col: col)
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/modin/frame/test_applymap.py
+++ b/tests/integ/modin/frame/test_applymap.py
@@ -17,6 +17,7 @@ from tests.integ.modin.series.test_apply import (
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equal_to_pandas,
+    create_test_dfs,
     eval_snowpark_pandas_result,
 )
 
@@ -58,6 +59,17 @@ def test_applymap_date_time_timestamp(data, func, return_type, expected_result):
     snow_df = pd.DataFrame(frame_data)
     result = snow_df.applymap(func_with_type_hint)
     assert_snowpark_pandas_equal_to_pandas(result, frame_expected_result)
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+@sql_count_checker(query_count=0)
+def test_frame_with_timedelta_index():
+    eval_snowpark_pandas_result(
+        *create_test_dfs(
+            native_pd.DataFrame([0], index=[native_pd.Timedelta(1)]),
+        ),
+        lambda df: df.applymap(lambda x: x),
+    )
 
 
 def test_applymap_kwargs():

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -832,6 +832,37 @@ class TestFuncReturnsScalar:
                 include_groups=False,
             )
 
+    @pytest.mark.xfail(strict=True, raises=AssertionError, reason="SNOW-1619940")
+    def test_return_timedelta(self):
+        eval_snowpark_pandas_result(
+            *create_test_dfs([[1, 2]]),
+            lambda df: df.groupby(0).apply(
+                lambda df: native_pd.Timedelta(df.sum().sum())
+            ),
+        )
+
+    @pytest.mark.xfail(strict=True, raises=NotImplementedError)
+    @pytest.mark.parametrize(
+        "pandas_df",
+        [
+            param(
+                native_pd.DataFrame([["key0", native_pd.Timedelta(1)]]),
+                id="timedelta_column",
+            ),
+            param(
+                native_pd.DataFrame(
+                    [["key0", "value1"]],
+                    index=native_pd.Index([native_pd.Timedelta(1)]),
+                ),
+                id="timedelta_index",
+            ),
+        ],
+    )
+    def test_timedelta_input(self, pandas_df):
+        eval_snowpark_pandas_result(
+            *create_test_dfs(pandas_df), lambda df: df.groupby(0).apply(lambda df: 1)
+        )
+
 
 class TestFuncReturnsSeries:
     @pytest.mark.parametrize(
@@ -1072,6 +1103,43 @@ class TestSeriesGroupBy:
                 group_keys=group_keys,
                 sort=sort,
             ).apply(func),
+        )
+
+
+class SeriesGroupByWithTimedelta:
+    @pytest.mark.xfail(strict=True, raises=AssertionError, reason="SNOW-1619940")
+    def test_return_timedelta(self):
+        eval_snowpark_pandas_result(
+            *create_test_dfs([[1, 2]]),
+            lambda df: df.groupby(0,)[
+                1
+            ].apply(lambda series: native_pd.Timedelta(series.sum())),
+        )
+
+    @pytest.mark.xfail(strict=True, raises=NotImplementedError)
+    @pytest.mark.parametrize(
+        "pandas_df",
+        [
+            param(
+                native_pd.DataFrame([["key0", native_pd.Timedelta(1)]]),
+                id="timedelta_column",
+            ),
+            param(
+                native_pd.DataFrame(
+                    [["key0", "value1"]],
+                    index=native_pd.Index([native_pd.Timedelta(1)]),
+                ),
+                id="timedelta_index",
+            ),
+        ],
+    )
+    def test_timedelta_input(
+        self,
+        pandas_df,
+    ):
+        eval_snowpark_pandas_result(
+            *create_test_dfs(pandas_df),
+            lambda df: df.groupby(0)[1].apply(lambda series: 1),
         )
 
 


### PR DESCRIPTION
Fixes SNOW-1640167

Test two scenarios for apply-like methods `apply`, `applymap`, `groupby.transform`, and `groupby.apply`:

1) input dataframe has timedelta data columns or index columns
2) output includes timedelta values.

Situation 1) currently raises `NotImplementedError` and will continue to do so after this commit. Recognizing that we have timedelta instead of the underlying integer as input inside the UD(T)F requires adding extra metadata. Postpone this task till a user asks for it. In this commit, just check for the `NotImplementedError`.

Situation 2) currently puts string outputs instead of `Timedelta` in the result. That's a bug, but it does follow what Snowflake does in this case. Fixing the bug is possible, but requires adding some extra metadata to the UD(T)F output. For now defer this task until a feature notices the discrepancy. In this commit, just check for an `AssertionError` that the Snowpark pandas result is not correct.