### PR TITLE
SNOW-1738540 Add Nop / No-execution mode for running ast expectation tests

### DIFF
--- a/src/snowflake/snowpark/mock/_nop_analyzer.py
+++ b/src/snowflake/snowpark/mock/_nop_analyzer.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from typing import Dict, List, Union
+
+from snowflake.snowpark._internal.analyzer.expression import Expression, Star
+from snowflake.snowpark._internal.analyzer.select_statement import (
+    Selectable,
+    SelectSnowflakePlan,
+    SelectStatement,
+)
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import LogicalPlan
+from snowflake.snowpark.mock._analyzer import MockAnalyzer
+from snowflake.snowpark.mock._nop_plan import NopExecutionPlan, resolve_attributes
+from snowflake.snowpark.mock._plan import MockExecutionPlan
+from snowflake.snowpark.mock._select_statement import (
+    MockSelectableEntity,
+    MockSelectExecutionPlan,
+    MockSelectStatement,
+    MockSetOperand,
+    MockSetStatement,
+)
+
+
+class NopSetStatement(MockSetStatement):
+    @property
+    def attributes(self):
+        return [val.expression for val in self.column_states.data.values()]
+
+
+class NopSelectStatement(MockSelectStatement):
+    @property
+    def attributes(self):
+        return (
+            resolve_attributes(self.from_)
+            if isinstance(self.projection[0], Star)
+            else self.projection
+        )
+
+    def _make_nop_select_statement_copy(self, statement: "MockSelectStatement"):
+        if isinstance(statement, NopSelectStatement):
+            return statement
+
+        nop_statement = NopSelectStatement(from_=self.from_, analyzer=self.analyzer)
+        nop_statement.__dict__.update(statement.__dict__)
+        return nop_statement
+
+    def select(self, cols: List[Expression]) -> "SelectStatement":
+        return self._make_nop_select_statement_copy(super().select(cols))
+
+    def filter(self, col: Expression) -> "MockSelectStatement":
+        return self._make_nop_select_statement_copy(super().filter(col))
+
+    def sort(self, cols: List[Expression]) -> "SelectStatement":
+        return self._make_nop_select_statement_copy(super().sort(cols))
+
+    def set_operator(
+        self,
+        *selectables: Union[
+            SelectSnowflakePlan,
+            "SelectStatement",
+        ],
+        operator: str,
+    ) -> "SelectStatement":
+        new_statement = super().set_operator(*selectables, operator=operator)
+
+        def recursive_copy_helper(
+            stmt_or_op: Union[Selectable, MockSetStatement, MockSetOperand]
+        ):
+            if isinstance(stmt_or_op, MockSetStatement):
+                operands = [recursive_copy_helper(op) for op in stmt_or_op.set_operands]
+                nop_set = NopSetStatement(*operands, analyzer=self.analyzer)
+                nop_set._attributes = nop_set.execution_plan.attributes
+                return nop_set
+            elif isinstance(stmt_or_op, MockSetOperand):
+                stmt_or_op.selectable = recursive_copy_helper(stmt_or_op.selectable)
+
+            return stmt_or_op
+
+        new_statement.from_ = recursive_copy_helper(new_statement.from_)
+        return self._make_nop_select_statement_copy(new_statement)
+
+    def limit(self, n: int, *, offset: int = 0) -> "SelectStatement":
+        return self._make_nop_select_statement_copy(super().limit(n, offset=offset))
+
+    def to_subqueryable(self) -> "Selectable":
+        return self._make_nop_select_statement_copy(super().to_subqueryable())
+
+
+class NopSelectExecutionPlan(MockSelectExecutionPlan):
+    @property
+    def attributes(self):
+        return (
+            self._attributes
+            if self._attributes
+            else resolve_attributes(self._execution_plan)
+        )
+
+
+class NopSelectableEntity(MockSelectableEntity):
+    @property
+    def attributes(self):
+        return resolve_attributes(self.entity_plan, session=self.analyzer.session)
+
+
+class NopAnalyzer(MockAnalyzer):
+    def do_resolve(
+        self, logical_plan: LogicalPlan, expr_to_alias: Dict[str, str]
+    ) -> MockExecutionPlan:
+        return NopExecutionPlan(logical_plan, self.session)
+
+    def create_select_statement(self, *args, **kwargs):
+        return NopSelectStatement(*args, **kwargs)
+
+    def create_select_snowflake_plan(self, *args, **kwargs):
+        return NopSelectExecutionPlan(*args, **kwargs)
+
+    def create_selectable_entity(self, *args, **kwargs):
+        return NopSelectableEntity(*args, **kwargs)

--- a/src/snowflake/snowpark/mock/_nop_connection.py
+++ b/src/snowflake/snowpark/mock/_nop_connection.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from logging import getLogger
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
+import pandas
+
+from snowflake.connector.cursor import ResultMetadata
+from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
+from snowflake.snowpark._internal.analyzer.expression import Attribute
+from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    LogicalPlan,
+    SaveMode,
+    SnowflakeCreateTable,
+)
+from snowflake.snowpark._internal.analyzer.table_merge_expression import TableUpdate
+from snowflake.snowpark._internal.analyzer.unary_plan_node import CreateViewCommand
+from snowflake.snowpark._internal.server_connection import DEFAULT_STRING_SIZE
+from snowflake.snowpark._internal.utils import result_set_to_rows
+from snowflake.snowpark.async_job import _AsyncResultType
+from snowflake.snowpark.mock._connection import MockServerConnection
+from snowflake.snowpark.mock._nop_plan import NopExecutionPlan
+from snowflake.snowpark.mock._telemetry import LocalTestOOBTelemetryService
+from snowflake.snowpark.mock._util import get_fully_qualified_name
+from snowflake.snowpark.row import Row, canonicalize_field
+from snowflake.snowpark.types import (
+    ArrayType,
+    BinaryType,
+    BooleanType,
+    DateType,
+    GeographyType,
+    GeometryType,
+    MapType,
+    NullType,
+    StringType,
+    StructType,
+    TimestampType,
+    TimeType,
+    VariantType,
+    _NumericType,
+)
+
+if TYPE_CHECKING:
+    try:
+        from snowflake.connector.cursor import ResultMetadataV2
+    except ImportError:
+        ResultMetadataV2 = ResultMetadata
+
+logger = getLogger(__name__)
+
+
+class NopConnection(MockServerConnection):
+    class NopEntityRegistry(MockServerConnection.TabularEntityRegistry):
+        def write_table(
+            self,
+            name: Union[str, Iterable[str]],
+            table: LogicalPlan,
+            mode: SaveMode,
+            column_names: Optional[List[str]] = None,
+        ) -> List[Row]:
+            current_schema = self.conn._get_current_parameter("schema")
+            current_database = self.conn._get_current_parameter("database")
+            name = get_fully_qualified_name(name, current_schema, current_database)
+            self.table_registry[name] = table
+            return [Row(status=f"Table {name} successfully created.")]
+
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(options)
+        self._conn._session_parameters = {
+            "ENABLE_ASYNC_QUERY_IN_PYTHON_STORED_PROCS": False,
+            "_PYTHON_SNOWPARK_USE_SCOPED_TEMP_OBJECTS_STRING": False,
+            "_PYTHON_SNOWPARK_USE_SQL_SIMPLIFIER_STRING": False,
+        }
+        self._disable_local_testing_telemetry = True
+        self._oob_telemetry = LocalTestOOBTelemetryService.get_instance()
+        self._oob_telemetry.disable()
+        self._suppress_not_implemented_error = True
+        self.entity_registry = NopConnection.NopEntityRegistry(self)
+
+    def execute(
+        self,
+        plan: NopExecutionPlan,
+        to_pandas: bool = False,
+        to_iter: bool = False,
+        block: bool = True,
+        data_type: _AsyncResultType = _AsyncResultType.ROW,
+        case_sensitive: bool = True,
+        **kwargs,
+    ) -> Union[
+        List[Row], "pandas.DataFrame", Iterator[Row], Iterator["pandas.DataFrame"]
+    ]:
+        source_plan = plan.source_plan
+
+        if isinstance(source_plan, SnowflakeCreateTable):
+            result = self.entity_registry.write_table(
+                source_plan.table_name,
+                source_plan,
+                source_plan.mode,
+                column_names=source_plan.column_names,
+            )
+        elif isinstance(source_plan, CreateViewCommand):
+            result = self.entity_registry.create_or_replace_view(
+                source_plan, source_plan.name
+            )
+        else:
+            result_meta = []
+            result_values = []
+            value = 0
+            for col in plan.attributes:
+                data_type = (
+                    _NumericType()
+                    if isinstance(source_plan, TableUpdate)
+                    else col.datatype
+                )
+                is_nullable = col.nullable
+                if is_nullable:
+                    if isinstance(
+                        data_type,
+                        (
+                            NullType,
+                            ArrayType,
+                            MapType,
+                            StructType,
+                            GeographyType,
+                            GeometryType,
+                        ),
+                    ):
+                        value = None
+
+                if isinstance(data_type, _NumericType):
+                    value = 0
+                elif isinstance(data_type, StringType):
+                    value = "a"
+                elif isinstance(data_type, BinaryType):
+                    value = ""
+                elif isinstance(data_type, DateType):
+                    value = "date('2020-9-16')"
+                elif isinstance(data_type, BooleanType):
+                    value = True
+                elif isinstance(data_type, TimeType):
+                    value = "to_time('04:15:29.999')"
+                elif isinstance(data_type, TimestampType):
+                    value = "to_timestamp('2020-09-16 06:30:00')"
+                elif isinstance(data_type, ArrayType):
+                    value = []
+                elif isinstance(data_type, MapType):
+                    value = {}
+                elif isinstance(data_type, VariantType):
+                    value = {}
+                elif isinstance(data_type, GeographyType):
+                    value = "to_geography('POINT(-122.35 37.55)')"
+                elif isinstance(data_type, GeometryType):
+                    value = "to_geometry('POINT(-122.35 37.55)')"
+                else:
+                    pass
+
+                result_meta.append(
+                    ResultMetadata(
+                        name=col.name
+                        if case_sensitive
+                        else unquote_if_quoted(canonicalize_field(col.name)),
+                        type_code=2,
+                        display_size=None,
+                        internal_size=DEFAULT_STRING_SIZE,
+                        precision=None,
+                        scale=None,
+                        is_nullable=col.nullable,
+                    )
+                )
+                result_values.append(value)
+
+            result_row = result_set_to_rows(
+                [tuple(result_values)], result_meta, case_sensitive
+            )
+
+            # Create a dummy single row DataFrame with the expected schema.  Note that the schema
+            # attributes is a based on best effort based on most common operators but won't work for
+            # things like dynamic pivot and possibly other operators.
+            if to_pandas:
+                result = pandas.DataFrame(
+                    [[v for v in result_row[0]]],
+                    columns=[rm.name for rm in result_meta],
+                )
+            else:
+                result = result_row
+
+        self.notify_mock_query_record_listener(kwargs)
+        return result
+
+    def get_result_and_metadata(
+        self, plan: SnowflakePlan, **kwargs
+    ) -> Tuple[List[Row], List[Attribute]]:
+        self.notify_mock_query_record_listener(kwargs)
+        return ([], [])

--- a/src/snowflake/snowpark/mock/_nop_plan.py
+++ b/src/snowflake/snowpark/mock/_nop_plan.py
@@ -1,0 +1,197 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+from functools import cached_property
+from typing import List, Optional
+
+import snowflake.snowpark
+from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
+from snowflake.snowpark._internal.analyzer.binary_plan_node import Join
+from snowflake.snowpark._internal.analyzer.expression import (
+    Attribute,
+    SnowflakeUDF,
+    UnresolvedAttribute,
+)
+from snowflake.snowpark._internal.analyzer.select_statement import SelectSQL
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    LogicalPlan,
+    SnowflakeCreateTable,
+    SnowflakeTable,
+)
+from snowflake.snowpark._internal.analyzer.table_function import (
+    TableFunctionJoin,
+    TableFunctionRelation,
+)
+from snowflake.snowpark._internal.analyzer.table_merge_expression import (
+    TableDelete,
+    TableMerge,
+    TableUpdate,
+)
+from snowflake.snowpark._internal.analyzer.unary_expression import (
+    Alias,
+    UnresolvedAlias,
+)
+from snowflake.snowpark._internal.analyzer.unary_plan_node import (
+    Aggregate,
+    Pivot,
+    Project,
+)
+from snowflake.snowpark.mock._plan import MockExecutionPlan
+from snowflake.snowpark.mock._select_statement import MockSelectable
+
+# from snowflake.snowpark.session import Session
+from snowflake.snowpark.types import PandasDataFrameType, _NumericType
+
+
+def resolve_attributes(
+    plan: LogicalPlan,
+    session: Optional["snowflake.snowpark.session.Session"] = None,
+):
+    if isinstance(plan, MockSelectable):
+        attributes = plan.attributes
+
+    elif isinstance(plan, Aggregate):
+        attributes = plan.grouping_expressions + plan.aggregate_expressions
+
+    elif isinstance(plan, Join):
+        attributes = plan.left.attributes + plan.right.attributes
+
+    elif isinstance(plan, SelectSQL):
+        # Since we don't know the attributes, we'll just assume it's a single column.
+        attributes = [Attribute("$1", _NumericType())]
+
+    elif isinstance(plan, SnowflakeCreateTable):
+        attributes = plan.query.attributes
+
+    elif isinstance(plan, Project):
+        project_attributes = {
+            unquote_if_quoted(attr.name): attr for attr in plan.project_list
+        }
+        if len(project_attributes) == 1 and (
+            "*" in project_attributes or "STAR()" in project_attributes
+        ):
+            attributes = plan.children[0].attributes
+        else:
+            source_attributes = {
+                unquote_if_quoted(attr.name): attr
+                for attr in plan.children[0].attributes
+            }
+            attributes = [
+                Attribute(
+                    attr.name,
+                    source_attributes[attr_name].datatype,
+                    source_attributes[attr_name].nullable,
+                )
+                if isinstance(attr, UnresolvedAttribute)
+                else attr
+                for attr_name, attr in project_attributes.items()
+            ]
+
+    elif isinstance(plan, Pivot):
+        pivot_attrs = plan.children[0].attributes.copy()
+        pivot_col_index = next(
+            i for i, v in enumerate(pivot_attrs) if v.name == plan.pivot_column.name
+        )
+        pivot_attrs.pop(pivot_col_index)
+        # TODO: This doesn't work for dynamic pivot cases.
+        pivot_result_cols = (
+            [
+                Attribute(str(val.value), _NumericType, False)
+                for val in plan.pivot_values
+            ]
+            if plan.pivot_values
+            else []
+        )
+        pivot_attrs.extend(pivot_result_cols)
+        attributes = pivot_attrs
+
+    elif isinstance(plan, TableUpdate):
+        attributes = [
+            Attribute(name, _NumericType(), False)
+            for name in ["multi_joined_rows_updated", "rows_updated"]
+        ]
+
+    elif isinstance(plan, TableMerge):
+        attributes = [
+            Attribute(name, _NumericType(), False)
+            for name in ["rows_deleted", "rows_inserted", "rows_updated"]
+        ]
+
+    elif isinstance(plan, TableDelete):
+        attributes = [
+            Attribute(name, _NumericType(), False) for name in ["rows_deleted"]
+        ]
+
+    elif isinstance(plan, SnowflakeTable):
+        entity_plan = session._conn.entity_registry.read_table(plan.name)
+        attributes = resolve_attributes(entity_plan, session)
+
+    elif isinstance(plan, TableFunctionRelation):
+        output_schema = session.udtf.get_udtf(
+            plan.table_function.func_name
+        )._output_schema
+        attributes = [
+            Attribute(col.name, col.datatype, col.nullable) for col in output_schema
+        ]
+
+    elif isinstance(plan, TableFunctionJoin):
+        left_attributes = resolve_attributes(plan.children[0], session)
+        output_schema = session.udtf.get_udtf(
+            plan.table_function.func_name
+        )._output_schema
+        if isinstance(output_schema, PandasDataFrameType):
+            right_attributes = [
+                Attribute(col_name, col_type, True)
+                for col_name, col_type in zip(
+                    output_schema.col_names, output_schema.col_types
+                )
+            ]
+        else:
+            right_attributes = [
+                Attribute(col.name, col.datatype, col.nullable) for col in output_schema
+            ]
+        # TODO: This assumes left_cols=['*'] and right_cols=['*']
+        attributes = left_attributes + right_attributes
+
+    elif hasattr(plan, "output"):
+        attributes = plan.output
+
+    elif hasattr(plan, "execution_plan"):
+        if hasattr(plan.execution_plan, "attributes"):
+            attributes = plan.execution_plan.attributes
+
+    elif hasattr(plan, "children"):
+        if plan.children:
+            attributes = resolve_attributes(plan.children[0], session)
+        else:
+            # If there's no attributes, it could be a SQL so will assume a single column response.
+            attributes = [Attribute("$1", _NumericType())]
+    else:
+        raise NotImplementedError
+
+    # Note this doesn't handle all unresolved attributes, just most common like Alias or UDF usage.
+    resolved_attributes = []
+    for i, attr in enumerate(attributes):
+        if isinstance(attr, (Alias, UnresolvedAlias)):
+            attr = Attribute(
+                attr.name, attr.children[0].datatype, attr.children[0].nullable
+            )
+        elif isinstance(attr, SnowflakeUDF):
+            data_type = session.udaf.get_udaf(attr.udf_name)._return_type
+            attr = Attribute(f"${i}", data_type, True)
+        elif not isinstance(attr, Attribute):
+            raise NotImplementedError
+        resolved_attributes.append(attr)
+
+    return resolved_attributes
+
+
+class NopExecutionPlan(MockExecutionPlan):
+    @property
+    def attributes(self) -> List[Attribute]:
+        return self.output
+
+    @cached_property
+    def output(self) -> List[Attribute]:
+        return resolve_attributes(self.source_plan, session=self.session)

--- a/tests/ast/conftest.py
+++ b/tests/ast/conftest.py
@@ -149,9 +149,12 @@ class TestTables:
 # setting above "function" (e.g. "module" or "session").
 # TODO: SNOW-1748311 use scope="module"
 @pytest.fixture(scope="function")
-def session(local_testing_mode):
-    with Session.builder.config("local_testing", local_testing_mode).create() as s:
+def session():
+    # Note: Do NOT use Session(MockServerConnection()), as this doesn't setup the correct registrations throughout snowpark.
+    # Need to use the Session.builder to properly register this as active session etc.
+    with Session.builder.config("nop_testing", True).create() as s:
         s.ast_enabled = True
+        s.sql_simplifier_enabled = False
         yield s
 
 

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -45,9 +45,9 @@ res8 = df.group_by("a").count()
 
 df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)], schema=["location", "temp_c"])
 
-res10 = udtf(_ApplyInPandas, output_schema=StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(16777216), DoubleType()])
+res10 = udtf(_ApplyInPandas, output_schema=StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()])
 
-df.group_by("location").apply_in_pandas(convert, StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(16777216), DoubleType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
+df.group_by("location").apply_in_pandas(convert, StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 
 df = session.create_dataframe([(1, "A", 10000, "JAN"), (1, "B", 400, "JAN"), (1, "B", 5000, "FEB")], schema=["empid", "team", "amount", "month"])
 
@@ -724,12 +724,11 @@ body {
           list {
             sp_string_type {
               length {
-                value: 16777216
               }
             }
           }
           list {
-            sp_double_type: true
+            sp_float_type: true
           }
         }
         output_schema {
@@ -813,7 +812,6 @@ body {
                   datatype {
                     sp_string_type {
                       length {
-                        value: 16777216
                       }
                     }
                   }
@@ -826,7 +824,7 @@ body {
               vs {
                 sp_datatype_val {
                   datatype {
-                    sp_double_type: true
+                    sp_float_type: true
                   }
                   src {
                     file: "SRC_POSITION_TEST_MODE"

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -32,7 +32,7 @@ df2 = session.create_dataframe([Row(1, 3, 2), Row(1, 2, 3), Row(3, 2, 1)])
 
 df3 = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df4 = session.create_dataframe([[1, "snow"], [3, "flake"]], schema=StructType([StructField("a", IntegerType(), nullable=True), StructField("b", StringType(16777216), nullable=True)], structured=False))
+df4 = session.create_dataframe([[1, "snow"], [3, "flake"]], schema=StructType([StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True)], structured=False))
 
 df5 = session.create_dataframe([1, 2, 3, 4], schema=["a"])
 
@@ -427,7 +427,6 @@ body {
                 data_type {
                   sp_string_type {
                     length {
-                      value: 16777216
                     }
                   }
                 }

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -6,11 +6,17 @@ df2 = session.table_function("my_fn", kwd=lit(3), foo=lit("bar"))
 
 df3 = session.table_function(["foo", "bar"])
 
-fn1 = table_function("my_fn")
-df4 = session.table_function(fn1)
+fn1 = table_function("my_fn1")
+df4 = session.table_function(fn1())
 
-fn2 = call_table_function("my_fn")
-df5 = session.table_function(fn2)
+fn2 = table_function("my_fn2")
+df5 = session.table_function(fn2("foo"))
+
+fn3 = call_table_function("my_fn3")
+df6 = session.table_function(fn3)
+
+fn4 = call_table_function("my_fn4", "foo")
+df7 = session.table_function(fn4)
 
 ## EXPECTED UNPARSER OUTPUT
 
@@ -20,9 +26,13 @@ df2 = session.table_function("my_fn", kwd=lit(3), foo=lit("bar"))
 
 df3 = session.table_function(["foo", "bar"])
 
-df4 = session.table_function(table_function("my_fn"))
+df4 = session.table_function(call_table_function("my_fn1"))
 
-df5 = session.table_function(call_table_function("my_fn"))
+df5 = session.table_function(call_table_function("my_fn2", "foo"))
+
+df6 = session.table_function(call_table_function("my_fn3"))
+
+df7 = session.table_function(call_table_function("my_fn4", "foo"))
 
 ## EXPECTED ENCODED AST
 
@@ -250,26 +260,17 @@ body {
     expr {
       apply_expr {
         fn {
-          builtin_fn {
+          call_table_function_expr {
             name {
               fn_name_flat {
-                name: "table_function"
+                name: "my_fn1"
               }
             }
           }
         }
-        pos_args {
-          string_val {
-            src {
-              file: "SRC_POSITION_TEST_MODE"
-              start_line: 31
-            }
-            v: "my_fn"
-          }
-        }
         src {
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 31
+          start_line: 32
         }
       }
     }
@@ -323,14 +324,23 @@ body {
           call_table_function_expr {
             name {
               fn_name_flat {
-                name: "my_fn"
+                name: "my_fn2"
               }
             }
           }
         }
+        pos_args {
+          string_val {
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 35
+            }
+            v: "foo"
+          }
+        }
         src {
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 34
+          start_line: 35
         }
       }
     }
@@ -373,6 +383,137 @@ body {
     uid: 7
     var_id {
       bitfield1: 7
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          call_table_function_expr {
+            name {
+              fn_name_flat {
+                name: "my_fn3"
+              }
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 37
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 8
+    var_id {
+      bitfield1: 8
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_session_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 8
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 38
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 38
+        }
+      }
+    }
+    symbol {
+      value: "df6"
+    }
+    uid: 9
+    var_id {
+      bitfield1: 9
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          call_table_function_expr {
+            name {
+              fn_name_flat {
+                name: "my_fn4"
+              }
+            }
+          }
+        }
+        pos_args {
+          string_val {
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 40
+            }
+            v: "foo"
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 40
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 10
+    var_id {
+      bitfield1: 10
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_session_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 10
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 41
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 41
+        }
+      }
+    }
+    symbol {
+      value: "df7"
+    }
+    uid: 11
+    var_id {
+      bitfield1: 11
     }
   }
 }

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -43,7 +43,7 @@ target.merge(source, join_expr=(target["num"] == source["num"]), clauses=[when_m
 
 ## EXPECTED UNPARSER OUTPUT
 
-source = session.create_dataframe([(1, "one"), (2, "two"), (3, "three")], schema=StructType([StructField("num", IntegerType(), nullable=True), StructField("str", StringType(16777216), nullable=True)], structured=False))
+source = session.create_dataframe([(1, "one"), (2, "two"), (3, "three")], schema=StructType([StructField("num", IntegerType(), nullable=True), StructField("str", StringType(), nullable=True)], structured=False))
 
 target = Table("test_table_1", session)
 
@@ -180,7 +180,6 @@ body {
                 data_type {
                   sp_string_type {
                     length {
-                      value: 16777216
                     }
                   }
                 }

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -222,7 +222,6 @@ def test_ast(session, tables, test_case):
                     actual.strip(),
                     "\n\n## EXPECTED ENCODED AST\n\n",
                     base64_lines_to_textproto(base64_str.strip()),
-                    "\n",
                 ]
             )
     else:


### PR DESCRIPTION
This adds a NopConnection, NopAnalyzer, NopExecutionPlan which adds a new backend that does no execution, ie. nothing is executed or sent to the server.  This is useful for AST expectation testing to avoid blocking on local testing gaps and performance issues, in many cases the gaps blocked writing tests.  The biggest challenge is supporting a no execution mode is there is schema validation code scattered throughout the dataframe API that fails without attributes.  To mitigate this the NopAnalyzer makes a best effort to figure out the dataframe attributes, while it isn't guaranteed to always be correct in all cases, it effectively unblocks tests because majority of the time complete accuracy is not required on the client side.  Note there is no use case for AST serialization in local testing since nothing is send to the snowflake server.

Fixed Session.table_function.test issue where the table function wasn't being passed in a valid form.