### PR TITLE
SNOW-1787507: Fix DataFrame.dropna() with subset empty, scalar, or native_pd.Index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 #### Bug Fixes
 
 - Fixed a bug where aggregating a single-column dataframe with a single callable function (e.g. `pd.DataFrame([0]).agg(np.mean)`) would fail to transpose the result.
+- Fixed bugs where `DataFrame.dropna()` would:
+  - Treat an empty `subset` (e.g. `[]`) as if it specified all columns instead of no columns.
+  - Raise a `TypeError` for a scalar `subset` instead of filtering on just that column.
+  - Raise a `ValueError` for a `subset` of type `pandas.Index` instead of filtering on the columns in the index.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -11289,7 +11289,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         axis: int,
         how: Literal["any", "all"],
         thresh: Optional[Union[int, lib.NoDefault]] = lib.no_default,
-        subset: IndexLabel = None,
+        subset: Optional[Iterable] = None,
     ) -> "SnowflakeQueryCompiler":
         """
         Remove missing values. If 'thresh' is specified then the 'how' parameter is ignored.
@@ -11316,7 +11316,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 self._modin_frame.data_column_pandas_labels,
                 self._modin_frame.data_column_snowflake_quoted_identifiers,
             )
-            if not subset or label in subset
+            if subset is None or label in subset
         ]
         if thresh is lib.no_default:
             thresh = None

--- a/src/snowflake/snowpark/modin/plugin/extensions/base_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/base_overrides.py
@@ -1011,7 +1011,9 @@ def _dropna(
         raise ValueError("invalid how option: %s" % how)
     if subset is not None:
         if axis != 1:
-            indices = self.columns.get_indexer_for(subset)
+            indices = self.columns.get_indexer_for(
+                subset if is_list_like(subset) else [subset]
+            )
             check = indices == -1
             if check.any():
                 raise KeyError(list(np.compress(check, subset)))

--- a/tests/integ/modin/frame/test_dropna.py
+++ b/tests/integ/modin/frame/test_dropna.py
@@ -6,6 +6,7 @@ import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
+from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import eval_snowpark_pandas_result
@@ -24,36 +25,29 @@ def test_dropna_df():
     )
 
 
-@sql_count_checker(query_count=5)
-def test_basic_arguments(test_dropna_df):
+@sql_count_checker(query_count=1)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"how": "any"},
+        {"how": "all"},
+        param({"subset": ["toy"]}, id="subset_list_length_1"),
+        param({"subset": ("toy", "born")}, id="subset_tuple_length_2"),
+        param(
+            {"subset": native_pd.Index(["toy", "born"])},
+            id="SNOW-1787507_subset_pandas_index_length_2",
+        ),
+        param({"subset": []}, id="SNOW-1787507_subset_empty"),
+        param({"subset": "toy"}, id="SNOW-1787507_subset_scalar"),
+        {"thresh": 1},
+    ],
+)
+def test_basic_arguments(test_dropna_df, kwargs):
     eval_snowpark_pandas_result(
         pd.DataFrame(test_dropna_df),
         test_dropna_df,
-        lambda df: df.dropna(),
-    )
-
-    eval_snowpark_pandas_result(
-        pd.DataFrame(test_dropna_df),
-        test_dropna_df,
-        lambda df: df.dropna(how="any"),
-    )
-
-    eval_snowpark_pandas_result(
-        pd.DataFrame(test_dropna_df),
-        test_dropna_df,
-        lambda df: df.dropna(how="all"),
-    )
-
-    eval_snowpark_pandas_result(
-        pd.DataFrame(test_dropna_df),
-        test_dropna_df,
-        lambda df: df.dropna(subset=["toy"]),
-    )
-
-    eval_snowpark_pandas_result(
-        pd.DataFrame(test_dropna_df),
-        test_dropna_df,
-        lambda df: df.dropna(thresh=1),
+        lambda df: df.dropna(**kwargs),
     )
 
 


### PR DESCRIPTION
Fixes SNOW-1787507

- Fix bugs where `DataFrame.dropna()` would:
  - Treat an empty `subset` (e.g. `[]`) as if it specified all columns instead of no columns.
  - Raise a `TypeError` for a scalar `subset` instead of filtering on just that column.
  - Raise a `ValueError` for a `subset` of type `pandas.Index` instead of filtering on the columns in the index.