### PR TITLE
SNOW-1032076 - Remove hacks for Unpivot Null Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 
 #### Improvements
-
+- Use UNPIVOT INCLUDE NULLS for unpivot operations in pandas instead of sentinal values
 
 
 ### Snowpark Local Testing Updates

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -906,6 +906,7 @@ class OrderedDataFrame:
                     value_column=value_column,
                     name_column=name_column,
                     column_list=unpivot_column_list,
+                    include_nulls=True,
                 ),
                 snowflake_quoted_identifiers=result_column_quoted_identifiers,
             ),

--- a/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
@@ -10,7 +10,7 @@ from typing import Optional
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
 )
-from snowflake.snowpark.column import CaseExpr, Column as SnowparkColumn
+from snowflake.snowpark.column import CaseExpr
 from snowflake.snowpark.functions import (
     cast,
     col,
@@ -31,7 +31,6 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     append_columns,
     generate_column_identifier_random,
     pandas_lit,
-    unquote_name_if_quoted,
 )
 from snowflake.snowpark.types import ArrayType, MapType, StringType, VariantType
 
@@ -760,9 +759,7 @@ def _simple_unpivot(
             )[0]
         )
         unpivot_columns_normalized_types.append(
-            to_variant(c).alias(
-                renamed_quoted_unpivot_col
-            )
+            to_variant(c).alias(renamed_quoted_unpivot_col)
         )
         renamed_quoted_unpivot_cols.append(renamed_quoted_unpivot_col)
         # create the column name mapper which is passed to unpivot

--- a/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
@@ -13,11 +13,9 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
 from snowflake.snowpark.column import CaseExpr, Column as SnowparkColumn
 from snowflake.snowpark.functions import (
     cast,
-    coalesce,
     col,
     get,
     get_path,
-    is_null,
     lit,
     object_construct,
     parse_json,
@@ -49,8 +47,6 @@ UNPIVOT_OBJ_NAME_COLUMN = "UNPIVOT_OBJ_NAME"
 
 VALUE_COLUMN_FOR_SINGLE_ROW = '\'{"0":"NULL","row":0}\''
 ROW_KEY = "row"
-# the value used to replace the NULL for unpivot columns
-UNPIVOT_NULL_REPLACE_VALUE = "NULL_REPLACE"
 UNPIVOT_ORDERING_COLUMN_PREFIX = "UNPIVOT_ORDERING_"
 UNPIVOT_SINGLE_INDEX_PREFIX = "UNPIVOT_SINGLE_INDEX"
 
@@ -368,13 +364,7 @@ def _prepare_unpivot_internal(
             json.dumps([i, pandas_label, generate_column_identifier_random()])
         )
         normalize_unpivot_select_list.append(
-            # Replace NULLs in the column with value UNPIVOT_NULL_REPLACE_VALUE. The column is cast to
-            # variant column first, so that we can replace NULLs with a value without considering the column
-            # data type.
-            coalesce(
-                to_variant(snowflake_quoted_identifier),
-                to_variant(pandas_lit(UNPIVOT_NULL_REPLACE_VALUE)),
-            ).as_(serialized_name)
+            to_variant(snowflake_quoted_identifier).as_(serialized_name)
         )
         unpivot_columns.append(serialized_name)
 
@@ -387,8 +377,8 @@ def _prepare_unpivot_internal(
     #                              UNPIVOT_IDX [0, "abc", "sxi8"]     [1, "123", "uhkz"]   abc  123 state
     # 0   {"0":"one","1":"there","row":-1}                "A"  1.000000000000000e+00     A  1.0    CA
     # 1    {"0":"one","1":"there","row":0}                "A"  1.000000000000000e+00     A  1.0    CA
-    # 2       {"0":"two","1":"be","row":1}                "B"         "NULL_REPLACE"     B  NaN    WA
-    # 3  {"0":"two","1":"dragons","row":2}     "NULL_REPLACE"  3.000000000000000e+00  None  3.0    NY
+    # 2       {"0":"two","1":"be","row":1}                "B"                   None     B  NaN    WA
+    # 3  {"0":"two","1":"dragons","row":2}               None  3.000000000000000e+00  None  3.0    NY
 
     # STEP 2) Perform an unpivot which flattens the original data columns into a single name and value rows
     # grouped by the temporary transpose index column.  In the earlier example, this would flatten the non-index
@@ -419,37 +409,14 @@ def _prepare_unpivot_internal(
     # 2    {"0":"one","1":"there","row":0}     A  1.0    CA  [0, "abc", "sxi8"]                    "A"
     # 3    {"0":"one","1":"there","row":0}     A  1.0    CA  [1, "123", "uhkz"]  1.000000000000000e+00
     # 4       {"0":"two","1":"be","row":1}     B  NaN    WA  [0, "abc", "sxi8"]                    "B"
-    # 5       {"0":"two","1":"be","row":1}     B  NaN    WA  [1, "123", "uhkz"]         "NULL_REPLACE"
-    # 6  {"0":"two","1":"dragons","row":2}  None  3.0    NY  [0, "abc", "sxi8"]         "NULL_REPLACE"
+    # 5       {"0":"two","1":"be","row":1}     B  NaN    WA  [1, "123", "uhkz"]                   None
+    # 6  {"0":"two","1":"dragons","row":2}  None  3.0    NY  [0, "abc", "sxi8"]                   None
     # 7  {"0":"two","1":"dragons","row":2}  None  3.0    NY  [1, "123", "uhkz"]  3.000000000000000e+00
     assert (
         len(original_frame.data_column_snowflake_quoted_identifiers) > 0
     ), "no data column to unpivot"
 
-    # Replace the null value back by checking if the value in the origin data column is null and also the
-    # unpivot name column value is original data column name.
-    case_conditions: list[SnowparkColumn] = []
-    for origin_data_column, serialized_name in zip(
-        original_frame.data_column_snowflake_quoted_identifiers, unpivot_columns
-    ):
-        unquoted_serialized_name = unquote_name_if_quoted(serialized_name)
-        case_conditions.append(
-            (
-                col(unpivot_value_quoted_snowflake_identifier)
-                == pandas_lit(UNPIVOT_NULL_REPLACE_VALUE)
-            )
-            & is_null(origin_data_column)
-            & (
-                col(unpivot_name_quoted_snowflake_identifier)
-                == pandas_lit(unquoted_serialized_name)
-            )
-        )
-    case_expr: CaseExpr = when(case_conditions[0], pandas_lit(None))
-    for case_condition in case_conditions[1:]:
-        case_expr = case_expr.when(case_condition, pandas_lit(None))
-
-    # add otherwise clause
-    case_column = case_expr.otherwise(col(unpivot_value_quoted_snowflake_identifier))
+    case_column = col(unpivot_value_quoted_snowflake_identifier)
     unpivot_value_column = (
         value_column_name
         if not is_single_row
@@ -674,9 +641,9 @@ def clean_up_unpivot(
     #       L1         L2 col_ordermg7c row_orderiq3v independent              dependent                        UNPIVOT_IDX   abc  123 state    UNPIVOT_VARIABLE          UNPIVOT_VALUE  __row_position__
     # 0  "one"    "there"             0             0       "abc"                    "A"    {"0":"one","1":"there","row":0}     A  1.0    CA  [0, "abc", "z851"]                    "A"                 0
     # 1  "two"       "be"             0             1       "abc"                    "B"       {"0":"two","1":"be","row":1}     B  NaN    WA  [0, "abc", "z851"]                    "B"                 1
-    # 2  "two"  "dragons"             0             2       "abc"                   None  {"0":"two","1":"dragons","row":2}  None  3.0    NY  [0, "abc", "z851"]         "NULL_REPLACE"                 2
+    # 2  "two"  "dragons"             0             2       "abc"                   None  {"0":"two","1":"dragons","row":2}  None  3.0    NY  [0, "abc", "z851"]                   None                 2
     # 3  "one"    "there"             1             0       "123"  1.000000000000000e+00    {"0":"one","1":"there","row":0}     A  1.0    CA  [1, "123", "kuxa"]  1.000000000000000e+00                 3
-    # 4  "two"       "be"             1             1       "123"                   None       {"0":"two","1":"be","row":1}     B  NaN    WA  [1, "123", "kuxa"]         "NULL_REPLACE"                 4
+    # 4  "two"       "be"             1             1       "123"                   None       {"0":"two","1":"be","row":1}     B  NaN    WA  [1, "123", "kuxa"]                   None                 4
     # 5  "two"  "dragons"             1             2       "123"  3.000000000000000e+00  {"0":"two","1":"dragons","row":2}  None  3.0    NY  [1, "123", "kuxa"]  3.000000000000000e+00                 5
     return new_internal_frame
 
@@ -783,7 +750,6 @@ def _simple_unpivot(
 
     suffix_to_unpivot_map: dict[str, str] = {}
     cast_suffix = generate_column_identifier_random()
-    null_replace_value = UNPIVOT_NULL_REPLACE_VALUE + "_" + cast_suffix
 
     for c in unpivot_quoted_columns:
         # Rename the columns to unpivot
@@ -793,10 +759,8 @@ def _simple_unpivot(
                 pandas_labels=[unquoted_col_name],
             )[0]
         )
-        # coalesce the values to unpivot and preserve null values This code
-        # can be removed when UNPIVOT_INCLUDE_NULLS is enabled
         unpivot_columns_normalized_types.append(
-            coalesce(to_variant(c), to_variant(pandas_lit(null_replace_value))).alias(
+            to_variant(c).alias(
                 renamed_quoted_unpivot_col
             )
         )
@@ -813,8 +777,8 @@ def _simple_unpivot(
     ##################################################
     #               abc_tavu             123_tavu
     # 0                  "A"                  "1"
-    # 1  "NULL_REPLACE_tavu"                  "2"
-    # 2                  "C"  "NULL_REPLACE_tavu"
+    # 1                 None                  "2"
+    # 2                  "C"                 None
 
     # Perform the unpivot
     ordered_dataframe = ordered_dataframe.unpivot(
@@ -830,24 +794,18 @@ def _simple_unpivot(
     #      variable                value
     # 0      123                  "1"
     # 1      123                  "2"
-    # 2      123  "NULL_REPLACE_tavu"
+    # 2      123                 None
     # 3      abc                  "A"
     # 4      abc                  "C"
-    # 5      abc  "NULL_REPLACE_tavu"
+    # 5      abc                 None
 
     corrected_value_column_name = (
         ordered_dataframe.generate_snowflake_quoted_identifiers(
             pandas_labels=["corrected_value_" + generate_column_identifier_random()],
         )[0]
     )
-    corrected_null_replace_case_expr: CaseExpr = when(
-        (col(value_quoted) == pandas_lit(null_replace_value)), pandas_lit(None)
-    )
 
-    # add otherwise clause to complete the normalization of values
-    corrected_null_replace_column = corrected_null_replace_case_expr.otherwise(
-        col(value_quoted)
-    ).alias(corrected_value_column_name)
+    value_column = col(value_quoted).alias(corrected_value_column_name)
 
     # Reorder the resulting expression to match pandas based on the original column order,
     # which is now in the "variable" column
@@ -855,7 +813,7 @@ def _simple_unpivot(
         ordered_dataframe._get_active_column_snowflake_quoted_identifiers()
     )
     ordered_dataframe = ordered_dataframe.select(
-        *unpivoted_columns, ordering_column_case_expr, corrected_null_replace_column
+        *unpivoted_columns, ordering_column_case_expr, value_column
     ).sort(OrderingColumn(ordering_column_name))
     ordered_dataframe = ordered_dataframe.ensure_row_position_column()
 
@@ -864,11 +822,11 @@ def _simple_unpivot(
     ###########################################################################################
     #   variable                value  UNPIVOT_ORDERING_ corrected_value_8ofo  __row_position__
     # 0      abc                  "A"                  0                  "A"                 0
-    # 1      abc  "NULL_REPLACE_tavu"                  0                 None                 1
+    # 1      abc                 None                  0                 None                 1
     # 2      abc                  "C"                  0                  "C"                 2
     # 3      123                  "1"                  1                  "1"                 3
     # 4      123                  "2"                  1                  "2"                 4
-    # 5      123  "NULL_REPLACE_tavu"                  1                 None                 5
+    # 5      123                 None                  1                 None                 5
 
     final_pandas_labels = id_col_names + [pandas_var_name, pandas_value_name]
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -13240,8 +13240,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ordered_dataframe = original_frame.ordered_dataframe.agg(
             *[
                 to_variant(
-                        column_quantile(col(col_identifier), interpolation, quantile)
-                    ).as_(new_ident)
+                    column_quantile(col(col_identifier), interpolation, quantile)
+                ).as_(new_ident)
                 for new_ident, quantile in zip(new_identifiers, q)
             ]
         )
@@ -13266,17 +13266,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # Restore NULL values in the data column and cast back to float
         ordered_dataframe = ordered_dataframe.select(
             index_identifier,
-            col(col_identifier)
-            .cast(FloatType())
-            .as_(col_after_cast_identifier),
+            col(col_identifier).cast(FloatType()).as_(col_after_cast_identifier),
         ).ensure_row_position_column()
         internal_frame = InternalFrame.create(
             ordered_dataframe=ordered_dataframe,
             data_column_pandas_labels=[col_label],
             data_column_pandas_index_names=[None],
-            data_column_snowflake_quoted_identifiers=[
-                col_after_cast_identifier
-            ],
+            data_column_snowflake_quoted_identifiers=[col_after_cast_identifier],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=[index_identifier],
             data_column_types=original_frame.cached_data_column_snowpark_pandas_types,

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -312,7 +312,6 @@ from snowflake.snowpark.modin.plugin._internal.type_utils import (
     is_compatible_snowpark_types,
 )
 from snowflake.snowpark.modin.plugin._internal.unpivot_utils import (
-    UNPIVOT_NULL_REPLACE_VALUE,
     StackOperation,
     unpivot,
     unpivot_empty_df,
@@ -13240,13 +13239,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
         ordered_dataframe = original_frame.ordered_dataframe.agg(
             *[
-                # Replace NULL values so they are preserved through the UNPIVOT
-                coalesce(
-                    to_variant(
+                to_variant(
                         column_quantile(col(col_identifier), interpolation, quantile)
-                    ),
-                    to_variant(pandas_lit(UNPIVOT_NULL_REPLACE_VALUE)),
-                ).as_(new_ident)
+                    ).as_(new_ident)
                 for new_ident, quantile in zip(new_identifiers, q)
             ]
         )
@@ -13263,7 +13258,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             if index is not None
             else dict(zip(new_identifiers, new_labels)),
         )
-        col_after_null_replace_identifier = (
+        col_after_cast_identifier = (
             ordered_dataframe.generate_snowflake_quoted_identifiers(
                 pandas_labels=[col_label]
             )[0]
@@ -13271,20 +13266,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # Restore NULL values in the data column and cast back to float
         ordered_dataframe = ordered_dataframe.select(
             index_identifier,
-            when(
-                col(col_identifier) == pandas_lit(UNPIVOT_NULL_REPLACE_VALUE),
-                pandas_lit(None),
-            )
-            .otherwise(col(col_identifier))
+            col(col_identifier)
             .cast(FloatType())
-            .as_(col_after_null_replace_identifier),
+            .as_(col_after_cast_identifier),
         ).ensure_row_position_column()
         internal_frame = InternalFrame.create(
             ordered_dataframe=ordered_dataframe,
             data_column_pandas_labels=[col_label],
             data_column_pandas_index_names=[None],
             data_column_snowflake_quoted_identifiers=[
-                col_after_null_replace_identifier
+                col_after_cast_identifier
             ],
             index_column_pandas_labels=[None],
             index_column_snowflake_quoted_identifiers=[index_identifier],
@@ -18648,9 +18639,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 na_position="last",
                 ignore_index=False,
             )
-
-        # TODO: SNOW-1524695: Remove the following replace once "NULL_REPLACE" values are fixed for 'melt'
-        qc = qc.replace(to_replace=UNPIVOT_NULL_REPLACE_VALUE, value=np.nan)
 
         if operation == StackOperation.STACK:
             qc = qc.set_index_from_columns(index_cols + [col_label])  # type: ignore

--- a/tests/integ/modin/frame/test_transpose.py
+++ b/tests/integ/modin/frame/test_transpose.py
@@ -11,9 +11,7 @@ import pytest
 from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from snowflake.snowpark.modin.plugin._internal.unpivot_utils import (
-    UNPIVOT_NULL_REPLACE_VALUE,
-)
+
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equal_to_pandas,
     assert_snowpark_pandas_equals_to_pandas_with_coerce_to_float64,
@@ -200,21 +198,12 @@ def test_dataframe_transpose_single_row(transpose_operation, expected_query_coun
         {"B": [1, 1, 1, 1, 1]},  # value all same
         {"None": [None]},
         {"none": [None, None, None]},
-        {UNPIVOT_NULL_REPLACE_VALUE: [np.nan, np.nan, np.nan]},
         {"NaT": [pd.NaT, pd.NaT, pd.NaT]},
         {"nan": [6.0, 7.1, np.nan]},
         {"A": [None, 1, 2, 3]},
         {"None": [None, 1, 1, None]},
         {"float": [1.1, 1.0 / 7]},
         {"str": ["abc", None, ("a", "c")]},
-        {
-            UNPIVOT_NULL_REPLACE_VALUE: [
-                None,
-                UNPIVOT_NULL_REPLACE_VALUE,
-                None,
-                UNPIVOT_NULL_REPLACE_VALUE,
-            ]
-        },
         {123: ["a", "b", "c"]},
         {False: [1, 2, 3], True: ["4", "5", "6"]},
         # Note that if no label is provided, a default integer label is created.


### PR DESCRIPTION
Remove hack for transpose and melt which uses UNPIVOT_…NULL_REPLACE; now that UNPIVOT INCLUDE NULLS is implemented. Existing tests continue to pass.

Fixes SNOW-1032076

pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://docs.google.com/document/d/162d_i4zZ2AfcGRXojj0jByt8EUq-DrSHPPnTa4QvwbA/edit#bookmark=id.e82u4nekq80k)

