### PR TITLE
SNOW-1760125: Disable test_read_snowflake_query_cte_with_python_anonymous_sproc test from precommit

### DIFF
--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -164,7 +164,7 @@ def test_read_snowflake_query_cte_with_cross_language_sproc(session):
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, native_df)
 
 
-# TODO: re-enable @pytest.mark.modin_sp_precommit
+# TODO: SNOW-1760467: re-enable @pytest.mark.modin_sp_precommit
 @sql_count_checker(query_count=5, sproc_count=1)
 def test_read_snowflake_query_cte_with_python_anonymous_sproc(session):
     # create table name

--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -164,6 +164,7 @@ def test_read_snowflake_query_cte_with_cross_language_sproc(session):
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, native_df)
 
 
+# TODO: re-enable @pytest.mark.modin_sp_precommit
 @sql_count_checker(query_count=5, sproc_count=1)
 def test_read_snowflake_query_cte_with_python_anonymous_sproc(session):
     # create table name

--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -3,7 +3,6 @@
 #
 import modin.pandas as pd
 import pandas as native_pd
-import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark._internal.utils import TempObjectType
@@ -165,7 +164,6 @@ def test_read_snowflake_query_cte_with_cross_language_sproc(session):
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, native_df)
 
 
-@pytest.mark.modin_sp_precommit
 @sql_count_checker(query_count=5, sproc_count=1)
 def test_read_snowflake_query_cte_with_python_anonymous_sproc(session):
     # create table name


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1760125

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   Disabling `test_read_snowflake_query_cte_with_python_anonymous_sproc` flaky test from Precommit run until there is a reliable fix
