### PR TITLE
Fix df alias test failure for new query generation when sql simplifier disabled

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -116,11 +116,13 @@ class QueryGenerator(Analyzer):
                 assert logical_plan.source_plan is not None
                 # when encounter a SnowflakePlan with no queries, try to re-resolve
                 # the source plan to construct the result
-                res = self.do_resolve(logical_plan.source_plan)
-                resolved_children[logical_plan] = res
-                resolved_plan = res
-            else:
-                resolved_plan = logical_plan
+                from snowflake.snowpark._internal.compiler.utils import (
+                    resolve_and_update_snowflake_plan,
+                )
+
+                resolve_and_update_snowflake_plan(logical_plan, self)
+
+            resolved_plan = logical_plan
 
         elif isinstance(logical_plan, SnowflakeCreateTable):
             from snowflake.snowpark._internal.compiler.utils import (

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -95,7 +95,7 @@ def resolve_and_update_snowflake_plan(
     node.expr_to_alias = new_snowflake_plan.expr_to_alias
     node.is_ddl_on_temp_object = new_snowflake_plan.is_ddl_on_temp_object
     node._output_dict = new_snowflake_plan._output_dict
-    node.df_aliased_col_name_to_real_col_name = (
+    node.df_aliased_col_name_to_real_col_name.update(
         new_snowflake_plan.df_aliased_col_name_to_real_col_name
     )
     node.placeholder_query = new_snowflake_plan.placeholder_query

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -105,6 +105,9 @@ def verify_multiple_create_queries(
     assert plan_queries[0].startswith("CREATE")
     assert plan_queries[1].startswith("INSERT")
     assert plan_queries[-1].startswith("SELECT")
+    # Note that that is only true when the creat is followed with INSERT, there
+    # could be cases that create with one single statement. So be careful when
+    # using this utility.
     assert len(post_action_queries) == int(num_queries / 2)
     assert post_action_queries[0].startswith("DROP")
 

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -105,7 +105,7 @@ def verify_multiple_create_queries(
     assert plan_queries[0].startswith("CREATE")
     assert plan_queries[1].startswith("INSERT")
     assert plan_queries[-1].startswith("SELECT")
-    assert len(post_action_queries) == (num_queries / 2)
+    assert len(post_action_queries) == int(num_queries / 2)
     assert post_action_queries[0].startswith("DROP")
 
 


### PR DESCRIPTION
1. Please describe how your code solves the related issue.
a) Fix alias query generation after transformation by propogating the alias map correctly to snowflake pln
b) fix a test that is actually doing wrong check