### PR TITLE
SNOW-1757892: Improve Dataframe.print_schema for structured types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
       - `base_location`
       - `catalog_sync`
       - `storage_serialization_policy`
+- Added support for nested data types to `DataFrame.print_schema`
 
 #### Bug Fixes
 

--- a/docs/source/snowpark/dataframe.rst
+++ b/docs/source/snowpark/dataframe.rst
@@ -63,6 +63,8 @@ DataFrame
     DataFrame.orderBy
     DataFrame.order_by
     DataFrame.pivot
+    DataFrame.print_schema
+    DataDrame.printSchema
     DataFrame.randomSplit
     DataFrame.random_split
     DataFrame.rename

--- a/docs/source/snowpark/dataframe.rst
+++ b/docs/source/snowpark/dataframe.rst
@@ -64,7 +64,7 @@ DataFrame
     DataFrame.order_by
     DataFrame.pivot
     DataFrame.print_schema
-    DataDrame.printSchema
+    DataFrame.printSchema
     DataFrame.randomSplit
     DataFrame.random_split
     DataFrame.rename


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1757892

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   This PR adds support to DataFrame.print_schema for nested data types. Before this change a nested schema would be printed like so:
```
root
 |-- "MAP": MapType(StringType(), ArrayType(StructType([StructField('FIELD1', StringType(), nullable=True), StructField('FIELD2', LongType(), nullable=True)]))) (nullable = True)
```

After the change the nested schema will instead look like this:
```
root
 |-- "MAP": MapType (nullable = True)
 |   |-- key: StringType()
 |   |-- value: ArrayType
 |   |   |-- element: StructType
 |   |   |   |-- "FIELD1": StringType() (nullable = True)
 |   |   |   |-- "FIELD2": LongType() (nullable = True)
```