### PR TITLE
Avoid unnecessary warning message when plotting is not enabled

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -356,14 +356,13 @@ def plot_plan_if_enabled(root: LogicalPlan, filename: str) -> None:
         filename: name of the file to save the image plot.
     """
     import os
-
-    import graphviz  # pyright: ignore[reportMissingImports]
-
     if (
         os.environ.get("ENABLE_SNOWPARK_LOGICAL_PLAN_PLOTTING", "false").lower()
         != "true"
     ):
         return
+
+    import graphviz  # pyright: ignore[reportMissingImports]
 
     def get_stat(node: LogicalPlan):
         def get_name(node: Optional[LogicalPlan]) -> str:

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -356,6 +356,7 @@ def plot_plan_if_enabled(root: LogicalPlan, filename: str) -> None:
         filename: name of the file to save the image plot.
     """
     import os
+
     if (
         os.environ.get("ENABLE_SNOWPARK_LOGICAL_PLAN_PLOTTING", "false").lower()
         != "true"


### PR DESCRIPTION
1. Please describe how your code solves the related issue.
import graphviz seems also introduces a set of warning message like 
```
DEBUG    graphviz._tools:_tools.py:147 deprecate positional args: graphviz.graphs.BaseGraph.__init__(['comment', 'filename', 'directory', 'format', 'engine', 'encoding', 'graph_attr', 'node_attr', 'edge_attr', 'body', 'strict'])
DEBUG    graphviz._tools:_tools.py:147 deprecate positional args: graphviz.sources.Source.from_file(['directory', 'format', 'engine', 'encoding', 'renderer', 'formatter'])
DEBUG    graphviz._tools:_tools.py:147 deprecate positional args: graphviz.sources.Source.__init__(['filename', 'directory', 'format', 'engine', 'encoding'])
DEBUG    graphviz._tools:_tools.py:147 deprecate positional args: graphviz.sources.Source.save(['directory'])
```
the warnings are very noisy even if plotting is disabled. move the import below the check of plotting enablement so that those debugging message does not shown up if plotting is disabled.