### PR TITLE
SNOW-1831923 Add AST encoding for `functions.size`

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -6790,11 +6790,17 @@ def size(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         ----------------------------------------------------------
         <BLANKLINE>
     """
+
+    # AST.
+    ast = None
+    if _emit_ast:
+        ast = proto.Expr()
+        build_builtin_fn_apply(ast, "size", col)
+
     c = _to_col_if_str(col, "size")
     v = to_variant(c)
 
-    # TODO: SNOW-1831923 build AST
-    return (
+    result = (
         when(
             is_array(v, _emit_ast=False),
             array_size(v, _emit_ast=False),
@@ -6808,6 +6814,8 @@ def size(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         .otherwise(lit(None), _emit_ast=False)
         .alias(f"SIZE({c.get_name()})", _emit_ast=False)
     )
+    result._ast = ast
+    return result
 
 
 @publicapi

--- a/tests/ast/data/functions.test
+++ b/tests/ast/data/functions.test
@@ -594,6 +594,8 @@ df303 = df.select(unix_timestamp("A"), unix_timestamp("A", None), unix_timestamp
 
 df304 = df.select(locate("needle", col("expr")), locate("needle", lit("test string"), 2))
 
+df305 = df.select(size(col("expr")), size("A"))
+
 ## EXPECTED UNPARSER OUTPUT
 
 df = session.table("table1")
@@ -1187,6 +1189,8 @@ df302 = df111.select(call_udf("name"), call_udf("test", col("A"), lit(10)))
 df303 = df111.select(unix_timestamp("A", None), unix_timestamp("A", None), unix_timestamp(col("B"), lit("YYYY")))
 
 df304 = df111.select(charindex(lit("needle"), col("expr"), lit(1)), charindex(lit("needle"), lit("test string"), lit(2)))
+
+df305 = df111.select(size(col("expr")), size("A"))
 
 ## EXPECTED ENCODED AST
 
@@ -38961,6 +38965,102 @@ body {
     uid: 296
     var_id {
       bitfield1: 296
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_select__columns {
+        cols {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  fn_name_flat {
+                    name: "size"
+                  }
+                }
+              }
+            }
+            pos_args {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      fn_name_flat {
+                        name: "col"
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_line: 619
+                    }
+                    v: "expr"
+                  }
+                }
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 619
+                }
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 619
+            }
+          }
+        }
+        cols {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  fn_name_flat {
+                    name: "size"
+                  }
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 619
+                }
+                v: "A"
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 619
+            }
+          }
+        }
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 112
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 619
+        }
+        variadic: true
+      }
+    }
+    symbol {
+      value: "df305"
+    }
+    uid: 297
+    var_id {
+      bitfield1: 297
     }
   }
 }


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
   Fixes SNOW-1831923

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Added AST encoding for `size(<col or name>)` in functions.py. The test for this resides in `functions.test`.
