### PR TITLE
SNOW-1769604: Remove 100000 row itertuples dataframe test due to CI timeout

### DIFF
--- a/tests/integ/modin/frame/test_itertuples.py
+++ b/tests/integ/modin/frame/test_itertuples.py
@@ -152,7 +152,7 @@ def test_df_itertuples_nan_data_negative():
     )
 
 
-@pytest.mark.parametrize("size", [100000, 10000, PARTITION_SIZE])
+@pytest.mark.parametrize("size", [10000, PARTITION_SIZE, PARTITION_SIZE * 2])
 @pytest.mark.skipif(running_on_public_ci(), reason="slow test")
 def test_df_itertuples_large_df(size):
     data = rng.integers(low=-1500, high=1500, size=size)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

    SNOW-1769604

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   This PR removes a 100,000 row itertuples dataframe test from CI which is only able to process around 50,000 rows before timeout. Instead, we test `PARTITION_SIZE` (4096 rows), `PARTITION_SIZE `* 2, and 10,000 rows to ensure the query counts are as expected.
