### PR TITLE
Exclude drop table sql from temp table cleaner in sql_counter.py

### DIFF
--- a/tests/integ/utils/sql_counter.py
+++ b/tests/integ/utils/sql_counter.py
@@ -77,12 +77,15 @@ HIGH_QUERY_COUNT_THRESHOLD = 9
 # it only runs at the first time of creating a fallback stored procedure
 # 5. test_table_fixture does a drop table which is inconsistently included but ultimately not related to the tested code
 # These cases should be excluded in our query counts.
+# 6. Unused temp tables to be dropped to temp table cleaner may happen any time when garbage collection kicks in,
+# so we should not count it
 FILTER_OUT_QUERIES = [
     ["create SCOPED TEMPORARY", "stage if not exists"],
     ["PUT", "file:///tmp/placeholder/snowpark.zip"],
     ["PUT", "file:///tmp/placeholder/udf_py_"],
     ['SELECT "PACKAGE_NAME"', 'array_agg("VERSION")'],
     ["drop table if exists", "TESTTABLENAME"],
+    ["drop table if exists", "/* internal query to drop unused temp table */"],
 ]
 
 # define global at module-level


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   Unused temp tables to be dropped to temp table cleaner may happen any time when garbage collection kicks in, so we should not count it
