### PR TITLE
[SNOW-1678113] Improve pivot_table performance

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -334,7 +334,7 @@ class OrderedDataFrame:
 
         return row_number().over(Window.order_by(self._ordering_snowpark_columns())) - 1
 
-    @property
+    @cached_property
     def projected_column_snowflake_quoted_identifiers(self) -> list[str]:
         """
         Returns:

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -545,9 +545,14 @@ class OrderedDataFrame:
             extracted as the quoted identifier.
         2) when it is a str
             a) if it is a start (*), then all projected columns snowflake quoted identifiers are added
-            b) otherwise, it is treated as a name of existing column, and only active columns of the current
-                ordered dataframe can be used.
+            b) otherwise, it is treated as a name of existing column, and a validation check is applied
+                to ensure that only active columns of the current ordered dataframe can be used
         e) AssertionError is raised for all cases can not be handled.
+
+        Args:
+            col: ColumnOrName, Snowpark Column expression or column name
+            active_columns: the active columns of the current ordered dataframe to perform the check against,
+                includes all projected columns, row position columns and ordering columns.
         """
         from snowflake.snowpark.modin.plugin._internal.utils import (
             is_valid_snowflake_quoted_identifier,

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -6,7 +6,6 @@ import sys
 import uuid
 from collections.abc import Hashable
 from dataclasses import dataclass
-from functools import cached_property
 from typing import Any, Optional, Union
 
 import pandas
@@ -334,8 +333,7 @@ class OrderedDataFrame:
 
         return row_number().over(Window.order_by(self._ordering_snowpark_columns())) - 1
 
-    @cached_property
-    # @property
+    @property
     def projected_column_snowflake_quoted_identifiers(self) -> list[str]:
         """
         Returns:

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -335,6 +335,7 @@ class OrderedDataFrame:
         return row_number().over(Window.order_by(self._ordering_snowpark_columns())) - 1
 
     @cached_property
+    # @property
     def projected_column_snowflake_quoted_identifiers(self) -> list[str]:
         """
         Returns:
@@ -508,7 +509,9 @@ class OrderedDataFrame:
 
         """
 
-        column_quoted_identifiers = self.projected_column_snowflake_quoted_identifiers
+        column_quoted_identifiers = (
+            self.projected_column_snowflake_quoted_identifiers.copy()
+        )
         if include_ordering_columns:
             extra_ordering_column_quoted_identifiers = [
                 quoted_identifier

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -503,9 +503,7 @@ class OrderedDataFrame:
 
         """
 
-        column_quoted_identifiers = (
-            self.projected_column_snowflake_quoted_identifiers.copy()
-        )
+        column_quoted_identifiers = self.projected_column_snowflake_quoted_identifiers
         if include_ordering_columns:
             extra_ordering_column_quoted_identifiers = [
                 quoted_identifier

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -295,7 +295,7 @@ class OrderedDataFrame:
             row_count_snowflake_quoted_identifier
         )
 
-    @cached_property
+    @property
     def ordering_columns(self) -> list[OrderingColumn]:
         return list(self._ordering_columns_tuple)
 
@@ -309,7 +309,7 @@ class OrderedDataFrame:
         """
         return [col.snowpark_column for col in self.ordering_columns]
 
-    @cached_property
+    @property
     def ordering_column_snowflake_quoted_identifiers(self) -> list[str]:
         """
         Get all snowflake quoted identifiers for the ordering columns.
@@ -334,7 +334,7 @@ class OrderedDataFrame:
 
         return row_number().over(Window.order_by(self._ordering_snowpark_columns())) - 1
 
-    @cached_property
+    @property
     def projected_column_snowflake_quoted_identifiers(self) -> list[str]:
         """
         Returns:

--- a/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
@@ -692,31 +692,6 @@ def single_pivot_helper(
             )
         pivot_frame_data_column_data_pandas_labels.append(pandas_label)
 
-        """
-                    pandas_label_column = str(pandas_label)
-                else:
-                    pandas_label_column = pandas_label
-
-                # If the snowflake quoted identifier conflicts with an earlier identifier, ensure it is unique in snowflake
-                renamed_snowflake_quoted_identifier = (
-                    pivot_ordered_dataframe.generate_snowflake_quoted_identifiers(
-                        pandas_labels=[pandas_label_column],
-                        excluded=existing_snowflake_quoted_identifiers,
-                    )[0]
-                )
-
-                if renamed_snowflake_quoted_identifier != snowflake_quoted_identifier:
-                    pivot_ordered_dataframe = append_columns(
-                        pivot_ordered_dataframe,
-                        renamed_snowflake_quoted_identifier,
-                        col(snowflake_quoted_identifier),
-                    )
-                    snowflake_quoted_identifier = renamed_snowflake_quoted_identifier
-
-                data_column_snowflake_quoted_identifiers.append(snowflake_quoted_identifier)
-                data_column_pandas_labels.append(pandas_label)
-                """
-
     pandas_labels = [
         str(label) if not isinstance(label, str) else label
         for label in pivot_frame_data_column_data_pandas_labels

--- a/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
@@ -655,11 +655,13 @@ def single_pivot_helper(
     # 2. Drop any that are None
     # 3. Add prefix pandas label if provided
     # 4. Generate output data_columns
-    for (
-        snowflake_quoted_identifier
-    ) in pivot_ordered_dataframe.projected_column_snowflake_quoted_identifiers[
-        len(index_snowflake_quoted_identifiers) :
-    ]:
+    pivot_frame_data_column_identifiers = (
+        pivot_ordered_dataframe.projected_column_snowflake_quoted_identifiers[
+            len(index_snowflake_quoted_identifiers) :
+        ]
+    )
+    pivot_frame_data_column_data_pandas_labels = []
+    for snowflake_quoted_identifier in pivot_frame_data_column_identifiers:
         if (
             pivot_snowflake_quoted_identifiers
             and len(pivot_snowflake_quoted_identifiers) > 1
@@ -688,6 +690,38 @@ def single_pivot_helper(
             pandas_label = prefix_pandas_labels + (
                 pandas_label if isinstance(pandas_label, tuple) else (pandas_label,)
             )
+        pivot_frame_data_column_data_pandas_labels.append(pandas_label)
+        pandas_labels = [
+            str(label) if not isinstance(label, str) else label
+            for label in pivot_frame_data_column_data_pandas_labels
+        ]
+
+        # If the snowflake quoted identifier conflicts with an earlier identifier, ensure it is unique in snowflake
+        renamed_snowflake_quoted_identifiers = (
+            pivot_ordered_dataframe.generate_snowflake_quoted_identifiers(
+                pandas_labels=pandas_labels,
+                excluded=existing_snowflake_quoted_identifiers,
+            )[0]
+        )
+
+        new_colum_identifiers = []
+        new_column_objects = []
+        for renamed_identifier, original_identifier in zip(
+            renamed_snowflake_quoted_identifiers, pivot_frame_data_column_identifiers
+        ):
+            if renamed_identifier != original_identifier:
+                new_colum_identifiers.append(renamed_identifier)
+                new_column_objects.append(col(original_identifier))
+        if len(new_colum_identifiers) > 0:
+            pivot_ordered_dataframe = append_columns(
+                pivot_ordered_dataframe, new_colum_identifiers, new_column_objects
+            )
+        data_column_snowflake_quoted_identifiers.extend(
+            renamed_snowflake_quoted_identifiers
+        )
+        data_column_pandas_labels.extend(pivot_frame_data_column_data_pandas_labels)
+
+        """
             pandas_label_column = str(pandas_label)
         else:
             pandas_label_column = pandas_label
@@ -710,6 +744,7 @@ def single_pivot_helper(
 
         data_column_snowflake_quoted_identifiers.append(snowflake_quoted_identifier)
         data_column_pandas_labels.append(pandas_label)
+        """
 
     return (
         pivot_ordered_dataframe,

--- a/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py
@@ -691,60 +691,61 @@ def single_pivot_helper(
                 pandas_label if isinstance(pandas_label, tuple) else (pandas_label,)
             )
         pivot_frame_data_column_data_pandas_labels.append(pandas_label)
-        pandas_labels = [
-            str(label) if not isinstance(label, str) else label
-            for label in pivot_frame_data_column_data_pandas_labels
-        ]
-
-        # If the snowflake quoted identifier conflicts with an earlier identifier, ensure it is unique in snowflake
-        renamed_snowflake_quoted_identifiers = (
-            pivot_ordered_dataframe.generate_snowflake_quoted_identifiers(
-                pandas_labels=pandas_labels,
-                excluded=existing_snowflake_quoted_identifiers,
-            )[0]
-        )
-
-        new_colum_identifiers = []
-        new_column_objects = []
-        for renamed_identifier, original_identifier in zip(
-            renamed_snowflake_quoted_identifiers, pivot_frame_data_column_identifiers
-        ):
-            if renamed_identifier != original_identifier:
-                new_colum_identifiers.append(renamed_identifier)
-                new_column_objects.append(col(original_identifier))
-        if len(new_colum_identifiers) > 0:
-            pivot_ordered_dataframe = append_columns(
-                pivot_ordered_dataframe, new_colum_identifiers, new_column_objects
-            )
-        data_column_snowflake_quoted_identifiers.extend(
-            renamed_snowflake_quoted_identifiers
-        )
-        data_column_pandas_labels.extend(pivot_frame_data_column_data_pandas_labels)
 
         """
-            pandas_label_column = str(pandas_label)
-        else:
-            pandas_label_column = pandas_label
+                    pandas_label_column = str(pandas_label)
+                else:
+                    pandas_label_column = pandas_label
 
-        # If the snowflake quoted identifier conflicts with an earlier identifier, ensure it is unique in snowflake
-        renamed_snowflake_quoted_identifier = (
-            pivot_ordered_dataframe.generate_snowflake_quoted_identifiers(
-                pandas_labels=[pandas_label_column],
-                excluded=existing_snowflake_quoted_identifiers,
-            )[0]
+                # If the snowflake quoted identifier conflicts with an earlier identifier, ensure it is unique in snowflake
+                renamed_snowflake_quoted_identifier = (
+                    pivot_ordered_dataframe.generate_snowflake_quoted_identifiers(
+                        pandas_labels=[pandas_label_column],
+                        excluded=existing_snowflake_quoted_identifiers,
+                    )[0]
+                )
+
+                if renamed_snowflake_quoted_identifier != snowflake_quoted_identifier:
+                    pivot_ordered_dataframe = append_columns(
+                        pivot_ordered_dataframe,
+                        renamed_snowflake_quoted_identifier,
+                        col(snowflake_quoted_identifier),
+                    )
+                    snowflake_quoted_identifier = renamed_snowflake_quoted_identifier
+
+                data_column_snowflake_quoted_identifiers.append(snowflake_quoted_identifier)
+                data_column_pandas_labels.append(pandas_label)
+                """
+
+    pandas_labels = [
+        str(label) if not isinstance(label, str) else label
+        for label in pivot_frame_data_column_data_pandas_labels
+    ]
+
+    # If the snowflake quoted identifier conflicts with an earlier identifier, ensure it is unique in snowflake
+    renamed_snowflake_quoted_identifiers = (
+        pivot_ordered_dataframe.generate_snowflake_quoted_identifiers(
+            pandas_labels=pandas_labels,
+            excluded=existing_snowflake_quoted_identifiers,
         )
+    )
 
-        if renamed_snowflake_quoted_identifier != snowflake_quoted_identifier:
-            pivot_ordered_dataframe = append_columns(
-                pivot_ordered_dataframe,
-                renamed_snowflake_quoted_identifier,
-                col(snowflake_quoted_identifier),
-            )
-            snowflake_quoted_identifier = renamed_snowflake_quoted_identifier
-
-        data_column_snowflake_quoted_identifiers.append(snowflake_quoted_identifier)
-        data_column_pandas_labels.append(pandas_label)
-        """
+    new_colum_identifiers = []
+    new_column_objects = []
+    for renamed_identifier, original_identifier in zip(
+        renamed_snowflake_quoted_identifiers, pivot_frame_data_column_identifiers
+    ):
+        if renamed_identifier != original_identifier:
+            new_colum_identifiers.append(renamed_identifier)
+            new_column_objects.append(col(original_identifier))
+    if len(new_colum_identifiers) > 0:
+        pivot_ordered_dataframe = append_columns(
+            pivot_ordered_dataframe, new_colum_identifiers, new_column_objects
+        )
+    data_column_snowflake_quoted_identifiers.extend(
+        renamed_snowflake_quoted_identifiers
+    )
+    data_column_pandas_labels.extend(pivot_frame_data_column_data_pandas_labels)
 
     return (
         pivot_ordered_dataframe,

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1902,11 +1902,12 @@ def append_columns(
         column_objects
     ), f"The number of column identifiers ({len(column_identifiers)}) is not equal to the number of column objects ({len(column_objects)})"
 
+    existing_columns = df.projected_column_snowflake_quoted_identifiers
     new_columns = [
         column_object.as_(column_identifier)
         for column_identifier, column_object in zip(column_identifiers, column_objects)
     ]
-    return df.select("*", *new_columns)
+    return df.select(*existing_columns, *new_columns)
 
 
 def cache_result(ordered_dataframe: OrderedDataFrame) -> OrderedDataFrame:

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1902,12 +1902,12 @@ def append_columns(
         column_objects
     ), f"The number of column identifiers ({len(column_identifiers)}) is not equal to the number of column objects ({len(column_objects)})"
 
-    existing_columns = df.projected_column_snowflake_quoted_identifiers
+    # existing_columns = df.projected_column_snowflake_quoted_identifiers
     new_columns = [
         column_object.as_(column_identifier)
         for column_identifier, column_object in zip(column_identifiers, column_objects)
     ]
-    return df.select(*existing_columns, *new_columns)
+    return df.select("*", *new_columns)
 
 
 def cache_result(ordered_dataframe: OrderedDataFrame) -> OrderedDataFrame:

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1906,7 +1906,7 @@ def append_columns(
         column_object.as_(column_identifier)
         for column_identifier, column_object in zip(column_identifiers, column_objects)
     ]
-    return df.select('*', *new_columns)
+    return df.select("*", *new_columns)
 
 
 def cache_result(ordered_dataframe: OrderedDataFrame) -> OrderedDataFrame:

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1902,12 +1902,11 @@ def append_columns(
         column_objects
     ), f"The number of column identifiers ({len(column_identifiers)}) is not equal to the number of column objects ({len(column_objects)})"
 
-    existing_columns = df.projected_column_snowflake_quoted_identifiers
     new_columns = [
         column_object.as_(column_identifier)
         for column_identifier, column_object in zip(column_identifiers, column_objects)
     ]
-    return df.select(*existing_columns, *new_columns)
+    return df.select('*', *new_columns)
 
 
 def cache_result(ordered_dataframe: OrderedDataFrame) -> OrderedDataFrame:

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -1902,7 +1902,6 @@ def append_columns(
         column_objects
     ), f"The number of column identifiers ({len(column_identifiers)}) is not equal to the number of column objects ({len(column_objects)})"
 
-    # existing_columns = df.projected_column_snowflake_quoted_identifiers
     new_columns = [
         column_object.as_(column_identifier)
         for column_identifier, column_object in zip(column_identifiers, column_objects)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -24,7 +24,7 @@ from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles,
 pytestmark = [
     pytest.mark.skipif(
         "config.getoption('local_testing_mode', default=False)",
-        reason="CTE is a SQL feature",
+        reason="CTE is a SQL feature and SQL counter check doesn't work for local testing mode",
         run=False,
     ),
     pytest.mark.skipif(

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -22,7 +22,7 @@ from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 pytestmark = [
-    pytest.mark.xfail(
+    pytest.mark.skipif(
         "config.getoption('local_testing_mode', default=False)",
         reason="CTE is a SQL feature",
         run=False,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -22,9 +22,9 @@ from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 pytestmark = [
-    pytest.mark.skipif(
+    pytest.mark.xfail(
         "config.getoption('local_testing_mode', default=False)",
-        reason="CTE is a SQL feature and SQL counter check doesn't work for local testing mode",
+        reason="CTE is a SQL feature",
         run=False,
     ),
     pytest.mark.skipif(

--- a/tests/unit/modin/test_utils.py
+++ b/tests/unit/modin/test_utils.py
@@ -842,7 +842,7 @@ def test_try_convert_to_simple_slice(input, output):
 
 def test_append_columns():
     mock_ordered_dataframe = mock.create_autospec(OrderedDataFrame)
-    mock_ordered_dataframe.select = lambda *x: x
+    # mock_ordered_dataframe.select = lambda *x: x
     mock_ordered_dataframe.projected_column_snowflake_quoted_identifiers = [
         '"a"',
         '"B"',
@@ -851,6 +851,8 @@ def test_append_columns():
     ]
 
     def check_column_equality(results: list, expected_results: list) -> None:
+        print(results)
+        print(expected_results)
         for result, expected_result in zip(results, expected_results):
             assert type(result) == type(expected_result)
             if isinstance(result, Column):

--- a/tests/unit/modin/test_utils.py
+++ b/tests/unit/modin/test_utils.py
@@ -10,11 +10,15 @@ import pandas as native_pd
 import pytest
 from modin.pandas import DataFrame, Series
 
-from snowflake.snowpark import Column
 from snowflake.snowpark._internal.analyzer.analyzer_utils import DOUBLE_QUOTE
 from snowflake.snowpark._internal.type_utils import VALID_PYTHON_TYPES_FOR_LITERAL_VALUE
+from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
 from snowflake.snowpark.functions import col
-from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import OrderedDataFrame
+from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
+    DataFrameReference,
+    OrderedDataFrame,
+    OrderingColumn,
+)
 from snowflake.snowpark.modin.plugin._internal.utils import (
     _MAX_IDENTIFIER_LENGTH,
     INDEX_LABEL,
@@ -49,6 +53,12 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
 )
 from snowflake.snowpark.modin.plugin.extensions.indexing_overrides import (
     is_boolean_array,
+)
+from snowflake.snowpark.types import (
+    ColumnIdentifier,
+    IntegerType,
+    StructField,
+    StructType,
 )
 
 
@@ -841,46 +851,54 @@ def test_try_convert_to_simple_slice(input, output):
 
 
 def test_append_columns():
-    mock_ordered_dataframe = mock.create_autospec(OrderedDataFrame)
-    # mock_ordered_dataframe.select = lambda *x: x
-    mock_ordered_dataframe.projected_column_snowflake_quoted_identifiers = [
+    fake_snowpark_dataframe = mock.create_autospec(SnowparkDataFrame)
+    snowpark_df_schema = StructType(
+        [
+            StructField(
+                column_identifier=ColumnIdentifier('"a"'), datatype=IntegerType
+            ),
+            StructField(
+                column_identifier=ColumnIdentifier('"B"'), datatype=IntegerType
+            ),
+            StructField(
+                column_identifier=ColumnIdentifier('"C"'), datatype=IntegerType
+            ),
+            StructField(
+                column_identifier=ColumnIdentifier('"d"'), datatype=IntegerType
+            ),
+        ]
+    )
+    fake_snowpark_dataframe.schema = snowpark_df_schema
+    ordered_dataframe = OrderedDataFrame(
+        DataFrameReference(fake_snowpark_dataframe),
+        ordering_columns=[OrderingColumn('"a"'), OrderingColumn('"B"')],
+        projected_column_snowflake_quoted_identifiers=['"a"', '"B"', '"C"', '"d"'],
+    )
+    new_ordered_dataframe = append_columns(ordered_dataframe, '"e"', col("E"))
+    assert new_ordered_dataframe.projected_column_snowflake_quoted_identifiers == [
         '"a"',
         '"B"',
         '"C"',
         '"d"',
+        '"e"',
     ]
 
-    def check_column_equality(results: list, expected_results: list) -> None:
-        print(results)
-        print(expected_results)
-        for result, expected_result in zip(results, expected_results):
-            assert type(result) == type(expected_result)
-            if isinstance(result, Column):
-                assert str(result._expression) == str(expected_result._expression)
-
-    expected_result = ['"a"', '"B"', '"C"', '"d"', col("E").as_('"e"')]
-    check_column_equality(
-        append_columns(mock_ordered_dataframe, '"e"', col("E")), expected_result
+    new_ordered_dataframe = append_columns(
+        ordered_dataframe, ['"e"', '"f"'], [col("E"), col("F")]
     )
-
-    expected_result = [
+    assert new_ordered_dataframe.projected_column_snowflake_quoted_identifiers == [
         '"a"',
         '"B"',
         '"C"',
         '"d"',
-        col("E").as_('"e"'),
-        col("F").as_('"f"'),
+        '"e"',
+        '"f"',
     ]
-    check_column_equality(
-        append_columns(mock_ordered_dataframe, ['"e"', '"f"'], [col("E"), col("F")]),
-        expected_result,
-    )
 
-    # negative tests
     with pytest.raises(
         AssertionError, match="is not equal to the number of column objects"
     ):
-        append_columns(mock_ordered_dataframe, ['"e"', '"f"'], [col("E")])
+        append_columns(ordered_dataframe, ['"e"', '"f"'], [col("E")])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1678113]

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.
In the reported case, the unstack calls pivot table underneath, and customer end with about 2000 columns after pivot. The pivot it's self took about 1~2 seconds to finish, but the after pivot it start looping over all columns and calling append_columns in each loop here [snowpark-python/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py at 272e4e1ee5da84f8ac0abfefda95aab3b0bf4d7e · snowflakedb/snowpark-python](https://github.com/snowflakedb/snowpark-python/blob/272e4e1ee5da84f8ac0abfefda95aab3b0bf4d7e/src/snowflake/snowpark/modin/plugin/_internal/pivot_utils.py#L704). The append columns eventually calls select with all existing projected columns, and the a check is performed on each column here [snowpark-python/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py at main · snowflakedb/snowpark-python](https://github.com/snowflakedb/snowpark-python/blob/main/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py#L616)

our profiling shows that each check too about 0.015s, and 2000 check is about 30seconds, and the snowpark select took about 0.5 seconds since it need to perform sql simplification. Since there is an outer loop of 2000, overall it could take about (30.5*2000)s , which is close to 16 h.

In order to handle the issue, we did the following:
1) use "*" for append_columns to avoid checking for each columns
2) instead of calling append_column in each loop, try to get all columns to append and only call append_columns once.
with manual testing, the customer case now took about 8.002492904663086 s to finish the unstack reported

TODO:
add this to our performance benchmark https://snowflakecomputing.atlassian.net/browse/SNOW-1706311 
