### PR TITLE
[SNOW-1731549] Disable sql simplification when sort is performed after limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 #### Improvements
 - Disables sql simplification when sort is performed after limit. 
-  - Improve performance of generated query since limit stops table scanning as soon as number of record is satisfied.
-  - Note before sort after limit and limit after sort will always return top k result, but now sort after limit will no longer return deterministic result.
+  - Respect the original clause order and improve performance of generated query since limit stops table scanning as soon as number of record is satisfied.
+  - Note that before `df.sort().limit()` and `df.limit().sort()` will generate same query with effect of `df.sort().limit()`. This will be no longer the case after the change, `df.limit().sort()` will keep its original clause order.
 
 ### Snowpark pandas API Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 #### New Features
 
+#### Improvements
+- Disables sql simplification when sort is performed after limit. 
+  - Improve performance of generated query since limit stops table scanning as soon as number of record is satisfied.
+  - Note before sort after limit and limit after sort will always return top k result, but now sort after limit will no longer return deterministic result.
+
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 #### Improvements
 - Disables sql simplification when sort is performed after limit. 
-  - Respect the original clause order, before `df.sort().limit()` and `df.limit().sort()` are the same as `df.sort().limit()`.
+  - Previously, `df.sort.limit()` and `df.limit.sort()` generates the same query with sort in front of limit. Now, `df.limit().sort()` will generate query that reads `df.limit().sort()`.
   - Improve performance of generated query for `df.limit().sort()`, because limit stops table scanning as soon as the number of records is satisfied.
 
 ### Snowpark pandas API Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 #### Improvements
 - Disables sql simplification when sort is performed after limit. 
-  - Respect the original clause order and improve performance of generated query since limit stops table scanning as soon as number of record is satisfied.
-  - Note that before `df.sort().limit()` and `df.limit().sort()` will generate same query with effect of `df.sort().limit()`. This will be no longer the case after the change, `df.limit().sort()` will keep its original clause order.
+  - Respect the original clause order, before `df.sort().limit()` and `df.limit().sort()` are the same as `df.sort().limit()`.
+  - Improve performance of generated query for `df.limit().sort()`, because limit stops table scanning as soon as the number of records is satisfied.
 
 ### Snowpark pandas API Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 #### Improvements
 - Disables sql simplification when sort is performed after limit. 
-  - Previously, `df.sort.limit()` and `df.limit.sort()` generates the same query with sort in front of limit. Now, `df.limit().sort()` will generate query that reads `df.limit().sort()`.
+  - Previously, `df.sort().limit()` and `df.limit().sort()` generates the same query with sort in front of limit. Now, `df.limit().sort()` will generate query that reads `df.limit().sort()`.
   - Improve performance of generated query for `df.limit().sort()`, because limit stops table scanning as soon as the number of records is satisfied.
 
 ### Snowpark pandas API Updates

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -1187,6 +1187,14 @@ class SelectStatement(Selectable):
     def sort(self, cols: List[Expression]) -> "SelectStatement":
         can_be_flattened = (
             (not self.flatten_disabled)
+            # limit order by and order by limit can cause big performance
+            # difference, because limit can stop table scanning whenever the
+            # number of record is satisfied.
+            # Therefore, disallow sql simplification when the
+            # current SelectStatement has a limit clause to avoid moving
+            # order by in front of limit.
+            and (not self.limit_)
+            and (not self.offset)
             and can_clause_dependent_columns_flatten(
                 derive_dependent_columns(*cols), self.column_states
             )

--- a/tests/integ/modin/frame/test_head_tail.py
+++ b/tests/integ/modin/frame/test_head_tail.py
@@ -90,9 +90,4 @@ def test_head_efficient_sql(session, ops):
     # check no row count
     assert "count" not in eval_query
     # check orderBy behinds limit
-    if session.sql_simplifier_enabled:
-        # TODO SNOW-1731549 fix this issue in sql simplifier
-        assert eval_query.index("limit") > eval_query.index("order by")
-    else:
-        assert "count" not in eval_query
-        assert eval_query.index("limit") < eval_query.index("order by")
+    assert eval_query.index("limit") < eval_query.index("order by")

--- a/tests/integ/modin/series/test_head_tail.py
+++ b/tests/integ/modin/series/test_head_tail.py
@@ -70,9 +70,4 @@ def test_head_efficient_sql(session, ops):
     # check no row count
     assert "count" not in eval_query
     # check orderBy behinds limit
-    if session.sql_simplifier_enabled:
-        # TODO SNOW-1731549 fix this issue in sql simplifier
-        assert eval_query.index("limit") > eval_query.index("order by")
-    else:
-        assert "count" not in eval_query
-        assert eval_query.index("limit") < eval_query.index("order by")
+    assert eval_query.index("limit") < eval_query.index("order by")

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -1365,3 +1365,7 @@ def test_select_limit_orderby(session):
     # sql simplification is applied, order by is in front of the limit
     expected_query = """SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (5 :: INT, 'a' :: STRING), (3 :: INT, 'b' :: STRING)) ORDER BY "A" ASC NULLS FIRST LIMIT 2"""
     assert df2.queries["queries"][0] == expected_query
+
+    df3 = df.select("a", "b").limit(2, offset=1).sort(col("a"))
+    expected_query = """SELECT  *  FROM ( SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (5 :: INT, 'a' :: STRING), (3 :: INT, 'b' :: STRING)) LIMIT 2 OFFSET 1) ORDER BY "A" ASC NULLS FIRST"""
+    assert df3.queries["queries"][0] == expected_query

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -1348,3 +1348,20 @@ def test_star_column(session):
     Utils.check_answer(
         df2, [Row('{\n  "B": "a",\n  "Y": 0\n}'), Row('{\n  "B": "b",\n  "Y": 1\n}')]
     )
+
+
+def test_select_limit_orderby(session):
+    # convert to a table
+    df = session.create_dataframe([[5, "a"], [3, "b"]], schema=["a", "b"])
+    # call sort after limit
+    df1 = df.select("a", "b").limit(2).sort(col("a"))
+    Utils.check_answer(df1, [Row(3, "b"), Row(5, "a")])
+    # sql simplification is not applied, and order by clause is attached at end
+    expected_query = """SELECT  *  FROM ( SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (5 :: INT, 'a' :: STRING), (3 :: INT, 'b' :: STRING)) LIMIT 2) ORDER BY "A" ASC NULLS FIRST"""
+    assert df1.queries["queries"][0] == expected_query
+
+    df2 = df.select("a", "b").sort(col("a")).limit(2)
+    Utils.check_answer(df2, [Row(3, "b"), Row(5, "a")])
+    # sql simplification is applied, order by is in front of the limit
+    expected_query = """SELECT "A", "B" FROM ( SELECT $1 AS "A", $2 AS "B" FROM  VALUES (5 :: INT, 'a' :: STRING), (3 :: INT, 'b' :: STRING)) ORDER BY "A" ASC NULLS FIRST LIMIT 2"""
+    assert df2.queries["queries"][0] == expected_query


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

SNOW-1731549

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.

3. Please describe how your code solves the related issue.

Today, sql simplification flattens df.limit(2).orderby(col1) into one SelectStatement, which always put order by clause in front of the limit clause during code generation. 
However, limit order by and order by limit can cause big performance difference, because limit can stop table scanning whenever the number of record is satisfied.

Therefore, this pr disallow sql simplification when the current SelectStatement has a limit clause to avoid moving order by in front of limit to respect what the user have coded.
