### PR TITLE
SNOW-None: Fix structured type test when simplfier disabled

### DIFF
--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -486,10 +486,15 @@ def test_structured_dtypes_iceberg(
         dynamic_ddl = structured_type_session._run_query(
             f"select get_ddl('table', '{dynamic_table_name}')"
         )
+        formatted_table_name = (
+            table_name
+            if structured_type_session.sql_simplifier_enabled
+            else f"({table_name})"
+        )
         assert dynamic_ddl[0][0] == (
             f"create or replace dynamic table {dynamic_table_name}(\n\tMAP,\n\tOBJ,\n\tARR\n) "
             f"target_lag = '16 hours, 40 minutes' refresh_mode = AUTO initialize = ON_CREATE "
-            f"warehouse = {warehouse}\n as  SELECT  *  FROM ( SELECT  *  FROM {table_name});"
+            f"warehouse = {warehouse}\n as  SELECT  *  FROM ( SELECT  *  FROM {formatted_table_name});"
         )
 
     finally:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->


2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

When the sql simplifier is disabled there is a set of braces in the query that don't get removed.