### PR TITLE
SNOW-1818207: skip test due to numpy conflict

### DIFF
--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -439,6 +439,9 @@ def test_add_unsupported_packages_should_fail_if_custom_packages_upload_enabled_
             session.add_packages("sktime==0.20.0")
 
 
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures. Unsupported package upload does not work well on Windows.",
@@ -501,6 +504,9 @@ def test_add_packages_should_fail_if_dependency_package_already_added(session):
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -530,6 +536,9 @@ def test_add_requirements_unsupported_usable_by_udf(session, resources_path):
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -560,6 +569,9 @@ def test_add_requirements_unsupported_usable_by_sproc(session, resources_path):
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -568,7 +580,7 @@ def test_add_requirements_with_native_dependency_force_push(session):
     session.custom_package_usage_config = {"enabled": True, "force_push": True}
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
         # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
-        session.add_packages(["numpy==1.26.4", "catboost==1.2"])
+        session.add_packages(["catboost==1.2"])
     udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
     @udf(name=udf_name)
@@ -720,6 +732,9 @@ def test_add_requirements_with_ranged_requirements_in_yaml(session, ranged_yaml_
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -731,7 +746,7 @@ def test_add_packages_unsupported_during_udf_registration(session):
     session.custom_package_usage_config = {"enabled": True}
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
         # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
-        packages = ["numpy==1.26.4", "scikit-fuzzy==0.4.2"]
+        packages = ["scikit-fuzzy==0.4.2"]
         udf_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
         @udf(name=udf_name, packages=packages)
@@ -750,6 +765,9 @@ def test_add_packages_unsupported_during_udf_registration(session):
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -761,7 +779,7 @@ def test_add_packages_unsupported_during_sproc_registration(session):
     session.custom_package_usage_config = {"enabled": True}
     with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
         # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
-        packages = ["numpy==1.26.4", "scikit-fuzzy==0.4.2", "snowflake-snowpark-python"]
+        packages = ["scikit-fuzzy==0.4.2", "snowflake-snowpark-python"]
         sproc_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
         @sproc(name=sproc_name, packages=packages, return_type=StringType())
@@ -829,6 +847,9 @@ def test_add_requirements_with_empty_stage_as_cache_path(
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -887,6 +908,9 @@ def test_add_requirements_unsupported_with_cache_path_negative(
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
@@ -929,6 +953,9 @@ def test_add_requirements_unsupported_with_cache_path_works_even_if_caching_fail
 
 
 @pytest.mark.udf
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1931,14 +1931,16 @@ def test_force_inline_code(session):
     assert any("AS $$" in query.sql_text for query in query_history.queries)
 
 
+@pytest.mark.skip(
+    reason="SNOW-1818207 conflict numpy dependency in snowpark python backend"
+)
 @pytest.mark.skipif(not is_pandas_available, reason="Requires pandas")
 def test_stored_proc_register_with_module(session):
     # use pandas module here
     session.custom_package_usage_config["enabled"] = True
     packages = list(session.get_packages().values())
     assert "pd" not in packages
-    # pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
-    packages = [pd] + packages + ["numpy==1.26.4"]
+    packages = [pd] + packages
 
     def proc_function(session_: Session) -> str:
         return "test response"

--- a/tests/resources/test_requirements_unsupported.txt
+++ b/tests/resources/test_requirements_unsupported.txt
@@ -2,7 +2,5 @@ pyyaml==6.0
 matplotlib
 # Line below is empty on purpose
 
-# pin numpy to resolve issue SNOW-1818207 caused by numpy package conflict
-numpy==1.26.4
 scikit-fuzzy==0.4.2
 # Commented line


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

The previous fix triggers another bug which causes local numpy resolve conflict:
https://github.com/snowflakedb/snowpark-python/pull/2654

this PR reverts the previous change and skips the test instead
