### PR TITLE
SNOW-1727257 test iceberg with large query breakdown

### DIFF
--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -559,7 +559,8 @@ def test_struct_dtype_iceberg_lqb(
         union_df = union_df.select(
             array_sort("ARR", sort_ascending=False).alias("ARR"), "MAP", "A", "B"
         )
-        queries = union_df.queries
+
+        assert union_df.schema == expected_schema
 
         union_df.write.save_as_table(
             write_table,
@@ -568,6 +569,7 @@ def test_struct_dtype_iceberg_lqb(
             iceberg_config=ICEBERG_CONFIG,
         )
 
+        queries = union_df.queries
         # assert that the queries are broken down into 2 queries and 1 post action
         assert len(queries["queries"]) == 2, queries["queries"]
         assert len(queries["post_actions"]) == 1

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -15,6 +15,7 @@ from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import (
     any_value,
     array_construct,
+    array_sort,
     col,
     lit,
     object_construct,
@@ -554,7 +555,8 @@ def test_struct_dtype_iceberg_lqb(
             any_value(col("ARR")).alias("ARR"),
             any_value(col("MAP")).alias("MAP"),
         )
-        union_df = df1.union_all(df2).select("ARR", "MAP", "A", "B")
+        union_df = df1.union_all(df2)
+        union_df = union_df.select(array_sort("ARR", sort_ascending=False).alias("ARR"), "MAP", "A", "B")
         queries = union_df.queries
 
         union_df.write.save_as_table(

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -556,7 +556,9 @@ def test_struct_dtype_iceberg_lqb(
             any_value(col("MAP")).alias("MAP"),
         )
         union_df = df1.union_all(df2)
-        union_df = union_df.select(array_sort("ARR", sort_ascending=False).alias("ARR"), "MAP", "A", "B")
+        union_df = union_df.select(
+            array_sort("ARR", sort_ascending=False).alias("ARR"), "MAP", "A", "B"
+        )
         queries = union_df.queries
 
         union_df.write.save_as_table(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1727257

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   This PR adds a test to ensure that large query breakdown preserves the final schema of table even when intermediate parts of the table are materialized. 
