### PR TITLE
[SNOW-1632898] Adjust SelectStatement projection complexity calculation

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/query_plan_analysis_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/query_plan_analysis_utils.py
@@ -51,6 +51,24 @@ def sum_node_complexities(
     return dict(counter_sum)
 
 
+def subtract_complexities(
+    complexities1: Dict[PlanNodeCategory, int],
+    complexities2: Dict[PlanNodeCategory, int],
+) -> Dict[PlanNodeCategory, int]:
+    """
+    This is a helper function for complexities1 - complexities2.
+    """
+
+    result_complexities = complexities1.copy()
+    for key, value in complexities2.items():
+        if key in result_complexities:
+            result_complexities[key] -= value
+        else:
+            result_complexities[key] = -value
+
+    return result_complexities
+
+
 def get_complexity_score(
     cumulative_node_complexity: Dict[PlanNodeCategory, int]
 ) -> int:

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -898,7 +898,10 @@ class SelectStatement(Selectable):
         if self._cumulative_node_complexity is None:
             self._cumulative_node_complexity = super().cumulative_node_complexity
             if self._merge_projection_complexity_with_subquery:
-                # subtract the from_ projection complexity
+                # if _merge_projection_complexity_with_subquery is true, the subquery
+                # projection complexity has already been merged with the current projection
+                # complexity, and we need to adjust the cumulative_node_complexity by
+                # subtracting the from_ projection complexity.
                 assert isinstance(self.from_, SelectStatement)
                 self._cumulative_node_complexity = subtract_complexities(
                     self._cumulative_node_complexity,
@@ -956,6 +959,9 @@ class SelectStatement(Selectable):
 
     @property
     def projection_complexities(self) -> List[Dict[PlanNodeCategory, int]]:
+        """
+        Return the complexity for each projection expression.
+        """
         if self.projection is None:
             return []
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -708,14 +708,11 @@ class SelectStatement(Selectable):
         copied._merge_projection_complexity_with_subquery = (
             self._merge_projection_complexity_with_subquery
         )
-<<<<<<< HEAD
-=======
         copied._projection_complexities = (
             deepcopy(self._projection_complexities)
             if not self._projection_complexities
             else None
         )
->>>>>>> 0dcc86343 (fix error)
         return copied
 
     @property
@@ -1104,7 +1101,6 @@ class SelectStatement(Selectable):
             new = SelectStatement(
                 projection=cols, from_=self.to_subqueryable(), analyzer=self.analyzer
             )
-<<<<<<< HEAD
             new._merge_projection_complexity_with_subquery = (
                 can_select_projection_complexity_be_merged(
                     cols,
@@ -1113,10 +1109,6 @@ class SelectStatement(Selectable):
                 )
             )
 
-=======
-            # set it to True for testing
-            new._merge_projection_complexity_with_subquery = True
->>>>>>> 0dcc86343 (fix error)
         new.flatten_disabled = disable_next_level_flatten
         assert new.projection is not None
         new._column_states = derive_column_states_from_subquery(

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -659,7 +659,9 @@ class SelectStatement(Selectable):
         self._merge_projection_complexity_with_subquery = False
         # cached list of projection complexities, each projection complexity is adjusted
         # with the subquery projection if _merge_projection_complexity_with_subquery is True.
-        self._projection_complexities: Optional[List[PlanNodeCategory, int]] = None
+        self._projection_complexities: Optional[
+            List[Dict[PlanNodeCategory, int]]
+        ] = None
 
     def __copy__(self):
         new = SelectStatement(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -25,7 +25,6 @@ from typing import (
 
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanNodeCategory,
-    sum_node_complexities,
 )
 from snowflake.snowpark._internal.analyzer.table_function import (
     GeneratorTableFunction,
@@ -441,10 +440,12 @@ class SnowflakePlan(LogicalPlan):
     @property
     def cumulative_node_complexity(self) -> Dict[PlanNodeCategory, int]:
         if self._cumulative_node_complexity is None:
-            self._cumulative_node_complexity = sum_node_complexities(
-                self.individual_node_complexity,
-                *(node.cumulative_node_complexity for node in self.children_plan_nodes),
-            )
+            if self.source_plan:
+                self._cumulative_node_complexity = (
+                    self.source_plan.cumulative_node_complexity
+                )
+            else:
+                self._cumulative_node_complexity = {}
         return self._cumulative_node_complexity
 
     @cumulative_node_complexity.setter

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -440,6 +440,8 @@ class SnowflakePlan(LogicalPlan):
     @property
     def cumulative_node_complexity(self) -> Dict[PlanNodeCategory, int]:
         if self._cumulative_node_complexity is None:
+            # if source plan is available, the source plan complexity
+            # is the snowflake plan complexity.
             if self.source_plan:
                 self._cumulative_node_complexity = (
                     self.source_plan.cumulative_node_complexity
@@ -451,6 +453,11 @@ class SnowflakePlan(LogicalPlan):
     @cumulative_node_complexity.setter
     def cumulative_node_complexity(self, value: Dict[PlanNodeCategory, int]):
         self._cumulative_node_complexity = value
+
+    def reset_cumulative_node_complexity(self) -> None:
+        self._cumulative_node_complexity = None
+        if self.source_plan:
+            self.source_plan.reset_cumulative_node_complexity()
 
     def __copy__(self) -> "SnowflakePlan":
         if self.session._cte_optimization_enabled:

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -136,6 +136,8 @@ def replace_child(
 
     elif isinstance(parent, SelectStatement):
         parent.from_ = to_selectable(new_child, query_generator)
+        # once the subquery is updated, set _try_merge_projection_complexity to False
+        parent._try_merge_projection_complexity = False
 
     elif isinstance(parent, SetStatement):
         new_child_as_selectable = to_selectable(new_child, query_generator)
@@ -235,6 +237,7 @@ def update_resolvable_node(
         # the projection expression can be re-analyzed during code generation
         node._projection_in_str = None
         node.analyzer = query_generator
+        node._projection_complexity = None
 
         # update the pre_actions and post_actions for the select statement
         node.pre_actions = node.from_.pre_actions

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -136,8 +136,9 @@ def replace_child(
 
     elif isinstance(parent, SelectStatement):
         parent.from_ = to_selectable(new_child, query_generator)
-        # once the subquery is updated, set _try_merge_projection_complexity to False
-        parent._try_merge_projection_complexity = False
+        # once the subquery is updated, set _merge_projection_complexity_with_subquery to False to
+        # disable the projection complexity merge
+        parent._merge_projection_complexity_with_subquery = False
 
     elif isinstance(parent, SetStatement):
         new_child_as_selectable = to_selectable(new_child, query_generator)
@@ -237,6 +238,7 @@ def update_resolvable_node(
         # the projection expression can be re-analyzed during code generation
         node._projection_in_str = None
         node.analyzer = query_generator
+        # reset the _projection_complexities fields to re-calculate the complexities
         node._projection_complexities = None
 
         # update the pre_actions and post_actions for the select statement

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -237,7 +237,7 @@ def update_resolvable_node(
         # the projection expression can be re-analyzed during code generation
         node._projection_in_str = None
         node.analyzer = query_generator
-        node._projection_complexity = None
+        node._projection_complexities = None
 
         # update the pre_actions and post_actions for the select statement
         node.pre_actions = node.from_.pre_actions

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -110,7 +110,6 @@ def test_no_valid_nodes_found(session, large_query_df, caplog):
 def test_large_query_breakdown_with_cte_optimization(session):
     """Test large query breakdown works with cte optimized plan"""
     session._cte_optimization_enabled = True
-    # session.large_query_breakdown_enabled = False
     df0 = session.sql("select 2 as b, 32 as c")
     df1 = session.sql("select 1 as a, 2 as b").filter(col("a") == 1)
     df1 = df1.join(df0, on=["b"], how="inner")

--- a/tests/integ/test_nested_select_plan_analysis.py
+++ b/tests/integ/test_nested_select_plan_analysis.py
@@ -2,8 +2,13 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+from typing import Dict, Optional
+
 import pytest
 
+from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
+    PlanNodeCategory,
+)
 from snowflake.snowpark._internal.analyzer.select_statement import SelectStatement
 from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.functions import (
@@ -19,6 +24,11 @@ from snowflake.snowpark.functions import (
     min as min_,
 )
 from snowflake.snowpark.window import Window
+from tests.integ.test_deepcopy import (
+    create_df_with_deep_nested_with_column_dependencies,
+)
+from tests.integ.test_query_plan_analysis import assert_df_subtree_query_complexity
+from tests.utils import Utils
 
 pytestmark = [
     pytest.mark.xfail(
@@ -27,6 +37,7 @@ pytestmark = [
         run=False,
     )
 ]
+
 
 paramList = [False, True]
 
@@ -44,51 +55,161 @@ def setup(request, session):
 
 @pytest.fixture(scope="function")
 def simple_dataframe(session) -> DataFrame:
+    """
+    The complexity of the simple_dataframe is {COLUMN: 6, LITERAL: 9}, and corresponds to the following query:
+
+    SELECT "A", "B", "C" FROM (
+        SELECT $1 AS "A", $2 AS "B", $3 AS "C" FROM  VALUES (
+            1 :: INT, \'a\' :: STRING, 2 :: INT), (2 :: INT, \'b\' :: STRING, 3 :: INT), (3 :: INT, \'c\' :: STRING, 7 :: INT))
+    """
     return session.create_dataframe(
         [[1, "a", 2], [2, "b", 3], [3, "c", 7]], schema=["a", "b", "c"]
     )
 
 
+@pytest.fixture(scope="function")
+def sample_table(session):
+    table_name = Utils.random_table_name()
+    Utils.create_table(
+        session, table_name, "a int, b int, c int, d int", is_temporary=True
+    )
+    session._run_query(
+        f"insert into {table_name}(a, b, c, d) values " "(1, 2, 3, 4), (5, 6, 7, 8)"
+    )
+    yield table_name
+    Utils.drop_table(session, table_name)
+
+
 def verify_dataframe_select_statement(
-    df: DataFrame, can_be_merged_when_enabled: bool
+    df: DataFrame,
+    can_be_merged_when_enabled: bool,
+    complexity_before_merge: Dict[PlanNodeCategory, int],
+    complexity_after_merge: Optional[Dict[PlanNodeCategory, int]] = None,
 ) -> None:
     assert isinstance(df._plan.source_plan, SelectStatement)
 
     if not df.session.large_query_breakdown_enabled:
         # if large query breakdown is disabled, _merge_projection_complexity_with_subquery will always be false
         assert df._plan.source_plan._merge_projection_complexity_with_subquery is False
+        assert_df_subtree_query_complexity(df, complexity_before_merge)
     else:
         assert (
             df._plan.source_plan._merge_projection_complexity_with_subquery
             == can_be_merged_when_enabled
         )
+        if can_be_merged_when_enabled:
+            assert (
+                complexity_after_merge
+            ), "no complexity after merge is provided for validation"
+            assert_df_subtree_query_complexity(df, complexity_after_merge)
+        else:
+            assert_df_subtree_query_complexity(df, complexity_before_merge)
 
 
 def test_simple_valid_nested_select(simple_dataframe):
     df_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select(
         (col("a") + 3).as_("a"), "c"
     )
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.COLUMN: 8,
+            PlanNodeCategory.LITERAL: 11,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.LITERAL: 11,
+            PlanNodeCategory.COLUMN: 5,
+        },
+    )
     # add one more select
     df_res = df_res.select(col("a") * 2, (col("c") + 2).as_("d"))
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 4,
+            PlanNodeCategory.COLUMN: 10,
+            PlanNodeCategory.LITERAL: 13,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LOW_IMPACT: 4,
+            PlanNodeCategory.LITERAL: 13,
+            PlanNodeCategory.COLUMN: 5,
+        },
+    )
 
 
 def test_nested_select_with_star(simple_dataframe):
     df_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select("*")
+    print(df_res._plan.cumulative_node_complexity)
     # star will be automatically flattened, the complexity won't be flattened
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.COLUMN: 6,
+            PlanNodeCategory.LITERAL: 10,
+        },
+    )
     df_res = df_res.select((col("a") + 3).as_("a"), "c")
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.COLUMN: 8,
+            PlanNodeCategory.LITERAL: 11,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.LITERAL: 11,
+            PlanNodeCategory.COLUMN: 5,
+        },
+    )
 
 
 def test_nested_select_with_valid_function_expressions(simple_dataframe):
     df_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select(
         concat("a", "b").as_("a"), initcap("c").as_("c"), "b"
     )
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.FUNCTION: 2,
+            PlanNodeCategory.COLUMN: 10,
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.LITERAL: 10,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.FUNCTION: 2,
+            PlanNodeCategory.COLUMN: 7,
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.LITERAL: 10,
+        },
+    )
+
     df_res = df_res.select(concat("a", initcap(concat("b", "c"))), add_months("a", 5))
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.FUNCTION: 6,
+            PlanNodeCategory.COLUMN: 14,
+            PlanNodeCategory.LITERAL: 11,
+            PlanNodeCategory.LOW_IMPACT: 1,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.FUNCTION: 7,
+            PlanNodeCategory.COLUMN: 9,
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.LITERAL: 12,
+        },
+    )
 
 
 def test_nested_select_with_window_functions(simple_dataframe):
@@ -99,7 +220,21 @@ def test_nested_select_with_window_functions(simple_dataframe):
     df_res = simple_dataframe.select(
         avg("a").over(window1).as_("a"), avg("b").over(window2).as_("b")
     ).select((col("a") + 1).as_("a"), "b")
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
+
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 6,
+            PlanNodeCategory.COLUMN: 10,
+            PlanNodeCategory.LITERAL: 11,
+            PlanNodeCategory.WINDOW: 2,
+            PlanNodeCategory.FUNCTION: 2,
+            PlanNodeCategory.PARTITION_BY: 1,
+            PlanNodeCategory.ORDER_BY: 2,
+            PlanNodeCategory.OTHERS: 2,
+        },
+    )
 
 
 def test_nested_select_with_table_functions(session):
@@ -110,7 +245,15 @@ def test_nested_select_with_table_functions(session):
     )
     df_res = df.select((col("a") + 1).as_("a"), "b", "c")
 
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.COLUMN: 3,
+            PlanNodeCategory.LITERAL: 1,
+        },
+    )
 
 
 def test_nested_select_with_valid_builtin_function(simple_dataframe):
@@ -118,65 +261,129 @@ def test_nested_select_with_valid_builtin_function(simple_dataframe):
         builtin("nvl")(col("a"), col("b")).as_("a"),
         builtin("nvl2")(col("b"), col("c")).as_("c"),
     )
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.FUNCTION: 2,
+            PlanNodeCategory.COLUMN: 10,
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.LITERAL: 10,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.FUNCTION: 2,
+            PlanNodeCategory.COLUMN: 7,
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.LITERAL: 10,
+        },
+    )
 
 
 def test_nested_select_with_agg_functions(simple_dataframe):
     df_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select(
         avg("a").as_("a"), min_("c").as_("c")
     )
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
 
-    df_res = simple_dataframe.select(max_("a"))
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.FUNCTION: 2,
+            PlanNodeCategory.COLUMN: 8,
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.LITERAL: 10,
+        },
+    )
+
+    df_res = simple_dataframe.select(
+        max_("a").as_("a"), (min_("c") + 1).as_("c")
+    ).select(col("a") + 1, "c")
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.COLUMN: 7,
+            PlanNodeCategory.LITERAL: 11,
+            PlanNodeCategory.FUNCTION: 2,
+        },
+    )
 
 
 def test_nested_select_with_limit_filter_order_by(simple_dataframe):
-    """
-    df_res_filtered = (
-        simple_dataframe.filter(col("a") == 1)
-        .select((col("a") + 1).as_("a"), "b", "c")
-        .select((col("a") + 1).as_("a"), "b")
-    )
-    verify_dataframe_select_statement(df_res_filtered, can_be_merged_when_enabled=False)
-
-    df_res_limit = (
-        simple_dataframe.select((col("a") + 1).as_("a"), "b", "c")
-        .limit(10, 5)
-        .select(concat("a", "b").as_("a"), initcap("c").as_("c"), "b")
-    )
-    verify_dataframe_select_statement(df_res_limit, can_be_merged_when_enabled=False)
-    """
-
     def_order_by_filter = (
         simple_dataframe.select((col("a") + 1).as_("a"), "b", "c")
         .order_by(col("a"))
         .filter(col("a") == 1)
     )
     df_res = def_order_by_filter.select((col("a") + 2).as_("a"))
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
+
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 3,
+            PlanNodeCategory.COLUMN: 9,
+            PlanNodeCategory.LITERAL: 12,
+            PlanNodeCategory.FILTER: 1,
+            PlanNodeCategory.OTHERS: 1,
+            PlanNodeCategory.ORDER_BY: 1,
+        },
+    )
 
 
 def test_select_with_dependency_within_same_level(simple_dataframe):
     df_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select(
         (col("a") + 2).as_("d"), (col("d") + 1).as_("e")
     )
-    # star will be automatically flattened, the complexity won't be flattened
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=False)
+
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 3,
+            PlanNodeCategory.COLUMN: 8,
+            PlanNodeCategory.LITERAL: 12,
+        },
+    )
 
 
 def test_select_with_duplicated_columns(simple_dataframe):
-    def_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select(
+    df_res = simple_dataframe.select((col("a") + 1).as_("a"), "b", "c").select(
         (col("a") + 2).as_("b"), (col("b") + 1).as_("b")
     )
-    verify_dataframe_select_statement(def_res, can_be_merged_when_enabled=True)
+
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 3,
+            PlanNodeCategory.COLUMN: 8,
+            PlanNodeCategory.LITERAL: 12,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LOW_IMPACT: 3,
+            PlanNodeCategory.LITERAL: 12,
+            PlanNodeCategory.COLUMN: 5,
+        },
+    )
 
 
 def test_select_with_dollar_dependency(simple_dataframe):
-    def_res = simple_dataframe.select((col("a") + 1), "b", "c").select(
+    df_res = simple_dataframe.select((col("a") + 1), "b", "c").select(
         (col("$1") + 2).as_("b"), col("$2").as_("c")
     )
-    verify_dataframe_select_statement(def_res, can_be_merged_when_enabled=False)
+
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.COLUMN: 8,
+            PlanNodeCategory.LITERAL: 11,
+        },
+    )
 
 
 def test_valid_after_invalid_nested_select(simple_dataframe):
@@ -185,7 +392,116 @@ def test_valid_after_invalid_nested_select(simple_dataframe):
         .select((col("a") + 1).as_("a"), "b", "c")
         .select((col("a") + 1).as_("a"), "b")
     )
-    verify_dataframe_select_statement(df_res_filtered, can_be_merged_when_enabled=False)
+    print(df_res_filtered._plan.cumulative_node_complexity)
+    verify_dataframe_select_statement(
+        df_res_filtered,
+        can_be_merged_when_enabled=False,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 3,
+            PlanNodeCategory.COLUMN: 9,
+            PlanNodeCategory.LITERAL: 12,
+            PlanNodeCategory.FILTER: 1,
+        },
+    )
 
     df_res = df_res_filtered.select((col("a") + 2).as_("a"), (col("b") + 2).as_("b"))
-    verify_dataframe_select_statement(df_res, can_be_merged_when_enabled=True)
+    print(df_res._plan.cumulative_node_complexity)
+    verify_dataframe_select_statement(
+        df_res,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 5,
+            PlanNodeCategory.COLUMN: 11,
+            PlanNodeCategory.LITERAL: 14,
+            PlanNodeCategory.FILTER: 1,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LOW_IMPACT: 5,
+            PlanNodeCategory.LITERAL: 14,
+            PlanNodeCategory.COLUMN: 9,
+            PlanNodeCategory.FILTER: 1,
+        },
+    )
+
+
+def test_simple_nested_select_with_repeated_column_dependency(session, sample_table):
+    df = session.table(sample_table)
+    df_select = df.select((col("a") + 1).as_("a"), "b", "c")
+    assert_df_subtree_query_complexity(
+        df_select,
+        {
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.COLUMN: 4,
+            PlanNodeCategory.LITERAL: 1,
+        },
+    )
+
+    df_select = df_select.select((col("a") + 3).as_("a"), "c")
+    # the two select complexity can be merged when large query breakdown enabled,
+    # and will be equivalent to the complexity of
+    # df.select((col("a") + 1 + 3).as_("a"), "c")
+    verify_dataframe_select_statement(
+        df_select,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LITERAL: 2,
+            PlanNodeCategory.COLUMN: 6,
+            PlanNodeCategory.LOW_IMPACT: 2,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LITERAL: 2,
+            PlanNodeCategory.COLUMN: 3,
+            PlanNodeCategory.LOW_IMPACT: 2,
+        },
+    )
+
+    # add one more select with duplicated reference
+    df_select = df_select.select(
+        col("a") * 2 + col("a") + col("c"), (col("c") + 2).as_("d")
+    )
+    print(df_select._plan.cumulative_node_complexity)
+    # the complexity can be continue merged with the previous select, and the whole tree complexity
+    # will be equivalent to df.select((col("a") + 3 + 1) * 2 + (col("a") + 3 + 1)  + col("c"), (col("c") + 2).as_("d")
+    verify_dataframe_select_statement(
+        df_select,
+        can_be_merged_when_enabled=True,
+        complexity_before_merge={
+            PlanNodeCategory.LOW_IMPACT: 6,
+            PlanNodeCategory.COLUMN: 10,
+            PlanNodeCategory.LITERAL: 4,
+        },
+        complexity_after_merge={
+            PlanNodeCategory.LOW_IMPACT: 8,
+            PlanNodeCategory.COLUMN: 5,
+            PlanNodeCategory.LITERAL: 6,
+        },
+    )
+
+
+def test_deep_nested_with_columns(session):
+    temp_table_name = Utils.random_table_name()
+    try:
+        df = create_df_with_deep_nested_with_column_dependencies(
+            session, temp_table_name, 5
+        )
+        verify_dataframe_select_statement(
+            df,
+            can_be_merged_when_enabled=True,
+            complexity_before_merge={
+                PlanNodeCategory.COLUMN: 97,
+                PlanNodeCategory.CASE_WHEN: 4,
+                PlanNodeCategory.LOW_IMPACT: 8,
+                PlanNodeCategory.LITERAL: 20,
+                PlanNodeCategory.FUNCTION: 60,
+            },
+            complexity_after_merge={
+                PlanNodeCategory.COLUMN: 389,
+                PlanNodeCategory.CASE_WHEN: 40,
+                PlanNodeCategory.LOW_IMPACT: 80,
+                PlanNodeCategory.LITERAL: 200,
+                PlanNodeCategory.FUNCTION: 600,
+            },
+        )
+        print(df._plan.cumulative_node_complexity)
+    finally:
+        Utils.drop_table(session, temp_table_name)

--- a/tests/integ/test_query_plan_analysis.py
+++ b/tests/integ/test_query_plan_analysis.py
@@ -21,6 +21,9 @@ from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.functions import avg, col, lit, seq1, table_function, uniform
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.window import Window
+from tests.integ.test_deepcopy import (
+    create_df_with_deep_nested_with_column_dependencies,
+)
 from tests.utils import Utils
 
 pytestmark = [
@@ -563,3 +566,57 @@ def test_select_statement_with_multiple_operations(session: Session, sample_tabl
             get_cumulative_node_complexity(df9), {PlanNodeCategory.LOW_IMPACT: 2}
         ),
     )
+
+
+def test_simple_nested_select_with_column_dependency(session, sample_table):
+    df = session.table(sample_table)
+    assert_df_subtree_query_complexity(df, {PlanNodeCategory.COLUMN: 1})
+    df_select = df.select((col("a") + 1).as_("a"), "b", "c")
+    assert_df_subtree_query_complexity(
+        df_select,
+        {
+            PlanNodeCategory.LOW_IMPACT: 1,
+            PlanNodeCategory.COLUMN: 4,
+            PlanNodeCategory.LITERAL: 1,
+        },
+    )
+    df_select = df_select.select((col("a") + 3).as_("a"), "c")
+    # the two select complexity can be merged, and will be equivalent to the
+    # complexity of df.select((col("a") + 3 + 1).as_("a"), "c")
+    # NOTE the LOW_IMPACT calculation is currently wrong, the LOW_IMPACT corresponds to
+    # alias, which should only be one after merge.
+    # TODO: adjust the calculation for ALIAS during nested SELECT merge
+    assert_df_subtree_query_complexity(
+        df_select,
+        {
+            PlanNodeCategory.LOW_IMPACT: 2,
+            PlanNodeCategory.LITERAL: 2,
+            PlanNodeCategory.COLUMN: 3,
+        },
+    )
+
+    # add one more select with duplicated reference
+    df_select = df_select.select(
+        col("a") * 2 + col("a") + col("c"), (col("c") + 2).as_("d")
+    )
+    # the complexity can be continue merged with the previous select, and the whole tree complexity
+    # will be equivalent to df.select((col("a") + 3 + 1) * 2 + (col("a") + 3 + 1)  + col("c"), (col("c") + 2).as_("d")
+    assert_df_subtree_query_complexity(
+        df_select,
+        {
+            PlanNodeCategory.LOW_IMPACT: 8,
+            PlanNodeCategory.COLUMN: 5,
+            PlanNodeCategory.LITERAL: 6,
+        },
+    )
+
+
+def test_deep_nested_with_columns(session):
+    temp_table_name = Utils.random_table_name()
+    try:
+        df = create_df_with_deep_nested_with_column_dependencies(
+            session, temp_table_name, 5
+        )
+        print(df._plan.cumulative_node_complexity)
+    finally:
+        Utils.drop_table(session, temp_table_name)

--- a/tests/unit/test_query_plan_analysis.py
+++ b/tests/unit/test_query_plan_analysis.py
@@ -157,7 +157,14 @@ def test_select_statement_individual_node_complexity(
 
     plan_node = SelectStatement(from_=from_, analyzer=mock_analyzer)
     setattr(plan_node, attribute, value)
-    assert plan_node.individual_node_complexity == expected_stat
+    if attribute == "projection" and isinstance(value[0], NamedExpression):
+        # NamedExpression is not a valid projection expression for selectStatement,
+        # and there is no individual_node_complexity or cumulative_node_complexity
+        # attributes associated with it
+        with pytest.raises(AttributeError):
+            plan_node.individual_node_complexity
+    else:
+        assert plan_node.individual_node_complexity == expected_stat
 
 
 def test_select_table_function_individual_node_complexity(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1632898

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

1) adjust the projection complexity calculation, and cumulative complexity for selectStatement when _merge_projection_complexity_with_subquery set to True.

2) update the complexity calculation for snowflake plan to directly get the complexity from source plan, and update the reset to reset the cumulative complexity. 