### PR TITLE
SNOW-1703599: Fix duplicate show query in save_as_table when new compilation stage is applied

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1015,6 +1015,7 @@ class Analyzer:
                 creation_source=logical_plan.creation_source,
                 child_attributes=resolved_child.attributes,
                 iceberg_config=logical_plan.iceberg_config,
+                table_exists=logical_plan.table_exists,
             )
 
         if isinstance(logical_plan, Limit):

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -865,6 +865,7 @@ class SnowflakePlanBuilder:
         creation_source: TableCreationSource,
         child_attributes: Optional[List[Attribute]],
         iceberg_config: Optional[dict] = None,
+        table_exists: Optional[bool] = None,
     ) -> SnowflakePlan:
         """Returns a SnowflakePlan to materialize the child plan into a table.
 
@@ -898,6 +899,8 @@ class SnowflakePlanBuilder:
                 base_location: the base directory that snowflake can write iceberg metadata and files to
                 catalog_sync: optionally sets the catalog integration configured for Polaris Catalog
                 storage_serialization_policy: specifies the storage serialization policy for the table
+            table_exists: whether the table already exists in the database.
+                Only used for APPEND and TRUNCATE mode.
         """
         is_generated = creation_source in (
             TableCreationSource.CACHE_RESULT,
@@ -1013,7 +1016,7 @@ class SnowflakePlanBuilder:
             )
 
         if mode == SaveMode.APPEND:
-            if self.session._table_exists(table_name):
+            if table_exists:
                 return self.build(
                     lambda x: insert_into_statement(
                         table_name=full_table_name,
@@ -1028,7 +1031,7 @@ class SnowflakePlanBuilder:
                 return get_create_and_insert_plan(child, replace=False, error=False)
 
         elif mode == SaveMode.TRUNCATE:
-            if self.session._table_exists(table_name):
+            if table_exists:
                 return self.build(
                     lambda x: insert_into_statement(
                         full_table_name, x, [x.name for x in child.attributes], True

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1016,6 +1016,7 @@ class SnowflakePlanBuilder:
             )
 
         if mode == SaveMode.APPEND:
+            assert table_exists is not None
             if table_exists:
                 return self.build(
                     lambda x: insert_into_statement(
@@ -1031,6 +1032,7 @@ class SnowflakePlanBuilder:
                 return get_create_and_insert_plan(child, replace=False, error=False)
 
         elif mode == SaveMode.TRUNCATE:
+            assert table_exists is not None
             if table_exists:
                 return self.build(
                     lambda x: insert_into_statement(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -223,6 +223,7 @@ class SnowflakeCreateTable(LogicalPlan):
         change_tracking: Optional[bool] = None,
         copy_grants: bool = False,
         iceberg_config: Optional[dict] = None,
+        table_exists: Optional[bool] = None,
     ) -> None:
         super().__init__()
 
@@ -244,6 +245,7 @@ class SnowflakeCreateTable(LogicalPlan):
         self.change_tracking = change_tracking
         self.copy_grants = copy_grants
         self.iceberg_config = iceberg_config
+        self.table_exists = table_exists
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -245,6 +245,8 @@ class SnowflakeCreateTable(LogicalPlan):
         self.change_tracking = change_tracking
         self.copy_grants = copy_grants
         self.iceberg_config = iceberg_config
+        # whether the table already exists in the database
+        # determines the compiled SQL for APPEND and TRUNCATE mode
         self.table_exists = table_exists
 
     @property

--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -167,6 +167,7 @@ class QueryGenerator(Analyzer):
                 creation_source=logical_plan.creation_source,
                 child_attributes=child_attributes,
                 iceberg_config=logical_plan.iceberg_config,
+                table_exists=logical_plan.table_exists,
             )
 
         elif isinstance(

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -30,6 +30,7 @@ from snowflake.snowpark._internal.utils import (
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.column import Column, _to_col_if_str
 from snowflake.snowpark.functions import sql_expr
+from snowflake.snowpark.mock._connection import MockServerConnection
 from snowflake.snowpark.row import Row
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
@@ -255,8 +256,12 @@ class DataFrameWriter:
                     f"Unsupported table type. Expected table types: {SUPPORTED_TABLE_TYPES}"
                 )
 
-            if save_mode in [SaveMode.APPEND, SaveMode.TRUNCATE]:
-                table_exists = self._dataframe._session._table_exists(table_name)
+            session = self._dataframe._session
+            if not isinstance(session._conn, MockServerConnection) and save_mode in [
+                SaveMode.APPEND,
+                SaveMode.TRUNCATE,
+            ]:
+                table_exists = session._table_exists(table_name)
             else:
                 table_exists = None
 
@@ -277,7 +282,6 @@ class DataFrameWriter:
                 iceberg_config,
                 table_exists,
             )
-            session = self._dataframe._session
             snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
             result = session._conn.execute(
                 snowflake_plan,

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -261,6 +261,10 @@ class DataFrameWriter:
                 SaveMode.APPEND,
                 SaveMode.TRUNCATE,
             ]:
+                # whether the table already exists in the database
+                # determines the compiled SQL for APPEND and TRUNCATE mode
+                # if the table does not exist, we need to create it first;
+                # if the table exists, we can skip the creation step and insert data directly
                 table_exists = session._table_exists(table_name)
             else:
                 table_exists = None

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -255,6 +255,11 @@ class DataFrameWriter:
                     f"Unsupported table type. Expected table types: {SUPPORTED_TABLE_TYPES}"
                 )
 
+            if save_mode in [SaveMode.APPEND, SaveMode.TRUNCATE]:
+                table_exists = self._dataframe._session._table_exists(table_name)
+            else:
+                table_exists = None
+
             create_table_logic_plan = SnowflakeCreateTable(
                 table_name,
                 column_names,
@@ -270,6 +275,7 @@ class DataFrameWriter:
                 change_tracking,
                 copy_grants,
                 iceberg_config,
+                table_exists,
             )
             session = self._dataframe._session
             snowflake_plan = session._analyzer.resolve(create_table_logic_plan)

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -175,6 +175,7 @@ def test_table_create(session, mode):
         table_type="temp",
         clustering_exprs=None,
         comment=None,
+        table_exists=False,
     )
     snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
     expected_query_count = 0

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -179,10 +179,6 @@ def test_table_create(session, mode):
     )
     snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
     expected_query_count = 0
-    if mode == SaveMode.APPEND or mode == SaveMode.TRUNCATE:
-        # when the mode is append or truncate, extra queries is issued to check if
-        # the table exists
-        expected_query_count = 2
     check_generated_plan_queries(
         snowflake_plan, expected_query_count=expected_query_count
     )

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -337,10 +337,13 @@ def test_same_duplicate_subtree(session):
 def test_save_as_table(session, mode):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     if mode == "append":
+        # 1 show query + 1 create table query + 1 insert query
         expected_query_count = 3
     elif mode == "truncate":
+        # 1 show query + 1 create table query
         expected_query_count = 2
     else:
+        # 1 create table query
         expected_query_count = 1
     with SqlCounter(query_count=expected_query_count, union_count=1):
         with session.query_history() as query_history:

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -331,7 +331,9 @@ def test_same_duplicate_subtree(session):
         assert count_number_of_ctes(df_result2.queries["queries"][-1]) == 3
 
 
-@pytest.mark.parametrize("mode", ["append", "overwrite", "errorifexists", "ignore"])
+@pytest.mark.parametrize(
+    "mode", ["append", "truncate", "overwrite", "errorifexists", "ignore"]
+)
 def test_save_as_table(session, mode):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     expected_query_count = 1
@@ -349,6 +351,8 @@ def test_save_as_table(session, mode):
     query = query_history.queries[-1].sql_text
     assert query.count(WITH) == 1
     assert count_number_of_ctes(query) == 1
+    if mode in ["append", "truncate"]:
+        assert sum("show" in q.sql_text for q in query_history.queries) == 1
 
 
 @sql_count_checker(query_count=1, union_count=1)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -336,11 +336,12 @@ def test_same_duplicate_subtree(session):
 )
 def test_save_as_table(session, mode):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
-    expected_query_count = 1
     if mode == "append":
-        # append mode uses create table with insert
-        # TODO (SNOW-1703599): Show table query is executed twice when new compilation stage is enabled
-        expected_query_count = 4 if session._query_compilation_stage_enabled else 3
+        expected_query_count = 3
+    elif mode == "truncate":
+        expected_query_count = 2
+    else:
+        expected_query_count = 1
     with SqlCounter(query_count=expected_query_count, union_count=1):
         with session.query_history() as query_history:
             df.union_all(df).write.save_as_table(

--- a/tests/integ/test_deepcopy.py
+++ b/tests/integ/test_deepcopy.py
@@ -337,6 +337,7 @@ def test_table_creation(session, mode):
         table_type="temp",
         clustering_exprs=None,
         comment=None,
+        table_exists=False,
     )
     snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
     copied_plan = copy.deepcopy(snowflake_plan)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1703599

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   We shouldn't call session._table_exists inside resolve, but we can call it before resolve. 
