### PR TITLE
SNOW-1704402 Fix sql counter test failure on describe_count when sql simplifier disabled

### DIFF
--- a/tests/integ/modin/test_sql_counter.py
+++ b/tests/integ/modin/test_sql_counter.py
@@ -85,31 +85,29 @@ def test_sql_counter_with_context_manager_inside_loop():
 
 
 @sql_count_checker(no_check=True)
-def test_sql_counter_with_multiple_checks():
-    with SqlCounter(
-        query_count=1, describe_count=1 if is_sql_simplifier_enabled() else 0
-    ):
+def test_sql_counter_with_multiple_checks(session):
+    expected_describe_count = 0
+    if session.sql_simplifier_enabled:
+        expected_describe_count = 1
+    with SqlCounter(query_count=1, describe_count=expected_describe_count):
         df = pd.DataFrame({"a": [1, 2, 3]})
         assert len(df) == 3
 
-    with SqlCounter(
-        query_count=1, describe_count=1 if is_sql_simplifier_enabled() else 0
-    ):
+    with SqlCounter(query_count=1, describe_count=expected_describe_count):
         df = pd.DataFrame({"b": [4, 5, 6]})
         assert len(df) == 3
 
-    with SqlCounter(
-        query_count=1, describe_count=1 if is_sql_simplifier_enabled() else 0
-    ):
+    with SqlCounter(query_count=1, describe_count=expected_describe_count):
         df = pd.DataFrame({"c": [7, 8, 9]})
         assert len(df) == 3
 
 
 @sql_count_checker(no_check=True)
-def test_sql_counter_with_context_manager_outside_loop():
-    sc = SqlCounter(
-        query_count=3, describe_count=3 if is_sql_simplifier_enabled() else 0
-    )
+def test_sql_counter_with_context_manager_outside_loop(session):
+    expected_describe_count = 0
+    if session.sql_simplifier_enabled:
+        expected_describe_count = 3
+    sc = SqlCounter(query_count=3, describe_count=expected_describe_count)
     sc.__enter__()
     for _ in range(3):
         df = pd.DataFrame({"a": [1, 2, 3]})

--- a/tests/integ/modin/test_sql_counter.py
+++ b/tests/integ/modin/test_sql_counter.py
@@ -8,7 +8,6 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark import QueryRecord
-from snowflake.snowpark.session import Session
 from tests.integ.modin.utils import assert_frame_equal
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 

--- a/tests/integ/modin/test_sql_counter.py
+++ b/tests/integ/modin/test_sql_counter.py
@@ -9,17 +9,12 @@ import pytest
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark import QueryRecord
 from snowflake.snowpark.session import Session
-from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import assert_frame_equal
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
 class CustomException(BaseException):
     pass
-
-
-def is_sql_simplifier_enabled():
-    return Session.SessionBuilder().getOrCreate().sql_simplifier_enabled
 
 
 @sql_count_checker(query_count=3)

--- a/tests/integ/modin/test_sql_counter.py
+++ b/tests/integ/modin/test_sql_counter.py
@@ -8,12 +8,18 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark import QueryRecord
+from snowflake.snowpark.session import Session
+from tests.integ.modin.sql_counter import SqlCounter, sql_count_checker
 from tests.integ.modin.utils import assert_frame_equal
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
 class CustomException(BaseException):
     pass
+
+
+def is_sql_simplifier_enabled():
+    return Session.SessionBuilder().getOrCreate().sql_simplifier_enabled
 
 
 @sql_count_checker(query_count=3)
@@ -80,22 +86,30 @@ def test_sql_counter_with_context_manager_inside_loop():
 
 @sql_count_checker(no_check=True)
 def test_sql_counter_with_multiple_checks():
-    with SqlCounter(query_count=1, describe_count=1):
+    with SqlCounter(
+        query_count=1, describe_count=1 if is_sql_simplifier_enabled() else 0
+    ):
         df = pd.DataFrame({"a": [1, 2, 3]})
         assert len(df) == 3
 
-    with SqlCounter(query_count=1, describe_count=1):
+    with SqlCounter(
+        query_count=1, describe_count=1 if is_sql_simplifier_enabled() else 0
+    ):
         df = pd.DataFrame({"b": [4, 5, 6]})
         assert len(df) == 3
 
-    with SqlCounter(query_count=1, describe_count=1):
+    with SqlCounter(
+        query_count=1, describe_count=1 if is_sql_simplifier_enabled() else 0
+    ):
         df = pd.DataFrame({"c": [7, 8, 9]})
         assert len(df) == 3
 
 
 @sql_count_checker(no_check=True)
 def test_sql_counter_with_context_manager_outside_loop():
-    sc = SqlCounter(query_count=3, describe_count=3)
+    sc = SqlCounter(
+        query_count=3, describe_count=3 if is_sql_simplifier_enabled() else 0
+    )
     sc.__enter__()
     for _ in range(3):
         df = pd.DataFrame({"a": [1, 2, 3]})


### PR DESCRIPTION

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.


   Fixes SNOW-1704402 Fix sql counter failure on describe_count when sql simplifier disabled

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Fix sql counter failure on describe_count when sql simplifier disabled
