### PR TITLE
SNOW-1625385, SNOW-1625384: Test and/or fix timedelta in integ/modin/{pivot,tools}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Fixed a bug where `Series.sort_values` failed if series name overlapped with index column name.
 - Fixed a bug where transposing a dataframe would map `Timedelta` index levels to integer column levels.
 - Fixed a bug where `Resampler` methods on timedelta columns would produce integer results.
+- Fixed a bug where `pd.to_numeric()` would leave `Timedelta` inputs as `Timedelta` instead of converting them to integers.
 
 ## 1.22.1 (2024-09-11)
 This is a re-release of 1.22.0. Please refer to the 1.22.0 release notes for detailed release content.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -9335,7 +9335,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     f"invalid error value specified: {errors}"
                 )  # pragma: no cover
 
-        if isinstance(col_id_sf_type, (_NumericType, BooleanType)):
+        if isinstance(col_id_sf_type, (_NumericType, BooleanType)) and not isinstance(
+            col_id_sf_type, TimedeltaType
+        ):
             # no need to convert
             return self
 
@@ -9352,6 +9354,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if isinstance(col_id_sf_type, TimestampType):
             # turn those date time type to nanoseconds
             new_col = date_part("epoch_nanosecond", new_col)
+            new_col_type_is_numeric = True
+        elif isinstance(col_id_sf_type, TimedeltaType):
+            new_col = column_astype(
+                col_id, col_id_sf_type, "int64", TypeMapper.to_snowflake("int64")
+            )
             new_col_type_is_numeric = True
         elif not isinstance(col_id_sf_type, StringType):
             # convert to string by default for better error message

--- a/tests/integ/modin/pivot/test_pivot_table_negative.py
+++ b/tests/integ/modin/pivot/test_pivot_table_negative.py
@@ -10,6 +10,7 @@ from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.pivot.pivot_utils import (
+    pivot_table_test_helper,
     pivot_table_test_helper_expects_exception,
 )
 from tests.integ.utils.sql_counter import sql_count_checker
@@ -205,3 +206,31 @@ def test_pivot_table_aggfunc_not_implemented_or_supported(df_data, func, error_p
         pd.DataFrame(df_data).pivot_table(
             index="A", columns="C", values=["D", "E", "F"], aggfunc=func
         )
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+@pytest.mark.parametrize(
+    "df_data",
+    [
+        {
+            "A": ["foo", "bar"],
+            "B": ["one", "two"],
+            "C": [pd.Timedelta(1), pd.Timedelta(2)],
+        },
+        {
+            "A": [pd.Timedelta(1), pd.Timedelta(2)],
+            "B": ["one", "two"],
+            "C": ["foo", "bar"],
+        },
+        {
+            "A": ["one", "two"],
+            "B": [pd.Timedelta(1), pd.Timedelta(2)],
+            "C": ["foo", "bar"],
+        },
+    ],
+)
+def test_timedelta_input_not_supported(df_data):
+    pivot_table_test_helper(
+        df_data,
+        pivot_table_kwargs=dict(index="A", columns="B", values="C", aggfunc="max"),
+    )

--- a/tests/integ/modin/tools/test_to_datetime.py
+++ b/tests/integ/modin/tools/test_to_datetime.py
@@ -18,6 +18,7 @@ import pytz
 from modin.pandas import NaT, Series, Timestamp, to_datetime
 from pandas import DatetimeIndex
 from pandas.core.arrays import DatetimeArray
+from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import (
@@ -28,6 +29,7 @@ from tests.integ.modin.utils import (
     assert_index_equal,
     assert_series_equal,
     assert_snowpark_pandas_equal_to_pandas,
+    create_test_series,
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import sql_count_checker
@@ -862,17 +864,23 @@ class TestToDatetime:
         assert pd.to_datetime(None) == native_pd.to_datetime(None)
 
     @sql_count_checker(query_count=0)
-    def test_bool(self):
+    @pytest.mark.parametrize(
+        "input_data,dtype_description_in_error",
+        [
+            param([True, False], "bool", id="bool"),
+            param(pd.Timedelta(1), "timedelta64[ns]", id="timedelta"),
+        ],
+    )
+    def test_invalid_input_type(self, input_data, dtype_description_in_error):
         eval_snowpark_pandas_result(
-            pd.Series([True, False]),
-            native_pd.Series([True, False]),
+            *create_test_series(input_data),
             lambda df: pd.to_datetime(df)
             if isinstance(df, pd.Series)
             else native_pd.to_datetime(df),
             expect_exception=True,
             expect_exception_type=TypeError,
             expect_exception_match=re.escape(
-                "dtype bool cannot be converted to datetime64[ns]"
+                f"dtype {dtype_description_in_error} cannot be converted to datetime64[ns]"
             ),
         )
 

--- a/tests/integ/modin/tools/test_to_numeric.py
+++ b/tests/integ/modin/tools/test_to_numeric.py
@@ -3,12 +3,14 @@
 #
 import contextlib
 import logging
+import re
 from datetime import date, time
 
 import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
+from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
@@ -69,6 +71,7 @@ def errors(request):
             None,
             "float64",
         ),  # <- deviate from pandas' behavior, pandas returns object
+        param([native_pd.Timedelta(1)], None, "int64", id="timedelta"),
     ],
 )
 @sql_count_checker(query_count=1)
@@ -113,6 +116,15 @@ def test_scalar_to_numeric(input, dtype):
         assert (np.isnan(snow) and np.isnan(native)) or snow == pytest.approx(native)
     else:
         assert snow == native
+
+
+@sql_count_checker(query_count=2)
+def test_scalar_timedelta_to_numeric():
+    # Test this case separately because of a bug in pandas: https://github.com/pandas-dev/pandas/issues/59944
+    input = native_pd.Timedelta(1)
+    with pytest.raises(TypeError, match=re.escape("Invalid object type at position 0")):
+        native_pd.to_numeric(input)
+    assert pd.to_numeric(input) == 1
 
 
 @sql_count_checker(query_count=2)


### PR DESCRIPTION
- Test that pivot() with timedelta inputs is not supported.
  - pivot() is complicated so defer this feature until a user requests it.
- Test that timedelta is invalid input to to_datetime()
- Fix a bug where to_numeric() would leave timedelta values alone instead of converting them to integer.

Fixes SNOW-1625385
Fixes SNOW-1625384