### PR TITLE
SNOW-1728988: Cache attributes on SelectStatement to reduce describe query 

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
@@ -36,9 +36,12 @@ def infer_metadata(
             attributes = source_plan.child._attributes
     # If source_plan is a SelectStatement, SQL simplifier is enabled
     elif isinstance(source_plan, SelectStatement):
+        # When attributes is cached on source_plan, just use it
+        if source_plan._attributes is not None:
+            attributes = source_plan._attributes
         # When source_plan.from_ is a Selectable and it doesn't have a projection,
         # it's a simple `SELECT * from ...`, which has the same metadata as it's child plan (source_plan.from_).
-        if (
+        elif (
             isinstance(source_plan.from_, Selectable)
             and source_plan.projection is None
             and source_plan.from_._snowflake_plan is not None

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -1183,7 +1183,8 @@ class SelectStatement(Selectable):
             new = SelectStatement(
                 from_=self.to_subqueryable(), where=col, analyzer=self.analyzer
             )
-        new._attributes = self._attributes
+        if self.analyzer.session.reduce_describe_query_enabled:
+            new._attributes = self._attributes
 
         return new
 
@@ -1209,7 +1210,8 @@ class SelectStatement(Selectable):
                 order_by=cols,
                 analyzer=self.analyzer,
             )
-        new._attributes = self._attributes
+        if self.analyzer.session.reduce_describe_query_enabled:
+            new._attributes = self._attributes
 
         return new
 
@@ -1292,7 +1294,8 @@ class SelectStatement(Selectable):
             new.pre_actions = new.from_.pre_actions
             new.post_actions = new.from_.post_actions
             new._merge_projection_complexity_with_subquery = False
-        new._attributes = self._attributes
+        if self.analyzer.session.reduce_describe_query_enabled:
+            new._attributes = self._attributes
 
         return new
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -683,6 +683,8 @@ class SelectStatement(Selectable):
         self._projection_complexities: Optional[
             List[Dict[PlanNodeCategory, int]]
         ] = None
+        # Metadata/Attributes for the plan
+        self._attributes: Optional[List[Attribute]] = None
 
     def __copy__(self):
         new = SelectStatement(
@@ -1181,6 +1183,7 @@ class SelectStatement(Selectable):
             new = SelectStatement(
                 from_=self.to_subqueryable(), where=col, analyzer=self.analyzer
             )
+        new._attributes = self._attributes
 
         return new
 
@@ -1206,6 +1209,8 @@ class SelectStatement(Selectable):
                 order_by=cols,
                 analyzer=self.analyzer,
             )
+        new._attributes = self._attributes
+
         return new
 
     def set_operator(
@@ -1287,6 +1292,8 @@ class SelectStatement(Selectable):
             new.pre_actions = new.from_.pre_actions
             new.post_actions = new.from_.post_actions
             new._merge_projection_complexity_with_subquery = False
+        new._attributes = self._attributes
+
         return new
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -412,7 +412,9 @@ class SnowflakePlan(LogicalPlan):
         self._attributes = analyze_attributes(self.schema_query, self.session)
         # We need to cache attributes on SelectStatement too because df._plan is not
         # carried over to next SelectStatement (e.g., check the implementation of df.filter()).
-        if isinstance(self.source_plan, SelectStatement):
+        if self.session.reduce_describe_query_enabled and isinstance(
+            self.source_plan, SelectStatement
+        ):
             self.source_plan._attributes = self._attributes
         # No simplifier case relies on this schema_query change to update SHOW TABLES to a nested sql friendly query.
         if not self.schema_query or not self.session.sql_simplifier_enabled:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -400,12 +400,20 @@ class SnowflakePlan(LogicalPlan):
 
     @property
     def attributes(self) -> List[Attribute]:
+        from snowflake.snowpark._internal.analyzer.select_statement import (
+            SelectStatement,
+        )
+
         if self._attributes is not None:
             return self._attributes
         assert (
             self.schema_query is not None
         ), "No schema query is available for the SnowflakePlan"
         self._attributes = analyze_attributes(self.schema_query, self.session)
+        # We need to cache attributes on SelectStatement too because df._plan is not
+        # carried over to next SelectStatement (e.g., check the implementation of df.filter()).
+        if isinstance(self.source_plan, SelectStatement):
+            self.source_plan._attributes = self._attributes
         # No simplifier case relies on this schema_query change to update SHOW TABLES to a nested sql friendly query.
         if not self.schema_query or not self.session.sql_simplifier_enabled:
             self.schema_query = schema_value_statement(self._attributes)

--- a/tests/integ/test_reduce_describe_query.py
+++ b/tests/integ/test_reduce_describe_query.py
@@ -7,7 +7,7 @@ from typing import List
 import pytest
 
 from snowflake.snowpark._internal.analyzer.expression import Attribute
-from snowflake.snowpark.functions import col
+from snowflake.snowpark.functions import col, lit, seq2, table_function
 from snowflake.snowpark.session import (
     _PYTHON_SNOWPARK_REDUCE_DESCRIBE_QUERY_ENABLED,
     Session,
@@ -31,20 +31,37 @@ def setup(session):
     session.reduce_describe_query_enabled = is_reduce_describe_query_enabled
 
 
-# TODO SNOW-1728988: add more test cases with select after caching attributes on SelectStatement
 # Create from SQL
 create_from_sql_funcs = [
     lambda session: session.sql("SELECT 1 AS a, 2 AS b"),
+    lambda session: session.sql("SELECT 1 AS a, 2 AS b").select("b"),
+    lambda session: session.sql("SELECT 1 AS a, 2 AS b").select(
+        "a", lit("2").alias("c")
+    ),
 ]
 
 # Create from Values
-create_from_values_funcs = []
+create_from_values_funcs = [
+    lambda session: session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"]),
+    lambda session: session.create_dataframe(
+        [[1, 2], [3, 4]], schema=["a", "b"]
+    ).select("b"),
+    lambda session: session.create_dataframe(
+        [[1, 2], [3, 4]], schema=["a", "b"]
+    ).select("a", lit("2").alias("c")),
+]
 
 # Create from Table
 create_from_table_funcs = [
     lambda session: session.create_dataframe(
         [[1, 2], [3, 4]], schema=["a", "b"]
     ).cache_result(),
+    lambda session: session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
+    .cache_result()
+    .select("b"),
+    lambda session: session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
+    .cache_result()
+    .select("a", lit("2").alias("c")),
 ]
 
 # Create from SnowflakePlan
@@ -58,7 +75,35 @@ create_from_snowflake_plan_funcs = [
     lambda session: session.create_dataframe(
         [[1, 2], [3, 4]], schema=["a", "b"]
     ).rename({"b": "c"}),
+    lambda session: session.range(10).to_df("a"),
+    lambda session: session.range(10).select(seq2().as_("a")),  # no flatten
 ]
+
+# Create from table functions
+create_from_table_function_funcs = [
+    lambda session: session.create_dataframe(
+        [[1, "some string value"]], schema=["a", "b"]
+    ).select("a", table_function("split_to_table")("b", lit(" "))),
+    lambda session: session.create_dataframe(
+        [[1, "some string value"]], schema=["a", "b"]
+    )
+    .select("a", table_function("split_to_table")("b", lit(" ")))
+    .select("a"),
+]
+
+# Create from unions
+create_from_unions_funcs = [
+    lambda session: session.sql("SELECT 1 AS a, 2 AS b").union(
+        session.sql("SELECT 3 AS a, 4 AS b")
+    ),
+    lambda session: session.sql("SELECT 1 AS a, 2 AS b")
+    .union(session.sql("SELECT 3 AS a, 4 AS b"))
+    .select("b"),
+    lambda session: session.sql("SELECT 1 AS a, 2 AS b")
+    .union(session.sql("SELECT 3 AS a, 4 AS b"))
+    .select("a", lit("2").alias("c")),
+]
+
 
 metadata_no_change_df_ops = [
     lambda df: df.filter(col("a") > 2),
@@ -66,6 +111,7 @@ metadata_no_change_df_ops = [
     lambda df: df.sort(col("a").desc()),
     lambda df: df.sort(-col("a")),
     lambda df: df.limit(2),
+    lambda df: df.sort(col("a").desc()).limit(2).filter(col("a") > 2),  # no flatten
     lambda df: df.filter(col("a") > 2).sort(col("a").desc()).limit(2),
     lambda df: df.sample(0.5),
     lambda df: df.sample(0.5).filter(col("a") > 2),
@@ -89,7 +135,9 @@ def check_attributes_equality(attrs1: List[Attribute], attrs2: List[Attribute]) 
     create_from_sql_funcs
     + create_from_values_funcs
     + create_from_table_funcs
-    + create_from_snowflake_plan_funcs,
+    + create_from_snowflake_plan_funcs
+    + create_from_table_function_funcs
+    + create_from_unions_funcs,
 )
 def test_metadata_no_change(session, action, create_df_func):
     df = create_df_func(session)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1728988

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   When sql simplifier is on, it can resolve the scenarios where 1) select() is called because df._plan is not carried over, 2) sql simplifier can't flatten the query