### PR TITLE
SNOW-1815432: Support `include_nulls` in unpivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - To `MapType`:
     - `keyType`: keys of the map
     - `valueType`: values of the map
+- Added support for `include_nulls` argument in `DataFrame.unpivot`.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -1123,6 +1123,7 @@ class Analyzer:
                     self.analyze(c, df_aliased_col_name_to_real_col_name)
                     for c in logical_plan.column_list
                 ],
+                logical_plan.include_nulls,
                 resolved_children[logical_plan.child],
                 logical_plan,
             )

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -174,6 +174,7 @@ LISTAGG = " LISTAGG "
 HEADER = " HEADER "
 COMMENT = " COMMENT "
 IGNORE_NULLS = " IGNORE NULLS "
+INCLUDE_NULLS = " INCLUDE NULLS "
 UNION = " UNION "
 UNION_ALL = " UNION ALL "
 RENAME = " RENAME "
@@ -1238,7 +1239,11 @@ def pivot_statement(
 
 
 def unpivot_statement(
-    value_column: str, name_column: str, column_list: List[str], child: str
+    value_column: str,
+    name_column: str,
+    column_list: List[str],
+    include_nulls: bool,
+    child: str,
 ) -> str:
     return (
         SELECT
@@ -1248,6 +1253,7 @@ def unpivot_statement(
         + child
         + RIGHT_PARENTHESIS
         + UNPIVOT
+        + (INCLUDE_NULLS if include_nulls else EMPTY_STRING)
         + LEFT_PARENTHESIS
         + value_column
         + FOR

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1071,11 +1071,14 @@ class SnowflakePlanBuilder:
         value_column: str,
         name_column: str,
         column_list: List[str],
+        include_nulls: bool,
         child: SnowflakePlan,
         source_plan: Optional[LogicalPlan],
     ) -> SnowflakePlan:
         return self.build(
-            lambda x: unpivot_statement(value_column, name_column, column_list, x),
+            lambda x: unpivot_statement(
+                value_column, name_column, column_list, include_nulls, x
+            ),
             child,
             source_plan,
         )

--- a/src/snowflake/snowpark/_internal/analyzer/unary_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/unary_plan_node.py
@@ -169,12 +169,14 @@ class Unpivot(UnaryNode):
         value_column: str,
         name_column: str,
         column_list: List[Expression],
+        include_nulls: bool,
         child: LogicalPlan,
     ) -> None:
         super().__init__(child)
         self.value_column = value_column
         self.name_column = name_column
         self.column_list = column_list
+        self.include_nulls = include_nulls
 
     @property
     def individual_node_complexity(self) -> Dict[PlanNodeCategory, int]:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1817,7 +1817,11 @@ class DataFrame:
 
     @df_api_usage
     def unpivot(
-        self, value_column: str, name_column: str, column_list: List[ColumnOrName]
+        self,
+        value_column: str,
+        name_column: str,
+        column_list: List[ColumnOrName],
+        include_nulls: bool = False,
     ) -> "DataFrame":
         """Rotates a table by transforming columns into rows.
         UNPIVOT is a relational operator that accepts two columns (from a table or subquery), along with a list of columns, and generates a row for each column specified in the list. In a query, it is specified in the FROM clause after the table name or subquery.
@@ -1827,6 +1831,7 @@ class DataFrame:
             value_column: The name to assign to the generated column that will be populated with the values from the columns in the column list.
             name_column: The name to assign to the generated column that will be populated with the names of the columns in the column list.
             column_list: The names of the columns in the source table or subequery that will be narrowed into a single pivot column. The column names will populate ``name_column``, and the column values will populate ``value_column``.
+            include_nulls: If True, include rows with NULL values in ``name_column``. The default value is False.
 
         Example::
 
@@ -1847,7 +1852,9 @@ class DataFrame:
             <BLANKLINE>
         """
         column_exprs = self._convert_cols_to_exprs("unpivot()", column_list)
-        unpivot_plan = Unpivot(value_column, name_column, column_exprs, self._plan)
+        unpivot_plan = Unpivot(
+            value_column, name_column, column_exprs, include_nulls, self._plan
+        )
 
         if self._select_statement:
             return self._with_plan(

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -3276,26 +3276,47 @@ def test_df_columns(session):
     "column_list",
     [["jan", "feb", "mar", "apr"], [col("jan"), col("feb"), col("mar"), col("apr")]],
 )
-def test_unpivot(session, column_list):
-    Utils.check_answer(
+@pytest.mark.parametrize("include_nulls", [True, False])
+def test_unpivot(session, column_list, include_nulls):
+    df = (
         TestData.monthly_sales_flat(session)
-        .unpivot("sales", "month", column_list)
-        .sort("empid"),
-        [
-            Row(1, "electronics", "JAN", 100),
-            Row(1, "electronics", "FEB", 200),
-            Row(1, "electronics", "MAR", 300),
-            Row(1, "electronics", "APR", 100),
-            Row(2, "clothes", "JAN", 100),
-            Row(2, "clothes", "FEB", 300),
-            Row(2, "clothes", "MAR", 150),
-            Row(2, "clothes", "APR", 200),
-            Row(3, "cars", "JAN", 200),
-            Row(3, "cars", "FEB", 400),
-            Row(3, "cars", "MAR", 100),
-            Row(3, "cars", "APR", 50),
-        ],
-        sort=False,
+        .unpivot("sales", "month", column_list, include_nulls)
+        .sort("empid")
+    )
+    expected_rows = [
+        Row(1, "electronics", "JAN", 100),
+        Row(1, "electronics", "FEB", 200),
+        Row(1, "electronics", "MAR", 300),
+        Row(1, "electronics", "APR", 100),
+        Row(2, "clothes", "JAN", 100),
+        Row(2, "clothes", "FEB", 300),
+        Row(2, "clothes", "MAR", 150),
+        Row(2, "clothes", "APR", 200),
+        Row(3, "cars", "JAN", 200),
+        Row(3, "cars", "FEB", 400),
+        Row(3, "cars", "MAR", 100),
+        Row(3, "cars", "APR", 50),
+    ]
+    if include_nulls:
+        expected_rows.extend(
+            [
+                Row(4, "appliances", "JAN", 100),
+                Row(4, "appliances", "FEB", None),
+                Row(4, "appliances", "MAR", 100),
+                Row(4, "appliances", "APR", 50),
+            ]
+        )
+    else:
+        expected_rows.extend(
+            [
+                Row(4, "appliances", "JAN", 100),
+                Row(4, "appliances", "MAR", 100),
+                Row(4, "appliances", "APR", 50),
+            ]
+        )
+    Utils.check_answer(
+        df,
+        expected_rows,
     )
 
 

--- a/tests/unit/compiler/test_large_query_breakdown.py
+++ b/tests/unit/compiler/test_large_query_breakdown.py
@@ -49,7 +49,10 @@ empty_selectable = SelectSQL("dummy_query", analyzer=mock.create_autospec(Analyz
     "node_generator,expected",
     [
         (lambda _: Pivot([], empty_expression, [], [], None, empty_logical_plan), True),
-        (lambda _: Unpivot("value_col", "name_col", [], empty_logical_plan), True),
+        (
+            lambda _: Unpivot("value_col", "name_col", [], False, empty_logical_plan),
+            True,
+        ),
         (lambda _: Sort([], empty_logical_plan), True),
         (lambda _: Aggregate([], [], empty_logical_plan), True),
         (lambda _: Sample(empty_logical_plan, None, 2, None), True),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1297,6 +1297,7 @@ class TestData:
                 (1, "electronics", 100, 200, 300, 100),
                 (2, "clothes", 100, 300, 150, 200),
                 (3, "cars", 200, 400, 100, 50),
+                (4, "appliances", 100, None, 100, 50),
             ],
             schema=["empid", "dept", "jan", "feb", "mar", "apr"],
         )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1815432

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

3. Please describe how your code solves the related issue.

   https://docs.snowflake.com/en/sql-reference/constructs/unpivot#parameters