### PR TITLE
SNOW-1615885: Don't use `snowflake_plan.attributes` in SQL simplifier and infer quoted identifiers 

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
@@ -2,18 +2,70 @@
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
 
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional
 
-from snowflake.snowpark._internal.analyzer.expression import Attribute
+from snowflake.snowpark._internal.analyzer.expression import Attribute, Expression, Star
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import Limit, LogicalPlan
+from snowflake.snowpark._internal.analyzer.unary_expression import UnresolvedAlias
+
+if TYPE_CHECKING:
+    from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
+
+
+@dataclass(frozen=True)
+class PlanMetadata:
+    """
+    Metadata of a plan including attributes (schema) and quoted identifiers (column names).
+    """
+
+    attributes: Optional[List[Attribute]]
+    quoted_identifiers: Optional[List[str]]
+
+    def __post_init__(self):
+        # If attributes is not None, then quoted_identifiers will be explicitly set to None.
+        # If quoted_identifiers is not None, then attributes will be None because we can't infer data types.
+        assert not (self.attributes is not None and self.quoted_identifiers is not None)
+
+
+def infer_quoted_identifiers_from_expressions(
+    expressions: List[Expression],
+    analyzer: "Analyzer",
+    df_aliased_col_name_to_real_col_name: DefaultDict[str, Dict[str, str]],
+) -> Optional[List[str]]:
+    """
+    Infer quoted identifiers from (named) expressions.
+    The list of quoted identifier will be only returned
+    if and only if the identifier can be derived from all expressions.
+    """
+    from snowflake.snowpark._internal.analyzer.select_statement import parse_column_name
+    from snowflake.snowpark._internal.utils import quote_name
+
+    result = []
+    for e in expressions:
+        # If we do select *, we may not be able to get all current quoted identifiers
+        # (e.g., when SQL simplifier is disabled), so we just be conservative and do
+        # not perform any inference in this case.
+        if isinstance(e, UnresolvedAlias) and isinstance(e.child, Star):
+            return None
+        column_name = parse_column_name(
+            e, analyzer, df_aliased_col_name_to_real_col_name
+        )
+        if column_name is not None:
+            result.append(quote_name(column_name))
+        else:
+            return None
+    return result
 
 
 def infer_metadata(
-    source_plan: LogicalPlan,
-) -> Optional[List[Attribute]]:
+    source_plan: Optional[LogicalPlan],
+    analyzer: "Analyzer",
+    df_aliased_col_name_to_real_col_name: DefaultDict[str, Dict[str, str]],
+) -> PlanMetadata:
     """
     Infer metadata from the source plan.
-    Returns the metadata including attributes (schema).
+    Returns the metadata including attributes (schema) and quoted identifiers (column names).
     """
     from snowflake.snowpark._internal.analyzer.select_statement import (
         Selectable,
@@ -22,31 +74,67 @@ def infer_metadata(
     from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
     from snowflake.snowpark._internal.analyzer.unary_plan_node import (
         Filter,
+        Project,
         Sample,
         Sort,
     )
 
     attributes = None
-    # If source_plan is a LogicalPlan, SQL simplifier is not enabled
-    # so we can try to infer the metadata from its child (SnowflakePlan)
-    # When source_plan is Filter, Sort, Limit, Sample, metadata won't be changed
-    # so we can use the metadata from its child directly
-    if isinstance(source_plan, (Filter, Sort, Limit, Sample)):
-        if isinstance(source_plan.child, SnowflakePlan):
-            attributes = source_plan.child._attributes
-    # If source_plan is a SelectStatement, SQL simplifier is enabled
-    elif isinstance(source_plan, SelectStatement):
-        # When attributes is cached on source_plan, just use it
-        if source_plan._attributes is not None:
-            attributes = source_plan._attributes
-        # When source_plan.from_ is a Selectable and it doesn't have a projection,
-        # it's a simple `SELECT * from ...`, which has the same metadata as it's child plan (source_plan.from_).
-        elif (
-            isinstance(source_plan.from_, Selectable)
-            and source_plan.projection is None
-            and source_plan.from_._snowflake_plan is not None
-            and source_plan.from_._snowflake_plan._attributes is not None
-        ):
-            attributes = source_plan.from_.snowflake_plan._attributes
+    quoted_identifiers = None
+    if analyzer.session.reduce_describe_query_enabled and source_plan is not None:
+        # If source_plan is a LogicalPlan, SQL simplifier is not enabled
+        # so we can try to infer the metadata from its child (SnowflakePlan)
+        # When source_plan is Filter, Sort, Limit, Sample, metadata won't be changed
+        # so we can use the metadata from its child directly
+        if isinstance(source_plan, (Filter, Sort, Limit, Sample)):
+            if isinstance(source_plan.child, SnowflakePlan):
+                attributes = source_plan.child._metadata.attributes
+                quoted_identifiers = source_plan.child._metadata.quoted_identifiers
+        elif isinstance(source_plan, Project):
+            quoted_identifiers = infer_quoted_identifiers_from_expressions(
+                source_plan.project_list,  # type: ignore
+                analyzer,
+                df_aliased_col_name_to_real_col_name,
+            )
+        # If source_plan is a SelectStatement, SQL simplifier is enabled
+        elif isinstance(source_plan, SelectStatement):
+            # When attributes is cached on source_plan, just use it
+            if source_plan._attributes is not None:
+                attributes = source_plan._attributes
+            # When _column_states.projection is available, we can just use it,
+            # which is either (only one happen):
+            # 1) cached on self._snowflake_plan._quoted_identifiers
+            # 2) inferred in `derive_column_states_from_subquery` during `select()` call
+            if source_plan._column_states is not None:
+                quoted_identifiers = [
+                    c.name for c in source_plan._column_states.projection
+                ]
+            # When source_plan.from_ is a Selectable and it doesn't have a projection,
+            # it's a simple `SELECT * from ...`, which has the same metadata as it's child plan (source_plan.from_).
+            if (
+                isinstance(source_plan.from_, Selectable)
+                and source_plan.projection is None
+                and source_plan.from_._snowflake_plan is not None
+            ):
+                # only set attributes and quoted_identifiers if they are not set in previous step
+                if (
+                    attributes is None
+                    and source_plan.from_._snowflake_plan._metadata.attributes
+                    is not None
+                ):
+                    attributes = source_plan.from_._snowflake_plan._metadata.attributes
+                elif (
+                    quoted_identifiers is None
+                    and source_plan.from_._snowflake_plan._metadata.quoted_identifiers
+                    is not None
+                ):
+                    quoted_identifiers = (
+                        source_plan.from_._snowflake_plan._metadata.quoted_identifiers
+                    )
 
-    return attributes
+        # If attributes is available, we always set quoted_identifiers to None
+        # as it can be retrieved later from attributes
+        if attributes is not None:
+            quoted_identifiers = None
+
+    return PlanMetadata(attributes=attributes, quoted_identifiers=quoted_identifiers)

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -353,8 +353,17 @@ class Selectable(LogicalPlan, ABC):
         Refer to class ColumnStateDict.
         """
         if self._column_states is None:
+            if self.analyzer.session.reduce_describe_query_enabled:
+                # data types are not needed in SQL simplifier, so we
+                # just create dummy data types here.
+                column_attrs = [
+                    Attribute(q, DataType())
+                    for q in self.snowflake_plan.quoted_identifiers
+                ]
+            else:
+                column_attrs = self.snowflake_plan.attributes
             self._column_states = initiate_column_states(
-                self.snowflake_plan.attributes,
+                column_attrs,
                 self.analyzer,
                 self.df_aliased_col_name_to_real_col_name,
             )

--- a/tests/integ/test_reduce_describe_query.py
+++ b/tests/integ/test_reduce_describe_query.py
@@ -6,8 +6,15 @@ from typing import List
 
 import pytest
 
-from snowflake.snowpark._internal.analyzer.expression import Attribute
-from snowflake.snowpark.functions import col, lit, seq2, table_function
+from snowflake.snowpark import DataFrame
+from snowflake.snowpark._internal.analyzer.expression import Attribute, Star
+from snowflake.snowpark._internal.analyzer.unary_expression import UnresolvedAlias
+from snowflake.snowpark._internal.analyzer.unary_plan_node import Project
+from snowflake.snowpark._internal.utils import (
+    TempObjectType,
+    random_name_for_temp_object,
+)
+from snowflake.snowpark.functions import col, count, lit, seq2, table_function
 from snowflake.snowpark.session import (
     _PYTHON_SNOWPARK_REDUCE_DESCRIBE_QUERY_ENABLED,
     Session,
@@ -23,12 +30,16 @@ pytestmark = [
 ]
 
 param_list = [False, True]
+temp_table_name = random_name_for_temp_object(TempObjectType.TABLE)
 
 
-@pytest.fixture(params=param_list, autouse=True)
+@pytest.fixture(params=param_list, autouse=True, scope="module")
 def setup(request, session):
     is_reduce_describe_query_enabled = session.reduce_describe_query_enabled
     session.reduce_describe_query_enabled = request.param
+    session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"]).write.save_as_table(
+        temp_table_name, table_type="temp", mode="overwrite"
+    )
     yield
     session.reduce_describe_query_enabled = is_reduce_describe_query_enabled
 
@@ -55,15 +66,9 @@ create_from_values_funcs = [
 
 # Create from Table
 create_from_table_funcs = [
-    lambda session: session.create_dataframe(
-        [[1, 2], [3, 4]], schema=["a", "b"]
-    ).cache_result(),
-    lambda session: session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
-    .cache_result()
-    .select("a"),
-    lambda session: session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
-    .cache_result()
-    .select("a", lit("2").alias("c")),
+    lambda session: session.table(temp_table_name),
+    lambda session: session.table(temp_table_name).select("a"),
+    lambda session: session.table(temp_table_name).select("a", lit("2").alias("c")),
 ]
 
 # Create from SnowflakePlan
@@ -106,6 +111,13 @@ create_from_unions_funcs = [
     .select("a", lit("2").alias("c")),
 ]
 
+create_without_select_funcs_expected_describe_count = [
+    (create_from_sql_funcs[0], 1),
+    (create_from_values_funcs[0], 0),
+    (create_from_table_funcs[0], 1),
+    (create_from_unions_funcs[0], 0),
+]
+
 
 metadata_no_change_df_ops = [
     lambda df: df.filter(col("a") > 2),
@@ -120,12 +132,45 @@ metadata_no_change_df_ops = [
     lambda df: df.filter(col("a") > 2).sample(0.5),
 ]
 
+select_df_ops_expected_quoted_identifiers = [
+    (lambda df: df.select("a", col("b")), ['"A"', '"B"']),
+    (lambda df: df.select("*", lit(1).as_('"c"')), ['"A"', '"B"', '"c"']),
+    (
+        lambda df: df.select("*", lit(1).as_('"c"')).select(col("a") == 2),
+        ['"(""A"" = 2)"'],
+    ),
+    (lambda df: df.select("a", (col("b") + 1).as_("b")), ['"A"', '"B"']),
+    (lambda df: df.select(count("*")), ['"COUNT(1)"']),
+    (
+        lambda df: df.select("a", (col("b") + 1).as_("b")).select(
+            (col("b") + 1).as_("b"), "a"
+        ),
+        ['"B"', '"A"'],
+    ),
+    (
+        lambda df: df.select("a", (col("b") + 1).as_("b")).filter(col("a") == 1),
+        ['"A"', '"B"'],
+    ),
+    (
+        lambda df: df.filter(col("a") == 1).select("a", (col("b") + 1).as_("b")),
+        ['"A"', '"B"'],
+    ),
+]
+
 
 def check_attributes_equality(attrs1: List[Attribute], attrs2: List[Attribute]) -> None:
     for attr1, attr2 in zip(attrs1, attrs2):
         assert attr1.name == attr2.name
         assert attr1.datatype == attr2.datatype
         assert attr1.nullable == attr2.nullable
+
+
+def has_star_in_projection(df: DataFrame) -> bool:
+    plan = df._plan.source_plan
+    return isinstance(plan, Project) and any(
+        isinstance(e, UnresolvedAlias) and isinstance(e.child, Star)
+        for e in plan.project_list
+    )
 
 
 @pytest.mark.parametrize(
@@ -145,16 +190,62 @@ def test_metadata_no_change(session, action, create_df_func):
     df = create_df_func(session)
     with SqlCounter(query_count=0, describe_count=1):
         attributes = df._plan.attributes
+        quoted_identifiers = df._plan.quoted_identifiers
+
     df = action(df)
     if session.reduce_describe_query_enabled:
-        check_attributes_equality(df._plan._attributes, attributes)
+        check_attributes_equality(df._plan._metadata.attributes, attributes)
         expected_describe_query_count = 0
     else:
-        assert df._plan._attributes is None
+        assert df._plan._metadata.attributes is None
         expected_describe_query_count = 1
+
     with SqlCounter(query_count=0, describe_count=expected_describe_query_count):
         _ = df.schema
         _ = df.columns
+        assert df._plan._metadata.quoted_identifiers is None
+        assert df._plan.quoted_identifiers == quoted_identifiers
+
+
+@pytest.mark.parametrize(
+    "action,expected_quoted_identifiers",
+    select_df_ops_expected_quoted_identifiers,
+)
+@pytest.mark.parametrize(
+    "create_df_func,expected_describe_query_count",
+    create_without_select_funcs_expected_describe_count,
+)
+def test_select_quoted_identifiers(
+    sql_simplifier_enabled,
+    session,
+    action,
+    expected_quoted_identifiers,
+    create_df_func,
+    expected_describe_query_count,
+):
+    df = create_df_func(session)
+
+    # if sql simplifier is disabled, there is no describe query
+    # because we don't need to get quoted identifiers
+    with SqlCounter(
+        query_count=0,
+        describe_count=expected_describe_query_count if sql_simplifier_enabled else 0,
+    ):
+        df = action(df)
+
+    # if we select a "*", it can't be inferred when sql simplifier is disabled
+    # because no describe query is issued before to get quoted identifiers
+    if session.reduce_describe_query_enabled and not has_star_in_projection(df):
+        assert df._plan._metadata.quoted_identifiers == expected_quoted_identifiers
+        expected_describe_query_count = 0
+    else:
+        assert df._plan._metadata.quoted_identifiers is None
+        expected_describe_query_count = 1
+
+    assert df._plan._metadata.attributes is None
+    with SqlCounter(query_count=0, describe_count=expected_describe_query_count):
+        quoted_identifiers = df._plan.quoted_identifiers
+        assert quoted_identifiers == expected_quoted_identifiers
 
 
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Can't create a session in SP")

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -16,6 +16,7 @@ from snowflake.snowpark import (
 )
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.expression import Attribute
+from snowflake.snowpark._internal.analyzer.metadata_utils import PlanMetadata
 from snowflake.snowpark._internal.analyzer.select_statement import SelectStatement
 from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlanBuilder
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import SnowflakeTable
@@ -289,10 +290,13 @@ def test_statement_params():
 def test_dataFrame_printSchema(capfd, mock_server_connection):
     session = snowflake.snowpark.session.Session(mock_server_connection)
     df = session.create_dataframe([[1, ""], [3, None]])
-    df._plan._attributes = [
-        Attribute("A", IntegerType(), False),
-        Attribute("B", StringType()),
-    ]
+    df._plan._metadata = PlanMetadata(
+        attributes=[
+            Attribute("A", IntegerType(), False),
+            Attribute("B", StringType()),
+        ],
+        quoted_identifiers=None,
+    )
     df.printSchema()
     out, err = capfd.readouterr()
     assert (


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1615885

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   Quoted identifiers (column names) are actually already inferred in derive_column_states, we can just use it instead of calling snowflake_plan.attributes to retrieve metadata from server side