### PR TITLE
[SNOW-1739096] Disallow detecting none select statement as repeated subquery

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
@@ -188,6 +188,9 @@ def encoded_query_id(node) -> Optional[str]:
         query_params = node.query_params
 
     if not is_sql_select_statement(query):
+        # common subquery elimination only supports eliminating
+        # subquery that is select statement. Skip encoding the query
+        # to avoid being detected as a common subquery.
         return None
 
     string = f"{query}#{query_params}" if query_params else query

--- a/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
@@ -15,6 +15,7 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
 from snowflake.snowpark._internal.utils import (
     TempObjectType,
     random_name_for_temp_object,
+    is_sql_select_statement,
 )
 
 if TYPE_CHECKING:
@@ -185,6 +186,9 @@ def encoded_query_id(node) -> Optional[str]:
     else:
         query = node.sql_query
         query_params = node.query_params
+
+    if not is_sql_select_statement(query):
+        return None
 
     string = f"{query}#{query_params}" if query_params else query
     try:

--- a/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/cte_utils.py
@@ -14,8 +14,8 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
 )
 from snowflake.snowpark._internal.utils import (
     TempObjectType,
-    random_name_for_temp_object,
     is_sql_select_statement,
+    random_name_for_temp_object,
 )
 
 if TYPE_CHECKING:

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -436,6 +436,9 @@ def test_non_select_query_composition(session):
     run=False,
 )
 def test_non_select_query_composition_union(session):
+    session.sql_simplifier_enabled = False
+    session.cte_optimization_enabled = True
+    # session._query_compilation_stage_enabled = True
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -437,7 +437,8 @@ def test_non_select_query_composition(session):
 )
 def test_non_select_query_composition_union(session):
     session.sql_simplifier_enabled = False
-    session.cte_optimization_enabled = True
+
+    # session.cte_optimization_enabled = True
     # session._query_compilation_stage_enabled = True
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -436,10 +436,6 @@ def test_non_select_query_composition(session):
     run=False,
 )
 def test_non_select_query_composition_union(session):
-    session.sql_simplifier_enabled = False
-
-    # session.cte_optimization_enabled = True
-    # session._query_compilation_stage_enabled = True
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     try:
         session.sql(

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -747,6 +747,25 @@ def test_sql(session, query):
         assert count_number_of_ctes(df_result.queries["queries"][-1]) == 1
 
 
+def test_sql_non_select(session):
+    df1 = session.sql("show tables in schema limit 10")
+    df2 = session.sql("show tables in schema limit 10")
+
+    df_result = df1.union(df2).select('"name"').filter(lit(True))
+
+    check_result(
+        session,
+        df_result,
+        # since the two show tables are called in two different dataframe, we
+        # won't be able to detect those as common subquery.
+        expect_cte_optimized=False,
+        query_count=3,
+        describe_count=0,
+        union_count=1,
+        join_count=0,
+    )
+
+
 @pytest.mark.parametrize(
     "action",
     [


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1739096

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

Repeated subquery elimination is only designed to eliminate subquery that is selectStatement. Since we do not distinguish query that is selectStatement and none selectStatement, we can incorrectly detect non selectstatement as candidate. for example, when we have 
```
  df1 = session.sql("show tables")
   df2 = session.sql("show tables")

   df_result = df1.union(df2)
```
The show table query its-self can be incorrectly detected as a common query and produced wrong query like
```
with_cte_xxx (show tables) xxxx
```

In this pr, we exclude none-selectstatment from the candidate node encoding to avoid count those node as candidate for repeated subquery elimination