### PR TITLE
[SNOW-1798141] Improve align operation for align are performed on row position column by avoid unnecessary filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@
 
 - Improve np.where with scalar x value by eliminating unnecessary join and temp table creation.
 - Improve get_dummies performance by flattening the pivot with join.
-- Improve align performance when align on row position column by removing unnecessary window functions.
+- Improve align performance when aligning on row position column by removing unnecessary window functions.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@
 
 - Improve np.where with scalar x value by eliminating unnecessary join and temp table creation.
 - Improve get_dummies performance by flattening the pivot with join.
+- Improve align performance when align on row position column by removing unnecessary window functions.
 
 
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1723,7 +1723,7 @@ class OrderedDataFrame:
         elif join_filter is not None:
             joined_ordered_frame = joined_ordered_frame.filter(join_filter)
 
-        joined_ordered_frame.sort(ordering_columns)
+        joined_ordered_frame = joined_ordered_frame.sort(ordering_columns)
 
         # call select to make sure only the result_projected_column_snowflake_quoted_identifiers are projected
         # in the join result

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1531,6 +1531,7 @@ class OrderedDataFrame:
         right_count = coalesce(max_(right_row_pos).over() + 1, lit(0))
         eq_row_pos_count = sum_(iff(left_row_pos == right_row_pos, 1, 0)).over()
 
+        # align_on_row_position_column = False
         ordering_columns = joined_ordered_frame.ordering_columns
         if align_on_row_position_column:
             align_filter = None

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1560,10 +1560,10 @@ class OrderedDataFrame:
             extra_columns_to_append.append(col_matching_expr)
 
             # Define the final ordering column.
-            # As we mentioned in docstring, when left_on_cols and right_on_cols matches, the left
-            # and right frame is merged row by row with the original order, and the row order of
+            # As we mentioned in docstring, when left_on_cols and right_on_cols match, the left
+            # and right frames are merged row by row with the original order, and the row order of
             # original frame is retained.
-            # However, when left_on_cols and right_on_cols doesn't match, we need to sort lexicographically
+            # However, when left_on_cols and right_on_cols don't match, we need to sort lexicographically
             # on the join keys for `outer` align, and preserve left order followed by right order for `left` align.
             # This means the ordering column changes based on the result of column matching situation. Due
             # to lazy evaluation, we do not know the column matching situation util the query is evaluated.
@@ -1571,7 +1571,7 @@ class OrderedDataFrame:
             # input frames have matching left_on_cols and right_on_cols, otherwise this will be set to constant
             # 1 (a dummy ordering column has no effect).
             # Note that this is only needed by `outer` methods because it needs to sort on join keys. For `left`,
-            # preserve the left order followed by right order can give the correct order for both matching case
+            # preserving the left order followed by right order can give the correct order for both matching case
             # and non-matching case.
             if how == "outer":
                 global_order_col_identifier = (

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1578,12 +1578,13 @@ class OrderedDataFrame:
                     OrderingColumn(global_order_col_identifier)
                 ] + ordering_columns
 
-            joined_ordered_frame = joined_ordered_frame.select(
-                joined_ordered_frame.projected_column_snowflake_quoted_identifiers
-                + extra_columns_to_append
-            )
             align_filter = not_(col_matching_column) | (left_row_pos == right_row_pos)
             # filter_expression = not_(col_matching_column) | (left_row_pos == right_row_pos)
+
+        joined_ordered_frame = joined_ordered_frame.select(
+            joined_ordered_frame.projected_column_snowflake_quoted_identifiers
+            + extra_columns_to_append
+        )
         # If left_on_cols matches with right_on_cols, include only the rows when left row
         # position is same as right row position.
         # If left_on_cols does not match right_on_cols, all values in 'col_matching' column will

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1443,13 +1443,10 @@ class OrderedDataFrame:
         left = self.ensure_row_position_column()
         right = right.ensure_row_position_column()
 
-        direct_join_map = False
-        if (
-            left_on_cols == [left.row_position_snowflake_quoted_identifier]
-            and right_on_cols == [right.row_position_snowflake_quoted_identifier]
-            and how != "coalesce"
-        ):
-            direct_join_map = True
+        align_on_row_position_column = left_on_cols == [
+            left.row_position_snowflake_quoted_identifier
+        ] and right_on_cols == [right.row_position_snowflake_quoted_identifier]
+        direct_join_map = align_on_row_position_column and how != "coalesce"
 
         # perform outer join
         joined_ordered_frame = left.join(
@@ -1535,55 +1532,58 @@ class OrderedDataFrame:
         eq_row_pos_count = sum_(iff(left_row_pos == right_row_pos, 1, 0)).over()
 
         ordering_columns = joined_ordered_frame.ordering_columns
-        # 'col_matching_expr' represents if left_on_cols is an exact match with right_on_cols.
-        # Add this as new column to frame. Note that ALL values for this column are same.
-        # It will be TRUE if left_on_cols matches with right_on_cols otherwise it will be FALSE.
-        col_matching_identifier = (
-            joined_ordered_frame.generate_snowflake_quoted_identifiers(
-                pandas_labels=["col_matching"]
-            )[0]
-        )
-        col_matching_expr = (
-            (left_count == right_count) & (left_count == eq_row_pos_count)
-        ).as_(col_matching_identifier)
-        col_matching_column = Column(col_matching_identifier)
-        extra_columns_to_append.append(col_matching_expr)
-
-        # Define the final ordering column.
-        # As we mentioned in docstring, when left_on_cols and right_on_cols matches, the left
-        # and right frame is merged row by row with the original order, and the row order of
-        # original frame is retained.
-        # However, when left_on_cols and right_on_cols doesn't match, we need to sort lexicographically
-        # on the join keys for `outer` align, and preserve left order followed by right order for `left` align.
-        # This means the ordering column changes based on the result of column matching situation. Due
-        # to lazy evaluation, we do not know the column matching situation util the query is evaluated.
-        # In order to achieve this, we add a column 'ordering_col' which is set to left row position if
-        # input frames have matching left_on_cols and right_on_cols, otherwise this will be set to constant
-        # 1 (a dummy ordering column has no effect).
-        # Note that this is only needed by `outer` methods because it needs to sort on join keys. For `left`,
-        # preserve the left order followed by right order can give the correct order for both matching case
-        # and non-matching case.
-        if how == "outer":
-            global_order_col_identifier = (
+        if align_on_row_position_column:
+            align_filter = None
+        else:
+            # 'col_matching_expr' represents if left_on_cols is an exact match with right_on_cols.
+            # Add this as new column to frame. Note that ALL values for this column are same.
+            # It will be TRUE if left_on_cols matches with right_on_cols otherwise it will be FALSE.
+            col_matching_identifier = (
                 joined_ordered_frame.generate_snowflake_quoted_identifiers(
-                    pandas_labels=[ORDERING_COLUMN_LABEL],
-                    excluded=[col_matching_identifier],
+                    pandas_labels=["col_matching"]
                 )[0]
             )
-            global_order_expr = iff(col_matching_column, left_row_pos, lit(1)).as_(
-                global_order_col_identifier
+            col_matching_expr = (
+                (left_count == right_count) & (left_count == eq_row_pos_count)
+            ).as_(col_matching_identifier)
+            col_matching_column = Column(col_matching_identifier)
+            extra_columns_to_append.append(col_matching_expr)
+
+            # Define the final ordering column.
+            # As we mentioned in docstring, when left_on_cols and right_on_cols matches, the left
+            # and right frame is merged row by row with the original order, and the row order of
+            # original frame is retained.
+            # However, when left_on_cols and right_on_cols doesn't match, we need to sort lexicographically
+            # on the join keys for `outer` align, and preserve left order followed by right order for `left` align.
+            # This means the ordering column changes based on the result of column matching situation. Due
+            # to lazy evaluation, we do not know the column matching situation util the query is evaluated.
+            # In order to achieve this, we add a column 'ordering_col' which is set to left row position if
+            # input frames have matching left_on_cols and right_on_cols, otherwise this will be set to constant
+            # 1 (a dummy ordering column has no effect).
+            # Note that this is only needed by `outer` methods because it needs to sort on join keys. For `left`,
+            # preserve the left order followed by right order can give the correct order for both matching case
+            # and non-matching case.
+            if how == "outer":
+                global_order_col_identifier = (
+                    joined_ordered_frame.generate_snowflake_quoted_identifiers(
+                        pandas_labels=[ORDERING_COLUMN_LABEL],
+                        excluded=[col_matching_identifier],
+                    )[0]
+                )
+                global_order_expr = iff(col_matching_column, left_row_pos, lit(1)).as_(
+                    global_order_col_identifier
+                )
+                extra_columns_to_append = extra_columns_to_append + [global_order_expr]
+                ordering_columns = [
+                    OrderingColumn(global_order_col_identifier)
+                ] + ordering_columns
+
+            joined_ordered_frame = joined_ordered_frame.select(
+                joined_ordered_frame.projected_column_snowflake_quoted_identifiers
+                + extra_columns_to_append
             )
-            extra_columns_to_append = extra_columns_to_append + [global_order_expr]
-            ordering_columns = [
-                OrderingColumn(global_order_col_identifier)
-            ] + ordering_columns
-
-        joined_ordered_frame = joined_ordered_frame.select(
-            joined_ordered_frame.projected_column_snowflake_quoted_identifiers
-            + extra_columns_to_append
-        )
-
-        filter_expression = not_(col_matching_column) | (left_row_pos == right_row_pos)
+            align_filter = not_(col_matching_column) | (left_row_pos == right_row_pos)
+            # filter_expression = not_(col_matching_column) | (left_row_pos == right_row_pos)
         # If left_on_cols matches with right_on_cols, include only the rows when left row
         # position is same as right row position.
         # If left_on_cols does not match right_on_cols, all values in 'col_matching' column will
@@ -1649,16 +1649,22 @@ class OrderedDataFrame:
         # NULL 3  NULL          1             NULL  e    False       0                 False         True     1          0
         # NULL 4  NULL          2             NULL  f    False       0                 False         True     1          0
 
+        join_filter = None
         if how == "coalesce":
             # For left align if left frame row count is 0 we convert this to right join
             # behavior by filtering out rows where right_row_pos is null. Otherwise,
             # we provide left join behavior by filtering out rows where left_row_pos is
             # null.
-            filter_expression = filter_expression & iff(
+            join_filter = iff(
                 left_count_column == 0,
                 right_row_pos.is_not_null(),  # right join
                 left_row_pos.is_not_null(),  # left join
             )
+            # filter_expression = filter_expression & iff(
+            #    left_count_column == 0,
+            #    right_row_pos.is_not_null(),  # right join
+            #    left_row_pos.is_not_null(),  # left join
+            # )
             from snowflake.snowpark.modin.plugin._internal.utils import (
                 unquote_name_if_quoted,
             )
@@ -1690,14 +1696,16 @@ class OrderedDataFrame:
                 else:
                     select_list.append(identifier)
         elif how == "left":
-            filter_expression = filter_expression & left_row_pos.is_not_null()
+            join_filter = left_row_pos.is_not_null()
+            # filter_expression = filter_expression & left_row_pos.is_not_null()
             select_list = result_projected_column_snowflake_quoted_identifiers
         elif how == "inner":
-            filter_expression = (
-                filter_expression
-                & left_row_pos.is_not_null()
-                & right_row_pos.is_not_null()
-            )
+            join_filter = left_row_pos.is_not_null() & right_row_pos.is_not_null()
+            # filter_expression = (
+            #    filter_expression
+            #    & left_row_pos.is_not_null()
+            #    & right_row_pos.is_not_null()
+            # )
             select_list = result_projected_column_snowflake_quoted_identifiers
         elif how == "outer":
             select_list = result_projected_column_snowflake_quoted_identifiers
@@ -1705,9 +1713,19 @@ class OrderedDataFrame:
             raise ValueError(
                 f"how={how} is not valid argument for ordered_dataframe.align."
             )
-        joined_ordered_frame = joined_ordered_frame.filter(filter_expression).sort(
-            ordering_columns
-        )
+        if (align_filter is not None) and (join_filter is not None):
+            joined_ordered_frame = joined_ordered_frame.filter(
+                align_filter & join_filter
+            )
+        elif align_filter is not None:
+            joined_ordered_frame = joined_ordered_frame.filter(align_filter)
+        elif join_filter is not None:
+            joined_ordered_frame = joined_ordered_frame.filter(join_filter)
+
+        # joined_ordered_frame = joined_ordered_frame.filter(filter_expression).sort(
+        #    ordering_columns
+        # )
+        joined_ordered_frame.sort(ordering_columns)
 
         # call select to make sure only the result_projected_column_snowflake_quoted_identifiers are projected
         # in the join result

--- a/tests/integ/modin/binary/test_binary_op.py
+++ b/tests/integ/modin/binary/test_binary_op.py
@@ -461,7 +461,9 @@ def test_binary_logic_operations_between_df_and_list_like(op, rhs):
     ],
 )
 @pytest.mark.parametrize("rhs", list_like_rhs_params([0, 2, -11, -12, -99]))
-@sql_count_checker(query_count=1, join_count=1, window_count=1)     # before optimization, the window count is 5
+@sql_count_checker(
+    query_count=1, join_count=1, window_count=1
+)  # before optimization, the window count is 5
 def test_binary_comparison_between_series_and_list_like(op, rhs):
     lhs = [1, 2, -10, 3.14, -99]
     eval_snowpark_pandas_result(

--- a/tests/integ/modin/binary/test_binary_op.py
+++ b/tests/integ/modin/binary/test_binary_op.py
@@ -461,7 +461,7 @@ def test_binary_logic_operations_between_df_and_list_like(op, rhs):
     ],
 )
 @pytest.mark.parametrize("rhs", list_like_rhs_params([0, 2, -11, -12, -99]))
-@sql_count_checker(query_count=1, join_count=1)
+@sql_count_checker(query_count=1, join_count=1, window_count=1)     # before optimization, the window count is 5
 def test_binary_comparison_between_series_and_list_like(op, rhs):
     lhs = [1, 2, -10, 3.14, -99]
     eval_snowpark_pandas_result(
@@ -481,7 +481,7 @@ def test_binary_comparison_between_series_and_list_like(op, rhs):
     ],
 )
 @pytest.mark.parametrize("rhs", list_like_rhs_params([1, 2, 3]))
-@sql_count_checker(query_count=1, join_count=1)
+@sql_count_checker(query_count=1, join_count=1, window_count=1)
 def test_binary_comparison_between_df_and_list_like_on_axis_0(op, rhs):
     lhs = [[1, 2], [2, 3], [1, 3]]
     eval_snowpark_pandas_result(
@@ -501,7 +501,7 @@ def test_binary_comparison_between_df_and_list_like_on_axis_0(op, rhs):
     ],
 )
 @pytest.mark.parametrize("rhs", list_like_rhs_params([1, 2, 3]))
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=1, join_count=0, window_count=0)
 def test_binary_comparison_between_df_and_list_like_on_axis_1(op, rhs):
     lhs = [[1, 2, 2], [3, 1, 3]]
     eval_snowpark_pandas_result(

--- a/tests/integ/modin/frame/test_align.py
+++ b/tests/integ/modin/frame/test_align.py
@@ -17,7 +17,8 @@ from tests.integ.modin.utils import (
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
-# @sql_count_checker(query_count=2, join_count=2, window_count=10)
+
+
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
 @pytest.mark.parametrize(
     "axis, join_count, window_count",

--- a/tests/integ/modin/frame/test_align.py
+++ b/tests/integ/modin/frame/test_align.py
@@ -17,6 +17,23 @@ from tests.integ.modin.utils import (
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
+def eval_dataframe_align_result(
+    native_df: native_pd.DataFrame,
+    native_other_df: native_pd.DataFrame,
+    check_dtype: bool,
+    **kwargs,
+) -> None:
+    snow_df = pd.DataFrame(native_df)
+    snow_other_df = pd.DataFrame(native_other_df)
+
+    native_left, native_right = native_df.align(native_other_df, **kwargs)
+    left, right = snow_df.align(snow_other_df, **kwargs)
+    if check_dtype:
+        assert_frame_equal(left, native_left)
+        assert_frame_equal(right, native_right)
+    else:
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(left, native_left)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -33,19 +50,9 @@ def test_align_basic(join, axis, join_count, window_count):
             [[10, 20, 30, 40], [60, 70, 80, 90], [600, 700, 800, 900]],
             columns=["A", "B", "C", "D"],
         )
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=True, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_frame_equal(left, native_left)
-        assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -74,19 +81,9 @@ def test_align_duplicate_idx(join, axis, join_count):
             columns=["A", "B", "B", "C", "D"],
             index=["one", "two", "two"],
         )
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=True, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_frame_equal(left, native_left)
-        assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -104,19 +101,9 @@ def test_align_basic_reorder(join, axis, join_count):
             columns=["A", "B", "C", "D"],
             index=["A", "B", "C"],
         )
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=True, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_frame_equal(left, native_left)
-        assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -134,19 +121,9 @@ def test_align_basic_diff_index(join, axis, join_count):
             columns=["A", "B", "C", "D"],
             index=["one", "two", "three"],
         )
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=False, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(left, native_left)
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -163,19 +140,9 @@ def test_align_basic_with_nulls(join, axis, join_count):
             [[10, 20, 30, np.nan], [60, np.nan, 80, 90], [600, 700, 800, 900]],
             columns=["A", "B", "C", "D"],
         )
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=True, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_frame_equal(left, native_left)
-        assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -196,19 +163,9 @@ def test_align_basic_with_all_null_row(join, axis, join_count):
             ],
             columns=["A", "B", "C", "D"],
         )
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=True, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_frame_equal(left, native_left)
-        assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -256,9 +213,6 @@ def test_align_basic_with_zero_cols(join, axis, join_count):
             native_other_df,
             join=join,
             axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
         )
         df = pd.DataFrame(native_df)
         other_df = pd.DataFrame(native_other_df)
@@ -281,19 +235,9 @@ def test_align_basic_with_zero_rows(join, axis, join_count):
         )
         native_other_df = native_pd.DataFrame(columns=["A", "B", "C"])
 
-        native_left, native_right = native_df.align(
-            native_other_df,
-            join=join,
-            axis=axis,
-            limit=None,
-            fill_axis=0,
-            broadcast_axis=None,
+        eval_dataframe_align_result(
+            native_df, native_other_df, check_dtype=True, join=join, axis=axis
         )
-        df = pd.DataFrame(native_df)
-        other_df = pd.DataFrame(native_other_df)
-        left, right = df.align(other_df, join=join, axis=axis)
-        assert_frame_equal(left, native_left)
-        assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -367,19 +311,9 @@ def test_align_frame_with_series(join):
         [[10, 20, 30, 40], [60, 70, 80, 90], [600, 700, 800, 900]],
         columns=["A", "B", "C", "D"],
     )
-    native_left, native_right = native_df.align(
-        native_other_df,
-        join=join,
-        axis=0,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
+    eval_dataframe_align_result(
+        native_df, native_other_df, check_dtype=True, join=join, axis=0
     )
-    df = pd.DataFrame(native_df)
-    other_df = pd.DataFrame(native_other_df)
-    left, right = df.align(other_df, join=join, axis=0)
-    assert_frame_equal(left, native_left)
-    assert_frame_equal(right, native_right)
 
 
 @pytest.mark.parametrize("join", ["outer", "inner", "left", "right"])
@@ -419,19 +353,9 @@ def test_align_basic_reorder_axis0(join):
         columns=["A", "B", "C", "D"],
         index=["A", "B", "C"],
     )
-    native_left, native_right = native_df.align(
-        native_other_df,
-        join=join,
-        axis=0,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
+    eval_dataframe_align_result(
+        native_df, native_other_df, check_dtype=True, join=join, axis=0
     )
-    df = pd.DataFrame(native_df)
-    other_df = pd.DataFrame(native_other_df)
-    left, right = df.align(other_df, join=join, axis=0)
-    assert_frame_equal(left, native_left)
-    assert_frame_equal(right, native_right)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -445,19 +369,9 @@ def test_align_basic_diff_index_axis0(join):
         columns=["A", "B", "C", "D"],
         index=["one", "two", "three"],
     )
-    native_left, native_right = native_df.align(
-        native_other_df,
-        join=join,
-        axis=0,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
+    eval_dataframe_align_result(
+        native_df, native_other_df, check_dtype=False, join=join, axis=0
     )
-    df = pd.DataFrame(native_df)
-    other_df = pd.DataFrame(native_other_df)
-    left, right = df.align(other_df, join=join, axis=0)
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(left, native_left)
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(right, native_right)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -493,12 +407,12 @@ def test_align_frame_with_series_axis_negative(join):
         ValueError,
         match="Must specify axis=0 or 1",
     ):
-        left, right = df.align(other_ser, join=join, axis=None)
+        df.align(other_ser, join=join, axis=None)
     with pytest.raises(
         NotImplementedError,
         match="The Snowpark pandas DataFrame.align with Series other does not support axis=1.",
     ):
-        left, right = df.align(other_ser, join=join, axis=1)
+        df.align(other_ser, join=join, axis=1)
 
 
 @sql_count_checker(query_count=0)
@@ -512,7 +426,7 @@ def test_align_frame_fill_value_negative():
         NotImplementedError,
         match="Snowpark pandas 'align' method doesn't support 'fill_value'",
     ):
-        left, right = df.align(other_df, join="outer", axis=0, fill_value="empty")
+        df.align(other_df, join="outer", axis=0, fill_value="empty")
 
 
 @sql_count_checker(query_count=0)
@@ -535,7 +449,7 @@ def test_level_negative(level, axis):
         NotImplementedError,
         match="Snowpark pandas 'align' method doesn't support 'level'",
     ):
-        left, right = df.align(other_df, join="outer", axis=axis, level=0)
+        df.align(other_df, join="outer", axis=axis, level=0)
 
 
 @sql_count_checker(query_count=0)
@@ -557,7 +471,7 @@ def test_multiindex_negative(axis):
         NotImplementedError,
         match="Snowpark pandas doesn't support `align` with MultiIndex",
     ):
-        left, right = df.align(other_df, join="outer", axis=axis)
+        df.align(other_df, join="outer", axis=axis)
 
 
 @sql_count_checker(query_count=0)
@@ -571,7 +485,7 @@ def test_align_frame_copy_negative():
         NotImplementedError,
         match="Snowpark pandas 'align' method doesn't support 'copy=False'",
     ):
-        left, right = df.align(other_df, join="outer", axis=0, copy=False)
+        df.align(other_df, join="outer", axis=0, copy=False)
 
 
 @sql_count_checker(query_count=0)
@@ -586,7 +500,7 @@ def test_align_frame_invalid_axis_negative():
         ValueError,
         match=f"No axis named {axis} for object type DataFrame",
     ):
-        left, right = df.align(other_df, join="outer", axis=axis)
+        df.align(other_df, join="outer", axis=axis)
 
 
 @sql_count_checker(query_count=0)
@@ -601,19 +515,19 @@ def test_align_frame_deprecated_negative():
             NotImplementedError,
             match="The 'method', 'limit', and 'fill_axis' keywords in DataFrame.align are deprecated and will be removed in a future version. Call fillna directly on the returned objects instead.",
         ):
-            left, right = df.align(other_df, join="outer", method=method)
+            df.align(other_df, join="outer", method=method)
     with pytest.raises(
         NotImplementedError,
         match="The 'method', 'limit', and 'fill_axis' keywords in DataFrame.align are deprecated and will be removed in a future version. Call fillna directly on the returned objects instead.",
     ):
-        left, right = df.align(other_df, join="outer", limit=5)
+        df.align(other_df, join="outer", limit=5)
     with pytest.raises(
         NotImplementedError,
         match="The 'method', 'limit', and 'fill_axis' keywords in DataFrame.align are deprecated and will be removed in a future version. Call fillna directly on the returned objects instead.",
     ):
-        left, right = df.align(other_df, join="outer", fill_axis=1)
+        df.align(other_df, join="outer", fill_axis=1)
     with pytest.raises(
         NotImplementedError,
         match="The 'broadcast_axis' keyword in DataFrame.align is deprecated and will be removed in a future version.",
     ):
-        left, right = df.align(other_df, join="outer", broadcast_axis=0)
+        df.align(other_df, join="outer", broadcast_axis=0)

--- a/tests/integ/modin/series/test_align.py
+++ b/tests/integ/modin/series/test_align.py
@@ -12,9 +12,22 @@ import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import (
     assert_series_equal,
     assert_snowpark_pandas_equal_to_pandas,
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
 )
 from tests.integ.utils.sql_counter import sql_count_checker
+
+
+def eval_series_align_result(
+    native_ser: native_pd.Series,
+    native_other_ser: native_pd.Series,
+    **kwargs,
+) -> None:
+    snow_ser = pd.Series(native_ser)
+    snow_other_ser = pd.Series(native_other_ser)
+
+    native_left, native_right = native_ser.align(native_other_ser, **kwargs)
+    left, right = snow_ser.align(snow_other_ser, **kwargs)
+    assert_series_equal(left, native_left)
+    assert_series_equal(right, native_right)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -23,19 +36,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 def test_align_basic_series(join, axis):
     native_ser = native_pd.Series([1, 2, 3])
     native_other_ser = native_pd.Series([60, 70, 80, 90, 100, np.nan])
-    native_left, native_right = native_ser.align(
-        native_other_ser,
-        join=join,
-        axis=axis,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
-    )
-    ser = pd.Series(native_ser)
-    other_ser = pd.Series(native_other_ser)
-    left, right = ser.align(other_ser, join=join, axis=axis)
-    assert_series_equal(left, native_left)
-    assert_series_equal(right, native_right)
+    eval_series_align_result(native_ser, native_other_ser, join=join, axis=axis)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -44,19 +45,7 @@ def test_align_basic_series(join, axis):
 def test_align_series_with_nulls(join, axis):
     native_ser = native_pd.Series([np.nan, np.nan, np.nan])
     native_other_ser = native_pd.Series([60, 70, 80, 90, 100, np.nan])
-    native_left, native_right = native_ser.align(
-        native_other_ser,
-        join=join,
-        axis=axis,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
-    )
-    ser = pd.Series(native_ser)
-    other_ser = pd.Series(native_other_ser)
-    left, right = ser.align(other_ser, join=join, axis=axis)
-    assert_series_equal(left, native_left)
-    assert_series_equal(right, native_right)
+    eval_series_align_result(native_ser, native_other_ser, join=join, axis=axis)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -65,19 +54,7 @@ def test_align_series_with_nulls(join, axis):
 def test_align_empty_series(join, axis):
     native_ser = native_pd.Series()
     native_other_ser = native_pd.Series([60, 70, 80, 90, 100, np.nan])
-    native_left, native_right = native_ser.align(
-        native_other_ser,
-        join=join,
-        axis=axis,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
-    )
-    ser = pd.Series()
-    other_ser = pd.Series(native_other_ser)
-    left, right = ser.align(other_ser, join=join, axis=axis)
-    assert_series_equal(left, native_left)
-    assert_series_equal(right, native_right)
+    eval_series_align_result(native_ser, native_other_ser, join=join, axis=axis)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -94,19 +71,7 @@ def test_align_basic_series_reorder_index(join, axis):
         ],
         index=["G", "H", "M", "A"],
     )
-    native_left, native_right = native_ser.align(
-        native_other_ser,
-        join=join,
-        axis=axis,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
-    )
-    ser = pd.Series(native_ser)
-    other_ser = pd.Series(native_other_ser)
-    left, right = ser.align(other_ser, join=join, axis=axis)
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(left, native_left)
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(right, native_right)
+    eval_series_align_result(native_ser, native_other_ser, join=join, axis=axis)
 
 
 @sql_count_checker(query_count=2, join_count=2)
@@ -116,14 +81,7 @@ def test_align_series_with_frame(join):
     native_df = native_pd.DataFrame(
         [[1, 2, np.nan, 4], [6, 7, 8, 9]], columns=["D", "B", "E", "A"]
     )
-    native_left, native_right = native_ser.align(
-        native_df,
-        join=join,
-        axis=0,
-        limit=None,
-        fill_axis=0,
-        broadcast_axis=None,
-    )
+    native_left, native_right = native_ser.align(native_df, join=join, axis=0)
     ser = pd.Series(native_ser)
     other_df = pd.DataFrame(native_df)
     left, right = ser.align(other_df, join=join, axis=0)
@@ -142,14 +100,14 @@ def test_align_series_with_frame_axis_negative(join):
         ValueError,
         match="No axis named 1 for object type Series",
     ):
-        left, right = ser.align(
+        ser.align(
             other_df, join=join, axis=1, limit=None, fill_axis=0, broadcast_axis=None
         )
     with pytest.raises(
         NotImplementedError,
         match="The Snowpark pandas Series.align with DataFrame other does not support axis=None.",
     ):
-        left, right = ser.align(
+        ser.align(
             other_df, join=join, axis=None, limit=None, fill_axis=0, broadcast_axis=None
         )
 
@@ -162,7 +120,7 @@ def test_align_series_fill_value_negative():
         NotImplementedError,
         match="Snowpark pandas 'align' method doesn't support 'fill_value'",
     ):
-        left, right = ser.align(other_ser, join="outer", axis=0, fill_value="empty")
+        ser.align(other_ser, join="outer", axis=0, fill_value="empty")
 
 
 @sql_count_checker(query_count=0)
@@ -173,7 +131,7 @@ def test_align_series_axis_1_negative():
         ValueError,
         match="No axis named 1 for object type Series",
     ):
-        left, right = ser.align(other_ser, join="outer", axis=1)
+        ser.align(other_ser, join="outer", axis=1)
 
 
 @sql_count_checker(query_count=0)
@@ -184,7 +142,7 @@ def test_align_series_copy_negative():
         NotImplementedError,
         match="Snowpark pandas 'align' method doesn't support 'copy=False'",
     ):
-        left, right = ser.align(other_ser, join="outer", copy=False)
+        ser.align(other_ser, join="outer", copy=False)
 
 
 @sql_count_checker(query_count=0)
@@ -196,7 +154,7 @@ def test_align_series_invalid_axis_negative():
         ValueError,
         match=f"No axis named {axis} for object type Series",
     ):
-        left, right = ser.align(other_ser, join="outer", axis=axis)
+        ser.align(other_ser, join="outer", axis=axis)
 
 
 @sql_count_checker(query_count=0)
@@ -208,19 +166,19 @@ def test_align_series_deprecated_negative():
             NotImplementedError,
             match="The 'method', 'limit', and 'fill_axis' keywords in Series.align are deprecated and will be removed in a future version. Call fillna directly on the returned objects instead.",
         ):
-            left, right = ser.align(other_ser, join="outer", method=method)
+            ser.align(other_ser, join="outer", method=method)
     with pytest.raises(
         NotImplementedError,
         match="The 'method', 'limit', and 'fill_axis' keywords in Series.align are deprecated and will be removed in a future version. Call fillna directly on the returned objects instead.",
     ):
-        left, right = ser.align(other_ser, join="outer", limit=5)
+        ser.align(other_ser, join="outer", limit=5)
     with pytest.raises(
         NotImplementedError,
         match="The 'method', 'limit', and 'fill_axis' keywords in Series.align are deprecated and will be removed in a future version. Call fillna directly on the returned objects instead.",
     ):
-        left, right = ser.align(other_ser, join="outer", fill_axis=1)
+        ser.align(other_ser, join="outer", fill_axis=1)
     with pytest.raises(
         NotImplementedError,
         match="The 'broadcast_axis' keyword in Series.align is deprecated and will be removed in a future version.",
     ):
-        left, right = ser.align(other_ser, join="outer", broadcast_axis=0)
+        ser.align(other_ser, join="outer", broadcast_axis=0)

--- a/tests/integ/modin/test_ordered_dataframe.py
+++ b/tests/integ/modin/test_ordered_dataframe.py
@@ -397,7 +397,8 @@ def test_join_with_column_conflict(session, df1, df2, how):
 
 @pytest.mark.parametrize(
     "how",
-    ["left", "outer", "inner"],
+    ["outer"],
+    # ["left", "outer", "inner"],
 )
 @sql_count_checker(query_count=1, join_count=1)
 def test_align_on_matching_columns(session, how):

--- a/tests/integ/modin/test_ordered_dataframe.py
+++ b/tests/integ/modin/test_ordered_dataframe.py
@@ -397,8 +397,7 @@ def test_join_with_column_conflict(session, df1, df2, how):
 
 @pytest.mark.parametrize(
     "how",
-    ["outer"],
-    # ["left", "outer", "inner"],
+    ["left", "outer", "inner"],
 )
 @sql_count_checker(query_count=1, join_count=1)
 def test_align_on_matching_columns(session, how):

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -227,7 +227,7 @@ def test_binary(session, type, action):
     assert len(plan_queries["post_actions"]) == 1
 
 
-@sql_count_checker(query_count=2, describe_count=1, join_count=2)
+@sql_count_checker(query_count=2, describe_count=5, join_count=2)
 def test_join_with_alias_dataframe(session):
     df1 = session.create_dataframe([[1, 6]], schema=["col1", "col2"])
     df_res = (

--- a/tests/integ/utils/sql_counter.py
+++ b/tests/integ/utils/sql_counter.py
@@ -383,7 +383,6 @@ def sql_count_checker(
     udf_count=None,
     udtf_count=None,
     union_count=None,
-    window_count=None,
     *args,
     **kwargs,
 ):
@@ -395,6 +394,10 @@ def sql_count_checker(
             filter(lambda k: k[0].endswith("_count"), all_args.locals.items())
         )
     }
+    # also look into kwargs for count information
+    for (key, value) in kwargs.items():
+        if key.endswith("_count"):
+            count_kwargs.update({key: value})
 
     def decorator(func):
         @functools.wraps(func)

--- a/tests/integ/utils/sql_counter.py
+++ b/tests/integ/utils/sql_counter.py
@@ -386,7 +386,17 @@ def sql_count_checker(
     *args,
     **kwargs,
 ):
-    """SqlCounter decorator that automatically validates the sql counts when test finishes."""
+    """
+    SqlCounter decorator that automatically validates the sql counts when test finishes.
+
+    The sql count checks are applied for all parameters in the format of *_count, for example,
+    join_count = 2 means we expect to see two joins in the sql queries.
+
+    Note that the *_count can be configured in two ways: clear declaration in the sql_count_check in
+    the signature, or passed through **kwargs. The check for count clearly declared in the signature
+    will be enforced, and 0 occurrence is expected if the value is None. Other count checks can be
+    optionally passed through the **kwargs, where the occurrence check will only be applied if specified.
+    """
     all_args = inspect.getargvalues(inspect.currentframe())
     count_kwargs = {
         key: value
@@ -394,7 +404,8 @@ def sql_count_checker(
             filter(lambda k: k[0].endswith("_count"), all_args.locals.items())
         )
     }
-    # also look into kwargs for count information
+    # also look into kwargs for count configuration. Right now, describe_count and window_count are the
+    # counts can be passed optionally
     for (key, value) in kwargs.items():
         if key.endswith("_count"):
             count_kwargs.update({key: value})

--- a/tests/integ/utils/sql_counter.py
+++ b/tests/integ/utils/sql_counter.py
@@ -34,6 +34,7 @@ INSERT = "INSERT "
 WITH = "WITH "
 CREATE_TEMP_TABLE = "CREATE  TEMPORARY  TABLE"
 UNION = " UNION "
+WINDOW = " OVER "
 
 NO_CHECK = "no_check"
 
@@ -44,6 +45,7 @@ UDF_COUNT_PARAMETER = "udf_count"
 UDTF_COUNT_PARAMETER = "udtf_count"
 SELECT_COUNT_PARAMETER = "select_count"
 UNION_COUNT_PARAMETER = "union_count"
+WINDOW_COUNT_PARAMETER = "window_count"
 DESCRIBE_COUNT_PARAMETER = "describe_count"
 EXPECT_HIGH_COUNT = "expect_high_count"
 HIGH_COUNT_REASON = "high_count_reason"
@@ -57,6 +59,7 @@ SQL_COUNT_PARAMETERS = [
     SELECT_COUNT_PARAMETER,
     UNION_COUNT_PARAMETER,
     DESCRIBE_COUNT_PARAMETER,
+    WINDOW_COUNT_PARAMETER,
 ]
 BOOL_PARAMETERS = [EXPECT_HIGH_COUNT]
 
@@ -345,6 +348,9 @@ class SqlCounter:
     def actual_union_count(self):
         return self._count_instances_by_query_substr(contains=[UNION])
 
+    def actual_window_count(self):
+        return self._count_instances_by_query_substr(contains=[WINDOW])
+
     def actual_describe_count(self):
         return len([q for q in self._queries if q.is_describe])
 
@@ -377,6 +383,7 @@ def sql_count_checker(
     udf_count=None,
     udtf_count=None,
     union_count=None,
+    window_count=None,
     *args,
     **kwargs,
 ):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1798141

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

The align operations is a very complicated operation when the alignment is not applied on the objects coming from the same dataframe, where extra steps are required to check whether columns are aligned etc. The extra checks requires generations of bunch of window function, which is inefficient.

However, when alignment is applied on the row positions columns, even if they are not coming from the same dataframe, we know they are unique, and some extra operations could be avoided.
