### PR TITLE
Revert "SNOW-1760125: Disable test_read_snowflake_query_cte_with_python_anonymous_sproc test from precommit"

### DIFF
--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -3,6 +3,7 @@
 #
 import modin.pandas as pd
 import pandas as native_pd
+import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark._internal.utils import TempObjectType
@@ -164,7 +165,7 @@ def test_read_snowflake_query_cte_with_cross_language_sproc(session):
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, native_df)
 
 
-# TODO: SNOW-1760467: re-enable @pytest.mark.modin_sp_precommit
+@pytest.mark.modin_sp_precommit
 @sql_count_checker(query_count=5, sproc_count=1)
 def test_read_snowflake_query_cte_with_python_anonymous_sproc(session):
     # create table name


### PR DESCRIPTION
Reverts snowflakedb/snowpark-python#2496

Disabling the test from the Snowfort Precommit test directly instead of from client.