### PR TITLE
SNOW-1727512: session.table(...)._plan.source_plan should be SelectStatement instead of SnowflakeTable 

### DIFF
--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -190,7 +190,10 @@ def test_execution_queries_and_post_actions(session):
 )
 def test_plan_height(session, temp_table, sql_simplifier_enabled):
     df1 = session.table(temp_table)
-    assert df1._plan.plan_state[PlanState.PLAN_HEIGHT] == 1
+    if sql_simplifier_enabled:
+        assert df1._plan.plan_state[PlanState.PLAN_HEIGHT] == 2
+    else:
+        assert df1._plan.plan_state[PlanState.PLAN_HEIGHT] == 1
 
     df2 = session.create_dataframe([(1, 20), (3, 40)], schema=["a", "c"])
     df3 = session.create_dataframe(
@@ -250,7 +253,7 @@ def test_plan_num_duplicate_nodes_describe_query(session, temp_table):
     assert len(query_history.queries) == 1
 
 
-def test_create_scoped_temp_table(session):
+def test_create_scoped_temp_table(session, sql_simplifier_enabled):
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         Utils.create_table(session, table_name, "num int, str string(8)")
@@ -305,6 +308,11 @@ def test_create_scoped_temp_table(session):
             .sql
             == f' CREATE  TEMPORARY  TABLE {temp_table_name}("NUM" BIGINT, "STR" STRING(8))  '
         )
+        inner_select_sql = (
+            f" SELECT  *  FROM {table_name}"
+            if sql_simplifier_enabled
+            else f" SELECT  *  FROM ({table_name})"
+        )
         assert (
             session._plan_builder.save_as_table(
                 table_name=[temp_table_name],
@@ -326,7 +334,7 @@ def test_create_scoped_temp_table(session):
             )
             .queries[0]
             .sql
-            == f" CREATE  TEMPORARY  TABLE  {temp_table_name}    AS  SELECT  *  FROM ( SELECT  *  FROM ({table_name}))"
+            == f" CREATE  TEMPORARY  TABLE  {temp_table_name}    AS  SELECT  *  FROM ({inner_select_sql})"
         )
         expected_sql = f' CREATE  TEMPORARY  TABLE  {temp_table_name}("NUM" BIGINT, "STR" STRING(8))'
         assert expected_sql in (

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -16,7 +16,9 @@ from snowflake.snowpark import (
 )
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.expression import Attribute
+from snowflake.snowpark._internal.analyzer.select_statement import SelectStatement
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlanBuilder
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import SnowflakeTable
 from snowflake.snowpark._internal.server_connection import ServerConnection
 from snowflake.snowpark.dataframe import _get_unaliased
 from snowflake.snowpark.exceptions import SnowparkCreateDynamicTableException
@@ -320,3 +322,15 @@ def test_session():
 
     assert df.session == fake_session
     assert df.session._session_id == fake_session._session_id
+
+
+def test_table_source_plan(sql_simplifier_enabled):
+    mock_connection = mock.create_autospec(ServerConnection)
+    mock_connection._conn = mock.MagicMock()
+    session = snowflake.snowpark.session.Session(mock_connection)
+    session._sql_simplifier_enabled = sql_simplifier_enabled
+    t = session.table("table")
+    assert isinstance(
+        t._plan.source_plan,
+        SelectStatement if sql_simplifier_enabled else SnowflakeTable,
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1727512

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

   It should be the same as session.table(...).select_statement. Otherwise, we will cache metadata on wrong source_plan in the future.
 
