### PR TITLE
SNOW-1770289: Add test for CTE on `session.sql("with ...")` 

### DIFF
--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -754,6 +754,25 @@ def test_sql_non_select(session):
     )
 
 
+def test_sql_with(session):
+    df1 = session.sql("with t as (select 1 as A) select * from t")
+    df2 = session.sql("with t as (select 1 as A) select * from t")
+
+    df_result = df1.union(df2).select("A").filter(lit(True))
+
+    check_result(
+        session,
+        df_result,
+        # with ... select is also treated as a select query
+        # see is_sql_select_statement() function
+        expect_cte_optimized=True,
+        query_count=1,
+        describe_count=0,
+        union_count=1,
+        join_count=0,
+    )
+
+
 @pytest.mark.parametrize(
     "action",
     [


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1770289

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   We don't have such an test before. The generated query is like:
```
WITH SNOWPARK_TEMP_CTE_N7V3KVPKOM AS (with t as (select 1 as A) select * from t) SELECT count(1) AS "COUNT(LITERAL())" FROM ( SELECT  *  FROM ( SELECT  *  FROM ( SELECT "A" FROM (( SELECT  *  FROM (SNOWPARK_TEMP_CTE_N7V3KVPKOM)) UNION ( SELECT  *  FROM (SNOWPARK_TEMP_CTE_N7V3KVPKOM)))) WHERE True :: BOOLEAN) ORDER BY "A" ASC NULLS FIRST) LIMIT 1
```
