### PR TITLE
SNOW-1818207: pin numpy to resolve package conflict in snowflake 8.44

### DIFF
--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -567,7 +567,8 @@ def test_add_requirements_unsupported_usable_by_sproc(session, resources_path):
 def test_add_requirements_with_native_dependency_force_push(session):
     session.custom_package_usage_config = {"enabled": True, "force_push": True}
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
-        session.add_packages(["catboost==1.2"])
+        # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
+        session.add_packages(["numpy==1.26.4", "catboost==1.2"])
     udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
     @udf(name=udf_name)
@@ -729,7 +730,8 @@ def test_add_packages_unsupported_during_udf_registration(session):
     """
     session.custom_package_usage_config = {"enabled": True}
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
-        packages = ["scikit-fuzzy==0.4.2"]
+        # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
+        packages = ["numpy==1.26.4", "scikit-fuzzy==0.4.2"]
         udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
         @udf(name=udf_name, packages=packages)
@@ -758,7 +760,8 @@ def test_add_packages_unsupported_during_sproc_registration(session):
     """
     session.custom_package_usage_config = {"enabled": True}
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
-        packages = ["scikit-fuzzy==0.4.2", "snowflake-snowpark-python"]
+        # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
+        packages = ["numpy==1.26.4", "scikit-fuzzy==0.4.2", "snowflake-snowpark-python"]
         sproc_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
         @sproc(name=sproc_name, packages=packages, return_type=StringType())

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1937,7 +1937,8 @@ def test_stored_proc_register_with_module(session):
     session.custom_package_usage_config["enabled"] = True
     packages = list(session.get_packages().values())
     assert "pd" not in packages
-    packages = [pd] + packages
+    # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
+    packages = [pd] + packages + ["numpy==1.26.4"]
 
     def proc_function(session_: Session) -> str:
         return "test response"

--- a/tests/resources/test_requirements_unsupported.txt
+++ b/tests/resources/test_requirements_unsupported.txt
@@ -2,5 +2,7 @@ pyyaml==6.0
 matplotlib
 # Line below is empty on purpose
 
+# pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
+numpy==1.26.4
 scikit-fuzzy==0.4.2
 # Commented line


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

snowflake 8.44 will have numpy 2.1.3 available in the package repo.
This breaks the test because previously numpy was uploaded to a stage and imported inside sproc or udf, however, after 8.44, the custom package logic will detect numpy 2.1.3 is available and use the version 2.1.3 which conflicts the numpy requirement by stored proc (numpy < 2.0a)
