### PR TITLE
changes for avoiding linter errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,15 @@ repos:
                 .github/repo_meta.yaml|
             )$
     -   id: debug-statements
+        exclude: >
+            (?x)^(
+                tests/ast/decoder.py
+            )$
     -   id: check-ast
+        exclude: >
+            (?x)^(
+                tests/ast/decoder.py
+            )$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
     rev: v1.1.13
     hooks:
@@ -83,7 +91,7 @@ repos:
         args:
           - --per-file-ignores=tests/*.py:T201 # prints are allowed in test files
           # Ignore errors for generated protocol buffer stubs
-          - --exclude=src/snowflake/snowpark/_internal/proto/generated/ast_pb2.py
+          - --exclude=src/snowflake/snowpark/_internal/proto/generated/ast_pb2.py,tests/ast/decoder.py
     # Use mypy for static type checking.
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.991'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,11 +55,13 @@ repos:
     -   id: debug-statements
         exclude: >
             (?x)^(
+                # Excluding decoder.py because it uses match that's only available in Python 3.10
                 tests/ast/decoder.py
             )$
     -   id: check-ast
         exclude: >
             (?x)^(
+                # Excluding decoder.py because it uses match that's only available in Python 3.10
                 tests/ast/decoder.py
             )$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
@@ -91,6 +93,7 @@ repos:
         args:
           - --per-file-ignores=tests/*.py:T201 # prints are allowed in test files
           # Ignore errors for generated protocol buffer stubs
+          # Excluding decoder.py because it uses match that's only available in Python 3.10
           - --exclude=src/snowflake/snowpark/_internal/proto/generated/ast_pb2.py,tests/ast/decoder.py
     # Use mypy for static type checking.
 -   repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1842673

3. Please describe how your code solves the related issue.
    decoder.py uses the match keyword that was introduced in Python 3.10. This keyword is not available in Python 3.9 and 
    so there are many lint failures on that file. This PR adds the file to a "ignore" list. 

I have read the CLA Document and I hereby sign the CLA
