### PR TITLE
SNOW-1694815: Propagate timedelta types through resampler methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fixed `inplace` argument for `Series` objects derived from other `Series` objects.
 - Fixed a bug where `Series.sort_values` failed if series name overlapped with index column name.
 - Fixed a bug where transposing a dataframe would map `Timedelta` index levels to integer column levels.
+- Fixed a bug where `Resampler` methods on timedelta columns would produce integer results.
 
 ## 1.22.1 (2024-09-11)
 This is a re-release of 1.22.0. Please refer to the 1.22.0 release notes for detailed release content.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -12264,10 +12264,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         frame = self._modin_frame
 
-        if any(
+        if resample_method in ("var", np.var) and any(
             isinstance(t, TimedeltaType)
             for t in frame.cached_data_column_snowpark_pandas_types
-        ) and resample_method in ("var", np.var):
+        ):
             raise TypeError("timedelta64 type does not support var operations")
 
         snowflake_index_column_identifier = (

--- a/tests/integ/modin/resample/test_resample.py
+++ b/tests/integ/modin/resample/test_resample.py
@@ -12,7 +12,7 @@ from snowflake.snowpark.modin.plugin._internal.resample_utils import (
     IMPLEMENTED_AGG_METHODS,
     IMPLEMENTED_DATEOFFSET_STRINGS,
 )
-from tests.integ.modin.sql_counter import sql_count_checker
+from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import (
     create_test_dfs,
     create_test_series,
@@ -34,7 +34,7 @@ def randomword(length):
 @agg_func
 # One extra query to convert index to native pandas for dataframe constructor
 @sql_count_checker(query_count=3, join_count=1)
-def test_resample_with_varying_freq_and_interval(freq, interval, agg_func):
+def test_resample_floats_with_varying_freq_and_interval(freq, interval, agg_func):
     rule = f"{interval}{freq}"
     eval_snowpark_pandas_result(
         *create_test_dfs(
@@ -44,6 +44,43 @@ def test_resample_with_varying_freq_and_interval(freq, interval, agg_func):
         lambda df: getattr(df.resample(rule=rule, closed="left"), agg_func)(),
         check_freq=False,
     )
+
+
+@freq
+@interval
+@agg_func
+def test_resample_timedelta_and_floats_with_varying_freq_and_interval(
+    freq, interval, agg_func
+):
+    rule = f"{interval}{freq}"
+    # One extra query to convert index to native pandas for dataframe constructor
+    with SqlCounter(query_count=1):
+        dfs = create_test_dfs(
+            {
+                "A": np.random.randn(15),
+                "B": native_pd.timedelta_range("1 day", periods=15),
+            },
+            index=native_pd.date_range("2020-01-01", periods=15, freq=f"1{freq}"),
+        )
+
+    def operation(df):
+        return getattr(df.resample(rule=rule, closed="left"), agg_func)()
+
+    if agg_func == "var":
+        with SqlCounter(query_count=0):
+            eval_snowpark_pandas_result(
+                *dfs,
+                operation,
+                expect_exception=True,
+                expect_exception_type=TypeError,
+            )
+    else:
+        with SqlCounter(query_count=2, join_count=1):
+            eval_snowpark_pandas_result(
+                *dfs,
+                operation,
+                check_freq=False,
+            )
 
 
 # One extra query to convert index to native pandas for dataframe constructor
@@ -152,7 +189,7 @@ def test_resample_duplicated_timestamps():
 @interval
 @agg_func
 @sql_count_checker(query_count=2, join_count=1)
-def test_resample_series(freq, interval, agg_func):
+def test_resample_int_series(freq, interval, agg_func):
     rule = f"{interval}{freq}"
     eval_snowpark_pandas_result(
         *create_test_series(
@@ -162,6 +199,36 @@ def test_resample_series(freq, interval, agg_func):
         lambda ser: getattr(ser.resample(rule=rule, closed="left"), agg_func)(),
         check_freq=False,
     )
+
+
+@freq
+@interval
+@agg_func
+def test_resample_timedelta_series(freq, interval, agg_func):
+    rule = f"{interval}{freq}"
+    series = create_test_series(
+        native_pd.timedelta_range("1 day", periods=15),
+        index=native_pd.date_range("2020-01-01", periods=15, freq=f"1{freq}"),
+    )
+
+    def operation(ser):
+        return getattr(ser.resample(rule=rule, closed="left"), agg_func)()
+
+    if agg_func == "var":
+        with SqlCounter(query_count=0):
+            eval_snowpark_pandas_result(
+                *series,
+                operation,
+                expect_exception=True,
+                expect_exception_type=TypeError,
+            )
+    else:
+        with SqlCounter(query_count=2, join_count=1):
+            eval_snowpark_pandas_result(
+                *series,
+                operation,
+                check_freq=False,
+            )
 
 
 # One extra query to convert index to native pandas for dataframe constructor

--- a/tests/integ/modin/resample/test_resample_asfreq.py
+++ b/tests/integ/modin/resample/test_resample_asfreq.py
@@ -21,7 +21,10 @@ def test_asfreq_no_method(freq, interval):
     rule = f"{interval}{freq}"
     eval_snowpark_pandas_result(
         *create_test_dfs(
-            {"A": np.random.randn(15)},
+            {
+                "A": np.random.randn(15),
+                "B": native_pd.timedelta_range("1 days", periods=15),
+            },
             index=native_pd.date_range("2020-01-01", periods=15, freq=f"1{freq}"),
         ),
         lambda df: df.asfreq(freq=rule),
@@ -46,7 +49,10 @@ def test_asfreq_ffill():
 def test_resampler_asfreq(freq):
     eval_snowpark_pandas_result(
         *create_test_dfs(
-            {"A": np.random.randn(15)},
+            {
+                "A": np.random.randn(15),
+                "B": native_pd.timedelta_range("1 days", periods=15),
+            },
             index=native_pd.date_range("2020-01-01", periods=15, freq="1min"),
         ),
         lambda df: df.resample(freq).asfreq(),

--- a/tests/integ/modin/resample/test_resample_fillna.py
+++ b/tests/integ/modin/resample/test_resample_fillna.py
@@ -35,7 +35,11 @@ def test_resample_fill(interval, agg_func):
     )
     eval_snowpark_pandas_result(
         *create_test_dfs(
-            {"a": range(len(datecol)), "b": range(len(datecol) - 1, -1, -1)},
+            {
+                "a": range(len(datecol)),
+                "b": range(len(datecol) - 1, -1, -1),
+                "c": native_pd.timedelta_range("1 days", periods=len(datecol)),
+            },
             index=datecol,
         ),
         lambda df: getattr(df.resample(rule=f"{interval}D"), agg_func)(),

--- a/tests/integ/modin/resample/test_resample_negative.py
+++ b/tests/integ/modin/resample/test_resample_negative.py
@@ -13,7 +13,7 @@ from snowflake.snowpark.modin.plugin._internal.resample_utils import (
     UNSUPPORTED_DATEOFFSET_STRINGS,
 )
 from tests.integ.modin.sql_counter import sql_count_checker
-from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.integ.modin.utils import create_test_dfs, eval_snowpark_pandas_result
 
 
 @pytest.mark.parametrize("index_col", [["datecol", "B"], ["A", "B"], ["A"]])
@@ -168,3 +168,13 @@ def test_resample_tz_negative():
         match="Cannot subtract tz-naive and tz-aware datetime-like objects.",
     ):
         snow_df.resample("2D").min()
+
+
+@pytest.mark.xfail(strict=True, raises=AssertionError, reason="SNOW-1704430")
+def test_resample_sum_timedelta_with_duplicate_column_label_changes_type_to_int():
+    eval_snowpark_pandas_result(
+        *create_test_dfs(
+            [[pd.Timedelta(1), 2]], columns=["a", "a"], index=[pd.Timestamp(1)]
+        ),
+        lambda df: df.resample("1s").sum(),
+    )


### PR DESCRIPTION
Fixes SNOW-1694815

Test passing timedelta types through resampler methods.

It turns out that we are currently converting the timedelta types to integers, so fix that bug in most cases.

We support all resample "fill" methods, along with all aggregations except for `std`, which pandas does not support.