### PR TITLE
SNOW-1762419: Getting profiler output when profiler is disabled throws an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Bug Fixes
 
-- Fixed a bug that when `Session.stored_procedure_profiler` is not enabled, error is raised while calling `Session.stored_procedure_profiler.get_output`
+- Fixed a bug that raised error `AttributeError` while calling `Session.stored_procedure_profiler.get_output` when `Session.stored_procedure_profiler` is disabled.
 
 ### Snowpark pandas API Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Added a dependency on `protoc-wheel-0` for the development profile.
 - Require `snowflake-connector-python>=3.12.0, <4.0.0` (was `>=3.10.0`).
 
+### Bug Fixes
+
+- Fixed a bug that when `Session.stored_procedure_profiler` is not enabled, error is raised while calling `Session.stored_procedure_profiler.get_output`
+
 ### Snowpark pandas API Updates
 
 #### Dependency Updates

--- a/src/snowflake/snowpark/stored_procedure_profiler.py
+++ b/src/snowflake/snowpark/stored_procedure_profiler.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
+import logging
 import threading
 from typing import List, Literal, Optional
 
@@ -10,6 +11,8 @@ from snowflake.snowpark._internal.utils import (
     parse_table_name,
     strip_double_quotes_in_like_statement_in_table_name,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class StoredProcedureProfiler:
@@ -127,6 +130,9 @@ class StoredProcedureProfiler:
         """
         # return empty string when profiler is not enabled to not interrupt user's code
         if not self._is_enabled:
+            logger.warning(
+                "You are seeing this warning because you try to get profiler output while profiler is disabled. Please use profiler.set_active_profiler() to enable profiler."
+            )
             return ""
         query_id = self._get_last_query_id()
         if query_id is None:

--- a/src/snowflake/snowpark/stored_procedure_profiler.py
+++ b/src/snowflake/snowpark/stored_procedure_profiler.py
@@ -136,6 +136,9 @@ class StoredProcedureProfiler:
             return ""
         query_id = self._get_last_query_id()
         if query_id is None:
-            raise ValueError("Last executed stored procedure does not exist")
+            logger.warning(
+                "You are seeing this warning because last executed stored procedure does not exist. Please run the store procedure before get profiler output."
+            )
+            return ""
         sql = f"select snowflake.core.get_python_profiler_output('{query_id}')"
         return self._session.sql(sql)._internal_collect_with_tag_no_telemetry()[0][0]  # type: ignore

--- a/tests/integ/test_stored_procedure_profiler.py
+++ b/tests/integ/test_stored_procedure_profiler.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
 #
+import logging
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -137,7 +138,9 @@ def test_anonymous_procedure(
     "config.getoption('local_testing_mode', default=False)",
     reason="session.sql is not supported in localtesting",
 )
-def test_set_incorrect_active_profiler(profiler_session, db_parameters, tmp_stage_name):
+def test_set_incorrect_active_profiler(
+    profiler_session, db_parameters, tmp_stage_name, caplog
+):
     with pytest.raises(ValueError) as e:
         profiler_session.stored_procedure_profiler.set_active_profiler(
             "wrong_active_profiler"
@@ -148,13 +151,13 @@ def test_set_incorrect_active_profiler(profiler_session, db_parameters, tmp_stag
         profiler_session.stored_procedure_profiler.set_target_stage(f"{tmp_stage_name}")
     assert "stage name must be fully qualified name" in str(e)
 
-    with pytest.raises(ValueError) as e:
+    with caplog.at_level(logging.WARNING):
         profiler_session.stored_procedure_profiler.set_target_stage(
             f"{db_parameters['database']}.{db_parameters['schema']}.{tmp_stage_name}"
         )
         profiler_session.stored_procedure_profiler.set_active_profiler("LINE")
         profiler_session.stored_procedure_profiler.get_output()
-    assert "Last executed stored procedure does not exist" in str(e)
+    assert "last executed stored procedure does not exist" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/test_stored_procedure_profiler.py
+++ b/tests/integ/test_stored_procedure_profiler.py
@@ -250,3 +250,10 @@ def test_create_temp_stage(profiler_session):
     finally:
         profiler_session.sql(f"drop database if exists {db_name}").collect()
         profiler_session.sql(f"use database {current_db}").collect()
+
+
+def test_when_sp_profiler_not_enabled(profiler_session):
+    pro = profiler_session.stored_procedure_profiler
+    # direct call get_output when profiler is not enabled
+    res = pro.get_output()
+    assert res == ""


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1762419

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   This PR is meant to fix the issue that error will be raised when call profiler.get_output if profiler is not enabled.
After fix, an empty string will be returned under that situation to make profiler not interrupt user code
