### PR TITLE
SNOW-1727163: Do not drop table in temp table cleaner if the session is already closed

### DIFF
--- a/tests/integ/test_temp_table_cleanup.py
+++ b/tests/integ/test_temp_table_cleanup.py
@@ -235,6 +235,18 @@ def test_save_as_table_no_drop(session, caplog):
     assert session._table_exists([temp_table_name])
 
 
+def test_session_close(db_parameters, caplog):
+    with Session.builder.configs(db_parameters).create() as new_session:
+        df = new_session.create_dataframe(
+            [[1, 2], [3, 4]], schema=["a", "b"]
+        ).cache_result()
+
+    with caplog.at_level(logging.WARNING):
+        del df
+        gc.collect()
+    assert "Failed to drop temp table" not in caplog.text
+
+
 def test_auto_clean_up_temp_table_enabled_parameter(db_parameters, session, caplog):
     warning_dict.clear()
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1727163

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   It's possible that the session is already closed before garbage collection kicks in, where we should avoid sending drop table sql and eliminate the warning 
