### PR TITLE
SNOW-1787415 Fix dataframe ast to register udtf for replay execution using client created udtf in same client session

### DIFF
--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -1171,7 +1171,7 @@ def build_udtf(
     statement_params: Optional[Dict[str, str]] = None,
     is_permanent: bool = False,
     session: "snowflake.snowpark.session.Session" = None,
-    udtf_name: Optional[Union[str, Iterable[str]]] = None,
+    _registered_object_name: Optional[Union[str, Iterable[str]]] = None,
     **kwargs,
 ):
     """Helper function to encode UDTF parameters (used in both regular and mock UDFRegistration)."""
@@ -1184,7 +1184,7 @@ def build_udtf(
         ast.handler,
         handler,
         session._ast_batch if session is not None else None,
-        udtf_name,
+        _registered_object_name,
     )
 
     if output_schema is not None:

--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -953,7 +953,7 @@ def build_proto_from_callable(
     expr_builder: proto.SpCallable,
     func: Union[Callable, Tuple[str, str]],
     ast_batch: Optional[AstBatch] = None,
-    object_name: Optional[str] = None,
+    object_name: Optional[Union[str, Iterable[str]]] = None,
 ):
     """Registers a python callable (i.e., a function or lambda) to the AstBatch and encodes it as SpCallable protobuf."""
 
@@ -979,7 +979,7 @@ def build_proto_from_callable(
         expr_builder.name = func.__name__
 
     if object_name is not None:
-        expr_builder.object_name = object_name
+        build_sp_table_name(expr_builder.object_name, object_name)
 
 
 def build_udf(
@@ -1171,7 +1171,7 @@ def build_udtf(
     statement_params: Optional[Dict[str, str]] = None,
     is_permanent: bool = False,
     session: "snowflake.snowpark.session.Session" = None,
-    udtf_name: str = None,
+    udtf_name: Optional[Union[str, Iterable[str]]] = None,
     **kwargs,
 ):
     """Helper function to encode UDTF parameters (used in both regular and mock UDFRegistration)."""

--- a/src/snowflake/snowpark/_internal/ast_utils.py
+++ b/src/snowflake/snowpark/_internal/ast_utils.py
@@ -16,7 +16,7 @@ from functools import reduce
 from logging import getLogger
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import dateutil
 from dateutil.tz import tzlocal
@@ -44,7 +44,7 @@ from snowflake.snowpark._internal.type_utils import (
     ColumnOrSqlExpr,
 )
 from snowflake.snowpark._internal.utils import str_to_enum
-from snowflake.snowpark.types import DataType
+from snowflake.snowpark.types import DataType, StructType
 
 # This flag causes an explicit error to be raised if any Snowpark object instance is missing an AST or field, when this
 # AST or field is required to populate the AST field of a different Snowpark object instance.
@@ -953,6 +953,7 @@ def build_proto_from_callable(
     expr_builder: proto.SpCallable,
     func: Union[Callable, Tuple[str, str]],
     ast_batch: Optional[AstBatch] = None,
+    object_name: Optional[str] = None,
 ):
     """Registers a python callable (i.e., a function or lambda) to the AstBatch and encodes it as SpCallable protobuf."""
 
@@ -976,6 +977,9 @@ def build_proto_from_callable(
     else:
         # Use the actual function name. Note: We do not support different scopes yet, need to be careful with this then.
         expr_builder.name = func.__name__
+
+    if object_name is not None:
+        expr_builder.object_name = object_name
 
 
 def build_udf(
@@ -1124,6 +1128,103 @@ def build_udaf(
             t._1 = k
             t._2 = v
 
+    if (
+        external_access_integrations is not None
+        and len(external_access_integrations) != 0
+    ):
+        ast.external_access_integrations.extend(external_access_integrations)
+    if secrets is not None and len(secrets) != 0:
+        for k, v in secrets.items():
+            t = ast.secrets.add()
+            t._1 = k
+            t._2 = v
+    ast.immutable = immutable
+    if comment is not None:
+        ast.comment.value = comment
+    for k, v in kwargs.items():
+        t = ast.kwargs.add()
+        t._1 = k
+        build_expr_from_python_val(t._2, v)
+
+
+def build_udtf(
+    ast: proto.Udtf,
+    handler: Union[Callable, Tuple[str, str]],
+    output_schema: Union[
+        StructType, Iterable[str], "PandasDataFrameType"  # noqa: F821
+    ],  # noqa: F821
+    input_types: Optional[List[DataType]],
+    name: Optional[str],
+    stage_location: Optional[str] = None,
+    imports: Optional[List[Union[str, Tuple[str, str]]]] = None,
+    packages: Optional[List[Union[str, ModuleType]]] = None,
+    replace: bool = False,
+    if_not_exists: bool = False,
+    parallel: int = 4,
+    max_batch_size: Optional[int] = None,
+    strict: bool = False,
+    secure: bool = False,
+    external_access_integrations: Optional[List[str]] = None,
+    secrets: Optional[Dict[str, str]] = None,
+    immutable: bool = False,
+    comment: Optional[str] = None,
+    statement_params: Optional[Dict[str, str]] = None,
+    is_permanent: bool = False,
+    session: "snowflake.snowpark.session.Session" = None,
+    udtf_name: str = None,
+    **kwargs,
+):
+    """Helper function to encode UDTF parameters (used in both regular and mock UDFRegistration)."""
+    # This is the name the UDTF is registered to. Not the name to display when unparsing, that name is captured in callable.
+
+    if name is not None:
+        _set_fn_name(name, ast)
+
+    build_proto_from_callable(
+        ast.handler,
+        handler,
+        session._ast_batch if session is not None else None,
+        udtf_name,
+    )
+
+    if output_schema is not None:
+        if isinstance(output_schema, DataType):
+            output_schema._fill_ast(ast.output_schema.udtf_schema__type.return_type)
+        elif isinstance(output_schema, Sequence) and all(
+            isinstance(el, str) for el in output_schema
+        ):
+            ast.output_schema.udtf_schema__names.schema.extend(output_schema)
+        else:
+            raise ValueError(f"Can not encode {output_schema} to AST.")
+
+    if input_types is not None and len(input_types) != 0:
+        for input_type in input_types:
+            input_type._fill_ast(ast.input_types.list.add())
+    ast.is_permanent = is_permanent
+    if stage_location is not None:
+        ast.stage_location = stage_location
+    if imports is not None and len(imports) != 0:
+        for import_ in imports:
+            import_expr = proto.SpTableName()
+            build_sp_table_name(import_expr, import_)
+            ast.imports.append(import_expr)
+    if packages is not None and len(packages) != 0:
+        for package in packages:
+            if isinstance(package, ModuleType):
+                raise NotImplementedError
+            ast.packages.append(package)
+    ast.replace = replace
+    ast.if_not_exists = if_not_exists
+    ast.parallel = parallel
+
+    if statement_params is not None and len(statement_params) != 0:
+        for k, v in statement_params.items():
+            t = ast.statement_params.add()
+            t._1 = k
+            t._2 = v
+
+    ast.strict = strict
+    ast.secure = secure
     if (
         external_access_integrations is not None
         and len(external_access_integrations) != 0

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -778,7 +778,7 @@ message FnRefExpr {
     StoredProcedure stored_procedure = 8;
     Udaf udaf = 9;
     Udf udf = 10;
-    Udtf udtf = 11;
+    UdtfRegister udtf_register = 11;
   }
 }
 
@@ -790,7 +790,7 @@ message FnNameRefExpr {
     StoredProcedure stored_procedure = 4;
     Udaf udaf = 5;
     Udf udf = 6;
-    Udtf udtf = 7;
+    UdtfRegister udtf_register = 7;
   }
 }
 
@@ -864,31 +864,16 @@ message Udf {
   bool strict = 22;
 }
 
-// expr-fn.ir:95
-message Udtf {
-  google.protobuf.StringValue comment = 1;
-  repeated string external_access_integrations = 2;
-  SpCallable handler = 3;
-  bool if_not_exists = 4;
-  bool immutable = 5;
-  repeated SpTableName imports = 6;
-  List_SpDataType input_types = 7;
-  bool is_permanent = 8;
-  repeated Tuple_String_Expr kwargs = 9;
-  FnName name = 10;
-  UdtfSchema output_schema = 11;
-  repeated string packages = 12;
-  int64 parallel = 13;
-  bool replace = 14;
-  repeated Tuple_String_String secrets = 15;
-  bool secure = 16;
-  SrcPosition src = 17;
-  string stage_location = 18;
-  repeated Tuple_String_String statement_params = 19;
-  bool strict = 20;
+// expr-fn.ir:94
+message UdtfRegister {
+  repeated SpDataType input_types = 1;
+  FnName name = 2;
+  UdtfSchema output_schema = 3;
+  FnName registered_name = 4;
+  SrcPosition src = 5;
 }
 
-// expr-fn.ir:118
+// expr-fn.ir:101
 message Udaf {
   google.protobuf.StringValue comment = 1;
   repeated string external_access_integrations = 2;
@@ -910,19 +895,19 @@ message Udaf {
   repeated Tuple_String_String statement_params = 18;
 }
 
-// expr-fn.ir:139
+// expr-fn.ir:122
 message IndirectTableFnNameRef {
   FnName name = 1;
   SrcPosition src = 2;
 }
 
-// expr-fn.ir:144
+// expr-fn.ir:127
 message IndirectTableFnIdRef {
   VarId id = 1;
   SrcPosition src = 2;
 }
 
-// expr-fn.ir:148
+// expr-fn.ir:131
 message CallTableFunctionExpr {
   FnName name = 1;
   SrcPosition src = 2;
@@ -1357,7 +1342,7 @@ message Expr {
     TupleVal tuple_val = 211;
     Udaf udaf = 212;
     Udf udf = 213;
-    Udtf udtf = 214;
+    UdtfRegister udtf_register = 214;
   }
 }
 
@@ -3125,7 +3110,7 @@ message HasSrcPosition {
     TupleVal tuple_val = 225;
     Udaf udaf = 226;
     Udf udf = 227;
-    Udtf udtf = 228;
+    UdtfRegister udtf_register = 228;
   }
 }
 

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -534,7 +534,7 @@ message SpDataframeSchema_Struct {
 message SpCallable {
   int64 id = 1;
   string name = 2;
-  string object_name = 3;
+  SpTableName object_name = 3;
 }
 
 // sp-type.ir:106

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -534,9 +534,10 @@ message SpDataframeSchema_Struct {
 message SpCallable {
   int64 id = 1;
   string name = 2;
+  string object_name = 3;
 }
 
-// sp-type.ir:104
+// sp-type.ir:106
 message SpPivotValue {
   oneof sealed_value {
     SpPivotValue_Dataframe sp_pivot_value__dataframe = 1;
@@ -544,12 +545,12 @@ message SpPivotValue {
   }
 }
 
-// sp-type.ir:105
+// sp-type.ir:107
 message SpPivotValue_Expr {
   Expr v = 1;
 }
 
-// sp-type.ir:106
+// sp-type.ir:108
 message SpPivotValue_Dataframe {
   SpDataframeRef v = 1;
 }
@@ -778,7 +779,7 @@ message FnRefExpr {
     StoredProcedure stored_procedure = 8;
     Udaf udaf = 9;
     Udf udf = 10;
-    UdtfRegister udtf_register = 11;
+    Udtf udtf = 11;
   }
 }
 
@@ -790,7 +791,7 @@ message FnNameRefExpr {
     StoredProcedure stored_procedure = 4;
     Udaf udaf = 5;
     Udf udf = 6;
-    UdtfRegister udtf_register = 7;
+    Udtf udtf = 7;
   }
 }
 
@@ -864,16 +865,31 @@ message Udf {
   bool strict = 22;
 }
 
-// expr-fn.ir:94
-message UdtfRegister {
-  repeated SpDataType input_types = 1;
-  FnName name = 2;
-  UdtfSchema output_schema = 3;
-  FnName registered_name = 4;
-  SrcPosition src = 5;
+// expr-fn.ir:95
+message Udtf {
+  google.protobuf.StringValue comment = 1;
+  repeated string external_access_integrations = 2;
+  SpCallable handler = 3;
+  bool if_not_exists = 4;
+  bool immutable = 5;
+  repeated SpTableName imports = 6;
+  List_SpDataType input_types = 7;
+  bool is_permanent = 8;
+  repeated Tuple_String_Expr kwargs = 9;
+  FnName name = 10;
+  UdtfSchema output_schema = 11;
+  repeated string packages = 12;
+  int64 parallel = 13;
+  bool replace = 14;
+  repeated Tuple_String_String secrets = 15;
+  bool secure = 16;
+  SrcPosition src = 17;
+  string stage_location = 18;
+  repeated Tuple_String_String statement_params = 19;
+  bool strict = 20;
 }
 
-// expr-fn.ir:101
+// expr-fn.ir:118
 message Udaf {
   google.protobuf.StringValue comment = 1;
   repeated string external_access_integrations = 2;
@@ -895,19 +911,19 @@ message Udaf {
   repeated Tuple_String_String statement_params = 18;
 }
 
-// expr-fn.ir:122
+// expr-fn.ir:139
 message IndirectTableFnNameRef {
   FnName name = 1;
   SrcPosition src = 2;
 }
 
-// expr-fn.ir:127
+// expr-fn.ir:144
 message IndirectTableFnIdRef {
   VarId id = 1;
   SrcPosition src = 2;
 }
 
-// expr-fn.ir:131
+// expr-fn.ir:148
 message CallTableFunctionExpr {
   FnName name = 1;
   SrcPosition src = 2;
@@ -1342,7 +1358,7 @@ message Expr {
     TupleVal tuple_val = 211;
     Udaf udaf = 212;
     Udf udf = 213;
-    UdtfRegister udtf_register = 214;
+    Udtf udtf = 214;
   }
 }
 
@@ -3110,7 +3126,7 @@ message HasSrcPosition {
     TupleVal tuple_val = 225;
     Udaf udaf = 226;
     Udf udf = 227;
-    UdtfRegister udtf_register = 228;
+    Udtf udtf = 228;
   }
 }
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -100,7 +100,7 @@ REGISTER_KWARGS_ALLOWLIST = {
     "_from_pandas_udf_function",
     "input_names",  # for pandas_udtf
     "max_batch_size",  # for pandas_udtf
-    "_registered_object_name",  # db object name if already registered
+    "_registered_object_name",  # object name within Snowflake (post registration)
 }
 
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -100,7 +100,7 @@ REGISTER_KWARGS_ALLOWLIST = {
     "_from_pandas_udf_function",
     "input_names",  # for pandas_udtf
     "max_batch_size",  # for pandas_udtf
-    "object_name",  # db object name if already exists
+    "_registered_object_name",  # db object name if already registered
 }
 
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -100,6 +100,7 @@ REGISTER_KWARGS_ALLOWLIST = {
     "_from_pandas_udf_function",
     "input_names",  # for pandas_udtf
     "max_batch_size",  # for pandas_udtf
+    "registered_name",  # registered name already exists
 }
 
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -100,7 +100,7 @@ REGISTER_KWARGS_ALLOWLIST = {
     "_from_pandas_udf_function",
     "input_names",  # for pandas_udtf
     "max_batch_size",  # for pandas_udtf
-    "registered_name",  # registered name already exists
+    "object_name",  # db object name if already exists
 }
 
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1445,6 +1445,8 @@ class DataFrame:
         stmt = _ast_stmt
         ast = None
 
+        # Note it's intentional the column expressions are AST serializerd earlier (ast_cols) to ensure any
+        # AST IDs created preceed the AST ID of the select statement so they are deserialized in dependent order.
         if _emit_ast and _ast_stmt is None:
             stmt = self._session._ast_batch.assign()
             ast = with_src_position(stmt.expr.sp_dataframe_select__columns, stmt)

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1359,31 +1359,24 @@ class DataFrame:
         if not exprs:
             raise ValueError("The input of select() cannot be empty")
 
-        # AST.
-        stmt = _ast_stmt
-        ast = None
-
-        if _emit_ast and _ast_stmt is None:
-            stmt = self._session._ast_batch.assign()
-            ast = with_src_position(stmt.expr.sp_dataframe_select__columns, stmt)
-            self._set_ast_ref(ast.df)
-            ast.variadic = is_variadic
-
         names = []
         table_func = None
         join_plan = None
 
+        ast_cols = []
+
         for e in exprs:
             if isinstance(e, Column):
                 names.append(e._named())
-                if _emit_ast and ast:
-                    ast.cols.append(e._ast)
+                if _emit_ast and _ast_stmt is None:
+                    ast_cols.append(e._ast)
 
             elif isinstance(e, str):
                 col_expr_ast = None
-                if ast:
-                    col_expr_ast = ast.cols.add() if ast else proto.Expr()
+                if _emit_ast and _ast_stmt is None:
+                    col_expr_ast = proto.Expr()
                     fill_ast_for_column(col_expr_ast, e, None)
+                    ast_cols.append(col_expr_ast)
 
                 col = Column(e, _ast=col_expr_ast)
                 names.append(col._named())
@@ -1395,9 +1388,11 @@ class DataFrame:
                         f"Called '{table_func.user_visible_name}' and '{e.user_visible_name}'."
                     )
                 table_func = e
-                if _emit_ast and ast:
+                if _emit_ast and _ast_stmt is None:
                     add_intermediate_stmt(self._session._ast_batch, table_func)
-                    build_indirect_table_fn_apply(ast.cols.add(), table_func)
+                    ast_col = proto.Expr()
+                    build_indirect_table_fn_apply(ast_col, table_func)
+                    ast_cols.append(ast_col)
 
                 func_expr = _create_table_function_expression(func=table_func)
 
@@ -1445,6 +1440,21 @@ class DataFrame:
                 raise TypeError(
                     "The input of select() must be Column, column name, TableFunctionCall, or a list of them"
                 )
+
+        # AST.
+        stmt = _ast_stmt
+        ast = None
+
+        if _emit_ast and _ast_stmt is None:
+            stmt = self._session._ast_batch.assign()
+            ast = with_src_position(stmt.expr.sp_dataframe_select__columns, stmt)
+            self._set_ast_ref(ast.df)
+            ast.variadic = is_variadic
+
+            # Add columns after the statement to ensure any dependent columns have lower ast id.
+            for ast_col in ast_cols:
+                if ast_col is not None:
+                    ast.cols.add().CopyFrom(ast_col)
 
         if self._select_statement:
             if join_plan:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1445,7 +1445,7 @@ class DataFrame:
         stmt = _ast_stmt
         ast = None
 
-        # Note it's intentional the column expressions are AST serializerd earlier (ast_cols) to ensure any
+        # Note it's intentional the column expressions are AST serialized earlier (ast_cols) to ensure any
         # AST IDs created preceed the AST ID of the select statement so they are deserialized in dependent order.
         if _emit_ast and _ast_stmt is None:
             stmt = self._session._ast_batch.assign()

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -8758,7 +8758,7 @@ def udtf(
     else:
         udtf_registration_method = session.udtf.register
 
-    if handler is None:
+    if handler is None and "registered_name" not in kwargs:
         return functools.partial(
             udtf_registration_method,
             output_schema=output_schema,

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -8758,7 +8758,7 @@ def udtf(
     else:
         udtf_registration_method = session.udtf.register
 
-    if handler is None and "object_name" not in kwargs:
+    if handler is None and kwargs.get("object_name") is None:
         return functools.partial(
             udtf_registration_method,
             output_schema=output_schema,

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -8758,7 +8758,7 @@ def udtf(
     else:
         udtf_registration_method = session.udtf.register
 
-    if handler is None and kwargs.get("object_name") is None:
+    if handler is None and kwargs.get("_registered_object_name") is None:
         return functools.partial(
             udtf_registration_method,
             output_schema=output_schema,

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -8758,7 +8758,7 @@ def udtf(
     else:
         udtf_registration_method = session.udtf.register
 
-    if handler is None and "registered_name" not in kwargs:
+    if handler is None and "object_name" not in kwargs:
         return functools.partial(
             udtf_registration_method,
             output_schema=output_schema,

--- a/src/snowflake/snowpark/mock/_nop_plan.py
+++ b/src/snowflake/snowpark/mock/_nop_plan.py
@@ -43,7 +43,12 @@ from snowflake.snowpark.mock._plan import MockExecutionPlan
 from snowflake.snowpark.mock._select_statement import MockSelectable
 
 # from snowflake.snowpark.session import Session
-from snowflake.snowpark.types import MapType, PandasDataFrameType, _NumericType
+from snowflake.snowpark.types import (
+    IntegerType,
+    MapType,
+    PandasDataFrameType,
+    _NumericType,
+)
 
 
 def resolve_attributes(
@@ -82,8 +87,12 @@ def resolve_attributes(
             attributes = [
                 Attribute(
                     attr.name,
-                    source_attributes[attr_name].datatype,
-                    source_attributes[attr_name].nullable,
+                    source_attributes[attr_name].datatype
+                    if attr_name in source_attributes
+                    else IntegerType(),
+                    source_attributes[attr_name].nullable
+                    if attr_name in source_attributes
+                    else True,
                 )
                 if isinstance(attr, UnresolvedAttribute)
                 else attr

--- a/src/snowflake/snowpark/mock/_udtf.py
+++ b/src/snowflake/snowpark/mock/_udtf.py
@@ -71,16 +71,18 @@ class MockUDTFRegistration(UDTFRegistration):
         _emit_ast: bool = True,
         **kwargs,
     ) -> UserDefinedTableFunction:
-        if kwargs.get("object_name") is not None:
-            stmt = self._session._ast_batch.assign()
-            ast = with_src_position(stmt.expr.udtf, stmt)
-            ast_id = stmt.var_id.bitfield1
+        if kwargs.get("_registered_object_name") is not None:
+            ast, ast_id = None, None
+            if _emit_ast:
+                stmt = self._session._ast_batch.assign()
+                ast = with_src_position(stmt.expr.udtf, stmt)
+                ast_id = stmt.var_id.bitfield1
 
             return MockUserDefinedTableFunction(
                 handler,
                 output_schema,
                 input_types,
-                kwargs["object_name"],
+                kwargs["_registered_object_name"],
                 _ast=ast,
                 _ast_id=ast_id,
             )

--- a/src/snowflake/snowpark/mock/_udtf.py
+++ b/src/snowflake/snowpark/mock/_udtf.py
@@ -78,14 +78,18 @@ class MockUDTFRegistration(UDTFRegistration):
                 ast = with_src_position(stmt.expr.udtf, stmt)
                 ast_id = stmt.var_id.bitfield1
 
-            return MockUserDefinedTableFunction(
+            object_name = kwargs["_registrated_object_name"]
+            udtf = MockUserDefinedTableFunction(
                 handler,
                 output_schema,
                 input_types,
-                kwargs["_registered_object_name"],
+                object_name,
                 _ast=ast,
                 _ast_id=ast_id,
             )
+            # Add to registry to MockPlan can execute.
+            self._registry[object_name] = udtf
+            return udtf
 
         if isinstance(output_schema, StructType):
             _validate_output_schema_names(output_schema.names)
@@ -108,7 +112,7 @@ class MockUDTFRegistration(UDTFRegistration):
 
         # get the udtf name, input types
         (
-            udtf_name,
+            object_name,
             is_pandas_udf,
             is_dataframe_input,
             output_schema,
@@ -153,21 +157,21 @@ class MockUDTFRegistration(UDTFRegistration):
                 statement_params=statement_params,
                 is_permanent=is_permanent,
                 session=self._session,
-                udtf_name=udtf_name,
+                _registered_object_name=object_name,
                 **kwargs,
             )
 
-        foo = MockUserDefinedTableFunction(
+        udtf = MockUserDefinedTableFunction(
             handler,
             output_schema,
             input_types,
-            udtf_name,
+            object_name,
             packages=packages,
             _ast=ast,
             _ast_id=ast_id,
         )
 
         # Add to registry to MockPlan can execute.
-        self._registry[udtf_name] = foo
+        self._registry[object_name] = udtf
 
-        return foo
+        return udtf

--- a/src/snowflake/snowpark/mock/_udtf.py
+++ b/src/snowflake/snowpark/mock/_udtf.py
@@ -71,7 +71,7 @@ class MockUDTFRegistration(UDTFRegistration):
         _emit_ast: bool = True,
         **kwargs,
     ) -> UserDefinedTableFunction:
-        if "object_name" in kwargs:
+        if kwargs.get("object_name") is not None:
             stmt = self._session._ast_batch.assign()
             ast = with_src_position(stmt.expr.udtf, stmt)
             ast_id = stmt.var_id.bitfield1

--- a/src/snowflake/snowpark/mock/_udtf.py
+++ b/src/snowflake/snowpark/mock/_udtf.py
@@ -6,6 +6,7 @@
 from types import ModuleType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
+from snowflake.snowpark._internal.ast_utils import build_udtf, with_src_position
 from snowflake.snowpark._internal.udf_utils import process_registration_inputs
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.types import DataType, PandasDataFrameType, StructType
@@ -70,12 +71,44 @@ class MockUDTFRegistration(UDTFRegistration):
         _emit_ast: bool = True,
         **kwargs,
     ) -> UserDefinedTableFunction:
-        if "registered_name" in kwargs:
+
+        # Capture original parameters.
+        ast = None
+        if _emit_ast:
+            stmt = self._session._ast_batch.assign()
+            ast = with_src_position(stmt.expr.udtf, stmt)
+
+            build_udtf(
+                ast,
+                handler,
+                output_schema=output_schema,
+                input_types=input_types,
+                name=name,
+                stage_location=stage_location,
+                imports=imports,
+                packages=packages,
+                replace=replace,
+                if_not_exists=if_not_exists,
+                parallel=parallel,
+                max_batch_size=max_batch_size,
+                strict=strict,
+                secure=secure,
+                external_access_integrations=external_access_integrations,
+                secrets=secrets,
+                immutable=immutable,
+                comment=comment,
+                statement_params=statement_params,
+                is_permanent=is_permanent,
+                session=self._session,
+                **kwargs,
+            )
+
+        if "object_name" in kwargs:
             return MockUserDefinedTableFunction(
-                lambda dummy: dummy,
+                handler if handler else lambda dummy: dummy,
                 output_schema,
                 input_types,
-                kwargs["registered_name"],
+                kwargs["object_name"],
             )
 
         if isinstance(output_schema, StructType):
@@ -115,12 +148,6 @@ class MockUDTFRegistration(UDTFRegistration):
             output_schema=output_schema,
         )
 
-        ast, ast_id = (
-            self._build_udtf_ast(name, output_schema, input_types, udtf_name)
-            if _emit_ast
-            else (None, None)
-        )
-
         foo = MockUserDefinedTableFunction(
             handler,
             output_schema,
@@ -128,7 +155,9 @@ class MockUDTFRegistration(UDTFRegistration):
             udtf_name,
             packages=packages,
             _ast=ast,
-            _ast_id=ast_id,
+            _ast_id=(
+                stmt.var_id.bitfield1
+            ),  # Reference UDTF by its assign/statement id.,
         )
 
         # Add to registry to MockPlan can execute.

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -114,25 +114,25 @@ class TableFunctionCall:
             expr = with_src_position(ast.sp_table_fn_call_over)
             expr.lhs.CopyFrom(self._ast)
             if partition_by is not None:
-                if isinstance(partition_by, Iterable):
+                if isinstance(partition_by, (str, Column)):
+                    build_expr_from_snowpark_column_or_col_name(
+                        expr.partition_by.add(), partition_by
+                    )
+                else:
                     for partition_clause in partition_by:
                         build_expr_from_snowpark_column_or_col_name(
                             expr.partition_by.add(), partition_clause
                         )
-                else:
-                    build_expr_from_snowpark_column_or_col_name(
-                        expr.partition_by.add(), partition_by
-                    )
             if order_by is not None:
-                if isinstance(order_by, Iterable):
+                if isinstance(order_by, (str, Column)):
+                    build_expr_from_snowpark_column_or_col_name(
+                        expr.order_by.add(), order_by
+                    )
+                else:
                     for order_clause in order_by:
                         build_expr_from_snowpark_column_or_col_name(
                             expr.order_by.add(), order_clause
                         )
-                else:
-                    build_expr_from_snowpark_column_or_col_name(
-                        expr.order_by.add(), order_by
-                    )
 
         new_table_function = TableFunctionCall(
             self.name, *self.arguments, _ast=ast, **self.named_arguments

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -944,7 +944,7 @@ class UDTFRegistration:
 
         # get the udtf name, input types
         (
-            udtf_name,
+            object_name,
             is_pandas_udf,
             is_dataframe_input,
             output_schema,
@@ -988,7 +988,7 @@ class UDTFRegistration:
                 statement_params=statement_params,
                 is_permanent=is_permanent,
                 session=self._session,
-                udtf_name=udtf_name,
+                _registered_object_name=object_name,
                 **kwargs,
             )
 
@@ -1008,7 +1008,7 @@ class UDTFRegistration:
             TempObjectType.TABLE_FUNCTION,
             handler,
             arg_names,
-            udtf_name,
+            object_name,
             stage_location,
             imports,
             packages,
@@ -1036,7 +1036,7 @@ class UDTFRegistration:
                 opt_arg_defaults=opt_arg_defaults,
                 handler=handler_name,
                 object_type=TempObjectType.FUNCTION,
-                object_name=udtf_name,
+                object_name=object_name,
                 all_imports=all_imports,
                 all_packages=all_packages,
                 raw_imports=imports,
@@ -1078,7 +1078,7 @@ class UDTFRegistration:
             handler,
             output_schema,
             input_types,
-            udtf_name,
+            object_name,
             packages=packages,
             _ast=ast,
             _ast_id=ast_id,

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -908,6 +908,20 @@ class UDTFRegistration:
         _emit_ast: bool = True,
         **kwargs,
     ) -> UserDefinedTableFunction:
+        if "object_name" in kwargs:
+            stmt = self._session._ast_batch.assign()
+            ast = with_src_position(stmt.expr.udtf, stmt)
+            ast_id = stmt.var_id.bitfield1
+
+            return UserDefinedTableFunction(
+                handler,
+                output_schema,
+                input_types,
+                kwargs["object_name"],
+                _ast=ast,
+                _ast_id=ast_id,
+            )
+
         check_output_schema_type(output_schema)
         check_imports_type(imports, "udtf-level")
 
@@ -974,16 +988,6 @@ class UDTFRegistration:
                 session=self._session,
                 udtf_name=udtf_name,
                 **kwargs,
-            )
-
-        if "object_name" in kwargs:
-            return UserDefinedTableFunction(
-                handler if handler else lambda dummy: dummy,
-                output_schema,
-                input_types,
-                kwargs["object_name"],
-                _ast=ast,
-                _ast_id=ast_id,
             )
 
         arg_names = input_names or [f"arg{i + 1}" for i in range(len(input_types))]

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -28,7 +28,6 @@ import snowflake.snowpark
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark._internal.ast_utils import (
-    build_udtf,
     build_udtf_apply,
     with_src_position,
 )
@@ -89,7 +88,7 @@ class UserDefinedTableFunction:
         input_types: List[DataType],
         name: str,
         packages: Optional[List[Union[str, ModuleType]]] = None,
-        _ast: Optional[proto.Udtf] = None,
+        _ast: Optional[proto.UdtfRegister] = None,
         _ast_id: Optional[int] = None,
     ) -> None:
         #: The Python class or a tuple containing the Python file path and the function name.
@@ -674,7 +673,7 @@ class UDTFRegistration:
         with open_telemetry_udf_context_manager(
             self.register, handler=handler, name=name
         ):
-            if not callable(handler):
+            if not callable(handler) and "registered_name" not in kwargs:
                 raise TypeError(
                     "Invalid function: not a function or callable "
                     f"(__call__ is not defined): {type(handler)}"
@@ -879,6 +878,28 @@ class UDTFRegistration:
                 _emit_ast=_emit_ast,
             )
 
+    def _build_udtf_ast(
+        self,
+        name: str,
+        output_schema: Union[StructType, Iterable[str], "PandasDataFrameType"],
+        input_types: Optional[List[DataType]],
+        udtf_name: str,
+    ) -> Tuple[proto.UdtfRegister, int]:
+        stmt = self._session._ast_batch.assign()
+        ast = with_src_position(stmt.expr.udtf_register, stmt)
+        ast_id = stmt.var_id.bitfield1
+
+        if name is not None:
+            ast.name.fn_name_flat.name = name
+
+        ast.registered_name.fn_name_flat.name = udtf_name
+
+        output_schema._fill_ast(ast.output_schema.udtf_schema__type.return_type)
+        for input_type in input_types:
+            input_type._fill_ast(ast.input_types.add())
+
+        return (ast, ast_id)
+
     def _do_register_udtf(
         self,
         handler: Union[Callable, Tuple[str, str]],
@@ -912,35 +933,12 @@ class UDTFRegistration:
         check_output_schema_type(output_schema)
         check_imports_type(imports, "udtf-level")
 
-        # Capture original parameters.
-        ast, ast_id = None, None
-        if _emit_ast:
-            stmt = self._session._ast_batch.assign()
-            ast = with_src_position(stmt.expr.udtf, stmt)
-            ast_id = stmt.var_id.bitfield1
-            build_udtf(
-                ast,
-                handler,
-                output_schema=output_schema,
-                input_types=input_types,
-                name=name,
-                stage_location=stage_location,
-                imports=imports,
-                packages=packages,
-                replace=replace,
-                if_not_exists=if_not_exists,
-                parallel=parallel,
-                max_batch_size=max_batch_size,
-                strict=strict,
-                secure=secure,
-                external_access_integrations=external_access_integrations,
-                secrets=secrets,
-                immutable=immutable,
-                comment=comment,
-                statement_params=statement_params,
-                is_permanent=is_permanent,
-                session=self._session,
-                **kwargs,
+        if "registered_name" in kwargs:
+            return UserDefinedTableFunction(
+                lambda dummy: dummy,
+                output_schema,
+                input_types,
+                kwargs["registered_name"],
             )
 
         if isinstance(output_schema, StructType):
@@ -974,6 +972,12 @@ class UDTFRegistration:
             input_types,
             name,
             output_schema=output_schema,
+        )
+
+        ast, ast_id = (
+            self._build_udtf_ast(name, output_schema, input_types, udtf_name)
+            if _emit_ast
+            else (None, None)
         )
 
         arg_names = input_names or [f"arg{i + 1}" for i in range(len(input_types))]

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -18,9 +18,9 @@ df.to_pandas()
 
 df.to_pandas(block=False)
 
-df.to_pandas(statement_params={"SF_PARTNER": "FAKE_PARTNER"})
+df.to_pandas(statement_params=statement_params={"SF_PARTNER": "FAKE_PARTNER"})
 
-df.to_pandas(statement_params={"SF_PARTNER": "FAKE_PARTNER"}, block=False)
+df.to_pandas(statement_params=statement_params={"SF_PARTNER": "FAKE_PARTNER"}, block=False)
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -18,9 +18,9 @@ df.to_pandas()
 
 df.to_pandas(block=False)
 
-df.to_pandas(statement_params=statement_params={"SF_PARTNER": "FAKE_PARTNER"})
+df.to_pandas(statement_params={"SF_PARTNER": "FAKE_PARTNER"})
 
-df.to_pandas(statement_params=statement_params={"SF_PARTNER": "FAKE_PARTNER"}, block=False)
+df.to_pandas(statement_params={"SF_PARTNER": "FAKE_PARTNER"}, block=False)
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -45,7 +45,7 @@ res8 = df.group_by("a").count()
 
 df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)], schema=["location", "temp_c"])
 
-res10 = udtf(output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+res10 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.group_by("location").apply_in_pandas(convert, StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 
@@ -716,15 +716,21 @@ body {
 body {
   assign {
     expr {
-      udtf_register {
-        input_types {
-          sp_string_type {
-            length {
-            }
-          }
+      udtf {
+        handler {
+          name: "_ApplyInPandas"
+          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
         }
         input_types {
-          sp_float_type: true
+          list {
+            sp_string_type {
+              length {
+              }
+            }
+          }
+          list {
+            sp_float_type: true
+          }
         }
         output_schema {
           udtf_schema__type {
@@ -749,11 +755,7 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
-          }
-        }
+        parallel: 4
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 43
@@ -773,6 +775,7 @@ body {
     expr {
       sp_relational_grouped_dataframe_apply_in_pandas {
         func {
+          id: 1
           name: "convert"
         }
         grouped_df {

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -45,7 +45,7 @@ res8 = df.group_by("a").count()
 
 df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)], schema=["location", "temp_c"])
 
-res10 = udtf(_ApplyInPandas, output_schema=StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()])
+res10 = udtf(output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.group_by("location").apply_in_pandas(convert, StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 
@@ -716,60 +716,44 @@ body {
 body {
   assign {
     expr {
-      udtf {
-        handler {
-          name: "_ApplyInPandas"
-        }
+      udtf_register {
         input_types {
-          list {
-            sp_string_type {
-              length {
-              }
+          sp_string_type {
+            length {
             }
           }
-          list {
-            sp_float_type: true
-          }
+        }
+        input_types {
+          sp_float_type: true
         }
         output_schema {
           udtf_schema__type {
             return_type {
-              sp_struct_type {
-                fields {
-                  column_identifier {
-                    name: "location"
-                  }
-                  data_type {
-                    sp_string_type {
-                      length {
-                      }
+              sp_pandas_data_frame_type {
+                col_names: "LOCATION"
+                col_names: "TEMP_C"
+                col_names: "TEMP_F"
+                col_types {
+                  sp_string_type {
+                    length {
                     }
                   }
-                  nullable: true
                 }
-                fields {
-                  column_identifier {
-                    name: "temp_c"
-                  }
-                  data_type {
-                    sp_float_type: true
-                  }
-                  nullable: true
+                col_types {
+                  sp_float_type: true
                 }
-                fields {
-                  column_identifier {
-                    name: "temp_f"
-                  }
-                  data_type {
-                    sp_float_type: true
-                  }
-                  nullable: true
+                col_types {
+                  sp_float_type: true
                 }
               }
             }
           }
         }
-        parallel: 4
+        registered_name {
+          fn_name_flat {
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          }
+        }
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 43
@@ -789,7 +773,6 @@ body {
     expr {
       sp_relational_grouped_dataframe_apply_in_pandas {
         func {
-          id: 1
           name: "convert"
         }
         grouped_df {

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -719,7 +719,11 @@ body {
       udtf {
         handler {
           name: "_ApplyInPandas"
-          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          object_name {
+            sp_table_name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+            }
+          }
         }
         input_types {
           list {

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -45,7 +45,7 @@ res8 = df.group_by("a").count()
 
 df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)], schema=["location", "temp_c"])
 
-res10 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+res10 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.group_by("location").apply_in_pandas(convert, StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -100,29 +100,29 @@ df.select("a", twoxsix_udtf("a").alias("double", "six_x"), "c").collect()
 
 ## EXPECTED UNPARSER OUTPUT
 
-prime_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+prime_udtf = udtf("PrimeSieve", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(prime_udtf(lit(20))).collect()
 
 df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df.with_column("total", udtf(output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
+df.with_column("total", udtf("sum_udtf", output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
 
-generator_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+generator_udtf = udtf("GeneratorUDTF", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(generator_udtf(lit(3))).collect()
 
-foo = udtf(output_schema=StructType([StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", registered_name="foo")
+foo = udtf("Foo", output_schema=StructType([StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", force_inline_code=True, object_name="foo")
 
 df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
 
 df = df.to_df(["a", "b", "c"])
 
-twox_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twox_udtf = udtf("TwoXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select((twox_udtf("a"))).collect()
 
-twoxsix_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 
@@ -133,9 +133,15 @@ df.select(col("a"), (twoxsix_udtf("a").alias("double", "six_x")), col("c")).coll
 body {
   assign {
     expr {
-      udtf_register {
+      udtf {
+        handler {
+          name: "PrimeSieve"
+          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+        }
         input_types {
-          sp_integer_type: true
+          list {
+            sp_integer_type: true
+          }
         }
         output_schema {
           udtf_schema__type {
@@ -154,11 +160,7 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
-          }
-        }
+        parallel: 4
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 46
@@ -292,12 +294,19 @@ body {
 body {
   assign {
     expr {
-      udtf_register {
-        input_types {
-          sp_long_type: true
+      udtf {
+        handler {
+          id: 1
+          name: "sum_udtf"
+          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
         }
         input_types {
-          sp_long_type: true
+          list {
+            sp_long_type: true
+          }
+          list {
+            sp_long_type: true
+          }
         }
         output_schema {
           udtf_schema__type {
@@ -316,11 +325,7 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
-          }
-        }
+        parallel: 4
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 51
@@ -559,9 +564,16 @@ body {
 body {
   assign {
     expr {
-      udtf_register {
+      udtf {
+        handler {
+          id: 2
+          name: "GeneratorUDTF"
+          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+        }
         input_types {
-          sp_integer_type: true
+          list {
+            sp_integer_type: true
+          }
         }
         output_schema {
           udtf_schema__type {
@@ -580,11 +592,7 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
-          }
-        }
+        parallel: 4
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 63
@@ -718,12 +726,48 @@ body {
 body {
   assign {
     expr {
-      udtf_register {
-        input_types {
-          sp_integer_type: true
+      udtf {
+        comment {
+          value: "fufufufu"
+        }
+        external_access_integrations: "gs"
+        handler {
+          id: 3
+          name: "Foo"
+          object_name: "foo"
+        }
+        immutable: true
+        imports {
+          sp_table_name_flat {
+            name: "numpy"
+          }
+        }
+        imports {
+          sp_table_name_structured {
+            name: "seaborn"
+            name: "sns"
+          }
         }
         input_types {
-          sp_long_type: true
+          list {
+            sp_integer_type: true
+          }
+          list {
+            sp_long_type: true
+          }
+        }
+        is_permanent: true
+        kwargs {
+          _1: "force_inline_code"
+          _2 {
+            bool_val {
+              src {
+                file: "SRC_POSITION_TEST_MODE"
+                start_line: 72
+              }
+              v: true
+            }
+          }
         }
         name {
           fn_name_flat {
@@ -756,15 +800,24 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "foo"
-          }
+        packages: "snowflake.snowpark"
+        parallel: 7
+        replace: true
+        secrets {
+          _1: "test"
+          _2: "verysecret"
         }
+        secure: true
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 72
         }
+        stage_location: "@"
+        statement_params {
+          _1: "a"
+          _2: "b"
+        }
+        strict: true
       }
     }
     symbol {
@@ -936,9 +989,16 @@ body {
 body {
   assign {
     expr {
-      udtf_register {
+      udtf {
+        handler {
+          id: 4
+          name: "TwoXUDTF"
+          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+        }
         input_types {
-          sp_integer_type: true
+          list {
+            sp_integer_type: true
+          }
         }
         output_schema {
           udtf_schema__type {
@@ -957,11 +1017,7 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
-          }
-        }
+        parallel: 4
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 99
@@ -1086,9 +1142,16 @@ body {
 body {
   assign {
     expr {
-      udtf_register {
+      udtf {
+        handler {
+          id: 5
+          name: "TwoXSixXUDTF"
+          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+        }
         input_types {
-          sp_integer_type: true
+          list {
+            sp_integer_type: true
+          }
         }
         output_schema {
           udtf_schema__type {
@@ -1116,11 +1179,7 @@ body {
             }
           }
         }
-        registered_name {
-          fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
-          }
-        }
+        parallel: 4
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 111

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -100,15 +100,15 @@ df.select("a", twoxsix_udtf("a").alias("double", "six_x"), "c").collect()
 
 ## EXPECTED UNPARSER OUTPUT
 
-prime_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
+prime_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(prime_udtf(lit(20))).collect()
 
 df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df.with_column("total", udtf(output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")(df["a"], df["b"])).sort(df["a"]).show()
+df.with_column("total", udtf(output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
 
-generator_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
+generator_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(generator_udtf(lit(3))).collect()
 
@@ -118,11 +118,11 @@ df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, 
 
 df = df.to_df(["a", "b", "c"])
 
-twox_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
+twox_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select((twox_udtf("a"))).collect()
 
-twoxsix_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
+twoxsix_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 
@@ -156,7 +156,7 @@ body {
         }
         registered_name {
           fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_7BVGNY8E88"
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
           }
         }
         src {
@@ -318,7 +318,7 @@ body {
         }
         registered_name {
           fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_W6QJ8DBO9M"
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
           }
         }
         src {
@@ -582,7 +582,7 @@ body {
         }
         registered_name {
           fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_DCEDCZMDYT"
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
           }
         }
         src {
@@ -959,7 +959,7 @@ body {
         }
         registered_name {
           fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_HTDQ14HC9Q"
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
           }
         }
         src {
@@ -1118,7 +1118,7 @@ body {
         }
         registered_name {
           fn_name_flat {
-            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_8GG0TX9HRG"
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
           }
         }
         src {

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -136,7 +136,11 @@ body {
       udtf {
         handler {
           name: "PrimeSieve"
-          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          object_name {
+            sp_table_name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+            }
+          }
         }
         input_types {
           list {
@@ -298,7 +302,11 @@ body {
         handler {
           id: 1
           name: "sum_udtf"
-          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          object_name {
+            sp_table_name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+            }
+          }
         }
         input_types {
           list {
@@ -568,7 +576,11 @@ body {
         handler {
           id: 2
           name: "GeneratorUDTF"
-          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          object_name {
+            sp_table_name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+            }
+          }
         }
         input_types {
           list {
@@ -734,7 +746,11 @@ body {
         handler {
           id: 3
           name: "Foo"
-          object_name: "foo"
+          object_name {
+            sp_table_name_flat {
+              name: "foo"
+            }
+          }
         }
         immutable: true
         imports {
@@ -993,7 +1009,11 @@ body {
         handler {
           id: 4
           name: "TwoXUDTF"
-          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          object_name {
+            sp_table_name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+            }
+          }
         }
         input_types {
           list {
@@ -1146,7 +1166,11 @@ body {
         handler {
           id: 5
           name: "TwoXSixXUDTF"
-          object_name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+          object_name {
+            sp_table_name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+            }
+          }
         }
         input_types {
           list {

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -66,35 +66,76 @@ foo = udtf(Foo,  output_schema= ["a", "b"],
            immutable = True,
            comment = "fufufufu")
 
+df = session.create_dataframe(
+    [(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)]
+).to_df(["a", "b", "c"])
+
+class TwoXUDTF:
+    def process(self, n: int):
+        yield (2 * n,)
+
+twox_udtf = udtf(
+    TwoXUDTF,
+    output_schema=StructType([StructField("two_x", IntegerType())]),
+    input_types=[IntegerType()],
+)
+
+df.select(twox_udtf("a")).collect()
+
+class TwoXSixXUDTF:
+    def process(self, n: int):
+        yield (2 * n, 6 * n)
+
+twoxsix_udtf = udtf(
+    TwoXSixXUDTF,
+    output_schema=StructType(
+        [StructField("two_x", IntegerType()), StructField("six_x", IntegerType())]
+    ),
+    input_types=[IntegerType()],
+)
+
+df.select(df.a, twoxsix_udtf(df.a)).collect()
+
+df.select("a", twoxsix_udtf("a").alias("double", "six_x"), "c").collect()
+
 ## EXPECTED UNPARSER OUTPUT
 
-prime_udtf = udtf(PrimeSieve, output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()])
+prime_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
 
 session.table_function(prime_udtf(lit(20))).collect()
 
 df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df.with_column("total", udtf(sum_udtf, output_schema=["number"])(df["a"], df["b"])).sort(df["a"]).show()
+df.with_column("total", udtf(output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")(df["a"], df["b"])).sort(df["a"]).show()
 
-generator_udtf = udtf(GeneratorUDTF, output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()])
+generator_udtf = udtf(output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
 
 session.table_function(generator_udtf(lit(3))).collect()
 
-foo = udtf(Foo, output_schema=["a", "b"], input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params=, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", force_inline_code=True)
+foo = udtf(output_schema=StructType([StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", registered_name="foo")
+
+df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
+
+df = df.to_df(["a", "b", "c"])
+
+twox_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
+
+df.select((twox_udtf("a"))).collect()
+
+twoxsix_udtf = udtf(output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], registered_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_xxx")
+
+df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
+
+df.select(col("a"), (twoxsix_udtf("a").alias("double", "six_x")), col("c")).collect()
 
 ## EXPECTED ENCODED AST
 
 body {
   assign {
     expr {
-      udtf {
-        handler {
-          name: "PrimeSieve"
-        }
+      udtf_register {
         input_types {
-          list {
-            sp_integer_type: true
-          }
+          sp_integer_type: true
         }
         output_schema {
           udtf_schema__type {
@@ -113,7 +154,11 @@ body {
             }
           }
         }
-        parallel: 4
+        registered_name {
+          fn_name_flat {
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_7BVGNY8E88"
+          }
+        }
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 46
@@ -247,17 +292,35 @@ body {
 body {
   assign {
     expr {
-      udtf {
-        handler {
-          id: 1
-          name: "sum_udtf"
+      udtf_register {
+        input_types {
+          sp_long_type: true
+        }
+        input_types {
+          sp_long_type: true
         }
         output_schema {
-          udtf_schema__names {
-            schema: "number"
+          udtf_schema__type {
+            return_type {
+              sp_struct_type {
+                fields {
+                  column_identifier {
+                    name: "number"
+                  }
+                  data_type {
+                    sp_long_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
           }
         }
-        parallel: 4
+        registered_name {
+          fn_name_flat {
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_W6QJ8DBO9M"
+          }
+        }
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 51
@@ -496,15 +559,9 @@ body {
 body {
   assign {
     expr {
-      udtf {
-        handler {
-          id: 2
-          name: "GeneratorUDTF"
-        }
+      udtf_register {
         input_types {
-          list {
-            sp_integer_type: true
-          }
+          sp_integer_type: true
         }
         output_schema {
           udtf_schema__type {
@@ -523,7 +580,11 @@ body {
             }
           }
         }
-        parallel: 4
+        registered_name {
+          fn_name_flat {
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_DCEDCZMDYT"
+          }
+        }
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 63
@@ -657,47 +718,12 @@ body {
 body {
   assign {
     expr {
-      udtf {
-        comment {
-          value: "fufufufu"
-        }
-        external_access_integrations: "gs"
-        handler {
-          id: 3
-          name: "Foo"
-        }
-        immutable: true
-        imports {
-          sp_table_name_flat {
-            name: "numpy"
-          }
-        }
-        imports {
-          sp_table_name_structured {
-            name: "seaborn"
-            name: "sns"
-          }
+      udtf_register {
+        input_types {
+          sp_integer_type: true
         }
         input_types {
-          list {
-            sp_integer_type: true
-          }
-          list {
-            sp_long_type: true
-          }
-        }
-        is_permanent: true
-        kwargs {
-          _1: "force_inline_code"
-          _2 {
-            bool_val {
-              src {
-                file: "SRC_POSITION_TEST_MODE"
-                start_line: 72
-              }
-              v: true
-            }
-          }
+          sp_long_type: true
         }
         name {
           fn_name_flat {
@@ -705,29 +731,40 @@ body {
           }
         }
         output_schema {
-          udtf_schema__names {
-            schema: "a"
-            schema: "b"
+          udtf_schema__type {
+            return_type {
+              sp_struct_type {
+                fields {
+                  column_identifier {
+                    name: "a"
+                  }
+                  data_type {
+                    sp_long_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    name: "b"
+                  }
+                  data_type {
+                    sp_long_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
           }
         }
-        packages: "snowflake.snowpark"
-        parallel: 7
-        replace: true
-        secrets {
-          _1: "test"
-          _2: "verysecret"
+        registered_name {
+          fn_name_flat {
+            name: "foo"
+          }
         }
-        secure: true
         src {
           file: "SRC_POSITION_TEST_MODE"
           start_line: 72
         }
-        stage_location: "@"
-        statement_params {
-          _1: "a"
-          _2: "b"
-        }
-        strict: true
       }
     }
     symbol {
@@ -736,6 +773,682 @@ body {
     uid: 17
     var_id {
       bitfield1: 17
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_create_dataframe {
+        data {
+          sp_dataframe_data__list {
+            vs {
+              tuple_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 91
+                }
+                vs {
+                  int64_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: 1
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: "one o one"
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: 10
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 91
+                }
+                vs {
+                  int64_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: "twenty two"
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: 20
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 91
+                }
+                vs {
+                  int64_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: 3
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: "thirty three"
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 91
+                    }
+                    v: 30
+                  }
+                }
+              }
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 91
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 18
+    var_id {
+      bitfield1: 18
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_to_df {
+        col_names: "a"
+        col_names: "b"
+        col_names: "c"
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 18
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 91
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 19
+    var_id {
+      bitfield1: 19
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf_register {
+        input_types {
+          sp_integer_type: true
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              sp_struct_type {
+                fields {
+                  column_identifier {
+                    name: "two_x"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        registered_name {
+          fn_name_flat {
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_HTDQ14HC9Q"
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 99
+        }
+      }
+    }
+    symbol {
+      value: "twox_udtf"
+    }
+    uid: 20
+    var_id {
+      bitfield1: 20
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          sp_fn_ref {
+            id {
+              bitfield1: 20
+            }
+          }
+        }
+        pos_args {
+          string_val {
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 105
+            }
+            v: "a"
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 105
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 21
+    var_id {
+      bitfield1: 21
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_select__columns {
+        cols {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 21
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 105
+            }
+          }
+        }
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 19
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 105
+        }
+        variadic: true
+      }
+    }
+    symbol {
+    }
+    uid: 22
+    var_id {
+      bitfield1: 22
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 22
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 105
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 23
+    var_id {
+      bitfield1: 23
+    }
+  }
+}
+body {
+  eval {
+    uid: 24
+    var_id {
+      bitfield1: 23
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf_register {
+        input_types {
+          sp_integer_type: true
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              sp_struct_type {
+                fields {
+                  column_identifier {
+                    name: "two_x"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    name: "six_x"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        registered_name {
+          fn_name_flat {
+            name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_8GG0TX9HRG"
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 111
+        }
+      }
+    }
+    symbol {
+      value: "twoxsix_udtf"
+    }
+    uid: 25
+    var_id {
+      bitfield1: 25
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          sp_fn_ref {
+            id {
+              bitfield1: 25
+            }
+          }
+        }
+        pos_args {
+          sp_dataframe_col {
+            col_name: "a"
+            df {
+              sp_dataframe_ref {
+                id {
+                  bitfield1: 19
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 119
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 119
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 26
+    var_id {
+      bitfield1: 26
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_select__columns {
+        cols {
+          sp_dataframe_col {
+            col_name: "a"
+            df {
+              sp_dataframe_ref {
+                id {
+                  bitfield1: 19
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 119
+            }
+          }
+        }
+        cols {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 26
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 119
+            }
+          }
+        }
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 19
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 119
+        }
+        variadic: true
+      }
+    }
+    symbol {
+    }
+    uid: 27
+    var_id {
+      bitfield1: 27
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 27
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 119
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 28
+    var_id {
+      bitfield1: 28
+    }
+  }
+}
+body {
+  eval {
+    uid: 29
+    var_id {
+      bitfield1: 28
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_table_fn_call_alias {
+        aliases {
+          args {
+            string_val {
+              src {
+                file: "SRC_POSITION_TEST_MODE"
+                start_line: 121
+              }
+              v: "double"
+            }
+          }
+          args {
+            string_val {
+              src {
+                file: "SRC_POSITION_TEST_MODE"
+                start_line: 121
+              }
+              v: "six_x"
+            }
+          }
+          variadic: true
+        }
+        lhs {
+          apply_expr {
+            fn {
+              sp_fn_ref {
+                id {
+                  bitfield1: 25
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 121
+                }
+                v: "a"
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 121
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 121
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 30
+    var_id {
+      bitfield1: 30
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_select__columns {
+        cols {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  fn_name_flat {
+                    name: "col"
+                  }
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 121
+                }
+                v: "a"
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 121
+            }
+          }
+        }
+        cols {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 30
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 121
+            }
+          }
+        }
+        cols {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  fn_name_flat {
+                    name: "col"
+                  }
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 121
+                }
+                v: "c"
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 121
+            }
+          }
+        }
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 19
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 121
+        }
+        variadic: true
+      }
+    }
+    symbol {
+    }
+    uid: 31
+    var_id {
+      bitfield1: 31
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 31
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 121
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 32
+    var_id {
+      bitfield1: 32
+    }
+  }
+}
+body {
+  eval {
+    uid: 33
+    var_id {
+      bitfield1: 32
     }
   }
 }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -100,29 +100,29 @@ df.select("a", twoxsix_udtf("a").alias("double", "six_x"), "c").collect()
 
 ## EXPECTED UNPARSER OUTPUT
 
-prime_udtf = udtf("PrimeSieve", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+prime_udtf = udtf("PrimeSieve", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(prime_udtf(lit(20))).collect()
 
 df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df.with_column("total", udtf("sum_udtf", output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
+df.with_column("total", udtf("sum_udtf", output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
 
-generator_udtf = udtf("GeneratorUDTF", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+generator_udtf = udtf("GeneratorUDTF", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(generator_udtf(lit(3))).collect()
 
-foo = udtf("Foo", output_schema=StructType([StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", force_inline_code=True, object_name="foo")
+foo = udtf("Foo", output_schema=StructType([StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", force_inline_code=True, _registered_object_name="foo")
 
 df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
 
 df = df.to_df(["a", "b", "c"])
 
-twox_udtf = udtf("TwoXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twox_udtf = udtf("TwoXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select((twox_udtf("a"))).collect()
 
-twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -21,7 +21,6 @@ from dateutil.tz import tzlocal
 
 from snowflake.snowpark._internal.ast_utils import (
     ClearTempTables,
-    base64_lines_to_request,
     base64_lines_to_textproto,
     textproto_to_request,
 )
@@ -207,7 +206,9 @@ def test_ast(session, tables, test_case):
         try:
             # Protobuf serialization is non-deterministic (cf. https://gist.github.com/kchristidis/39c8b310fd9da43d515c4394c3cd9510)
             # Therefore unparse from base64, and then check equality using deterministic (python) protobuf serialization.
-            actual_message = textproto_to_request(normalize_temp_names(base64_lines_to_textproto(base64_str.strip())))
+            actual_message = textproto_to_request(
+                normalize_temp_names(base64_lines_to_textproto(base64_str.strip()))
+            )
             expected_message = textproto_to_request(
                 test_case.expected_ast_encoded.strip()
             )

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -207,7 +207,7 @@ def test_ast(session, tables, test_case):
         try:
             # Protobuf serialization is non-deterministic (cf. https://gist.github.com/kchristidis/39c8b310fd9da43d515c4394c3cd9510)
             # Therefore unparse from base64, and then check equality using deterministic (python) protobuf serialization.
-            actual_message = base64_lines_to_request(base64_str.strip())
+            actual_message = textproto_to_request(normalize_temp_names(base64_lines_to_textproto(base64_str.strip())))
             expected_message = textproto_to_request(
                 test_case.expected_ast_encoded.strip()
             )

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -109,7 +109,7 @@ def indent_lines(source: str, n_indents: int = 0):
 
 def normalize_temp_names(s: str):
     return re.sub(
-        "SNOWPARK_TEMP_([a-zA-Z]*(_FUNCTION)?)_(\w+)", r"SNOWPARK_TEMP_\1_xxx", s
+        r"SNOWPARK_TEMP_([a-zA-Z]*(_FUNCTION)?)_(\w+)", r"SNOWPARK_TEMP_\1_xxx", s
     )
 
 

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -108,6 +108,7 @@ def indent_lines(source: str, n_indents: int = 0):
 
 
 def normalize_temp_names(s: str):
+    """Replace random part of db object names with constant so value is deterministic for comparisons"""
     return re.sub(
         r"SNOWPARK_TEMP_([a-zA-Z]*(_FUNCTION)?)_(\w+)", r"SNOWPARK_TEMP_\1_xxx", s
     )

--- a/tests/integ/scala/test_udtf_suite.py
+++ b/tests/integ/scala/test_udtf_suite.py
@@ -23,6 +23,7 @@ from snowflake.snowpark.types import (
     StructType,
     Variant,
 )
+
 from tests.utils import Utils
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
@@ -45,16 +46,19 @@ wordcount_table_name = Utils.random_table_name()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_data(session):
+def setup_data(session, validate_ast):
     df = session.sql(
         "SELECT $1 AS \"C1\", $2 AS \"C2\" FROM  VALUES ('w1 w2', 'g1'), ('w1 w1 w1', 'g2')"
     )
-    df.write.save_as_table(wordcount_table_name)
+    df.write.save_as_table(
+        wordcount_table_name,
+        mode="ignore" if validate_ast else "errorifexists",
+    )
     yield
     Utils.drop_table(session, wordcount_table_name)
 
 
-def test_basic_udtf_word_count_without_end_partition(session):
+def test_basic_udtf_word_count_without_end_partition(session, validate_ast):
     func_name = Utils.random_function_name()
 
     class MyWordCount:
@@ -63,15 +67,21 @@ def test_basic_udtf_word_count_without_end_partition(session):
             return counter.items()
 
     wordcount_udtf = session.udtf.register(
-        MyWordCount, ["word", "count"], name=func_name, is_permanent=False, replace=True
-    )
-
-    wordcount_udtf_with_statemenet_params = session.udtf.register(
         MyWordCount,
         ["word", "count"],
         name=func_name,
         is_permanent=False,
-        replace=True,
+        replace=not validate_ast,
+        if_not_exists=validate_ast,
+    )
+
+    wordcount_udtf_with_statement_params = session.udtf.register(
+        MyWordCount,
+        ["word", "count"],
+        name=func_name,
+        is_permanent=False,
+        replace=not validate_ast,
+        if_not_exists=validate_ast,
         statement_params={"SF_PARTNER": "FAKE_PARTNER"},
     )
 
@@ -87,7 +97,7 @@ def test_basic_udtf_word_count_without_end_partition(session):
         assert df2.columns == ["WORD", "COUNT"]
 
         df2_with_statement_params = session.table_function(
-            wordcount_udtf_with_statemenet_params(lit("w1 w2 w2 w3 w3 w3"))
+            wordcount_udtf_with_statement_params(lit("w1 w2 w2 w3 w3 w3"))
         )
         Utils.check_answer(
             df2_with_statement_params,

--- a/tests/integ/utils/sql_counter.py
+++ b/tests/integ/utils/sql_counter.py
@@ -88,7 +88,7 @@ FILTER_OUT_QUERIES = [
 # define global at module-level
 sql_count_records = {}
 
-_active_session = None
+sql_counter_state = threading.local()
 
 
 class SqlCounter(QueryListener):
@@ -156,8 +156,6 @@ class SqlCounter(QueryListener):
 
         if self._no_check:
             self.session = None
-        elif _active_session is not None:
-            self.session = _active_session
         else:
             self.session = Session.SessionBuilder().getOrCreate()
 
@@ -197,7 +195,8 @@ class SqlCounter(QueryListener):
         self._mark_as_dead()
 
     def _notify(self, query_record: QueryRecord, **kwargs: dict):
-        self._queries.append(query_record)
+        if not is_suppress_sql_counter_listener():
+            self._queries.append(query_record)
 
     def expects(self, **kwargs):
         """
@@ -641,3 +640,18 @@ def is_sql_counter_called():
     if SQL_COUNTER_CALLED in threading.current_thread().__dict__:
         return threading.current_thread().__dict__.get(SQL_COUNTER_CALLED)
     return False
+
+
+def enable_sql_counting():
+    sql_counter_state.suppress_sql_counter_listener = False
+
+
+def suppress_sql_counting():
+    sql_counter_state.suppress_sql_counter_listener = True
+
+
+def is_suppress_sql_counter_listener():
+    return (
+        hasattr(sql_counter_state, "suppress_sql_counter_listener")
+        and sql_counter_state.suppress_sql_counter_listener
+    )


### PR DESCRIPTION
Add Udtf registration that reuses the client registered UDTF.  Doesn't need all the previous parameters as they were only required for original creation of udtf.

Fix Full AST Validation to use same session for replay execution of unparser AST, thereby allowing reuse of client defined UDTFs.
