### PR TITLE
Skip child replace for new query compilation stage if the child has been updated already

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -127,7 +127,13 @@ def replace_child(
         raise ValueError(f"parent node {parent} is not valid for replacement.")
 
     if old_child not in getattr(parent, "children_plan_nodes", parent.children):
-        raise ValueError(f"old_child {old_child} is not a child of parent {parent}.")
+        if new_child in getattr(parent, "children_plan_nodes", parent.children):
+            # the child has already been updated
+            return
+        else:
+            raise ValueError(
+                f"old_child {old_child} is not a child of parent {parent}."
+            )
 
     if isinstance(parent, SnowflakePlan):
         assert parent.source_plan is not None

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -949,6 +949,36 @@ def test_select_with_column_expr_alias(session):
     )
 
 
+def test_time_series_aggregation_grouping(session):
+    data = [
+        ["2024-02-01 00:00:00", "product_A", "transaction_1", 10],
+        ["2024-02-15 00:00:00", "product_A", "transaction_2", 15],
+        ["2024-02-15 08:00:00", "product_A", "transaction_3", 7],
+        ["2024-02-17 00:00:00", "product_A", "transaction_4", 3],
+    ]
+    df = session.create_dataframe(data).to_df(
+        "TS", "PRODUCT_ID", "TRANSACTION_ID", "QUANTITY"
+    )
+
+    res = df.analytics.time_series_agg(
+        time_col="TS",
+        group_by=["PRODUCT_ID"],
+        aggs={"QUANTITY": ["SUM"]},
+        windows=["-1D", "-7D"],
+        sliding_interval="1D",
+    )
+    check_result(
+        session,
+        res,
+        expect_cte_optimized=True,
+        query_count=1,
+        describe_count=0,
+        union_count=0,
+        join_count=8,
+        cte_join_count=4,
+    )
+
+
 @pytest.mark.skipif(
     IS_IN_STORED_PROC, reason="SNOW-609328: support caplog in SP regression test"
 )

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -949,34 +949,40 @@ def test_select_with_column_expr_alias(session):
     )
 
 
-def test_time_series_aggregation_grouping(session):
-    data = [
-        ["2024-02-01 00:00:00", "product_A", "transaction_1", 10],
-        ["2024-02-15 00:00:00", "product_A", "transaction_2", 15],
-        ["2024-02-15 08:00:00", "product_A", "transaction_3", 7],
-        ["2024-02-17 00:00:00", "product_A", "transaction_4", 3],
-    ]
-    df = session.create_dataframe(data).to_df(
-        "TS", "PRODUCT_ID", "TRANSACTION_ID", "QUANTITY"
-    )
+@pytest.mark.parametrize("enable_sql_simplifier", [True, False])
+def test_time_series_aggregation_grouping(session, enable_sql_simplifier):
+    original_sql_simplifier_enabled = session.sql_simplifier_enabled
+    try:
+        session.sql_simplifier_enabled = enable_sql_simplifier
+        data = [
+            ["2024-02-01 00:00:00", "product_A", "transaction_1", 10],
+            ["2024-02-15 00:00:00", "product_A", "transaction_2", 15],
+            ["2024-02-15 08:00:00", "product_A", "transaction_3", 7],
+            ["2024-02-17 00:00:00", "product_A", "transaction_4", 3],
+        ]
+        df = session.create_dataframe(data).to_df(
+            "TS", "PRODUCT_ID", "TRANSACTION_ID", "QUANTITY"
+        )
 
-    res = df.analytics.time_series_agg(
-        time_col="TS",
-        group_by=["PRODUCT_ID"],
-        aggs={"QUANTITY": ["SUM"]},
-        windows=["-1D", "-7D"],
-        sliding_interval="1D",
-    )
-    check_result(
-        session,
-        res,
-        expect_cte_optimized=True,
-        query_count=1,
-        describe_count=0,
-        union_count=0,
-        join_count=8,
-        cte_join_count=4,
-    )
+        res = df.analytics.time_series_agg(
+            time_col="TS",
+            group_by=["PRODUCT_ID"],
+            aggs={"QUANTITY": ["SUM"]},
+            windows=["-1D", "-7D"],
+            sliding_interval="1D",
+        )
+        check_result(
+            session,
+            res,
+            expect_cte_optimized=True,
+            query_count=1,
+            describe_count=0,
+            union_count=0,
+            join_count=8,
+            cte_join_count=4,
+        )
+    finally:
+        session.sql_simplifier_enabled = original_sql_simplifier_enabled
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
In replace_child, if the child of a parent has already been updated, the old child won't exist anymore, and an error could raise with the current code. However, if the child has already been updated with the new child, we should simply skip the update.

For this case, the original plan have 4 resolved snowflake plan node that is pointing to the same source plan, therefore updating the child of one parent automatically updates the other parents.

daily precommit test verification https://github.com/snowflakedb/snowpark-python/actions/runs/11545868356