### PR TITLE
[SNOW-1731783] Refactor node query comparison for Repeated subquery elimination

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
@@ -127,7 +127,9 @@ def create_cte_query(root: "TreeNode", duplicated_node_ids: Set[str]) -> str:
                     # replace the placeholder (id) with child query
                     plan_to_query_map[node.encoded_id] = plan_to_query_map[
                         node.encoded_id
-                    ].replace(child.encoded_id, plan_to_query_map[child.encoded_id])
+                    ].replace(
+                        child.encoded_query_id, plan_to_query_map[child.encoded_id]
+                    )
 
             # duplicate subtrees will be converted CTEs
             if node.encoded_id in duplicated_node_ids:
@@ -150,6 +152,17 @@ def create_cte_query(root: "TreeNode", duplicated_node_ids: Set[str]) -> str:
     )
     final_query = with_stmt + SPACE + plan_to_query_map[root.encoded_id]
     return final_query
+
+
+def encoded_query_id(
+    query: str, query_params: Optional[Sequence[Any]] = None
+) -> Optional[str]:
+    string = f"{query}#{query_params}" if query_params else query
+    try:
+        return hashlib.sha256(string.encode()).hexdigest()[:10]
+    except Exception as ex:
+        logging.warning(f"Encode SnowflakePlan ID failed: {ex}")
+        return None
 
 
 def encode_id(

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -257,7 +257,7 @@ class Selectable(LogicalPlan, ABC):
         return encode_id(type(self).__name__, self.sql_query, self.query_params)
 
     @cached_property
-    def encoded_query_id(self) -> str:
+    def encoded_query_id(self) -> Optional[str]:
         """Returns the id of the queries for this Selectable logical plan."""
         return encoded_query_id(self.sql_query, self.query_params)
 
@@ -509,7 +509,7 @@ class SelectSQL(Selectable):
         return encode_id(type(self).__name__, self.original_sql, self.query_params)
 
     @cached_property
-    def encoded_query_id(self) -> str:
+    def encoded_query_id(self) -> Optional[str]:
         """
         Returns the id of this SelectSQL logical plan. The original SQL is used to encode its ID,
         which might be a non-select SQL.
@@ -594,7 +594,7 @@ class SelectSnowflakePlan(Selectable):
         return self._snowflake_plan.placeholder_query
 
     @cached_property
-    def encoded_query_id(self) -> str:
+    def encoded_query_id(self) -> Optional[str]:
         return self._snowflake_plan.encoded_query_id
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -239,8 +239,6 @@ class Selectable(LogicalPlan, ABC):
         self._api_calls = api_calls.copy() if api_calls is not None else None
         self._cumulative_node_complexity: Optional[Dict[PlanNodeCategory, int]] = None
 
-        # self.encoded_id = encode_id(self.sql_query, self.query_params)
-
     @property
     @abstractmethod
     def sql_query(self) -> str:

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -260,7 +260,7 @@ class Selectable(LogicalPlan, ABC):
 
     @cached_property
     def encoded_query_id(self) -> str:
-        """Returns the id of this Selectable logical plan."""
+        """Returns the id of the queries for this Selectable logical plan."""
         return encoded_query_id(self.sql_query, self.query_params)
 
     @property
@@ -594,10 +594,6 @@ class SelectSnowflakePlan(Selectable):
     @property
     def placeholder_query(self) -> Optional[str]:
         return self._snowflake_plan.placeholder_query
-
-    # @cached_property
-    # def encoded_id(self) -> str:
-    #    return self._snowflake_plan.encoded_id
 
     @cached_property
     def encoded_query_id(self) -> str:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -86,6 +86,7 @@ from snowflake.snowpark._internal.analyzer.binary_plan_node import (
 from snowflake.snowpark._internal.analyzer.cte_utils import (
     create_cte_query,
     encode_id,
+    encoded_query_id,
     find_duplicate_subtrees,
 )
 from snowflake.snowpark._internal.analyzer.expression import Attribute
@@ -261,6 +262,7 @@ class SnowflakePlan(LogicalPlan):
         self.encoded_id = encode_id(
             type(self).__name__, queries[-1].sql, queries[-1].params
         )
+        self.encoded_query_id = encoded_query_id(queries[-1].sql, queries[-1].params)
         self.referenced_ctes: Set[WithQueryBlock] = (
             referenced_ctes.copy() if referenced_ctes else set()
         )
@@ -581,9 +583,9 @@ class SnowflakePlanBuilder:
             new_schema_query = schema_query or sql_generator(child.schema_query)
 
         placeholder_query = (
-            sql_generator(select_child.encoded_id)
+            sql_generator(select_child.encoded_query_id)
             if self.session._cte_optimization_enabled
-            and select_child.encoded_id is not None
+            and select_child.encoded_query_id is not None
             else None
         )
 
@@ -621,10 +623,10 @@ class SnowflakePlanBuilder:
             schema_query = sql_generator(left_schema_query, right_schema_query)
 
         placeholder_query = (
-            sql_generator(select_left.encoded_id, select_right.encoded_id)
+            sql_generator(select_left.encoded_query_id, select_right.encoded_query_id)
             if self.session._cte_optimization_enabled
-            and select_left.encoded_id is not None
-            and select_right.encoded_id is not None
+            and select_left.encoded_query_id is not None
+            and select_right.encoded_query_id is not None
             else None
         )
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -85,7 +85,7 @@ from snowflake.snowpark._internal.analyzer.binary_plan_node import (
 )
 from snowflake.snowpark._internal.analyzer.cte_utils import (
     create_cte_query,
-    encode_id,
+    encode_node_id_with_query,
     encoded_query_id,
     find_duplicate_subtrees,
 )
@@ -259,13 +259,11 @@ class SnowflakePlan(LogicalPlan):
         # encode an id for CTE optimization. This is generated based on the main
         # query, query parameters and the node type. We use this id for equality
         # comparison to determine if two plans are the same.
-        self.encoded_id = encode_id(
-            type(self).__name__, queries[-1].sql, queries[-1].params
-        )
+        self.encoded_node_id_with_query = encode_node_id_with_query(self)
         # encode id for the main query and query parameters, this is currently only used
         # by the create_cte_query process.
         # TODO (SNOW-1541096) remove this filed along removing the old cte implementation
-        self.encoded_query_id = encoded_query_id(queries[-1].sql, queries[-1].params)
+        self.encoded_query_id = encoded_query_id(self)
         self.referenced_ctes: Set[WithQueryBlock] = (
             referenced_ctes.copy() if referenced_ctes else set()
         )
@@ -414,7 +412,7 @@ class SnowflakePlan(LogicalPlan):
 
     @cached_property
     def num_duplicate_nodes(self) -> int:
-        duplicated_nodes, _ = find_duplicate_subtrees(self)
+        duplicated_nodes = find_duplicate_subtrees(self)
         return len(duplicated_nodes)
 
     @cached_property

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -257,11 +257,14 @@ class SnowflakePlan(LogicalPlan):
         # It is used for optimization, by replacing a subquery with a CTE
         self.placeholder_query = placeholder_query
         # encode an id for CTE optimization. This is generated based on the main
-        # query and the associated query parameters. We use this id for equality comparison
-        # to determine if two plans are the same.
+        # query, query parameters and the node type. We use this id for equality
+        # comparison to determine if two plans are the same.
         self.encoded_id = encode_id(
             type(self).__name__, queries[-1].sql, queries[-1].params
         )
+        # encode id for the main query and query parameters, this is currently only used
+        # by the create_cte_query process.
+        # TODO (SNOW-1541096) remove this filed along removing the old cte implementation
         self.encoded_query_id = encoded_query_id(queries[-1].sql, queries[-1].params)
         self.referenced_ctes: Set[WithQueryBlock] = (
             referenced_ctes.copy() if referenced_ctes else set()

--- a/src/snowflake/snowpark/_internal/compiler/repeated_subquery_elimination.py
+++ b/src/snowflake/snowpark/_internal/compiler/repeated_subquery_elimination.py
@@ -156,11 +156,13 @@ class RepeatedSubqueryElimination:
 
             # if the node is a duplicated node and deduplication is not done for the node,
             # start the deduplication transformation use CTE
-            if node.encoded_id in duplicated_node_ids:
-                if node.encoded_id in resolved_with_block_map:
+            if node.encoded_node_id_with_query in duplicated_node_ids:
+                if node.encoded_node_id_with_query in resolved_with_block_map:
                     # if the corresponding CTE block has been created, use the existing
                     # one.
-                    resolved_with_block = resolved_with_block_map[node.encoded_id]
+                    resolved_with_block = resolved_with_block_map[
+                        node.encoded_node_id_with_query
+                    ]
                 else:
                     # create a WithQueryBlock node
                     with_block = WithQueryBlock(
@@ -169,7 +171,9 @@ class RepeatedSubqueryElimination:
                     with_block._is_valid_for_replacement = True
 
                     resolved_with_block = self._query_generator.resolve(with_block)
-                    resolved_with_block_map[node.encoded_id] = resolved_with_block
+                    resolved_with_block_map[
+                        node.encoded_node_id_with_query
+                    ] = resolved_with_block
                     self._total_number_ctes += 1
                 _update_parents(
                     node, should_replace_child=True, new_child=resolved_with_block

--- a/src/snowflake/snowpark/_internal/compiler/repeated_subquery_elimination.py
+++ b/src/snowflake/snowpark/_internal/compiler/repeated_subquery_elimination.py
@@ -2,8 +2,8 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import Dict, List, Optional, Set
 from collections import defaultdict
+from typing import Dict, List, Optional, Set
 
 from snowflake.snowpark._internal.analyzer.cte_utils import find_duplicate_subtrees
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
@@ -130,7 +130,7 @@ class RepeatedSubqueryElimination:
                 stack1.append(child)
 
         # tack node that is already visited to avoid repeated operation on the same node
-        # visited_nodes: Set[TreeNode] = set()
+        visited_nodes: Set[TreeNode] = set()
         updated_nodes: Set[TreeNode] = set()
         resolved_with_block_map: Dict[str, SnowflakePlan] = {}
 
@@ -151,8 +151,8 @@ class RepeatedSubqueryElimination:
 
         while stack2:
             node = stack2.pop()
-            # if node in visited_nodes:
-            #    continue
+            if node in visited_nodes:
+                continue
 
             # if the node is a duplicated node and deduplication is not done for the node,
             # start the deduplication transformation use CTE
@@ -176,6 +176,6 @@ class RepeatedSubqueryElimination:
                 # if the node is updated, make sure all nodes up to parent is updated
                 _update_parents(node, should_replace_child=False)
 
-            # visited_nodes.add(node)
+            visited_nodes.add(node)
 
         return root

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -42,7 +42,9 @@ binary_operations = [
 
 WITH = "WITH"
 
-paramList = [False, True]
+# paramList = [False, True]
+
+paramList = [True]
 
 
 @pytest.fixture(params=paramList, autouse=True)
@@ -155,6 +157,9 @@ def count_number_of_ctes(query):
 def test_unary(session, action):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     df_action = action(df)
+    df_res = df_action.union_all(df_action)
+    print(df_res.queries)
+    """
     check_result(
         session,
         df_action,
@@ -173,6 +178,7 @@ def test_unary(session, action):
         union_count=1,
         join_count=0,
     )
+    """
 
 
 @pytest.mark.parametrize("type, action", binary_operations)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -44,7 +44,7 @@ WITH = "WITH"
 
 # paramList = [False, True]
 
-paramList = [True]
+paramList = [False]
 
 
 @pytest.fixture(params=paramList, autouse=True)
@@ -157,9 +157,6 @@ def count_number_of_ctes(query):
 def test_unary(session, action):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     df_action = action(df)
-    df_res = df_action.union_all(df_action)
-    print(df_res.queries)
-    """
     check_result(
         session,
         df_action,
@@ -178,7 +175,6 @@ def test_unary(session, action):
         union_count=1,
         join_count=0,
     )
-    """
 
 
 @pytest.mark.parametrize("type, action", binary_operations)

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -155,9 +155,6 @@ def count_number_of_ctes(query):
 def test_unary(session, action):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     df_action = action(df)
-    # df_res = df_action.union_all(df_action)
-    # df_res.count()
-    # print(df_res.queries)
     check_result(
         session,
         df_action,
@@ -808,7 +805,6 @@ def test_join_table_function(session):
     )
     df1 = df.join_table_function("split_to_table", df["addresses"], lit(" "))
     df_result = df1.join(df1.select("name", "addresses"), rsuffix="_y")
-    df_result.collect()
     check_result(
         session,
         df_result,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -42,9 +42,7 @@ binary_operations = [
 
 WITH = "WITH"
 
-# paramList = [False, True]
-
-paramList = [False]
+paramList = [False, True]
 
 
 @pytest.fixture(params=paramList, autouse=True)
@@ -146,21 +144,20 @@ def count_number_of_ctes(query):
     "action",
     [
         lambda x: x.select("a", "b").select("b"),
-        # lambda x: x.filter(col("a") == 1).select("b"),
-        # lambda x: x.select("a").filter(col("a") == 1),
-        # lambda x: x.select_expr("sum(a) as a").with_column("b", seq1()),
-        # lambda x: x.drop("b").sort("a", ascending=False),
-        # lambda x: x.rename(col("a"), "new_a").limit(1),
-        # lambda x: x.to_df("a1", "b1").alias("L"),
+        lambda x: x.filter(col("a") == 1).select("b"),
+        lambda x: x.select("a").filter(col("a") == 1),
+        lambda x: x.select_expr("sum(a) as a").with_column("b", seq1()),
+        lambda x: x.drop("b").sort("a", ascending=False),
+        lambda x: x.rename(col("a"), "new_a").limit(1),
+        lambda x: x.to_df("a1", "b1").alias("L"),
     ],
 )
 def test_unary(session, action):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     df_action = action(df)
-    df_res = df_action.union_all(df_action)
-    df_res.count()
+    # df_res = df_action.union_all(df_action)
+    # df_res.count()
     # print(df_res.queries)
-    """
     check_result(
         session,
         df_action,
@@ -179,7 +176,6 @@ def test_unary(session, action):
         union_count=1,
         join_count=0,
     )
-    """
 
 
 @pytest.mark.parametrize("type, action", binary_operations)
@@ -812,6 +808,7 @@ def test_join_table_function(session):
     )
     df1 = df.join_table_function("split_to_table", df["addresses"], lit(" "))
     df_result = df1.join(df1.select("name", "addresses"), rsuffix="_y")
+    df_result.collect()
     check_result(
         session,
         df_result,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -146,17 +146,21 @@ def count_number_of_ctes(query):
     "action",
     [
         lambda x: x.select("a", "b").select("b"),
-        lambda x: x.filter(col("a") == 1).select("b"),
-        lambda x: x.select("a").filter(col("a") == 1),
-        lambda x: x.select_expr("sum(a) as a").with_column("b", seq1()),
-        lambda x: x.drop("b").sort("a", ascending=False),
-        lambda x: x.rename(col("a"), "new_a").limit(1),
-        lambda x: x.to_df("a1", "b1").alias("L"),
+        # lambda x: x.filter(col("a") == 1).select("b"),
+        # lambda x: x.select("a").filter(col("a") == 1),
+        # lambda x: x.select_expr("sum(a) as a").with_column("b", seq1()),
+        # lambda x: x.drop("b").sort("a", ascending=False),
+        # lambda x: x.rename(col("a"), "new_a").limit(1),
+        # lambda x: x.to_df("a1", "b1").alias("L"),
     ],
 )
 def test_unary(session, action):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
     df_action = action(df)
+    df_res = df_action.union_all(df_action)
+    df_res.count()
+    # print(df_res.queries)
+    """
     check_result(
         session,
         df_action,
@@ -175,6 +179,7 @@ def test_unary(session, action):
         union_count=1,
         join_count=0,
     )
+    """
 
 
 @pytest.mark.parametrize("type, action", binary_operations)

--- a/tests/integ/test_deepcopy.py
+++ b/tests/integ/test_deepcopy.py
@@ -401,30 +401,14 @@ def test_deepcopy_no_duplicate(session, generator):
     copied_plan = copy.deepcopy(final_df._plan)
     check_copied_plan(copied_plan, final_df._plan)
 
-    # we will traverse the plan to assert that the tuple (plan._id, type(plan)) have a unique id(plan)
-    # note that two nodes with same plan._id can have different id(plan) since SnowflakePlan inherits plan._id
-    # from its source selectable.
-    #   plan._id: calculated by hashing the query sql and query params of plan
-    #   type(plan): the type of the plan
-    #   id(plan): the memory address of the plan object
-    # If the same plan._id has multiple id(plan), it means the deepcopy is duplicating source nodes
-
     def traverse_plan(plan, plan_id_map):
-        plan_id = plan._id
-        plan_type = type(plan)
         plan_memo = id(plan)
-        identifier_tuple = (plan_id, plan_type)
 
         local_deepcopy_memo = {}
         first_deepcopy = copy.deepcopy(plan, local_deepcopy_memo)
         second_deepcopy = copy.deepcopy(plan, local_deepcopy_memo)
         assert plan_memo in local_deepcopy_memo
         assert first_deepcopy is second_deepcopy
-
-        if identifier_tuple not in plan_id_map:
-            plan_id_map[identifier_tuple] = plan_memo
-        else:
-            assert plan_id_map[identifier_tuple] == plan_memo
 
         for child in plan.children_plan_nodes:
             traverse_plan(child, plan_id_map)

--- a/tests/unit/compiler/test_replace_child_and_update_node.py
+++ b/tests/unit/compiler/test_replace_child_and_update_node.py
@@ -441,7 +441,7 @@ def test_select_statement(
 
     assert_precondition(plan, new_plan, mock_query_generator, using_deep_copy=True)
     plan = copy.deepcopy(plan)
-    replace_child(plan, from_, new_plan, mock_query_generator)
+    replace_child(plan, plan.children_plan_nodes[0], new_plan, mock_query_generator)
     assert len(plan.children_plan_nodes) == 1
 
     new_replaced_plan = plan.children_plan_nodes[0]
@@ -566,11 +566,11 @@ def test_set_statement(
     assert_precondition(plan, new_plan, mock_analyzer, using_deep_copy=True)
     plan = copy.deepcopy(plan)
 
-    replace_child(plan, selectable1, new_plan, mock_query_generator)
+    replace_child(plan, plan.children_plan_nodes[0], new_plan, mock_query_generator)
     assert len(plan.children_plan_nodes) == 2
     new_replaced_plan = plan.children_plan_nodes[0]
-    assert isinstance(new_replaced_plan, SelectSnowflakePlan)
-    assert plan.children_plan_nodes[1] == selectable2
+    assert isinstance(plan.children_plan_nodes[0], SelectSnowflakePlan)
+    assert isinstance(plan.children_plan_nodes[1], SelectSQL)
 
     mocked_snowflake_plan = mock_snowflake_plan()
     verify_snowflake_plan(new_replaced_plan.snowflake_plan, mocked_snowflake_plan)

--- a/tests/unit/test_cte.py
+++ b/tests/unit/test_cte.py
@@ -13,7 +13,7 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
 def test_case1():
     nodes = [mock.create_autospec(SnowflakePlan) for _ in range(7)]
     for i, node in enumerate(nodes):
-        node.encoded_id = i
+        node.encoded_node_id_with_query = i
         node.source_plan = None
     nodes[0].children_plan_nodes = [nodes[1], nodes[3]]
     nodes[1].children_plan_nodes = [nodes[2], nodes[2]]
@@ -30,7 +30,7 @@ def test_case1():
 def test_case2():
     nodes = [mock.create_autospec(SnowflakePlan) for _ in range(7)]
     for i, node in enumerate(nodes):
-        node.encoded_id = i
+        node.encoded_node_id_with_query = i
         node.source_plan = None
     nodes[0].children_plan_nodes = [nodes[1], nodes[3]]
     nodes[1].children_plan_nodes = [nodes[2], nodes[2]]

--- a/tests/unit/test_cte.py
+++ b/tests/unit/test_cte.py
@@ -13,7 +13,7 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
 def test_case1():
     nodes = [mock.create_autospec(SnowflakePlan) for _ in range(7)]
     for i, node in enumerate(nodes):
-        node._id = i
+        node.encoded_id = i
         node.source_plan = None
     nodes[0].children_plan_nodes = [nodes[1], nodes[3]]
     nodes[1].children_plan_nodes = [nodes[2], nodes[2]]
@@ -30,7 +30,7 @@ def test_case1():
 def test_case2():
     nodes = [mock.create_autospec(SnowflakePlan) for _ in range(7)]
     for i, node in enumerate(nodes):
-        node._id = i
+        node.encoded_id = i
         node.source_plan = None
     nodes[0].children_plan_nodes = [nodes[1], nodes[3]]
     nodes[1].children_plan_nodes = [nodes[2], nodes[2]]
@@ -47,5 +47,5 @@ def test_case2():
 @pytest.mark.parametrize("test_case", [test_case1(), test_case2()])
 def test_find_duplicate_subtrees(test_case):
     plan, expected_duplicate_subtree_ids = test_case
-    duplicate_subtrees, _ = find_duplicate_subtrees(plan)
-    assert {node._id for node in duplicate_subtrees} == expected_duplicate_subtree_ids
+    duplicate_subtrees_ids = find_duplicate_subtrees(plan)
+    assert duplicate_subtrees_ids == expected_duplicate_subtree_ids


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.
   
   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1731783

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

In the previous repeated subquery elimination, we updated the node comparison for SnowflakePlan for Selectable to 
```
    def __eq__(self, other: "SnowflakePlan") -> bool:
        if not isinstance(other, SnowflakePlan):
            return False
        if self._id is not None and other._id is not None:
            return isinstance(other, SnowflakePlan) and self._id == other._id
        else:
            return super().__eq__(other)

    def __hash__(self) -> int:
        return hash(self._id) if self._id else super().__hash__()
```
where the id is generated based on the query and query parameter, this means two node are treated as the same if they have same type and same query. This make sense when we do repeated subquery elimination, but not expected by other transformations.

Refactor the comparison to make sure that we only use the id comparison for repeated subquery eliminations, not for others.