### PR TITLE
SNOW-1730546: Bug fix for to_csv on stage with empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 - Added numpy compatibility support for `np.float_power`, `np.mod`, `np.remainder`, `np.greater`, `np.greater_equal`, `np.less`, `np.less_equal`, `np.not_equal`, and `np.equal`.
 
+#### Bug Fixes
+- Fixed a bug where `to_csv` on Snowflake stage fails when data contains empty strings.
+
 ## 1.23.0 (2024-10-09)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -1436,6 +1436,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 "NULL_IF": na_sep if na_sep else (),
                 "ESCAPE": _get_param("escapechar"),
                 "DATE_FORMAT": _get_param("date_format"),
+                "EMPTY_FIELD_AS_NULL": False,
             },
             header=_get_param("header"),
             single=True,


### PR DESCRIPTION
Fixes: SNOW-1730546

RCA: 
We have two different code paths depending on destination location.
When calling to_csv on the local path we use native pandas to_csv. This works because native pandas doesn’t differentiate between null and empty strings when writing to csv. Empty strings are treated as null values. As a side effect, calling to_csv and read_csv again will result in replacing all empty strings with NULL/NA.

When calling to_csv on the snowflake stage path we use snowflake’s copy command. Snowflake copy command is not able to handle empty strings out of box and requires users to pass FIELD_OPTIONALLY_ENCLOSED_BY (which is NONE by default).

Solution:
Always set EMPTY_FIELD_AS_NULL = False when to_csv on stage is called.