### PR TITLE
SNOW-1842455: fix pandas import in local testing

### DIFF
--- a/src/snowflake/snowpark/mock/_nop_connection.py
+++ b/src/snowflake/snowpark/mock/_nop_connection.py
@@ -16,7 +16,7 @@ from typing import (
     Union,
 )
 
-import pandas
+from snowflake.snowpark.mock._options import pandas
 
 from snowflake.connector.cursor import ResultMetadata
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted

--- a/src/snowflake/snowpark/mock/_snowflake_data_type.py
+++ b/src/snowflake/snowpark/mock/_snowflake_data_type.py
@@ -3,14 +3,6 @@
 #
 from typing import Any, Dict, Iterable, NamedTuple, Optional, Union
 
-from pandas.core.dtypes.common import (
-    is_bool_dtype,
-    is_float_dtype,
-    is_integer_dtype,
-    is_object_dtype,
-    is_string_dtype,
-)
-
 from snowflake.snowpark.mock._options import installed_pandas, pandas as pd
 from snowflake.snowpark.mock._telemetry import LocalTestOOBTelemetryService
 from snowflake.snowpark.mock.exceptions import SnowparkLocalTestingException
@@ -55,6 +47,13 @@ _TIMESTAMP_TYPE_TIMEZONE_MAPPING = {
 
 def infer_sp_type_from_python_type(p: Any) -> DataType:
     """helper function to map python types (using pandas) to Snowpark types."""
+    from pandas.core.dtypes.common import (
+        is_bool_dtype,
+        is_float_dtype,
+        is_integer_dtype,
+        is_object_dtype,
+        is_string_dtype,
+    )
 
     # TODO SNOW-1826001: refactor this with Snowpark pandas to avoid redundancy.
 
@@ -534,6 +533,8 @@ class ColumnEmulator(PandasSeriesType):
             # Can not use short cut self.isna().any() as this leads to endless recursion
             # due to ColumnEmulator inheriting from a pandas Series.
             nullable = any([isna_helper(obj) for obj in self.values])
+
+            from pandas.core.dtypes.common import is_object_dtype
 
             if is_object_dtype(self.dtype) and len(self) != 0:
                 # Infer from data when object type for the type to become more specific.


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.


fix the local testing change in https://github.com/snowflakedb/snowpark-python/commit/9f9398bcb4bb3435d20321d6d64d571eb2dde182

pandas is not a required dependency for snowpark python
in local testing we should avoid hard dependency on pandas which causes import error to users if pandas is not installed.
