### PR TITLE
SNOW-1748403: Use Aggregate.aggregate_expressions to infer quoted identifiers

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
@@ -77,6 +77,7 @@ def infer_metadata(
     )
     from snowflake.snowpark._internal.analyzer.snowflake_plan import SnowflakePlan
     from snowflake.snowpark._internal.analyzer.unary_plan_node import (
+        Aggregate,
         Filter,
         Project,
         Sample,
@@ -97,6 +98,13 @@ def infer_metadata(
         # When source_plan is a SnowflakeValues, metadata is already defined locally
         elif isinstance(source_plan, SnowflakeValues):
             attributes = source_plan.output
+        # When source_plan is Aggregate or Project, we already have quoted_identifiers
+        elif isinstance(source_plan, Aggregate):
+            quoted_identifiers = infer_quoted_identifiers_from_expressions(
+                source_plan.aggregate_expressions,  # type: ignore
+                analyzer,
+                df_aliased_col_name_to_real_col_name,
+            )
         elif isinstance(source_plan, Project):
             quoted_identifiers = infer_quoted_identifiers_from_expressions(
                 source_plan.project_list,  # type: ignore

--- a/tests/integ/test_reduce_describe_query.py
+++ b/tests/integ/test_reduce_describe_query.py
@@ -168,7 +168,7 @@ select_df_ops_expected_quoted_identifiers = [
 
 agg_df_ops_expected_quoted_identifiers = [
     (lambda df: df.agg(avg("a").as_("a"), count("b")), ['"A"', '"COUNT(B)"']),
-    (lambda df: df.agg(avg("a").as_("a"), count("b")).select("a"), ['"A"']),
+    (lambda df: df.agg(avg("a").as_('"a"'), count("b")).select('"a"'), ['"a"']),
     (lambda df: df.group_by("a").agg(avg("b")), ['"A"', '"AVG(B)"']),
     (lambda df: df.rollup("a").agg(min_("b")), ['"A"', '"MIN(B)"']),
     (lambda df: df.cube("a").agg(max_("b")), ['"A"', '"MAX(B)"']),


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1748403

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   We can use Aggregare.aggregate_expressions directly for quoted identifiers
