### PR TITLE
Fix test_query_generator for query generation test on each snowflake plan node

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -797,7 +797,7 @@ class Analyzer:
 
         if isinstance(logical_plan, Selectable):
             # Selectable doesn't have children. It already has the expr_to_alias dict.
-            self.alias_maps_to_use = logical_plan.expr_to_alias
+            self.alias_maps_to_use = logical_plan.expr_to_alias.copy()
         else:
             use_maps = {}
             # get counts of expr_to_alias keys

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -50,13 +50,18 @@ pytestmark = [
 ]
 
 
-def reset_node(node: LogicalPlan) -> None:
+def reset_node(node: LogicalPlan, query_generator: QueryGenerator) -> None:
     def reset_selectable(selectable_node: Selectable) -> None:
+        # reset the analyzer to use the current query generator instance to
+        # ensure the new query generator is used during the resolve process
+        selectable_node.analyzer = query_generator
         if not isinstance(selectable_node, (SelectSnowflakePlan, SelectSQL)):
             selectable_node._snowflake_plan = None
         if isinstance(selectable_node, (SelectStatement, SetStatement)):
             selectable_node._sql_query = None
             selectable_node._projection_in_str = None
+        if isinstance(selectable_node, SelectStatement):
+            selectable_node.expr_to_alias = selectable_node.from_.expr_to_alias
 
     if isinstance(node, SnowflakePlan):
         # do not reset leaf snowflake plan
@@ -100,9 +105,9 @@ def check_generated_plan_queries(
 
         nodes = nodes[::-1]  # reverse the list
         for node in nodes:
-            reset_node(node)
+            reset_node(node, query_generator)
             if isinstance(node, SnowflakePlan):
-                re_resolve_and_compare_plan_queries(plan, query_generator)
+                re_resolve_and_compare_plan_queries(node, query_generator)
 
 
 def verify_multiple_create_queries(
@@ -372,8 +377,8 @@ def test_multiple_plan_query_generation(session):
     )
     snowflake_plan = session._analyzer.resolve(create_table_logic_plan)
     query_generator = create_query_generator(snowflake_plan)
-    reset_node(snowflake_plan)
-    reset_node(df_res._plan)
+    reset_node(snowflake_plan, query_generator)
+    reset_node(df_res._plan, query_generator)
     logical_plans = [snowflake_plan.source_plan, df_res._plan.source_plan]
     with SqlCounter(query_count=0, describe_count=0):
         generated_queries = query_generator.generate_queries(logical_plans)


### PR DESCRIPTION

1. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

2. Please describe how your code solves the related issue.

1) fix a bug in test_query_generator that is was repeated test the query generation on the same plan node
2) use a copy for the alias_map to to use  during resolve to avoid unexpected update of the alias map 
