### PR TITLE
SNOW-1810534: fix boolean value parse in session.read.options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - Removed warnings that dynamic pivot features were in private preview, because
   dynamic pivot is now generally available.
+- Fixed a bug in `session.read.options` where `False` Boolean values were incorrectly parsed as `True` in the generated file format.
 
 
 #### Dependency Updates

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1190,7 +1190,7 @@ class SnowflakePlanBuilder:
             "String": str,
             "List": process_list,
             "Integer": int,
-            "Boolean": bool,
+            "Boolean": lambda x: str(x).lower() == "true",
         }
         new_options = {**file_format_options}
         # SNOW-1628625: This query and subsequent merge operations should be done lazily

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -781,7 +781,7 @@ def test_csv_external_file_format(session, resources_path, temp_schema):
         FIELD_OPTIONALLY_ENCLOSED_BY = '\"'
         ESCAPE_UNENCLOSED_FIELD = none
         SKIP_BLANK_LINES = TRUE
-        EMPTY_FIELD_AS_NULL = TRUE
+        EMPTY_FIELD_AS_NULL = FALSE
         PARSE_HEADER = True
         ENCODING = 'UTF8';
         """
@@ -796,6 +796,7 @@ def test_csv_external_file_format(session, resources_path, temp_schema):
         assert df._session._plan_builder._merge_file_format_options(
             {}, {"FORMAT_NAME": file_format}
         ) == {
+            "EMPTY_FIELD_AS_NULL": False,
             "PARSE_HEADER": True,
             "ESCAPE": r"\\",
             "ESCAPE_UNENCLOSED_FIELD": "NONE",


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

the previous implementation would convert bool("false") to True which is incorrect.
in snowflake, booleans are represented as "true" and "false" as per the doc: https://docs.snowflake.com/en/sql-reference/data-types-logical#boolean
