### PR TITLE
SNOW-1794381: session api improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### New Features
 
+- Added support for property `version` and class method `get_active_session` for `Session` class.
 - Added support for following methods in class `DataType`, derived class of `DataType` and `StructField`:
   - `type_name`
   - `simple_string`

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -672,6 +672,18 @@ class Session:
             )
         return self._thread_store.analyzer
 
+    @classmethod
+    def get_active_session(cls) -> Optional["Session"]:
+        """Gets the last created session."""
+        try:
+            return _get_active_session()
+        except SnowparkClientException as ex:
+            if ex.error_code == "1403":
+                return None
+            raise ex
+
+    getActiveSession = get_active_session
+
     def close(self) -> None:
         """Close this session."""
         if is_in_stored_procedure():
@@ -699,6 +711,11 @@ class Session:
     @property
     def conf(self) -> RuntimeConfig:
         return self._conf
+
+    @property
+    def version(self) -> str:
+        """Get the version of the Snowpark library."""
+        return get_version()
 
     @property
     def sql_simplifier_enabled(self) -> bool:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -520,6 +520,7 @@ class Session:
 "python.connector.session.id" : {self._session_id},
 "os.name" : {get_os_name()}
 """
+        self.version = get_version()
         self._session_stage = None
 
         if isinstance(conn, MockServerConnection):
@@ -712,11 +713,6 @@ class Session:
     @property
     def conf(self) -> RuntimeConfig:
         return self._conf
-
-    @property
-    def version(self) -> str:
-        """Get the version of the Snowpark library."""
-        return get_version()
 
     @property
     def sql_simplifier_enabled(self) -> bool:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -678,6 +678,7 @@ class Session:
         try:
             return _get_active_session()
         except SnowparkClientException as ex:
+            # If there is no active session, return None
             if ex.error_code == "1403":
                 return None
             raise ex

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -137,6 +137,7 @@ def test_multiple_active_sessions(session, db_parameters):
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot create session in SP")
 def test_get_active_session(session, db_parameters):
     assert Session.get_active_session() == session
+    assert Session.getActiveSession() == session
 
     with Session.builder.configs(db_parameters).create():
         with pytest.raises(

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -5,7 +5,6 @@
 
 import os
 from functools import partial
-from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -13,7 +12,11 @@ import pytest
 import snowflake.connector
 from snowflake.connector.errors import ProgrammingError
 from snowflake.snowpark import Row, Session
-from snowflake.snowpark._internal.utils import TempObjectType, parse_table_name
+from snowflake.snowpark._internal.utils import (
+    TempObjectType,
+    get_version,
+    parse_table_name,
+)
 from snowflake.snowpark.exceptions import (
     SnowparkClientException,
     SnowparkInvalidObjectNameException,
@@ -122,9 +125,7 @@ def test_active_session(session):
 
 
 def test_session_version(session):
-    with mock.patch.object(snowflake.snowpark.session, "get_version") as mock_fn:
-        mock_fn.return_value = "0.0.1"
-        assert session.version == "0.0.1"
+    assert session.version == get_version()
 
 
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="Cannot create session in SP")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -62,6 +62,11 @@ def test_str(account, role, database, schema, warehouse):
     )
 
 
+def test_get_active_session_when_no_active_sessions():
+    assert Session.get_active_session() is None
+    assert Session.getActiveSession() is None
+
+
 def test_used_scoped_temp_object():
     fake_connection = mock.create_autospec(ServerConnection)
     fake_connection._conn = mock.Mock()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1794381

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   This PR adds the following to `Session` class
   - property `version` to get current snowpark client version.
   - class method `get_active_session` and `getActiveSession` that return the current active session or `None` is there are no active sessions.
