### PR TITLE
Failing count() test case

### DIFF
--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -1,0 +1,29 @@
+## TEST CASE
+
+# This test creates a Pandas dataframe literal and gets the count.
+import pandas as pd
+
+df = session.create_dataframe(pd.DataFrame([["one", 1], ["two", 2], ["three", 3]], columns=["A", "B"]))
+
+df.count()
+
+df.count(block=False)
+
+df.count(block=False, statement_params={"SF_PARTNER": "FAKE_PARTNER"})
+
+## EXPECTED UNPARSER OUTPUT
+
+df = session.table("test_table")
+
+df.count()
+
+df.count(block=False)
+
+df.count(statement_params={"SF_PARTNER": "FAKE_PARTNER"}, block=False)
+
+## EXPECTED ENCODED AST
+
+CkMKQQozqgswEg4KDAoKdGVzdF90YWJsZRoaGhZTUkNfUE9TSVRJT05fVEVTVF9NT0RFKFoiAggBEgQKAmRmGAEiAggBCjEKLwolugYiCAESAggBGhoaFlNSQ19QT1NJVElPTl9URVNUX01PREUoXBIAGAIiAggCCggSBggDEgIIAhABGhESDwoNCgVmaW5hbBADGAggEyIEEAEYFQ==
+Ci8KLQojugYgEgIIARoaGhZTUkNfUE9TSVRJT05fVEVTVF9NT0RFKF4SABgEIgIIBAoIEgYIBRICCAQQARoREg8KDQoFZmluYWwQAxgIIBMiBBABGBU=
+CksKSQo/ugY8EgIIARoaGhZTUkNfUE9TSVRJT05fVEVTVF9NT0RFKGAiGgoKU0ZfUEFSVE5FUhIMRkFLRV9QQVJUTkVSEgAYBiICCAYKCBIGCAcSAggGEAEaERIPCg0KBWZpbmFsEAMYCCATIgQQARgV
+EAEaERIPCg0KBWZpbmFsEAMYCCATIgQQARgV


### PR DESCRIPTION
This test fails with a missing AST error.

The expectations were copied/pasted from the other `count()` test. This should be invoked with `--update-expectations`.