### PR TITLE
SNOW-1730742: Use SnowflakeValues.output as cached attributes 

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional
 
 from snowflake.snowpark._internal.analyzer.expression import Attribute, Expression, Star
-from snowflake.snowpark._internal.analyzer.snowflake_plan_node import Limit, LogicalPlan
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    Limit,
+    LogicalPlan,
+    SnowflakeValues,
+)
 from snowflake.snowpark._internal.analyzer.unary_expression import UnresolvedAlias
 
 if TYPE_CHECKING:
@@ -90,6 +94,9 @@ def infer_metadata(
             if isinstance(source_plan.child, SnowflakePlan):
                 attributes = source_plan.child._metadata.attributes
                 quoted_identifiers = source_plan.child._metadata.quoted_identifiers
+        # When source_plan is a SnowflakeValues, metadata is already defined locally
+        elif isinstance(source_plan, SnowflakeValues):
+            attributes = source_plan.output
         elif isinstance(source_plan, Project):
             quoted_identifiers = infer_quoted_identifiers_from_expressions(
                 source_plan.project_list,  # type: ignore

--- a/tests/integ/test_reduce_describe_query.py
+++ b/tests/integ/test_reduce_describe_query.py
@@ -248,6 +248,19 @@ def test_select_quoted_identifiers(
         assert quoted_identifiers == expected_quoted_identifiers
 
 
+def test_snowflake_values(session):
+    df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
+    expected_quoted_identifiers = ['"A"', '"B"']
+    if session.reduce_describe_query_enabled:
+        with SqlCounter(query_count=0, describe_count=0):
+            assert df._plan._metadata.quoted_identifiers == expected_quoted_identifiers
+            assert df._plan.quoted_identifiers == expected_quoted_identifiers
+    else:
+        with SqlCounter(query_count=0, describe_count=1):
+            assert df._plan._metadata.quoted_identifiers is None
+            assert df._plan.quoted_identifiers == expected_quoted_identifiers
+
+
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Can't create a session in SP")
 def test_reduce_describe_query_enabled_on_session(db_parameters):
     with Session.builder.configs(db_parameters).create() as new_session:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1730742

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

    When source_plan is a SnowflakeValues, metadata is already defined locally
