### PR TITLE
SNOW-1694806: Add support for rolling and expanding count with timedelta.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added support for `DataFrame.rolling.corr` and `Series.rolling.corr` for `pairwise = False` and int `window`.
 - Added support for string time-based `window` and `min_periods = None` for `Rolling`.
 - Added support for `pd.read_sas` (Uses native pandas for processing).
+- Added suppport for applying `rolling().count` to `Timedelta` series and columns.
 
 #### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Added support for `DataFrame.rolling.corr` and `Series.rolling.corr` for `pairwise = False` and int `window`.
 - Added support for string time-based `window` and `min_periods = None` for `Rolling`.
 - Added support for `pd.read_sas` (Uses native pandas for processing).
-- Added suppport for applying `rolling().count` to `Timedelta` series and columns.
+- Added suppport for applying `rolling().count()` and `expanding().count()` to `Timedelta` series and columns.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -63,6 +63,7 @@ from pandas.api.types import (
 from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.common import is_dict_like, is_list_like, pandas_dtype
 from pandas.core.indexes.base import ensure_index
+from pandas.errors import DataError
 from pandas.io.formats.format import format_percentiles
 from pandas.io.formats.printing import PrettyDict
 
@@ -398,6 +399,13 @@ NANOSECONDS_PER_SECOND = 10**9
 NANOSECONDS_PER_MICROSECOND = 10**3
 MICROSECONDS_PER_SECOND = 10**6
 NANOSECONDS_PER_DAY = SECONDS_PER_DAY * NANOSECONDS_PER_SECOND
+
+# Matches pandas
+_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED = "No numeric types to aggregate"
+# Matches pandas
+_TIMEDELTA_ROLLING_CORR_NOT_SUPPORTED = (
+    "ops for Rolling for this dtype timedelta64[ns] are not implemented"
+)
 
 
 class SnowflakeQueryCompiler(BaseQueryCompiler):
@@ -13663,8 +13671,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         return self._window_agg(
             window_func=WindowFunction.ROLLING,
             agg_func="count",
@@ -13682,8 +13688,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_sum", engine, engine_kwargs
         )
@@ -13704,8 +13708,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_mean", engine, engine_kwargs
         )
@@ -13738,8 +13740,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
         )
@@ -13761,8 +13761,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
         )
@@ -13783,8 +13781,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_min", engine, engine_kwargs
         )
@@ -13805,8 +13801,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_max", engine, engine_kwargs
         )
@@ -13917,8 +13911,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         return self._window_agg(
             window_func=WindowFunction.ROLLING,
             agg_func="sem",
@@ -14017,8 +14009,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 -create_snowpark_interval_from_window(window), Window.CURRENT_ROW
             )
 
+        input_contains_timedelta = any(
+            isinstance(t, TimedeltaType)
+            for t in frame.cached_data_column_snowpark_pandas_types
+        )
+
         # Perform Aggregation over the window_expr
         if agg_func == "sem":
+            if input_contains_timedelta:
+                raise DataError(_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED)
+
             # Standard error of mean (SEM) does not have native Snowflake engine support
             # so calculate as STDDEV/SQRT(N-ddof)
             ddof = agg_kwargs.get("ddof", 1)
@@ -14057,6 +14057,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 }
             ).frame
         elif agg_func == "corr":
+            if input_contains_timedelta:
+                ErrorMessage.not_implemented(_TIMEDELTA_ROLLING_CORR_NOT_SUPPORTED)
             if not isinstance(window, int):
                 ErrorMessage.not_implemented(
                     "Snowpark pandas does not yet support non-integer 'window' for 'Rolling.corr'"
@@ -14134,6 +14136,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 ErrorMessage.not_implemented(  # pragma: no cover
                     f"Window aggregation does not support the aggregation {repr_aggregate_function(agg_func, agg_kwargs)}"
                 )
+            if (
+                snowflake_agg_func.snowpark_aggregation is not count
+                and input_contains_timedelta
+            ):
+                raise DataError(_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED)
+
             new_frame = frame.update_snowflake_quoted_identifiers_with_expressions(
                 {
                     # If aggregation is count use count on row_position_quoted_identifier

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -14138,6 +14138,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 )
             if (
                 snowflake_agg_func.snowpark_aggregation is not count
+                # pandas only supports rolling aggregation for count(), so we
+                # do the same.
                 and input_contains_timedelta
             ):
                 raise DataError(_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -14172,8 +14172,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         expanding_kwargs: dict,
         numeric_only: bool = False,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         return self._window_agg(
             window_func=WindowFunction.EXPANDING,
             agg_func="count",
@@ -14189,8 +14187,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_sum", engine, engine_kwargs
         )
@@ -14209,8 +14205,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_mean", engine, engine_kwargs
         )
@@ -14240,8 +14234,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
         )
@@ -14261,8 +14253,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_std", engine, engine_kwargs
         )
@@ -14281,8 +14271,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_min", engine, engine_kwargs
         )
@@ -14301,8 +14289,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         engine: Optional[Literal["cython", "numba"]] = None,
         engine_kwargs: Optional[dict[str, bool]] = None,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         WarningMessage.warning_if_engine_args_is_set(
             "expanding_max", engine, engine_kwargs
         )
@@ -14391,8 +14377,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ddof: int = 1,
         numeric_only: bool = False,
     ) -> "SnowflakeQueryCompiler":
-        self._raise_not_implemented_error_for_timedelta()
-
         return self._window_agg(
             window_func=WindowFunction.EXPANDING,
             agg_func="sem",

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -14138,8 +14138,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 )
             if (
                 snowflake_agg_func.snowpark_aggregation is not count
-                # pandas only supports rolling aggregation for count(), so we
-                # do the same.
+                # pandas only supports rolling timedelta aggregation for
+                # count(), so we do the same.
                 and input_contains_timedelta
             ):
                 raise DataError(_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED)

--- a/tests/integ/modin/window/test_expanding.py
+++ b/tests/integ/modin/window/test_expanding.py
@@ -231,6 +231,7 @@ class TestTimedelta:
     )
     @pytest.mark.parametrize("agg_func", agg_func_supported_for_timedelta)
     @min_periods
+    @sql_count_checker(query_count=1)
     def test_expanding_aggregation_supported(
         self, create_function, agg_func, min_periods
     ):

--- a/tests/integ/modin/window/test_expanding.py
+++ b/tests/integ/modin/window/test_expanding.py
@@ -2,18 +2,30 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
+import re
+
 import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
+from pandas.errors import DataError
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
-from tests.integ.modin.utils import eval_snowpark_pandas_result
-
-agg_func = pytest.mark.parametrize(
-    "agg_func", ["count", "sum", "mean", "var", "std", "min", "max", "sem"]
+from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
+    _TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED,
 )
+from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
+from tests.integ.modin.utils import (
+    create_test_dfs,
+    create_test_series,
+    eval_snowpark_pandas_result,
+)
+from tests.integ.modin.window.utils import (
+    agg_func,
+    agg_func_not_supported_for_timedelta,
+    agg_func_supported_for_timedelta,
+)
+
 min_periods = pytest.mark.parametrize("min_periods", [None, 0, 1, 2, 10])
 
 
@@ -174,3 +186,68 @@ def test_expanding_aggregation_series_unsupported(agg_func, agg_func_kwargs):
     snow_df = pd.Series([2, 3, 4, 1], index=["a", "b", "c", "d"])
     with pytest.raises(NotImplementedError):
         getattr(snow_df.expanding(), agg_func)(agg_func_kwargs)
+
+
+class TestTimedelta:
+    @pytest.mark.parametrize(
+        "create_function",
+        [
+            pytest.param(create_test_dfs, id="dataframe"),
+            pytest.param(create_test_series, id="series"),
+        ],
+    )
+    @pytest.mark.parametrize("agg_func", agg_func_not_supported_for_timedelta)
+    @sql_count_checker(query_count=0)
+    def test_expanding_aggregation_unsupported(self, create_function, agg_func):
+        eval_snowpark_pandas_result(
+            *create_function(
+                [
+                    native_pd.Timedelta(-1),
+                    native_pd.Timedelta(1),
+                    native_pd.Timedelta(2),
+                    native_pd.Timedelta(5),
+                    native_pd.NaT,
+                ]
+            ),
+            lambda object: getattr(object.expanding(), agg_func)(numeric_only=False),
+            expect_exception=True,
+            expect_exception_type=DataError,
+            # pandas error message is different for dataframe and series, but
+            # Snowpark pandas always uses the same message. Accept either
+            # message.
+            expect_exception_match=(
+                f"(?:{re.escape('No numeric types to aggregate')})|"
+                + f"(?:{re.escape(_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED)})"
+            ),
+            assert_exception_equal=False,
+        )
+
+    @pytest.mark.parametrize(
+        "create_function",
+        [
+            pytest.param(create_test_dfs, id="dataframe"),
+            pytest.param(create_test_series, id="series"),
+        ],
+    )
+    @pytest.mark.parametrize("agg_func", agg_func_supported_for_timedelta)
+    @min_periods
+    def test_expanding_aggregation_supported(
+        self, create_function, agg_func, min_periods
+    ):
+        snow_series, native_series = create_function(
+            [
+                native_pd.Timedelta(-1),
+                native_pd.Timedelta(1),
+                native_pd.Timedelta(2),
+                native_pd.Timedelta(5),
+                native_pd.NaT,
+            ]
+        )
+        eval_snowpark_pandas_result(
+            snow_series,
+            native_series,
+            lambda series: getattr(
+                series.expanding(min_periods=min_periods),
+                agg_func,
+            )(),
+        )

--- a/tests/integ/modin/window/test_rolling.py
+++ b/tests/integ/modin/window/test_rolling.py
@@ -22,21 +22,12 @@ from tests.integ.modin.utils import (
     create_test_series,
     eval_snowpark_pandas_result,
 )
-
-agg_func_supported_for_timedelta = ["count"]
-agg_func_not_supported_for_timedelta = [
-    "sum",
-    "mean",
-    "var",
-    "std",
-    "min",
-    "max",
-    "sem",
-]
-agg_func = pytest.mark.parametrize(
-    "agg_func",
-    [*agg_func_supported_for_timedelta, *agg_func_not_supported_for_timedelta],
+from tests.integ.modin.window.utils import (
+    agg_func,
+    agg_func_not_supported_for_timedelta,
+    agg_func_supported_for_timedelta,
 )
+
 window = pytest.mark.parametrize("window", [1, 2, 3, 4, 6])
 min_periods = pytest.mark.parametrize("min_periods", [None, 1, 2])
 center = pytest.mark.parametrize("center", [True, False])

--- a/tests/integ/modin/window/test_rolling.py
+++ b/tests/integ/modin/window/test_rolling.py
@@ -7,17 +7,35 @@ import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
+from pandas.errors import DataError
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
+from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
+    _TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED,
+    _TIMEDELTA_ROLLING_CORR_NOT_SUPPORTED,
+)
 from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     assert_series_equal,
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
+    create_test_dfs,
+    create_test_series,
     eval_snowpark_pandas_result,
 )
 
+agg_func_supported_for_timedelta = ["count"]
+agg_func_not_supported_for_timedelta = [
+    "sum",
+    "mean",
+    "var",
+    "std",
+    "min",
+    "max",
+    "sem",
+]
 agg_func = pytest.mark.parametrize(
-    "agg_func", ["count", "sum", "mean", "var", "std", "min", "max", "sem"]
+    "agg_func",
+    [*agg_func_supported_for_timedelta, *agg_func_not_supported_for_timedelta],
 )
 window = pytest.mark.parametrize("window", [1, 2, 3, 4, 6])
 min_periods = pytest.mark.parametrize("min_periods", [None, 1, 2])
@@ -485,3 +503,118 @@ def test_rolling_aggregation_unsupported(agg_func, agg_func_kwargs):
     snow_df = pd.DataFrame({"B": [0, 1, 2, np.nan, 4]})
     with pytest.raises(NotImplementedError):
         getattr(snow_df.rolling(window=2, min_periods=1), agg_func)(agg_func_kwargs)
+
+
+class TestTimedelta:
+    @pytest.mark.parametrize(
+        "create_function",
+        [
+            pytest.param(create_test_dfs, id="dataframe"),
+            pytest.param(create_test_series, id="series"),
+        ],
+    )
+    @pytest.mark.parametrize("agg_func", agg_func_not_supported_for_timedelta)
+    @sql_count_checker(query_count=0)
+    def test_rolling_aggregation_unsupported(self, create_function, agg_func):
+        eval_snowpark_pandas_result(
+            *create_function(
+                [
+                    native_pd.Timedelta(-1),
+                    native_pd.Timedelta(1),
+                    native_pd.Timedelta(2),
+                    native_pd.Timedelta(5),
+                    native_pd.NaT,
+                ]
+            ),
+            lambda object: getattr(object.rolling(window=1), agg_func)(
+                numeric_only=False
+            ),
+            expect_exception=True,
+            expect_exception_type=DataError,
+            # pandas error message is different for dataframe and series, but
+            # Snowpark pandas always uses the same message. Accept either
+            # message.
+            expect_exception_match=(
+                f"(?:{re.escape('No numeric types to aggregate')})|"
+                + f"(?:{re.escape(_TIMEDELTA_ROLLING_AGGREGATION_NOT_SUPPORTED)})"
+            ),
+            assert_exception_equal=False,
+        )
+
+    @pytest.mark.parametrize(
+        "create_function, input_data",
+        [
+            pytest.param(
+                create_test_dfs,
+                [
+                    [pd.Timedelta(3), pd.Timedelta(4)],
+                    [pd.Timedelta(1), pd.Timedelta(2)],
+                ],
+                id="dataframe",
+            ),
+            pytest.param(
+                create_test_series, [pd.Timedelta(3), pd.Timedelta(4)], id="series"
+            ),
+        ],
+    )
+    @sql_count_checker(query_count=0)
+    def test_rolling_corr_unsupported(self, create_function, input_data):
+        eval_snowpark_pandas_result(
+            *create_function(input_data),
+            lambda object: object.rolling(window=2).corr(other=object),
+            expect_exception=True,
+            expect_exception_type=NotImplementedError,
+            expect_exception_match=re.escape(_TIMEDELTA_ROLLING_CORR_NOT_SUPPORTED),
+        )
+
+    @pytest.mark.parametrize(
+        "create_function",
+        [
+            pytest.param(create_test_dfs, id="dataframe"),
+            pytest.param(create_test_series, id="series"),
+        ],
+    )
+    @pytest.mark.parametrize("agg_func", agg_func_supported_for_timedelta)
+    @window
+    @min_periods
+    @center
+    def test_rolling_aggregation_supported(
+        self, create_function, agg_func, window, min_periods, center
+    ):
+        snow_series, native_series = create_function(
+            [
+                native_pd.Timedelta(-1),
+                native_pd.Timedelta(1),
+                native_pd.Timedelta(2),
+                native_pd.Timedelta(5),
+                native_pd.NaT,
+            ]
+        )
+
+        if min_periods is not None and min_periods > window:
+            with SqlCounter(query_count=0):
+                eval_snowpark_pandas_result(
+                    snow_series,
+                    native_series,
+                    lambda series: getattr(
+                        series.rolling(
+                            window=window, min_periods=min_periods, center=center
+                        ),
+                        agg_func,
+                    )(),
+                    expect_exception=True,
+                    expect_exception_type=ValueError,
+                    expect_exception_match=f"min_periods {min_periods} must be <= window {window}",
+                )
+        else:
+            with SqlCounter(query_count=1):
+                eval_snowpark_pandas_result(
+                    snow_series,
+                    native_series,
+                    lambda series: getattr(
+                        series.rolling(
+                            window=window, min_periods=min_periods, center=center
+                        ),
+                        agg_func,
+                    )(),
+                )

--- a/tests/integ/modin/window/utils.py
+++ b/tests/integ/modin/window/utils.py
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+agg_func_supported_for_timedelta = ("count",)
+agg_func_not_supported_for_timedelta = (
+    "sum",
+    "mean",
+    "var",
+    "std",
+    "min",
+    "max",
+    "sem",
+)
+agg_func = pytest.mark.parametrize(
+    "agg_func",
+    (*agg_func_supported_for_timedelta, *agg_func_not_supported_for_timedelta),
+)


### PR DESCRIPTION
Fixes SNOW-1694806

Add support for rolling().count() and expanding().count() for both Series and DataFrames.

For other rolling and expanding methods, match pandas behavior, which is to raise some kind of error.
