### PR TITLE
SNOW-1842459 Fix line no issues in ast expectation validation tests.

### DIFF
--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 import dateutil
 from dateutil.tz import tzlocal
 from google.protobuf.text_format import MessageToString, Parse
+from google.protobuf.message import Message
 
 import snowflake.snowpark
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
@@ -1494,3 +1495,28 @@ def base64_lines_to_textproto(base64_str: str) -> str:
 def textproto_to_request(textproto_str: str) -> proto.Request:
     request = Parse(textproto_str, proto.Request())
     return request
+
+
+def clear_line_no_in_ast(ast: Any) -> None:
+    """Clear any 'src' information in the statement body."""
+    if isinstance(ast, Iterable) and not isinstance(ast, str):
+        for c in ast:
+            clear_line_no_in_ast(c)
+    elif hasattr(ast, "DESCRIPTOR"):
+        if hasattr(ast, "src"):
+            ast.ClearField("src")  # type: ignore[union-attr]
+
+        for f in ast.DESCRIPTOR.fields:
+            c = getattr(ast, f.name)
+            if (isinstance(c, Iterable) and not isinstance(c, str) and len(c) > 0) or (  # type: ignore[arg-type]
+                isinstance(c, Message) and c.ByteSize() > 0
+            ):
+                clear_line_no_in_ast(c)
+
+
+def clear_line_no_in_request(request: proto.Request) -> None:
+    """There are inconsistencies in the frame_info.line_no depending on the python version, this seems to be due to
+    fixes in determining better line_no info for chained python code, etc.  We will only record line_no info for
+    python 3.9 during test validation and exclude otherwise."""
+    for stmt in request.body:
+        clear_line_no_in_ast(stmt)

--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -1516,7 +1516,6 @@ def clear_line_no_in_ast(ast: Any) -> None:
 
 def clear_line_no_in_request(request: proto.Request) -> None:
     """There are inconsistencies in the frame_info.line_no depending on the python version, this seems to be due to
-    fixes in determining better line_no info for chained python code, etc.  We will only record line_no info for
-    python 3.9 during test validation and exclude otherwise."""
+    fixes in determining better line_no info for chained python code, etc."""
     for stmt in request.body:
         clear_line_no_in_ast(stmt)

--- a/tests/ast/README.md
+++ b/tests/ast/README.md
@@ -8,6 +8,8 @@ All generated AST should be tested using this mechanism. To add a test, create a
 
 N.B. No eager evaluation is permitted, as any intermediate batches will not be observed. This can easily be changed if necessary, however.
 
+The src line no information is only captured when run with python 3.11+ because of bug fix/differences in frame line no across earlier python versions.
+
 ```python
 ## TEST CASE
 

--- a/tests/ast/data/DataFrame.agg.test
+++ b/tests/ast/data/DataFrame.agg.test
@@ -31,13 +31,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 82
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 1
@@ -46,7 +52,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 2
@@ -57,13 +66,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 82
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 3
@@ -72,7 +87,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 4
@@ -83,13 +101,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 82
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 1
@@ -98,7 +122,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 4
@@ -115,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 82
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -166,20 +196,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 36
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 29
                       }
                       v: "a"
                     }
                   }
                   src {
+                    end_column: 36
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 37
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 29
               }
             }
@@ -209,20 +248,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 58
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 50
                         start_line: 29
                       }
                       v: "a"
                     }
                   }
                   src {
+                    end_column: 58
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 50
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 59
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 39
                 start_line: 29
               }
             }
@@ -230,7 +278,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 60
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -259,13 +310,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 48
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "a"
@@ -274,7 +331,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "min"
@@ -285,13 +345,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 48
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "b"
@@ -300,7 +366,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "max"
@@ -311,7 +380,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 48
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -343,7 +415,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "a"
@@ -352,7 +427,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "count"
@@ -363,7 +441,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "b"
@@ -372,7 +453,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "sum"
@@ -380,7 +464,10 @@ body {
                 }
               }
               src {
+                end_column: 48
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
             }
@@ -388,7 +475,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }

--- a/tests/ast/data/DataFrame.collect.test
+++ b/tests/ast/data/DataFrame.collect.test
@@ -46,7 +46,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -73,7 +76,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 20
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -103,7 +109,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 31
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -134,7 +143,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 67
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {
@@ -168,7 +180,10 @@ body {
         }
         log_on_exception: true
         src {
+          end_column: 125
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {
@@ -203,7 +218,10 @@ body {
         }
         no_wait: true
         src {
+          end_column: 27
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
       }
@@ -234,7 +252,10 @@ body {
         }
         no_wait: true
         src {
+          end_column: 74
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 37
         }
         statement_params {
@@ -269,7 +290,10 @@ body {
         log_on_exception: true
         no_wait: true
         src {
+          end_column: 119
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         statement_params {

--- a/tests/ast/data/DataFrame.count.test
+++ b/tests/ast/data/DataFrame.count.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,7 +59,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 18
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -85,7 +91,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 29
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -114,7 +123,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 78
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -62,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 28
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 28
         }
       }
@@ -85,7 +88,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 18
+          end_line: 30
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 30
         }
       }
@@ -114,7 +120,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 29
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 32
         }
       }
@@ -143,7 +152,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 78
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 34
         }
         statement_params {

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -68,7 +68,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -103,7 +106,10 @@ body {
         name: "test_schema"
         name: "test_view"
         src {
+          end_column: 89
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -129,7 +135,10 @@ body {
         }
         name: "test_view"
         src {
+          end_column: 79
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         statement_params {
@@ -165,7 +174,10 @@ body {
         name: "test_schema"
         name: "test_view"
         src {
+          end_column: 94
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -192,7 +204,10 @@ body {
         is_temp: true
         name: "test_view"
         src {
+          end_column: 84
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {
@@ -218,7 +233,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: true
@@ -239,7 +257,10 @@ body {
           _2 {
             string_val {
               src {
+                end_column: 9
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: "GZIP"
@@ -251,7 +272,10 @@ body {
           _2 {
             string_val {
               src {
+                end_column: 9
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: "|"
@@ -262,7 +286,10 @@ body {
           value: "[A-Z]+"
         }
         src {
+          end_column: 9
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         statement_params {
@@ -290,14 +317,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 45
                     }
                     v: "n"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 45
                 }
               }
@@ -305,14 +338,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 45
                 }
                 v: 10
               }
             }
             src {
+              end_column: 42
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 45
             }
           }
@@ -331,14 +370,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 54
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 45
                 }
                 v: "str"
               }
             }
             src {
+              end_column: 54
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 45
             }
           }
@@ -376,7 +421,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
       }
@@ -402,7 +450,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
       }
@@ -428,7 +479,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 53
         }
         statement_params {
@@ -458,7 +512,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 53
         }
       }
@@ -492,7 +549,10 @@ body {
         }
         name: "test_dyn_table"
         src {
+          end_column: 110
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
         warehouse: "test_wh"

--- a/tests/ast/data/DataFrame.cross_join.lsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.lsuffix.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -53,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -92,7 +98,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -113,7 +122,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 54
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -126,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.cross_join.rsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.rsuffix.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -53,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -92,7 +98,10 @@ body {
           value: "_t2"
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -113,7 +122,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 54
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -126,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.cross_join.suffix.test
+++ b/tests/ast/data/DataFrame.cross_join.suffix.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -53,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -95,7 +101,10 @@ body {
           value: "_t2"
         }
         src {
+          end_column: 57
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -116,7 +125,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 69
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -129,7 +141,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.describe.test
+++ b/tests/ast/data/DataFrame.describe.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,7 +65,10 @@ body {
           }
         }
         src {
+          end_column: 27
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -84,7 +90,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 32
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -100,7 +109,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -122,7 +134,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 39
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "STR"
@@ -131,7 +146,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 39
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -147,7 +165,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }

--- a/tests/ast/data/DataFrame.flatten.test
+++ b/tests/ast/data/DataFrame.flatten.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
         input {
           string_val {
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "STR"
@@ -71,7 +77,10 @@ body {
           value: "path"
         }
         src {
+          end_column: 52
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -110,14 +119,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: "NUM"
               }
             }
             src {
+              end_column: 35
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -127,7 +142,10 @@ body {
         }
         recursive: true
         src {
+          end_column: 66
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/DataFrame.indexers.test
+++ b/tests/ast/data/DataFrame.indexers.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,7 +65,10 @@ body {
               }
             }
             src {
+              end_column: 37
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 27
             }
           }
@@ -75,7 +81,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 27
         }
         variadic: true
@@ -105,7 +114,10 @@ body {
               }
             }
             src {
+              end_column: 34
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -118,7 +130,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 29
         }
         variadic: true
@@ -148,7 +163,10 @@ body {
               }
             }
             src {
+              end_column: 37
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 31
             }
           }
@@ -161,7 +179,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.column.test
+++ b/tests/ast/data/DataFrame.join.inner.column.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -79,7 +85,10 @@ body {
         join_expr {
           string_val {
             src {
+              end_column: 34
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
             v: "num"
@@ -103,7 +112,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -134,14 +146,20 @@ body {
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 29
                 }
               }
             }
             name: "n1"
             src {
+              end_column: 61
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 29
             }
             variant_is_as {
@@ -159,7 +177,10 @@ body {
               }
             }
             src {
+              end_column: 70
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 63
               start_line: 29
             }
           }
@@ -175,7 +196,10 @@ body {
               }
             }
             src {
+              end_column: 79
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 72
               start_line: 29
             }
           }
@@ -188,7 +212,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.column_list.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -81,7 +87,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "num"
@@ -90,7 +99,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "str"
@@ -116,7 +128,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -138,7 +153,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 55
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -151,7 +169,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -91,7 +97,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 29
                     }
                   }
@@ -107,13 +116,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 49
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 29
                 }
               }
@@ -131,7 +146,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 64
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 29
                     }
                   }
@@ -147,19 +165,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -182,7 +209,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -213,14 +243,20 @@ body {
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 29
                 }
               }
             }
             name: "num_1"
             src {
+              end_column: 111
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 88
               start_line: 29
             }
             variant_is_as {
@@ -241,14 +277,20 @@ body {
                   }
                 }
                 src {
+                  end_column: 123
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 113
                   start_line: 29
                 }
               }
             }
             name: "str_1"
             src {
+              end_column: 136
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 113
               start_line: 29
             }
             variant_is_as {
@@ -264,7 +306,10 @@ body {
           }
         }
         src {
+          end_column: 137
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -89,7 +95,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 29
                 }
               }
@@ -105,13 +114,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -134,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -165,14 +183,20 @@ body {
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 29
                 }
               }
             }
             name: "num1"
             src {
+              end_column: 76
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 29
             }
             variant_is_as {
@@ -192,14 +216,20 @@ body {
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 29
                 }
               }
             }
             name: "num2"
             src {
+              end_column: 99
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 29
             }
             variant_is_as {
@@ -217,7 +247,10 @@ body {
               }
             }
             src {
+              end_column: 108
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 101
               start_line: 29
             }
           }
@@ -230,7 +263,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -91,7 +97,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 29
                     }
                   }
@@ -107,13 +116,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 52
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 29
                 }
               }
@@ -131,7 +146,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 67
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 29
                     }
                   }
@@ -147,19 +165,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 81
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 71
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -185,7 +212,10 @@ body {
           value: "_2"
         }
         src {
+          end_column: 97
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -207,7 +237,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 109
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -220,7 +253,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.left_outer.column.test
+++ b/tests/ast/data/DataFrame.join.left_outer.column.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -81,7 +87,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "num"
@@ -90,7 +99,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "str"
@@ -116,7 +128,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -138,7 +153,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 63
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -151,7 +169,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.right_outer.predicate.test
+++ b/tests/ast/data/DataFrame.join.right_outer.predicate.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -89,7 +95,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 29
                 }
               }
@@ -105,13 +114,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -134,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -156,7 +174,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 73
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -169,7 +190,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.natural_join.test
+++ b/tests/ast/data/DataFrame.natural_join.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -53,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -92,7 +98,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -113,7 +122,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 41
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -126,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.pivot.test
+++ b/tests/ast/data/DataFrame.pivot.test
@@ -44,13 +44,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -59,7 +65,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 10000
@@ -68,7 +77,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -79,13 +91,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -94,7 +112,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 400
@@ -103,7 +124,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -114,13 +138,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -129,7 +159,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 4500
@@ -138,7 +171,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -149,13 +185,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -164,7 +206,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 35000
@@ -173,7 +218,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -184,13 +232,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -199,7 +253,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 5000
@@ -208,7 +265,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "FEB"
@@ -219,13 +279,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -234,7 +300,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 3000
@@ -243,7 +312,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "FEB"
@@ -254,13 +326,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -269,7 +347,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 200
@@ -278,7 +359,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "FEB"
@@ -296,7 +380,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -317,7 +404,10 @@ body {
         default_on_null {
           null_val {
             src {
+              end_column: 44
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
           }
@@ -332,14 +422,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 44
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
             v: "mo"
           }
         }
         src {
+          end_column: 44
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
         values {
@@ -347,13 +443,19 @@ body {
             v {
               list_val {
                 src {
+                  end_column: 44
+                  end_line: 38
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 38
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 38
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 38
                     }
                     v: "JAN"
@@ -362,7 +464,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 38
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 38
                     }
                     v: "FEB"
@@ -392,7 +497,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 53
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 38
               }
               v: "t"
@@ -408,7 +516,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
       }
@@ -429,7 +540,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 63
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
             v: "k"
@@ -444,7 +558,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
       }
@@ -465,7 +582,10 @@ body {
         default_on_null {
           string_val {
             src {
+              end_column: 78
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "Nothing"
@@ -481,14 +601,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 78
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "mo"
           }
         }
         src {
+          end_column: 78
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
         values {
@@ -496,13 +622,19 @@ body {
             v {
               list_val {
                 src {
+                  end_column: 78
+                  end_line: 40
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 40
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 40
                     }
                     v: "JAN"
@@ -511,7 +643,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 40
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 40
                     }
                     v: "FEB"
@@ -541,7 +676,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 87
+                end_line: 40
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 40
               }
               v: "t"
@@ -557,7 +695,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
       }
@@ -578,7 +719,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 97
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "k"
@@ -593,7 +737,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
       }

--- a/tests/ast/data/DataFrame.select_expr.test
+++ b/tests/ast/data/DataFrame.select_expr.test
@@ -35,7 +35,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -65,7 +68,10 @@ body {
         }
         exprs: "$1"
         src {
+          end_column: 33
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -93,7 +99,10 @@ body {
         }
         exprs: "$1"
         src {
+          end_column: 35
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }
@@ -125,7 +134,10 @@ body {
         exprs: "MAX $5"
         exprs: "COUNT DISTINCT $6"
         src {
+          end_column: 100
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -158,7 +170,10 @@ body {
         exprs: "MAX $5"
         exprs: "COUNT DISTINCT $6"
         src {
+          end_column: 102
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
       }

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -80,7 +80,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -104,7 +107,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 51
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "NUM"
@@ -115,7 +121,10 @@ body {
         }
         percentile: 0.5
         src {
+          end_column: 51
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -144,7 +153,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 96
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
             v: "NUM"
@@ -153,7 +165,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 96
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
             v: "NUM"
@@ -166,7 +181,10 @@ body {
         percentile: 0.2
         percentile: 0.4
         src {
+          end_column: 96
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         statement_params {
@@ -201,13 +219,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 94
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.1
@@ -216,7 +240,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.5
@@ -227,13 +254,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 94
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.2
@@ -242,7 +275,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.6
@@ -253,13 +289,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 94
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.3
@@ -268,7 +310,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.7
@@ -285,7 +330,10 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
       }
@@ -306,7 +354,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 35
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
             v: "a"
@@ -315,7 +366,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 35
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
             v: "b"
@@ -325,7 +379,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 35
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -354,7 +411,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 63
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
             v: "a"
@@ -363,7 +423,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 63
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
             v: "b"
@@ -373,7 +436,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 63
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         statement_params {
@@ -406,7 +472,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 36
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
             v: "a"
@@ -415,7 +484,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 36
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
             v: "b"
@@ -425,7 +497,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 36
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -454,7 +529,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 64
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
             v: "a"
@@ -463,7 +541,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 64
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
             v: "b"
@@ -473,7 +554,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 64
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
         statement_params {
@@ -508,13 +592,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 1
@@ -523,59 +613,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 1
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 41
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 1
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 2
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 41
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 2
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 1
@@ -586,13 +627,54 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 1
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 120
+                  end_line: 41
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 41
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 2
@@ -601,7 +683,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 1
@@ -612,13 +697,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 2
@@ -627,7 +718,45 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 120
+                  end_line: 41
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 41
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -638,13 +767,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -653,7 +788,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 2
@@ -664,13 +802,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -679,7 +823,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -696,7 +843,10 @@ body {
           }
         }
         src {
+          end_column: 120
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
       }
@@ -717,7 +867,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 45
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 43
             }
             v: "key"
@@ -726,7 +879,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 45
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 43
             }
             v: "value"
@@ -736,7 +892,10 @@ body {
           bitfield1: 15
         }
         src {
+          end_column: 45
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
       }
@@ -757,7 +916,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 74
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 45
             }
             v: "key"
@@ -766,7 +928,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 74
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 45
             }
             v: "value"
@@ -776,7 +941,10 @@ body {
           bitfield1: 15
         }
         src {
+          end_column: 74
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 45
         }
         statement_params {
@@ -803,13 +971,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Bob"
@@ -818,7 +992,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 17
@@ -829,13 +1006,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Alice"
@@ -844,7 +1027,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 10
@@ -855,13 +1041,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Nico"
@@ -870,7 +1062,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 8
@@ -881,13 +1076,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Bob"
@@ -896,7 +1097,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 12
@@ -913,7 +1117,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
       }
@@ -934,7 +1141,10 @@ body {
         col {
           string_val {
             src {
+              end_column: 56
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 20
               start_line: 51
             }
             v: "name"
@@ -951,7 +1161,10 @@ body {
           _1 {
             string_val {
               src {
+                end_column: 56
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 51
               }
               v: "Bob"
@@ -963,7 +1176,10 @@ body {
           _1 {
             string_val {
               src {
+                end_column: 56
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 51
               }
               v: "Nico"
@@ -972,7 +1188,10 @@ body {
           _2: 1.0
         }
         src {
+          end_column: 56
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 51
         }
       }

--- a/tests/ast/data/DataFrame.to_df.test
+++ b/tests/ast/data/DataFrame.to_df.test
@@ -27,7 +27,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,7 +61,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 27
         }
         variadic: true
@@ -87,7 +93,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 23
           start_line: 29
         }
       }

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -47,7 +47,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -74,7 +77,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 27
         }
       }
@@ -104,7 +110,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 64
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 29
         }
       }
@@ -133,7 +142,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 45
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 31
             }
           }
@@ -146,7 +158,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 31
         }
         variadic: true
@@ -171,7 +186,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 65
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 31
         }
       }
@@ -202,7 +220,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 100
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 33
         }
         statement_params {
@@ -244,7 +265,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
               }
@@ -252,14 +276,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 54
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 v: 1
               }
             }
             src {
+              end_column: 54
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 35
             }
           }
@@ -272,7 +302,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 35
         }
       }
@@ -295,7 +328,10 @@ body {
           bitfield1: 11
         }
         src {
+          end_column: 86
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 35
         }
       }
@@ -325,7 +361,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 122
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 37
         }
         statement_params {

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -34,7 +34,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,7 +63,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 22
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -89,7 +95,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 33
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -119,7 +128,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 69
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {
@@ -152,7 +164,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 82
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {

--- a/tests/ast/data/DataFrame.to_pandas_batch.test
+++ b/tests/ast/data/DataFrame.to_pandas_batch.test
@@ -34,7 +34,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,7 +63,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 30
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -89,7 +95,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -119,7 +128,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 77
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {
@@ -152,7 +164,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 90
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {

--- a/tests/ast/data/DataFrame.unpivot.test
+++ b/tests/ast/data/DataFrame.unpivot.test
@@ -23,13 +23,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 28
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -38,7 +44,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "electronics"
@@ -47,7 +56,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 100
@@ -56,7 +68,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 200
@@ -67,13 +82,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 28
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -82,7 +103,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "clothes"
@@ -91,7 +115,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 100
@@ -100,7 +127,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 300
@@ -119,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 28
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -140,7 +173,10 @@ body {
         column_list {
           string_val {
             src {
+              end_column: 57
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 29
             }
             v: "jan"
@@ -149,7 +185,10 @@ body {
         column_list {
           string_val {
             src {
+              end_column: 57
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 29
             }
             v: "feb"
@@ -164,7 +203,10 @@ body {
         }
         name_column: "month"
         src {
+          end_column: 57
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         value_column: "sales"

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -78,7 +78,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -107,7 +110,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -130,7 +136,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 45
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         table_name {
@@ -171,7 +180,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 16
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -194,7 +206,10 @@ body {
           bitfield1: 5
         }
         src {
+          end_column: 87
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         table_name {
@@ -236,7 +251,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 16
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }
@@ -262,7 +280,10 @@ body {
           sp_save_mode_ignore: true
         }
         src {
+          end_column: 102
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         table_name {
@@ -304,7 +325,10 @@ body {
           sp_save_mode_truncate: true
         }
         src {
+          end_column: 16
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
       }
@@ -326,7 +350,10 @@ body {
           list {
             string_val {
               src {
+                end_column: 231
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 35
               }
               v: "STR"
@@ -346,14 +373,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 173
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 162
                     start_line: 35
                   }
                   v: "num1"
                 }
               }
               src {
+                end_column: 173
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 162
                 start_line: 35
               }
             }
@@ -367,7 +400,10 @@ body {
           bitfield1: 11
         }
         src {
+          end_column: 231
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
         statement_params {
@@ -404,7 +440,10 @@ body {
       sp_sql {
         query: "create temp stage if not exists test_stage"
         src {
+          end_column: 88
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 37
         }
       }
@@ -428,7 +467,10 @@ body {
           bitfield1: 14
         }
         src {
+          end_column: 98
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 37
         }
       }
@@ -461,7 +503,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -484,7 +529,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 72
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -517,7 +565,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -540,7 +591,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 123
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               v: true
@@ -552,7 +606,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 123
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               v: true
@@ -568,7 +625,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 123
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -601,7 +661,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 45
         }
       }
@@ -623,7 +686,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 181
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 45
               }
               v: true
@@ -635,7 +701,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 181
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 45
               }
             }
@@ -653,7 +722,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 181
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 45
         }
       }
@@ -686,7 +758,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
       }
@@ -708,7 +783,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 207
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 47
               }
               v: true
@@ -720,7 +798,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 207
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 47
               }
             }
@@ -742,7 +823,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 207
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
       }
@@ -775,7 +859,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
       }
@@ -798,7 +885,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 125
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 51
               }
               v: true
@@ -810,7 +900,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 125
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 51
               }
               v: true
@@ -827,7 +920,10 @@ body {
         }
         location: "@test_stage/test.csv"
         src {
+          end_column: 125
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
       }
@@ -860,7 +956,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -883,7 +982,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 114
+                end_line: 55
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 55
               }
               v: true
@@ -895,7 +997,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 114
+                end_line: 55
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 55
               }
               v: true
@@ -911,7 +1016,10 @@ body {
         }
         location: "@test_stage/test.json"
         src {
+          end_column: 114
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -944,7 +1052,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 59
         }
       }
@@ -967,7 +1078,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 130
+                end_line: 59
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 59
               }
               v: true
@@ -979,7 +1093,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 130
+                end_line: 59
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 59
               }
               v: true
@@ -995,7 +1112,10 @@ body {
         }
         location: "@test_stage/test.parquet"
         src {
+          end_column: 130
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 59
         }
       }

--- a/tests/ast/data/Dataframe.cube.test
+++ b/tests/ast/data/Dataframe.cube.test
@@ -50,7 +50,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -82,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -104,7 +110,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 29
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -120,7 +129,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -142,7 +154,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 31
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -157,7 +172,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -179,7 +197,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "num"
@@ -188,7 +209,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "str"
@@ -203,7 +227,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -236,14 +263,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 33
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 35
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 33
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
             }
@@ -258,7 +291,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -291,14 +327,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 34
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 37
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 34
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 37
               }
             }
@@ -312,7 +354,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -345,14 +390,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 33
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 39
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 33
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 39
               }
             }
@@ -360,7 +411,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 41
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               v: "str"
@@ -376,7 +430,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -409,14 +466,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 34
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 41
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 34
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 41
               }
             }
@@ -424,7 +487,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 43
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               v: "str"
@@ -439,7 +505,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Dataframe.distinct.test
+++ b/tests/ast/data/Dataframe.distinct.test
@@ -22,7 +22,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -51,7 +54,10 @@ body {
           }
         }
         src {
+          end_column: 27
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }

--- a/tests/ast/data/Dataframe.drop_duplicates.test
+++ b/tests/ast/data/Dataframe.drop_duplicates.test
@@ -38,7 +38,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -67,7 +70,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -94,7 +100,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -123,7 +132,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true
@@ -152,7 +164,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -178,7 +193,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }

--- a/tests/ast/data/Dataframe.filter.test
+++ b/tests/ast/data/Dataframe.filter.test
@@ -34,7 +34,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -73,14 +76,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 34
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 26
                           start_line: 27
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 34
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 27
                     }
                   }
@@ -88,14 +97,20 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 38
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 27
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 27
                 }
               }
@@ -116,14 +131,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 51
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 27
                         }
                         v: "B"
                       }
                     }
                     src {
+                      end_column: 51
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 27
                     }
                   }
@@ -131,20 +152,29 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 57
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 27
                     }
                     v: 100
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 27
             }
           }
@@ -157,7 +187,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -191,14 +224,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 29
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
               }
@@ -206,14 +245,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 37
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: 1
               }
             }
             src {
+              end_column: 37
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -226,7 +271,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -248,7 +296,10 @@ body {
           sp_column_sql_expr {
             sql: "a > 1 and b < 100"
             src {
+              end_column: 45
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
           }
@@ -261,7 +312,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -283,7 +337,10 @@ body {
           sp_column_sql_expr {
             sql: "a > 1"
             src {
+              end_column: 33
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
           }
@@ -296,7 +353,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,7 +61,10 @@ body {
               }
             }
             src {
+              end_column: 24
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 27
             }
           }
@@ -74,7 +80,10 @@ body {
               }
             }
             src {
+              end_column: 35
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 27
             }
           }
@@ -87,7 +96,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
         variadic: true
@@ -111,7 +123,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 46
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -150,14 +165,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 26
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 29
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 26
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -176,14 +197,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 26
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 29
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 26
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -196,7 +223,10 @@ body {
           }
         }
         src {
+          end_column: 26
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -219,7 +249,10 @@ body {
           bitfield1: 5
         }
         src {
+          end_column: 36
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }

--- a/tests/ast/data/Dataframe.group_by.test
+++ b/tests/ast/data/Dataframe.group_by.test
@@ -50,7 +50,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -82,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -104,7 +110,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 33
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -120,7 +129,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -142,7 +154,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 35
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -157,7 +172,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -179,7 +197,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 42
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "num"
@@ -188,7 +209,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 42
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "str"
@@ -203,7 +227,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -236,14 +263,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 27
                     start_line: 35
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 37
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 27
                 start_line: 35
               }
             }
@@ -258,7 +291,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -291,14 +327,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 38
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 37
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 38
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 28
                 start_line: 37
               }
             }
@@ -312,7 +354,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -345,14 +390,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 27
                     start_line: 39
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 37
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 27
                 start_line: 39
               }
             }
@@ -360,7 +411,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 45
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               v: "str"
@@ -376,7 +430,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -409,14 +466,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 38
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 41
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 38
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 28
                 start_line: 41
               }
             }
@@ -424,7 +487,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 47
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               v: "str"
@@ -439,7 +505,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Dataframe.group_by_grouping_sets.test
+++ b/tests/ast/data/Dataframe.group_by_grouping_sets.test
@@ -60,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -104,14 +107,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 62
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 29
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 29
                 }
               }
@@ -119,12 +128,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 63
+            end_line: 29
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 29
           }
         }
         src {
+          end_column: 64
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -166,26 +181,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 31
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 31
                 }
               }
             }
           }
           src {
+            end_column: 65
+            end_line: 31
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 31
           }
         }
         src {
+          end_column: 66
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true
@@ -216,7 +243,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 77
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 33
                 }
                 vs {
@@ -233,14 +263,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 63
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 55
                           start_line: 33
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 63
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 33
                     }
                   }
@@ -250,7 +286,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 77
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 33
                 }
                 vs {
@@ -267,14 +306,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 75
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 67
                           start_line: 33
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 33
                     }
                   }
@@ -284,12 +329,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 77
+            end_line: 33
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 33
           }
         }
         src {
+          end_column: 78
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
         variadic: true
@@ -320,7 +371,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 87
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 vs {
@@ -337,14 +391,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 63
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 55
                           start_line: 35
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 63
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 35
                     }
                   }
@@ -363,14 +423,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 73
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 65
                           start_line: 35
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 73
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 35
                     }
                   }
@@ -380,7 +446,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 87
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 vs {
@@ -397,14 +466,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 85
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 77
                           start_line: 35
                         }
                         v: "c"
                       }
                     }
                     src {
+                      end_column: 85
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 35
                     }
                   }
@@ -414,12 +489,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 87
+            end_line: 35
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 35
           }
         }
         src {
+          end_column: 88
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variadic: true
@@ -450,7 +531,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 49
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 37
                 }
                 vs {
@@ -467,14 +551,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 35
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 27
                           start_line: 37
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 35
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 27
                       start_line: 37
                     }
                   }
@@ -484,7 +574,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 49
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 37
                 }
                 vs {
@@ -501,14 +594,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 47
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 39
                           start_line: 37
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 47
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 37
                     }
                   }
@@ -518,12 +617,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 49
+            end_line: 37
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 37
           }
         }
         src {
+          end_column: 44
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
         variadic: true
@@ -554,7 +659,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
@@ -571,14 +679,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 35
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 27
                           start_line: 41
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 35
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 27
                       start_line: 41
                     }
                   }
@@ -597,14 +711,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 46
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 38
                           start_line: 41
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 41
                     }
                   }
@@ -614,7 +734,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
@@ -631,14 +754,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 58
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 50
                           start_line: 41
                         }
                         v: "c"
                       }
                     }
                     src {
+                      end_column: 58
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 41
                     }
                   }
@@ -657,14 +786,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 68
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 60
                           start_line: 41
                         }
                         v: "d"
                       }
                     }
                     src {
+                      end_column: 68
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 41
                     }
                   }
@@ -674,12 +809,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 70
+            end_line: 41
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 41
           }
         }
         src {
+          end_column: 44
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
         variadic: true
@@ -721,14 +862,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 27
                       start_line: 45
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 27
                   start_line: 45
                 }
               }
@@ -747,26 +894,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 45
                     }
                     v: "b"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 45
                 }
               }
             }
           }
           src {
+            end_column: 47
+            end_line: 45
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 45
           }
         }
         src {
+          end_column: 44
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 47
         }
         variadic: true
@@ -808,14 +967,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 49
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 49
                 }
               }
@@ -834,14 +999,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 49
                     }
                     v: "b"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 49
                 }
               }
@@ -849,12 +1020,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 45
+            end_line: 49
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 49
           }
         }
         src {
+          end_column: 44
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
         variadic: true

--- a/tests/ast/data/Dataframe.join.asof.test
+++ b/tests/ast/data/Dataframe.join.asof.test
@@ -32,13 +32,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "A"
@@ -47,7 +53,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 1
@@ -56,7 +65,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 15
@@ -65,7 +77,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3.21
@@ -76,13 +91,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "A"
@@ -91,7 +112,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 2
@@ -100,7 +124,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 16
@@ -109,7 +136,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3.22
@@ -120,13 +150,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "B"
@@ -135,7 +171,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 1
@@ -144,7 +183,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 17
@@ -153,7 +195,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3.23
@@ -164,13 +209,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "B"
@@ -179,7 +230,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 2
@@ -188,7 +242,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 18
@@ -197,7 +254,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 4.23
@@ -216,7 +276,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -239,13 +302,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 30
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: "A"
@@ -254,7 +323,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 1
@@ -263,7 +335,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 14
@@ -272,7 +347,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 3.19
@@ -283,13 +361,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 30
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: "B"
@@ -298,7 +382,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 2
@@ -307,7 +394,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 16
@@ -316,7 +406,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 3.04
@@ -335,7 +428,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 30
         }
       }
@@ -368,7 +464,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 32
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 34
                     }
                   }
@@ -384,13 +483,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 42
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 34
                     }
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 34
                 }
               }
@@ -408,7 +513,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 53
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 34
                     }
                   }
@@ -424,19 +532,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 63
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 34
                     }
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 34
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 34
             }
           }
@@ -467,7 +584,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 35
                 }
               }
@@ -483,13 +603,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 34
               start_line: 35
             }
           }
@@ -505,7 +631,10 @@ body {
           value: "_R"
         }
         src {
+          end_column: 80
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 34
         }
       }
@@ -525,8 +654,11 @@ body {
         cols {
           string_val {
             src {
+              end_column: 42
+              end_line: 36
               file: "SRC_POSITION_TEST_MODE"
-              start_line: 34
+              start_column: 18
+              start_line: 36
             }
             v: "C1_L"
           }
@@ -534,8 +666,11 @@ body {
         cols {
           string_val {
             src {
+              end_column: 42
+              end_line: 36
               file: "SRC_POSITION_TEST_MODE"
-              start_line: 34
+              start_column: 18
+              start_line: 36
             }
             v: "C2_L"
           }
@@ -549,8 +684,11 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 34
+          start_column: 18
+          start_line: 36
         }
       }
     }
@@ -572,8 +710,11 @@ body {
           bitfield1: 4
         }
         src {
+          end_column: 52
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 34
+          start_column: 43
+          start_line: 36
         }
       }
     }

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -37,13 +37,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 140
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 1
@@ -52,7 +58,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 2
@@ -61,7 +70,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3
@@ -70,7 +82,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 4
@@ -79,7 +94,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 5
@@ -88,7 +106,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 6
@@ -109,7 +130,10 @@ body {
           }
         }
         src {
+          end_column: 140
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -132,13 +156,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 122
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 1
@@ -147,7 +177,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 2
@@ -156,7 +189,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 3
@@ -165,7 +201,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 4
@@ -174,7 +213,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 5
@@ -194,7 +236,10 @@ body {
           }
         }
         src {
+          end_column: 122
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -228,14 +273,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 29
                     }
                     v: "\"A\""
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
               }
@@ -243,14 +294,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: 1
               }
             }
             src {
+              end_column: 42
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -263,7 +320,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -299,14 +359,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 73
+                          end_line: 29
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 61
                           start_line: 29
                         }
                         v: "\"A\""
                       }
                     }
                     src {
+                      end_column: 73
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 29
                     }
                   }
@@ -314,21 +380,30 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 77
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 29
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 29
                 }
               }
             }
             name: "\"A\""
             src {
+              end_column: 91
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 29
             }
             variant_is_as {
@@ -350,14 +425,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 105
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 29
                 }
                 v: "\"B\""
               }
             }
             src {
+              end_column: 105
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 93
               start_line: 29
             }
           }
@@ -376,14 +457,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 119
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 29
                 }
                 v: "\"C\""
               }
             }
             src {
+              end_column: 119
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 107
               start_line: 29
             }
           }
@@ -402,14 +489,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 140
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 121
                   start_line: 29
                 }
                 v: "\"l_0001_C\""
               }
             }
             src {
+              end_column: 140
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 121
               start_line: 29
             }
           }
@@ -428,14 +521,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 161
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 142
                   start_line: 29
                 }
                 v: "\"l_0003_B\""
               }
             }
             src {
+              end_column: 161
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 142
               start_line: 29
             }
           }
@@ -448,7 +547,10 @@ body {
           }
         }
         src {
+          end_column: 162
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 49
           start_line: 29
         }
         variadic: true
@@ -485,7 +587,10 @@ body {
           }
         }
         src {
+          end_column: 163
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -506,7 +611,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0004_A\""
@@ -515,7 +623,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0004_B\""
@@ -524,7 +635,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0004_C\""
@@ -533,7 +647,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0000_A\""
@@ -542,7 +659,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0000_A\""
@@ -551,7 +671,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0002_A\""
@@ -560,7 +683,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0006_A\""
@@ -569,7 +695,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0006_B\""
@@ -578,7 +707,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0006_C\""
@@ -587,7 +719,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0001_C\""
@@ -596,7 +731,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0003_B\""
@@ -610,7 +748,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -634,7 +775,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 21
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }

--- a/tests/ast/data/Dataframe.rollup.test
+++ b/tests/ast/data/Dataframe.rollup.test
@@ -50,7 +50,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -82,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 26
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -104,7 +110,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 31
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -120,7 +129,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -142,7 +154,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 33
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -157,7 +172,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -179,7 +197,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 40
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "num"
@@ -188,7 +209,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 40
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "str"
@@ -203,7 +227,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -236,14 +263,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 35
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 35
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 35
               }
             }
@@ -258,7 +291,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -291,14 +327,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 26
                     start_line: 37
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 36
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 26
                 start_line: 37
               }
             }
@@ -312,7 +354,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -345,14 +390,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 39
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 35
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 39
               }
             }
@@ -360,7 +411,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 43
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               v: "str"
@@ -376,7 +430,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -409,14 +466,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 26
                     start_line: 41
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 36
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 26
                 start_line: 41
               }
             }
@@ -424,7 +487,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 45
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               v: "str"
@@ -439,7 +505,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Dataframe.with_col_fns.test
+++ b/tests/ast/data/Dataframe.with_col_fns.test
@@ -54,7 +54,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -93,14 +96,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 48
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 38
                           start_line: 27
                         }
                         v: "num"
                       }
                     }
                     src {
+                      end_column: 48
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 27
                     }
                   }
@@ -119,20 +128,29 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 61
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 51
                           start_line: 27
                         }
                         v: "num"
                       }
                     }
                     src {
+                      end_column: 61
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 27
                     }
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 27
                 }
               }
@@ -140,14 +158,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 27
                 }
                 v: 2
               }
             }
             src {
+              end_column: 66
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 27
             }
           }
@@ -161,7 +185,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -188,7 +215,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         values {
@@ -207,14 +237,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 29
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 29
                 }
               }
@@ -233,20 +269,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 29
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 29
             }
           }
@@ -276,7 +321,10 @@ body {
           }
         }
         src {
+          end_column: 98
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         values {
@@ -295,14 +343,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 31
                 }
               }
@@ -321,20 +375,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 71
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 31
             }
           }
@@ -355,14 +418,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 73
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 73
                   start_line: 31
                 }
               }
@@ -381,20 +450,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 73
               start_line: 31
             }
           }
@@ -428,14 +506,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 34
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 33
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 34
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
           }
@@ -451,7 +535,10 @@ body {
           value: "NEW"
         }
         src {
+          end_column: 42
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -486,14 +573,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 35
                       }
                       v: "STR"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 35
                   }
                 }
@@ -501,7 +594,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 44
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 35
                   }
                   v: "NEW"
@@ -509,7 +605,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
           }
@@ -522,7 +621,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -557,14 +659,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 37
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 37
                       }
                       v: "STR"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 37
                   }
                 }
@@ -572,7 +680,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 66
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 37
                   }
                   v: "NEW_STR"
@@ -583,7 +694,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 66
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 37
                   }
                   v: "NUM"
@@ -592,7 +706,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 66
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 37
                   }
                   v: "NEW_NUM"
@@ -600,7 +717,10 @@ body {
               }
             }
             src {
+              end_column: 66
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
           }
@@ -613,7 +733,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -634,7 +757,10 @@ body {
         col {
           string_val {
             src {
+              end_column: 50
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
             v: "STR"
@@ -649,7 +775,10 @@ body {
         }
         new_name: "NEW"
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -681,14 +810,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 41
                 }
                 v: "NUM"
               }
             }
             src {
+              end_column: 47
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 41
             }
           }
@@ -702,7 +837,10 @@ body {
         }
         new_name: "NEW_NUM"
         src {
+          end_column: 59
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }
@@ -734,14 +872,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 43
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 48
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 43
             }
           }
@@ -755,7 +899,10 @@ body {
         }
         new_name: "NEW_STR"
         src {
+          end_column: 60
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 43
         }
       }

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -70,7 +70,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -100,7 +103,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 28
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 27
         }
       }
@@ -127,7 +133,10 @@ body {
         }
         how: "all"
         src {
+          end_column: 37
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 29
         }
       }
@@ -154,7 +163,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 48
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 31
         }
         thresh {
@@ -184,7 +196,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 40
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 33
         }
         subset {
@@ -214,7 +229,10 @@ body {
         }
         how: "all"
         src {
+          end_column: 60
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 35
         }
         subset {
@@ -245,7 +263,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 64
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 37
         }
         subset {
@@ -277,13 +298,19 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 39
         }
         value {
           int64_val {
             src {
+              end_column: 30
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 16
               start_line: 39
             }
             v: 42
@@ -312,7 +339,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 41
         }
         value_map {
@@ -321,7 +351,10 @@ body {
             _2 {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 41
                 }
                 v: 42
@@ -333,7 +366,10 @@ body {
             _2 {
               string_val {
                 src {
+                  end_column: 53
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 41
                 }
                 v: "abc"
@@ -364,7 +400,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 43
         }
         subset {
@@ -373,7 +412,10 @@ body {
         value {
           int64_val {
             src {
+              end_column: 44
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 16
               start_line: 43
             }
             v: 42
@@ -402,7 +444,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 45
         }
         subset {
@@ -411,7 +456,10 @@ body {
         value {
           string_val {
             src {
+              end_column: 49
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 16
               start_line: 45
             }
             v: "def"
@@ -444,7 +492,10 @@ body {
             _1 {
               int64_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: 1
@@ -453,7 +504,10 @@ body {
             _2 {
               int64_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: 10
@@ -464,7 +518,10 @@ body {
             _1 {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: "three"
@@ -473,7 +530,10 @@ body {
             _2 {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: "trzy"
@@ -482,13 +542,19 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 47
         }
         value {
           null_val {
             src {
+              end_column: 58
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 47
             }
           }
@@ -516,14 +582,20 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 49
         }
         to_replace_list {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 1
@@ -532,7 +604,10 @@ body {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 2
@@ -543,7 +618,10 @@ body {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 10
@@ -552,7 +630,10 @@ body {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 20
@@ -582,7 +663,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 51
         }
         subset {
@@ -591,7 +675,10 @@ body {
         to_replace_value {
           int64_val {
             src {
+              end_column: 55
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 51
             }
             v: 1
@@ -600,7 +687,10 @@ body {
         value {
           int64_val {
             src {
+              end_column: 55
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 51
             }
             v: 10

--- a/tests/ast/data/RelationalGroupedDataFrame.agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.agg.test
@@ -70,7 +70,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -95,7 +98,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 35
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 16
                 start_line: 27
               }
               v: "str"
@@ -111,7 +117,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 27
         }
       }
@@ -140,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 25
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -184,20 +196,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 34
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 24
                         start_line: 31
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 34
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 31
                   }
                 }
               }
               src {
+                end_column: 34
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 31
               }
             }
@@ -212,7 +233,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -256,20 +280,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 33
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 33
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 33
                   }
                 }
               }
               src {
+                end_column: 35
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 33
               }
             }
@@ -283,7 +316,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -327,20 +363,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 34
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 24
                         start_line: 35
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 34
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 34
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 35
               }
             }
@@ -370,20 +415,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 46
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 35
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 46
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 36
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 46
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 36
                 start_line: 35
               }
             }
@@ -398,7 +452,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -442,20 +499,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 37
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 37
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 37
                   }
                 }
               }
               src {
+                end_column: 35
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 37
               }
             }
@@ -485,20 +551,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 47
+                        end_line: 37
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 37
                         start_line: 37
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 47
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 37
                     start_line: 37
                   }
                 }
               }
               src {
+                end_column: 47
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 37
                 start_line: 37
               }
             }
@@ -512,7 +587,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -534,13 +612,19 @@ body {
           args {
             list_val {
               src {
+                end_column: 37
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               vs {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: "num"
@@ -549,7 +633,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: "max"
@@ -567,7 +654,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -589,7 +679,10 @@ body {
           args {
             list_val {
               src {
+                end_column: 42
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               vs {
@@ -606,14 +699,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 34
+                        end_line: 41
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 24
                         start_line: 41
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 34
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 41
                   }
                 }
@@ -621,7 +720,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 42
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 41
                   }
                   v: "max"
@@ -639,7 +741,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }
@@ -661,13 +766,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 63
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 43
               }
               vs {
                 string_val {
                   src {
+                    end_column: 63
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 43
                   }
                   v: "num"
@@ -676,7 +787,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 63
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 43
                   }
                   v: "max"
@@ -687,7 +801,10 @@ body {
           args {
             list_val {
               src {
+                end_column: 63
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 43
               }
               vs {
@@ -704,14 +821,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 53
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 43
                         start_line: 43
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 53
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 43
                     start_line: 43
                   }
                 }
@@ -719,7 +842,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 63
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 43
                   }
                   v: "sum"
@@ -736,7 +862,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 43
         }
       }
@@ -780,20 +909,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 45
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 45
                   }
                 }
               }
               src {
+                end_column: 35
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 45
               }
             }
@@ -801,13 +939,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 85
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 45
               }
               vs {
                 string_val {
                   src {
+                    end_column: 85
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 45
                   }
                   v: "num"
@@ -816,7 +960,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 85
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 45
                   }
                   v: "max"
@@ -849,20 +996,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 63
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 53
                         start_line: 45
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 63
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 53
                     start_line: 45
                   }
                 }
               }
               src {
+                end_column: 63
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 53
                 start_line: 45
               }
             }
@@ -870,7 +1026,10 @@ body {
           args {
             list_val {
               src {
+                end_column: 85
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 45
               }
               vs {
@@ -887,14 +1046,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 76
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 66
                         start_line: 45
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 76
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 66
                     start_line: 45
                   }
                 }
@@ -902,7 +1067,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 85
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 45
                   }
                   v: "sum"
@@ -920,7 +1088,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 45
         }
       }
@@ -942,7 +1113,10 @@ body {
           args {
             seq_map_val {
               src {
+                end_column: 28
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 47
               }
             }
@@ -957,7 +1131,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 47
         }
       }
@@ -982,7 +1159,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 49
                     }
                     v: "num"
@@ -991,7 +1171,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 49
                     }
                     v: "max"
@@ -999,7 +1182,10 @@ body {
                 }
               }
               src {
+                end_column: 40
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 49
               }
             }
@@ -1014,7 +1200,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 49
         }
       }
@@ -1039,7 +1228,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "num"
@@ -1048,7 +1240,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "max"
@@ -1059,7 +1254,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "str"
@@ -1068,7 +1266,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "sum"
@@ -1076,7 +1277,10 @@ body {
                 }
               }
               src {
+                end_column: 54
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 51
               }
             }
@@ -1091,7 +1295,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 51
         }
       }

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -66,13 +66,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -81,59 +87,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 1
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 25
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 1
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 2
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 25
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 2
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -144,22 +101,31 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
-                    v: 2
+                    v: 1
                   }
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -170,13 +136,89 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 3
@@ -185,7 +227,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -196,13 +241,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 3
@@ -211,7 +262,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -228,7 +282,10 @@ body {
           }
         }
         src {
+          end_column: 101
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -250,7 +307,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 24
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 27
               }
               v: "a"
@@ -266,7 +326,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -288,7 +351,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 36
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 27
               }
               v: "b"
@@ -304,7 +370,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -327,7 +396,10 @@ body {
           bitfield1: 3
         }
         src {
+          end_column: 46
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -356,7 +428,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 24
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 29
               }
               v: "a"
@@ -372,7 +447,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -394,7 +472,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 45
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 29
               }
               v: "b"
@@ -410,7 +491,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -433,7 +517,10 @@ body {
           bitfield1: 7
         }
         src {
+          end_column: 55
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -462,7 +549,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 24
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 31
               }
               v: "a"
@@ -478,7 +568,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -504,7 +597,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -526,13 +622,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "SF"
@@ -541,7 +643,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 21.0
@@ -552,13 +657,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "SF"
@@ -567,7 +678,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 17.5
@@ -578,13 +692,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "SF"
@@ -593,7 +713,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 24.0
@@ -604,13 +727,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "NY"
@@ -619,7 +748,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 30.9
@@ -630,13 +762,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "NY"
@@ -645,7 +783,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 33.6
@@ -662,7 +803,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 40
         }
       }
@@ -684,7 +828,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 31
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               v: "location"
@@ -700,7 +847,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -741,7 +891,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 75
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
             }
@@ -772,7 +925,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 75
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -805,7 +961,10 @@ body {
           _2 {
             list_val {
               src {
+                end_column: 75
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               vs {
@@ -817,7 +976,10 @@ body {
                     }
                   }
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                 }
@@ -828,7 +990,10 @@ body {
                     sp_float_type: true
                   }
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                 }
@@ -841,13 +1006,19 @@ body {
           _2 {
             list_val {
               src {
+                end_column: 75
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               vs {
                 string_val {
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                   v: "LOCATION"
@@ -856,7 +1027,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                   v: "TEMP_C"
@@ -898,7 +1072,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -918,8 +1095,11 @@ body {
         cols {
           string_val {
             src {
+              end_column: 94
+              end_line: 46
               file: "SRC_POSITION_TEST_MODE"
-              start_line: 43
+              start_column: 76
+              start_line: 46
             }
             v: "temp_c"
           }
@@ -933,8 +1113,11 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 43
+          start_column: 76
+          start_line: 46
         }
       }
     }
@@ -956,8 +1139,11 @@ body {
           bitfield1: 16
         }
         src {
+          end_column: 104
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 43
+          start_column: 95
+          start_line: 46
         }
       }
     }
@@ -986,13 +1172,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 153
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 49
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 1
@@ -1001,7 +1193,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "A"
@@ -1010,7 +1205,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 10000
@@ -1019,7 +1217,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "JAN"
@@ -1030,13 +1231,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 153
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 49
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 1
@@ -1045,7 +1252,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "B"
@@ -1054,7 +1264,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 400
@@ -1063,7 +1276,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "JAN"
@@ -1074,13 +1290,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 153
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 49
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 1
@@ -1089,7 +1311,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "B"
@@ -1098,7 +1323,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 5000
@@ -1107,7 +1335,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "FEB"
@@ -1126,7 +1357,10 @@ body {
           }
         }
         src {
+          end_column: 153
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
       }
@@ -1148,7 +1382,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 28
+                end_line: 54
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 54
               }
               v: "empid"
@@ -1164,7 +1401,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
       }
@@ -1191,14 +1431,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 59
+              end_line: 54
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 54
             }
             v: "month"
           }
         }
         src {
+          end_column: 59
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
         values {
@@ -1206,13 +1452,19 @@ body {
             v {
               list_val {
                 src {
+                  end_column: 59
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 54
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 54
                     }
                     v: "JAN"
@@ -1221,7 +1473,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 54
                     }
                     v: "FEB"
@@ -1250,7 +1505,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 73
+                end_line: 54
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 54
               }
               v: "amount"
@@ -1266,7 +1524,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
       }
@@ -1312,7 +1573,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 56
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 56
               }
               v: "empid"
@@ -1321,7 +1585,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 56
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 56
               }
               v: "team"
@@ -1336,7 +1603,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1363,14 +1633,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 53
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 56
             }
             v: "month"
           }
         }
         src {
+          end_column: 53
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1392,7 +1668,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 67
+                end_line: 56
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 56
               }
               v: "amount"
@@ -1408,7 +1687,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1428,7 +1710,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 89
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 56
             }
             v: "empid"
@@ -1437,7 +1722,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 89
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 56
             }
             v: "team"
@@ -1452,7 +1740,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -86,7 +86,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 124
+          end_line: 30
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 22
           start_line: 30
         }
       }
@@ -118,7 +121,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: 1
@@ -127,7 +133,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: "two"
@@ -139,7 +148,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param1"
@@ -148,7 +160,10 @@ body {
               vs {
                 int64_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: 10
@@ -159,7 +174,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param2"
@@ -168,7 +186,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "twenty"
@@ -176,7 +197,10 @@ body {
               }
             }
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
           }
@@ -184,14 +208,20 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: true
           }
         }
         src {
+          end_column: 89
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
       }
@@ -219,7 +249,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: 1
@@ -228,7 +261,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: "two"
@@ -240,7 +276,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param1"
@@ -249,7 +288,10 @@ body {
               vs {
                 int64_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: 10
@@ -260,7 +302,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param2"
@@ -269,7 +314,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "twenty"
@@ -277,7 +325,10 @@ body {
               }
             }
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
           }
@@ -285,14 +336,20 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: true
           }
         }
         src {
+          end_column: 89
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
       }
@@ -331,7 +388,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: 2
@@ -340,7 +400,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: "one"
@@ -349,7 +412,10 @@ body {
         pos_args {
           seq_map_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
@@ -357,13 +423,19 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
         }
         src {
+          end_column: 63
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 34
         }
       }
@@ -391,7 +463,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: 2
@@ -400,7 +475,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: "one"
@@ -409,7 +487,10 @@ body {
         pos_args {
           seq_map_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
@@ -417,13 +498,19 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
         }
         src {
+          end_column: 63
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 34
         }
       }

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -60,13 +60,19 @@ body {
                   list: "c"
                 }
                 src {
+                  end_column: 74
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 29
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 1
@@ -75,7 +81,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 2
@@ -84,7 +93,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 3
@@ -99,13 +111,19 @@ body {
                   list: "a"
                 }
                 src {
+                  end_column: 74
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 29
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 4
@@ -114,7 +132,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 2
@@ -125,7 +146,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }
@@ -148,13 +172,19 @@ body {
             vs {
               sp_row {
                 src {
+                  end_column: 82
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 1
@@ -163,7 +193,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 3
@@ -172,7 +205,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 2
@@ -183,13 +219,19 @@ body {
             vs {
               sp_row {
                 src {
+                  end_column: 82
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 1
@@ -198,7 +240,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 2
@@ -207,7 +252,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 3
@@ -218,13 +266,19 @@ body {
             vs {
               sp_row {
                 src {
+                  end_column: 82
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 3
@@ -233,7 +287,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 2
@@ -242,7 +299,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 1
@@ -253,7 +313,10 @@ body {
           }
         }
         src {
+          end_column: 82
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -276,13 +339,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 33
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 1
@@ -291,7 +360,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 2
@@ -302,13 +374,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 33
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 3
@@ -317,7 +395,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 4
@@ -334,7 +415,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -357,13 +441,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: 1
@@ -372,7 +462,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: "snow"
@@ -383,13 +476,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: 3
@@ -398,7 +497,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: "flake"
@@ -436,7 +538,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -459,7 +564,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 1
@@ -468,7 +576,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 2
@@ -477,7 +588,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 3
@@ -486,7 +600,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 4
@@ -500,7 +617,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -523,13 +643,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 83
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 1
@@ -538,7 +664,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 2
@@ -547,7 +676,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 3
@@ -556,7 +688,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 4
@@ -575,7 +710,10 @@ body {
           }
         }
         src {
+          end_column: 83
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }
@@ -598,13 +736,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 43
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 1
@@ -613,7 +757,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 2
@@ -624,13 +771,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 43
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 3
@@ -639,7 +792,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 4
@@ -656,7 +812,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
       }
@@ -685,13 +844,19 @@ body {
                   list: "d"
                 }
                 src {
+                  end_column: 65
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 45
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 1
@@ -700,7 +865,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 2
@@ -709,7 +877,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 3
@@ -718,7 +889,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 4
@@ -729,7 +903,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 45
         }
       }
@@ -755,7 +932,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: "a"
@@ -764,7 +944,10 @@ body {
                   vs {
                     int64_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: 1
@@ -772,7 +955,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 47
                 }
               }
@@ -783,7 +969,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: "b"
@@ -792,7 +981,10 @@ body {
                   vs {
                     int64_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: 2
@@ -800,7 +992,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 47
                 }
               }
@@ -808,7 +1003,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 47
         }
       }

--- a/tests/ast/data/Session.flatten.test
+++ b/tests/ast/data/Session.flatten.test
@@ -41,20 +41,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 25
                     }
                     v: "{\"a\": [1,2]}"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 25
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 25
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 25
             }
           }
@@ -66,7 +75,10 @@ body {
           value: "a"
         }
         src {
+          end_column: 89
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -98,14 +110,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 27
                 }
                 v: "NUM"
               }
             }
             src {
+              end_column: 40
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 27
             }
           }
@@ -115,7 +133,10 @@ body {
         }
         recursive: true
         src {
+          end_column: 71
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -65,14 +65,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 51
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 25
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 25
                 }
               }
@@ -91,26 +97,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 25
                     }
                     v: "two"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 25
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 25
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 25
             }
           }
         }
         src {
+          end_column: 64
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -155,14 +173,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 72
+                        end_line: 27
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 62
                         start_line: 27
                       }
                       v: "bar"
                     }
                   }
                   src {
+                    end_column: 72
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 62
                     start_line: 27
                   }
                 }
@@ -184,27 +208,39 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 56
+                        end_line: 27
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 50
                         start_line: 27
                       }
                       v: 3
                     }
                   }
                   src {
+                    end_column: 56
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 50
                     start_line: 27
                   }
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
           }
         }
         src {
+          end_column: 73
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -235,13 +271,19 @@ body {
               }
             }
             src {
+              end_column: 52
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
         }
         src {
+          end_column: 52
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -269,7 +311,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 37
           start_line: 32
         }
       }
@@ -296,13 +341,19 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 32
             }
           }
         }
         src {
+          end_column: 43
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 32
         }
       }
@@ -332,14 +383,20 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 47
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 35
             }
             v: "foo"
           }
         }
         src {
+          end_column: 47
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 37
           start_line: 35
         }
       }
@@ -366,13 +423,19 @@ body {
               }
             }
             src {
+              end_column: 48
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
           }
         }
         src {
+          end_column: 48
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -400,7 +463,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -427,13 +493,19 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
           }
         }
         src {
+          end_column: 41
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
       }
@@ -463,14 +535,20 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 50
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "foo"
           }
         }
         src {
+          end_column: 50
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
       }
@@ -497,13 +575,19 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 41
             }
           }
         }
         src {
+          end_column: 41
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Table.delete.test
+++ b/tests/ast/data/Table.delete.test
@@ -58,7 +58,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -84,7 +87,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 19
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -115,7 +121,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variant {
@@ -140,7 +149,10 @@ body {
           bitfield1: 4
         }
         src {
+          end_column: 30
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -171,7 +183,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variant {
@@ -196,7 +211,10 @@ body {
           bitfield1: 7
         }
         src {
+          end_column: 79
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
         statement_params {
@@ -231,7 +249,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variant {
@@ -266,7 +287,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 27
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 39
                 }
               }
@@ -274,14 +298,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 32
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 39
                 }
                 v: 1
               }
             }
             src {
+              end_column: 32
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 39
             }
           }
@@ -290,7 +320,10 @@ body {
           bitfield1: 10
         }
         src {
+          end_column: 33
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -321,7 +354,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variant {
@@ -347,7 +383,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 2
@@ -356,7 +395,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 3
@@ -365,7 +407,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 4
@@ -374,7 +419,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 5
@@ -388,7 +436,10 @@ body {
           }
         }
         src {
+          end_column: 72
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 43
         }
       }
@@ -420,7 +471,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 45
                 }
               }
@@ -428,13 +482,19 @@ body {
             rhs {
               list_val {
                 src {
+                  end_column: 40
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 45
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 45
                     }
                     v: "num"
@@ -443,7 +503,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 45
             }
           }
@@ -459,7 +522,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 45
         }
       }

--- a/tests/ast/data/Table.drop_table.test
+++ b/tests/ast/data/Table.drop_table.test
@@ -22,7 +22,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -47,7 +50,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 23
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }

--- a/tests/ast/data/Table.init.test
+++ b/tests/ast/data/Table.init.test
@@ -22,7 +22,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -57,14 +60,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 39
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 27
             }
           }
@@ -83,14 +92,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 27
             }
           }
@@ -103,7 +118,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -84,13 +84,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 96
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 17
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: 1
@@ -99,7 +105,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: "one"
@@ -110,13 +119,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 96
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 17
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: 2
@@ -125,7 +140,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: "two"
@@ -136,13 +154,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 96
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 17
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: 3
@@ -151,7 +175,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: "three"
@@ -189,7 +216,10 @@ body {
           }
         }
         src {
+          end_column: 96
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 27
         }
       }
@@ -213,7 +243,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 32
         }
         variant {
@@ -242,7 +275,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 136
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 34
                     }
                     v: "str"
@@ -251,7 +287,10 @@ body {
                 _2 {
                   string_val {
                     src {
+                      end_column: 136
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 34
                     }
                     v: "value"
@@ -279,7 +318,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 43
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 34
                     }
                   }
@@ -295,13 +337,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 60
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 34
                     }
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 34
                 }
               }
@@ -319,7 +367,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 34
                     }
                   }
@@ -327,20 +378,29 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 34
                     }
                     v: "too_old"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 34
                 }
               }
             }
             src {
+              end_column: 92
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 34
             }
           }
@@ -353,7 +413,10 @@ body {
           }
         }
         src {
+          end_column: 136
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 34
         }
       }
@@ -384,7 +447,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 37
         }
         variant {
@@ -421,7 +487,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 88
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 39
                     }
                   }
@@ -429,14 +498,20 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 39
                     }
                     v: "too_new"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 39
                 }
               }
@@ -446,7 +521,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: "str"
@@ -455,7 +533,10 @@ body {
                 _2 {
                   string_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: "value2"
@@ -472,7 +553,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: "num"
@@ -481,7 +565,10 @@ body {
                 _2 {
                   int64_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: 123
@@ -507,7 +594,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 39
                 }
               }
@@ -515,14 +605,20 @@ body {
             rhs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 39
                 }
                 v: "bar"
               }
             }
             src {
+              end_column: 51
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 39
             }
           }
@@ -535,7 +631,10 @@ body {
           }
         }
         src {
+          end_column: 167
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -566,7 +665,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 42
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 42
         }
         variant {
@@ -594,7 +696,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 140
+                    end_line: 44
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 44
                   }
                   v: "str"
@@ -605,7 +710,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 140
+                    end_line: 44
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 44
                   }
                   v: "value"
@@ -632,7 +740,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 43
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 44
                     }
                   }
@@ -648,13 +759,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 60
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 44
                     }
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 44
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 44
                 }
               }
@@ -672,7 +789,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 44
                     }
                   }
@@ -680,20 +800,29 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 44
                     }
                     v: "too_old"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 44
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 44
                 }
               }
             }
             src {
+              end_column: 92
+              end_line: 44
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 44
             }
           }
@@ -706,7 +835,10 @@ body {
           }
         }
         src {
+          end_column: 140
+          end_line: 44
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 44
         }
       }
@@ -737,7 +869,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 46
         }
         variant {
@@ -774,7 +909,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 92
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 49
                     }
                   }
@@ -782,14 +920,20 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 49
                     }
                     v: "too_new"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 49
                 }
               }
@@ -798,7 +942,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 175
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 49
                   }
                   v: "str"
@@ -809,7 +956,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 175
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 49
                   }
                   v: "value"
@@ -825,7 +975,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 175
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 49
                     }
                     v: "str"
@@ -834,7 +987,10 @@ body {
                 _2 {
                   string_val {
                     src {
+                      end_column: 175
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 49
                     }
                     v: "value3"
@@ -860,7 +1016,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 49
                 }
               }
@@ -868,14 +1027,20 @@ body {
             rhs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 49
                 }
                 v: "foo"
               }
             }
             src {
+              end_column: 51
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 49
             }
           }
@@ -888,7 +1053,10 @@ body {
           }
         }
         src {
+          end_column: 175
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 49
         }
       }
@@ -919,7 +1087,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 52
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 52
         }
         variant {
@@ -961,7 +1132,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 54
                 }
               }
@@ -977,13 +1151,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 54
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 54
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 54
             }
           }
@@ -996,7 +1176,10 @@ body {
           }
         }
         src {
+          end_column: 114
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
       }
@@ -1027,7 +1210,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 57
         }
         variant {
@@ -1063,7 +1249,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 113
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 59
                     }
                   }
@@ -1071,14 +1260,20 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 59
                     }
                     v: "too_new"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 100
                   start_line: 59
                 }
               }
@@ -1103,7 +1298,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 43
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 59
                     }
                   }
@@ -1111,14 +1309,20 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 59
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 59
                 }
               }
@@ -1136,7 +1340,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 66
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 59
                     }
                   }
@@ -1152,19 +1359,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 83
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 59
                     }
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 59
             }
           }
@@ -1177,7 +1393,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 59
         }
       }
@@ -1208,7 +1427,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 62
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 62
         }
         variant {
@@ -1245,7 +1467,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 64
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 64
                 }
               }
@@ -1261,13 +1486,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 64
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 64
                 }
               }
             }
             src {
+              end_column: 70
+              end_line: 64
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 64
             }
           }
@@ -1280,7 +1511,10 @@ body {
           }
         }
         src {
+          end_column: 160
+          end_line: 64
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 64
         }
         statement_params {

--- a/tests/ast/data/Table.sample.test
+++ b/tests/ast/data/Table.sample.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -65,7 +68,10 @@ body {
           value: 100
         }
         src {
+          end_column: 38
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -100,7 +106,10 @@ body {
           value: 123
         }
         src {
+          end_column: 72
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -132,7 +141,10 @@ body {
           value: "SYSTEM"
         }
         src {
+          end_column: 59
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }

--- a/tests/ast/data/Table.update.test
+++ b/tests/ast/data/Table.update.test
@@ -50,7 +50,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -76,7 +79,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 21
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -106,7 +112,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 27
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 29
               }
             }
@@ -117,7 +126,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 27
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -147,7 +159,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 40
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 31
               }
               v: 1
@@ -167,7 +182,10 @@ body {
                 }
               }
               src {
+                end_column: 38
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 32
                 start_line: 31
               }
             }
@@ -178,7 +196,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 40
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -208,7 +229,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 43
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 33
               }
               v: 2
@@ -229,7 +253,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 33
                 }
               }
@@ -237,14 +264,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 33
                 }
                 v: 1
               }
             }
             src {
+              end_column: 42
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 33
             }
           }
@@ -253,7 +286,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 43
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }
@@ -283,7 +319,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 1
@@ -292,7 +331,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 2
@@ -301,7 +343,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 3
@@ -310,7 +355,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 4
@@ -324,7 +372,10 @@ body {
           }
         }
         src {
+          end_column: 72
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 35
         }
       }
@@ -347,7 +398,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 64
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 37
               }
               v: 3
@@ -368,7 +422,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 37
                 }
               }
@@ -384,13 +441,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 37
             }
           }
@@ -406,7 +469,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 37
         }
       }
@@ -436,7 +502,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 80
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: 4
@@ -456,7 +525,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 39
                 }
               }
@@ -472,13 +544,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 39
             }
           }
@@ -494,7 +572,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -524,7 +605,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 129
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 41
               }
               v: 5
@@ -544,7 +628,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 41
                 }
               }
@@ -560,13 +647,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 41
             }
           }
@@ -582,7 +675,10 @@ body {
           }
         }
         src {
+          end_column: 129
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 41
         }
         statement_params {

--- a/tests/ast/data/case_when.test
+++ b/tests/ast/data/case_when.test
@@ -62,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -100,26 +103,38 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 43
+                        end_line: 27
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 27
                       }
                       v: "bool_col"
                     }
                   }
                   src {
+                    end_column: 43
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 27
                   }
                 }
               }
               src {
+                end_column: 52
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 27
               }
               value {
                 string_val {
                   src {
+                    end_column: 52
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 27
                   }
                   v: "true"
@@ -127,7 +142,10 @@ body {
               }
             }
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -140,7 +158,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -178,14 +199,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 29
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 29
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 29
                       }
                     }
@@ -193,26 +220,38 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 41
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 29
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 41
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 49
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 29
               }
               value {
                 string_val {
                   src {
+                    end_column: 49
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 29
                   }
                   v: "one"
@@ -236,14 +275,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 63
+                            end_line: 29
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 55
                             start_line: 29
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 63
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 55
                         start_line: 29
                       }
                     }
@@ -251,26 +296,38 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 68
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 55
                         start_line: 29
                       }
                       v: 2
                     }
                   }
                   src {
+                    end_column: 68
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 55
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 76
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 29
               }
               value {
                 string_val {
                   src {
+                    end_column: 76
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 29
                   }
                   v: "two"
@@ -279,13 +336,19 @@ body {
             }
             cases {
               src {
+                end_column: 95
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 29
               }
               value {
                 string_val {
                   src {
+                    end_column: 95
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 29
                   }
                   v: "other"
@@ -293,7 +356,10 @@ body {
               }
             }
             src {
+              end_column: 49
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -306,7 +372,10 @@ body {
           }
         }
         src {
+          end_column: 96
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -344,14 +413,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 31
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 31
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 31
                       }
                     }
@@ -359,20 +434,29 @@ body {
                   lower_bound {
                     int64_val {
                       src {
+                        end_column: 52
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 31
                       }
                       v: 37
                     }
                   }
                   src {
+                    end_column: 52
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 31
                   }
                   upper_bound {
                     int64_val {
                       src {
+                        end_column: 52
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 31
                       }
                       v: 42
@@ -381,7 +465,10 @@ body {
                 }
               }
               src {
+                end_column: 63
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 31
               }
               value {
@@ -398,14 +485,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 62
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 54
                         start_line: 31
                       }
                       v: "B"
                     }
                   }
                   src {
+                    end_column: 62
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 54
                     start_line: 31
                   }
                 }
@@ -413,7 +506,10 @@ body {
             }
             cases {
               src {
+                end_column: 83
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 31
               }
               value {
@@ -430,21 +526,30 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 82
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 74
                         start_line: 31
                       }
                       v: "C"
                     }
                   }
                   src {
+                    end_column: 82
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 74
                     start_line: 31
                   }
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -457,7 +562,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -495,32 +603,47 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 33
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 33
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 33
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 33
                       }
                     }
                   }
                   src {
+                    end_column: 48
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 33
                   }
                 }
               }
               src {
+                end_column: 57
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 33
               }
               value {
                 string_val {
                   src {
+                    end_column: 57
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 33
                   }
                   v: "one"
@@ -529,13 +652,19 @@ body {
             }
             cases {
               src {
+                end_column: 76
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 33
               }
               value {
                 string_val {
                   src {
+                    end_column: 76
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 33
                   }
                   v: "other"
@@ -543,7 +672,10 @@ body {
               }
             }
             src {
+              end_column: 57
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -556,7 +688,10 @@ body {
           }
         }
         src {
+          end_column: 77
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -594,26 +729,38 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 35
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 35
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 35
                       }
                     }
                   }
                   src {
+                    end_column: 46
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 55
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
               value {
@@ -630,14 +777,20 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 54
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 48
                         start_line: 35
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 54
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 48
                     start_line: 35
                   }
                 }
@@ -660,14 +813,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 69
+                            end_line: 35
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 61
                             start_line: 35
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 69
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 61
                         start_line: 35
                       }
                     }
@@ -675,20 +834,29 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 74
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 61
                         start_line: 35
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 74
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 61
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 83
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
               value {
@@ -705,14 +873,20 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 82
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 76
                         start_line: 35
                       }
                       v: 2
                     }
                   }
                   src {
+                    end_column: 82
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 76
                     start_line: 35
                   }
                 }
@@ -720,7 +894,10 @@ body {
             }
             cases {
               src {
+                end_column: 101
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
               value {
@@ -737,21 +914,30 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 100
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 94
                         start_line: 35
                       }
                       v: 3
                     }
                   }
                   src {
+                    end_column: 100
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 94
                     start_line: 35
                   }
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -764,7 +950,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -802,14 +991,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 38
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 38
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 38
                       }
                     }
@@ -817,26 +1012,38 @@ body {
                   pattern {
                     string_val {
                       src {
+                        end_column: 52
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 38
                       }
                       v: "foo"
                     }
                   }
                   src {
+                    end_column: 52
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 38
                   }
                 }
               }
               src {
+                end_column: 60
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 38
               }
               value {
                 string_val {
                   src {
+                    end_column: 60
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 38
                   }
                   v: "foo"
@@ -845,13 +1052,19 @@ body {
             }
             cases {
               src {
+                end_column: 78
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 38
               }
               value {
                 string_val {
                   src {
+                    end_column: 78
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 38
                   }
                   v: "null"
@@ -875,14 +1088,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 92
+                            end_line: 38
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 84
                             start_line: 38
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 92
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 84
                         start_line: 38
                       }
                     }
@@ -890,26 +1109,38 @@ body {
                   pattern {
                     string_val {
                       src {
+                        end_column: 108
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 84
                         start_line: 38
                       }
                       v: "bar"
                     }
                   }
                   src {
+                    end_column: 108
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 84
                     start_line: 38
                   }
                 }
               }
               src {
+                end_column: 116
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 38
               }
               value {
                 string_val {
                   src {
+                    end_column: 116
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 38
                   }
                   v: "bar"
@@ -917,7 +1148,10 @@ body {
               }
             }
             src {
+              end_column: 60
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 38
             }
           }
@@ -930,7 +1164,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 38
         }
         variadic: true
@@ -968,14 +1205,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 40
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 40
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 40
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 40
                       }
                     }
@@ -994,32 +1237,47 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 47
+                            end_line: 40
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 39
                             start_line: 40
                           }
                           v: "b"
                         }
                       }
                       src {
+                        end_column: 47
+                        end_line: 40
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 39
                         start_line: 40
                       }
                     }
                   }
                   src {
+                    end_column: 47
+                    end_line: 40
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 40
                   }
                 }
               }
               src {
+                end_column: 56
+                end_line: 40
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 40
               }
               value {
                 string_val {
                   src {
+                    end_column: 56
+                    end_line: 40
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 40
                   }
                   v: "both"
@@ -1028,13 +1286,19 @@ body {
             }
             cases {
               src {
+                end_column: 75
+                end_line: 40
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 40
               }
               value {
                 string_val {
                   src {
+                    end_column: 75
+                    end_line: 40
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 40
                   }
                   v: "other"
@@ -1042,7 +1306,10 @@ body {
               }
             }
             src {
+              end_column: 56
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 40
             }
           }
@@ -1055,7 +1322,10 @@ body {
           }
         }
         src {
+          end_column: 76
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 40
         }
         variadic: true
@@ -1093,14 +1363,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 25
+                            end_line: 43
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 17
                             start_line: 43
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 25
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 17
                         start_line: 43
                       }
                     }
@@ -1108,26 +1384,38 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 30
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 17
                         start_line: 43
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 30
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 17
                     start_line: 43
                   }
                 }
               }
               src {
+                end_column: 38
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 12
                 start_line: 43
               }
               value {
                 string_val {
                   src {
+                    end_column: 38
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 12
                     start_line: 43
                   }
                   v: "one"
@@ -1136,14 +1424,20 @@ body {
             }
             cases {
               src {
+                end_column: 35
+                end_line: 44
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 44
               }
               value {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 44
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 44
                   }
                   v: "other_one"
                 }
@@ -1166,14 +1460,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 45
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 45
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 45
                       }
                     }
@@ -1181,27 +1481,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 45
                       }
                       v: 2
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 45
                   }
                 }
               }
               src {
+                end_column: 39
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 45
               }
               value {
                 string_val {
                   src {
+                    end_column: 39
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 45
                   }
                   v: "two"
                 }
@@ -1209,14 +1521,20 @@ body {
             }
             cases {
               src {
+                end_column: 35
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 46
               }
               value {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 46
                   }
                   v: "other_two"
                 }
@@ -1239,14 +1557,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 47
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 47
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 47
                       }
                     }
@@ -1254,27 +1578,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 47
                       }
                       v: 3
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 47
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 47
                   }
                 }
               }
               src {
+                end_column: 41
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 47
               }
               value {
                 string_val {
                   src {
+                    end_column: 41
+                    end_line: 47
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 47
                   }
                   v: "three"
                 }
@@ -1282,14 +1618,20 @@ body {
             }
             cases {
               src {
+                end_column: 37
+                end_line: 48
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 48
               }
               value {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 48
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 48
                   }
                   v: "other_three"
                 }
@@ -1312,14 +1654,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 49
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 49
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 49
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 49
                       }
                     }
@@ -1327,27 +1675,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 49
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 49
                       }
                       v: 4
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 49
                   }
                 }
               }
               src {
+                end_column: 40
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 49
               }
               value {
                 string_val {
                   src {
+                    end_column: 40
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 49
                   }
                   v: "four"
                 }
@@ -1355,14 +1715,20 @@ body {
             }
             cases {
               src {
+                end_column: 36
+                end_line: 50
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 50
               }
               value {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 50
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 50
                   }
                   v: "other_four"
                 }
@@ -1385,14 +1751,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 51
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 51
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 51
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 51
                       }
                     }
@@ -1400,27 +1772,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 51
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 51
                       }
                       v: 5
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 51
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 51
                   }
                 }
               }
               src {
+                end_column: 40
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 51
               }
               value {
                 string_val {
                   src {
+                    end_column: 40
+                    end_line: 51
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 51
                   }
                   v: "five"
                 }
@@ -1428,21 +1812,30 @@ body {
             }
             cases {
               src {
+                end_column: 36
+                end_line: 52
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 52
               }
               value {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 52
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 52
                   }
                   v: "other_five"
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 43
             }
           }
@@ -1455,7 +1848,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 42
         }
         variadic: true

--- a/tests/ast/data/col_alias.test
+++ b/tests/ast/data/col_alias.test
@@ -36,7 +36,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -73,21 +76,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 29
                 }
               }
             }
             name: "test"
             src {
+              end_column: 44
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 29
             }
             variant_is_as {
@@ -103,7 +115,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -138,21 +153,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 31
                 }
               }
             }
             name: "test"
             src {
+              end_column: 46
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 31
             }
             variant_is_as {
@@ -167,7 +191,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true
@@ -202,21 +229,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 33
                 }
               }
             }
             name: "test"
             src {
+              end_column: 45
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
           }
@@ -229,7 +265,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
         variadic: true
@@ -266,14 +305,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 33
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 35
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 33
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 35
                     }
                   }
@@ -281,21 +326,30 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 37
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 35
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 35
                 }
               }
             }
             name: "test"
             src {
+              end_column: 51
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 35
             }
           }
@@ -308,7 +362,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variadic: true

--- a/tests/ast/data/col_asc.test
+++ b/tests/ast/data/col_asc.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -69,20 +72,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -95,7 +107,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -130,14 +145,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -146,7 +167,10 @@ body {
               value: true
             }
             src {
+              end_column: 49
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -159,7 +183,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -194,14 +221,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
@@ -209,7 +242,10 @@ body {
             nulls_first {
             }
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -222,7 +258,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true

--- a/tests/ast/data/col_between.test
+++ b/tests/ast/data/col_between.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -86,26 +95,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             upper_bound {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 42
@@ -121,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/col_binops.test
+++ b/tests/ast/data/col_binops.test
@@ -75,7 +75,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -112,14 +115,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -138,20 +147,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -164,7 +182,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -199,14 +220,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -225,20 +252,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 29
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -251,7 +287,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -286,14 +325,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -312,20 +357,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 31
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -338,7 +392,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -373,14 +430,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
@@ -399,20 +462,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 33
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -425,7 +497,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -460,14 +535,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
@@ -486,20 +567,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 35
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -512,7 +602,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -547,14 +640,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
@@ -573,20 +672,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 37
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -599,7 +707,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -634,14 +745,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
@@ -660,20 +777,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 39
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -686,7 +812,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -721,14 +850,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
@@ -747,20 +882,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 41
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
           }
@@ -773,7 +917,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -808,14 +955,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
@@ -834,20 +987,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 43
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
           }
@@ -860,7 +1022,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -895,14 +1060,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
@@ -921,20 +1092,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 45
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
           }
@@ -947,7 +1127,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -982,14 +1165,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
@@ -1008,20 +1197,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 47
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
           }
@@ -1034,7 +1232,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -1069,14 +1270,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
@@ -1095,20 +1302,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 49
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
           }
@@ -1121,7 +1337,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -1156,14 +1375,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
@@ -1182,20 +1407,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 51
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
           }
@@ -1208,7 +1442,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1243,14 +1480,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
@@ -1269,20 +1512,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 53
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
           }
@@ -1295,7 +1547,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true

--- a/tests/ast/data/col_bitops.test
+++ b/tests/ast/data/col_bitops.test
@@ -31,7 +31,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -68,14 +71,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -94,20 +103,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -120,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -155,14 +176,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -181,20 +208,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 29
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -207,7 +243,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -242,14 +281,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -268,20 +313,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 31
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -294,7 +348,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -127,7 +127,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -164,20 +167,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             to {
@@ -193,7 +205,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -228,20 +243,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
             to {
@@ -257,7 +281,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -292,20 +319,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             to {
@@ -321,7 +357,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -356,20 +395,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             to {
@@ -385,7 +433,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -420,20 +471,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
             to {
@@ -452,7 +512,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -487,20 +550,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
             to {
@@ -516,7 +588,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -551,20 +626,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
             to {
@@ -580,7 +664,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -615,20 +702,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
             to {
@@ -644,7 +740,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -679,20 +778,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
             to {
@@ -708,7 +816,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -743,20 +854,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
             to {
@@ -772,7 +892,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -807,20 +930,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
             to {
@@ -836,7 +968,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -871,20 +1006,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
             to {
@@ -904,7 +1048,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -939,20 +1086,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
             to {
@@ -968,7 +1124,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1003,20 +1162,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
             to {
@@ -1039,7 +1207,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -1074,20 +1245,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 55
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 55
             }
             to {
@@ -1116,7 +1296,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
         variadic: true
@@ -1151,20 +1334,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 59
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 57
             }
             to {
@@ -1185,7 +1377,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 57
         }
         variadic: true
@@ -1220,20 +1415,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 59
             }
             to {
@@ -1250,7 +1454,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 59
         }
         variadic: true
@@ -1285,20 +1492,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 61
             }
             to {
@@ -1314,7 +1530,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 61
         }
         variadic: true
@@ -1349,20 +1568,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 63
             }
             to {
@@ -1378,7 +1606,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 63
         }
         variadic: true
@@ -1413,20 +1644,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 65
             }
             to {
@@ -1442,7 +1682,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 65
         }
         variadic: true
@@ -1477,20 +1720,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 67
             }
             to {
@@ -1506,7 +1758,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 67
         }
         variadic: true
@@ -1541,20 +1796,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 69
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 69
             }
             to {
@@ -1570,7 +1834,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 69
         }
         variadic: true
@@ -1605,20 +1872,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 71
             }
             to {
@@ -1634,7 +1910,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 71
         }
         variadic: true
@@ -1669,20 +1948,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 73
             }
             to {
@@ -1698,7 +1986,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 73
         }
         variadic: true
@@ -1733,20 +2024,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 75
             }
             to {
@@ -1764,7 +2064,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 75
         }
         variadic: true
@@ -1799,20 +2102,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 77
             }
             to {
@@ -1830,7 +2142,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 77
         }
         variadic: true
@@ -1865,20 +2180,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 79
             }
             to {
@@ -1907,7 +2231,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 79
         }
         variadic: true

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -55,7 +55,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -92,20 +95,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             to {
@@ -125,7 +137,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -160,20 +175,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
             to {
@@ -193,7 +217,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -228,20 +255,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             to {
@@ -261,7 +297,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -296,20 +335,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             to {
@@ -329,7 +377,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -364,20 +415,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 80
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
             to {
@@ -398,7 +458,10 @@ body {
           }
         }
         src {
+          end_column: 81
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -433,20 +496,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
             to {
@@ -470,7 +542,10 @@ body {
           }
         }
         src {
+          end_column: 95
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -505,20 +580,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
             to {
@@ -539,7 +623,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -574,20 +661,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 28
+              end_line: 46
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
             to {
@@ -662,7 +758,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true

--- a/tests/ast/data/col_desc.test
+++ b/tests/ast/data/col_desc.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -67,20 +70,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -93,7 +105,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -128,14 +143,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -144,7 +165,10 @@ body {
               value: true
             }
             src {
+              end_column: 50
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -157,7 +181,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -192,14 +219,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -207,7 +240,10 @@ body {
             nulls_first {
             }
             src {
+              end_column: 49
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -220,7 +256,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/col_getitem.test
+++ b/tests/ast/data/col_getitem.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,21 +63,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             idx: 2
             src {
+              end_column: 34
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -95,21 +107,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 27
                 }
               }
             }
             field: "test"
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 36
               start_line: 27
             }
           }
@@ -122,7 +143,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -67,14 +70,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -82,7 +91,10 @@ body {
             values {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 1
@@ -91,7 +103,10 @@ body {
             values {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 2
@@ -100,7 +115,10 @@ body {
             values {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 3
@@ -116,7 +134,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -151,14 +172,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -180,7 +207,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -215,14 +245,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -230,13 +266,19 @@ body {
             values {
               list_val {
                 src {
+                  end_column: 48
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: 1
@@ -245,7 +287,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: 2
@@ -254,7 +299,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: 3
@@ -272,7 +320,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/col_literal.test
+++ b/tests/ast/data/col_literal.test
@@ -163,7 +163,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variant {
@@ -200,14 +203,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -215,13 +224,19 @@ body {
             rhs {
               null_val {
                 src {
+                  end_column: 38
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -234,7 +249,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -269,14 +287,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
@@ -284,14 +308,20 @@ body {
             rhs {
               bool_val {
                 src {
+                  end_column: 38
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
                 v: true
               }
             }
             src {
+              end_column: 38
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -304,7 +334,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -339,14 +372,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
@@ -354,13 +393,19 @@ body {
             rhs {
               bool_val {
                 src {
+                  end_column: 39
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -373,7 +418,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -408,14 +456,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
@@ -423,14 +477,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
                 v: 42
               }
             }
             src {
+              end_column: 36
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -443,7 +503,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -478,14 +541,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
@@ -493,14 +562,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 39
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
                 v: 42.24
               }
             }
             src {
+              end_column: 39
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -513,7 +588,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -548,14 +626,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
@@ -563,14 +647,20 @@ body {
             rhs {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 40
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
           }
@@ -583,7 +673,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -618,14 +711,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
@@ -633,14 +732,20 @@ body {
             rhs {
               binary_val {
                 src {
+                  end_column: 60
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 60
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
           }
@@ -653,7 +758,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -688,14 +796,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
@@ -703,14 +817,20 @@ body {
             rhs {
               binary_val {
                 src {
+                  end_column: 56
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 56
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
           }
@@ -723,7 +843,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -758,14 +881,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
@@ -779,7 +908,10 @@ body {
                 month: 6
                 second: 33
                 src {
+                  end_column: 83
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
                 tz {
@@ -792,7 +924,10 @@ body {
               }
             }
             src {
+              end_column: 83
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
           }
@@ -805,7 +940,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -840,14 +978,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
@@ -861,7 +1005,10 @@ body {
                 month: 6
                 second: 33
                 src {
+                  end_column: 156
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
                 tz {
@@ -874,7 +1021,10 @@ body {
               }
             }
             src {
+              end_column: 156
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
           }
@@ -887,7 +1037,10 @@ body {
           }
         }
         src {
+          end_column: 157
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -922,14 +1075,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
@@ -943,7 +1102,10 @@ body {
                 month: 6
                 second: 33
                 src {
+                  end_column: 145
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
                 tz {
@@ -956,7 +1118,10 @@ body {
               }
             }
             src {
+              end_column: 145
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
           }
@@ -969,7 +1134,10 @@ body {
           }
         }
         src {
+          end_column: 146
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1004,14 +1172,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
@@ -1021,14 +1195,20 @@ body {
                 day: 7
                 month: 6
                 src {
+                  end_column: 59
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
                 year: 2024
               }
             }
             src {
+              end_column: 59
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
           }
@@ -1041,7 +1221,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -1076,14 +1259,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 55
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
               }
@@ -1095,7 +1284,10 @@ body {
                 minute: 42
                 second: 23
                 src {
+                  end_column: 66
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
                 tz {
@@ -1107,7 +1299,10 @@ body {
               }
             }
             src {
+              end_column: 66
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 55
             }
           }
@@ -1120,7 +1315,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
         variadic: true
@@ -1155,14 +1353,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
               }
@@ -1174,7 +1378,10 @@ body {
                 minute: 42
                 second: 23
                 src {
+                  end_column: 139
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
                 tz {
@@ -1186,7 +1393,10 @@ body {
               }
             }
             src {
+              end_column: 139
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 57
             }
           }
@@ -1199,7 +1409,10 @@ body {
           }
         }
         src {
+          end_column: 140
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 57
         }
         variadic: true
@@ -1234,14 +1447,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
               }
@@ -1253,7 +1472,10 @@ body {
                 minute: 42
                 second: 23
                 src {
+                  end_column: 128
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
                 tz {
@@ -1265,7 +1487,10 @@ body {
               }
             }
             src {
+              end_column: 128
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 59
             }
           }
@@ -1278,7 +1503,10 @@ body {
           }
         }
         src {
+          end_column: 129
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 59
         }
         variadic: true
@@ -1313,14 +1541,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
               }
@@ -1328,14 +1562,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 42
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
                 v: inf
               }
             }
             src {
+              end_column: 42
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 61
             }
           }
@@ -1348,7 +1588,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 61
         }
         variadic: true
@@ -1383,14 +1626,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
               }
@@ -1398,14 +1647,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 42
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
                 v: inf
               }
             }
             src {
+              end_column: 42
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 63
             }
           }
@@ -1418,7 +1673,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 63
         }
         variadic: true
@@ -1453,14 +1711,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
               }
@@ -1468,14 +1732,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 42
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
                 v: nan
               }
             }
             src {
+              end_column: 42
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 65
             }
           }
@@ -1488,7 +1758,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 65
         }
         variadic: true
@@ -1523,14 +1796,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
               }
@@ -1538,14 +1817,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 46
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
                 v: inf
               }
             }
             src {
+              end_column: 46
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 67
             }
           }
@@ -1558,7 +1843,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 67
         }
         variadic: true
@@ -1593,14 +1881,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 69
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
               }
@@ -1608,14 +1902,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 47
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
                 v: -inf
               }
             }
             src {
+              end_column: 47
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 69
             }
           }
@@ -1628,7 +1928,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 69
         }
         variadic: true
@@ -1663,14 +1966,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
               }
@@ -1678,14 +1987,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 46
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
                 v: nan
               }
             }
             src {
+              end_column: 46
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 71
             }
           }
@@ -1698,7 +2013,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 71
         }
         variadic: true
@@ -1733,14 +2051,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
               }
@@ -1749,14 +2073,20 @@ body {
               big_decimal_val {
                 scale: -6
                 src {
+                  end_column: 66
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
                 unscaled_value: "]\361\271\260\255"
               }
             }
             src {
+              end_column: 66
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 73
             }
           }
@@ -1769,7 +2099,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 73
         }
         variadic: true
@@ -1804,14 +2137,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
               }
@@ -1820,14 +2159,20 @@ body {
               big_decimal_val {
                 scale: -6
                 src {
+                  end_column: 67
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
                 unscaled_value: "\242\016FOS"
               }
             }
             src {
+              end_column: 67
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 75
             }
           }
@@ -1840,7 +2185,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 75
         }
         variadic: true
@@ -1875,14 +2223,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
               }
@@ -1890,14 +2244,20 @@ body {
             rhs {
               big_decimal_val {
                 src {
+                  end_column: 57
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
                 unscaled_value: "\006(\037"
               }
             }
             src {
+              end_column: 57
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 77
             }
           }
@@ -1910,7 +2270,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 77
         }
         variadic: true
@@ -1945,14 +2308,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
               }
@@ -1960,14 +2329,20 @@ body {
             rhs {
               big_decimal_val {
                 src {
+                  end_column: 60
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
                 unscaled_value: "\030\014\271\030"
               }
             }
             src {
+              end_column: 60
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 79
             }
           }
@@ -1980,7 +2355,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 79
         }
         variadic: true
@@ -2015,14 +2393,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 81
                 }
               }
@@ -2030,14 +2414,20 @@ body {
             rhs {
               big_decimal_val {
                 src {
+                  end_column: 60
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 81
                 }
                 unscaled_value: "\030\014\271\030"
               }
             }
             src {
+              end_column: 60
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 81
             }
           }
@@ -2050,7 +2440,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 81
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 81
         }
         variadic: true
@@ -2085,14 +2478,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 83
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 83
                 }
               }
@@ -2103,13 +2502,19 @@ body {
                   value: "+F"
                 }
                 src {
+                  end_column: 61
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 83
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 83
             }
           }
@@ -2122,7 +2527,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 83
         }
         variadic: true
@@ -2157,14 +2565,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 85
                 }
               }
@@ -2175,13 +2589,19 @@ body {
                   value: "-F"
                 }
                 src {
+                  end_column: 62
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 85
             }
           }
@@ -2194,7 +2614,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 85
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 85
         }
         variadic: true
@@ -2229,14 +2652,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 87
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 87
                 }
               }
@@ -2247,13 +2676,19 @@ body {
                   value: "+n"
                 }
                 src {
+                  end_column: 56
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 87
             }
           }
@@ -2266,7 +2701,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 87
         }
         variadic: true
@@ -2301,14 +2739,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 89
                 }
               }
@@ -2319,13 +2763,19 @@ body {
                   value: "-n"
                 }
                 src {
+                  end_column: 57
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 89
             }
           }
@@ -2338,7 +2788,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 89
         }
         variadic: true
@@ -2373,14 +2826,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 91
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 91
                 }
               }
@@ -2391,13 +2850,19 @@ body {
                   value: "+N"
                 }
                 src {
+                  end_column: 57
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 91
             }
           }
@@ -2410,7 +2875,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 91
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 91
         }
         variadic: true
@@ -2445,14 +2913,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 93
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 93
                 }
               }
@@ -2463,13 +2937,19 @@ body {
                   value: "-N"
                 }
                 src {
+                  end_column: 58
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 93
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 93
             }
           }
@@ -2482,7 +2962,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 93
         }
         variadic: true
@@ -2517,14 +3000,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 95
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 95
                 }
               }
@@ -2535,7 +3024,10 @@ body {
                   vs {
                     int64_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                     }
@@ -2543,7 +3035,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: "test"
@@ -2554,7 +3049,10 @@ body {
                   vs {
                     float64_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: 42.24
@@ -2563,7 +3061,10 @@ body {
                   vs {
                     null_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                     }
@@ -2573,7 +3074,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: "hello"
@@ -2582,7 +3086,10 @@ body {
                   vs {
                     binary_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: "test"
@@ -2593,7 +3100,10 @@ body {
                   vs {
                     bool_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: true
@@ -2603,7 +3113,10 @@ body {
                     big_decimal_val {
                       scale: -6
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       unscaled_value: "\242\016FOS"
@@ -2614,7 +3127,10 @@ body {
                   vs {
                     null_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                     }
@@ -2624,7 +3140,10 @@ body {
                       day: 7
                       month: 6
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       year: 2024
@@ -2632,13 +3151,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 165
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 95
                 }
               }
             }
             src {
+              end_column: 165
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 95
             }
           }
@@ -2651,7 +3176,10 @@ body {
           }
         }
         src {
+          end_column: 166
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 95
         }
         variadic: true
@@ -2686,14 +3214,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 97
                 }
               }
@@ -2701,19 +3235,28 @@ body {
             rhs {
               list_val {
                 src {
+                  end_column: 169
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 97
                 }
                 vs {
                   tuple_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     vs {
                       int64_val {
                         src {
+                          end_column: 169
+                          end_line: 97
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 97
                         }
                       }
@@ -2721,7 +3264,10 @@ body {
                     vs {
                       string_val {
                         src {
+                          end_column: 169
+                          end_line: 97
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 97
                         }
                         v: "test"
@@ -2730,7 +3276,10 @@ body {
                     vs {
                       float64_val {
                         src {
+                          end_column: 169
+                          end_line: 97
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 97
                         }
                         v: 42.24
@@ -2741,7 +3290,10 @@ body {
                 vs {
                   null_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                   }
@@ -2749,7 +3301,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     v: "hello"
@@ -2758,7 +3313,10 @@ body {
                 vs {
                   binary_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     v: "test"
@@ -2770,7 +3328,10 @@ body {
                       vs {
                         bool_val {
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                           v: true
@@ -2780,7 +3341,10 @@ body {
                         big_decimal_val {
                           scale: -6
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                           unscaled_value: "\242\016FOS"
@@ -2791,7 +3355,10 @@ body {
                       vs {
                         null_val {
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                         }
@@ -2801,7 +3368,10 @@ body {
                           day: 7
                           month: 6
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                           year: 2024
@@ -2809,7 +3379,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                   }
@@ -2817,7 +3390,10 @@ body {
               }
             }
             src {
+              end_column: 169
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 97
             }
           }
@@ -2830,7 +3406,10 @@ body {
           }
         }
         src {
+          end_column: 170
+          end_line: 97
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 97
         }
         variadic: true
@@ -2865,14 +3444,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 99
                 }
               }
@@ -2880,13 +3465,19 @@ body {
             rhs {
               tuple_val {
                 src {
+                  end_column: 175
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 99
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 175
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                   }
@@ -2894,13 +3485,19 @@ body {
                 vs {
                   tuple_val {
                     src {
+                      end_column: 175
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                     vs {
                       string_val {
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         v: "test"
@@ -2909,7 +3506,10 @@ body {
                     vs {
                       float64_val {
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         v: 42.24
@@ -2921,7 +3521,10 @@ body {
                           vs {
                             null_val {
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                             }
@@ -2929,13 +3532,19 @@ body {
                           vs {
                             tuple_val {
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                               vs {
                                 string_val {
                                   src {
+                                    end_column: 175
+                                    end_line: 99
                                     file: "SRC_POSITION_TEST_MODE"
+                                    start_column: 23
                                     start_line: 99
                                   }
                                   v: "hello"
@@ -2944,7 +3553,10 @@ body {
                               vs {
                                 binary_val {
                                   src {
+                                    end_column: 175
+                                    end_line: 99
                                     file: "SRC_POSITION_TEST_MODE"
+                                    start_column: 23
                                     start_line: 99
                                   }
                                   v: "test"
@@ -2954,7 +3566,10 @@ body {
                           }
                         }
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                       }
@@ -2964,13 +3579,19 @@ body {
                 vs {
                   list_val {
                     src {
+                      end_column: 175
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                     vs {
                       bool_val {
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         v: true
@@ -2980,7 +3601,10 @@ body {
                       big_decimal_val {
                         scale: -6
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         unscaled_value: "\242\016FOS"
@@ -2992,7 +3616,10 @@ body {
                           vs {
                             null_val {
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                             }
@@ -3002,7 +3629,10 @@ body {
                               day: 7
                               month: 6
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                               year: 2024
@@ -3010,7 +3640,10 @@ body {
                           }
                         }
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                       }
@@ -3020,7 +3653,10 @@ body {
               }
             }
             src {
+              end_column: 175
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 99
             }
           }
@@ -3033,7 +3669,10 @@ body {
           }
         }
         src {
+          end_column: 176
+          end_line: 99
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 99
         }
         variadic: true

--- a/tests/ast/data/col_null_nan.test
+++ b/tests/ast/data/col_null_nan.test
@@ -35,7 +35,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -72,14 +75,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -98,20 +107,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -124,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -159,20 +180,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -185,7 +215,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -220,20 +253,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -246,7 +288,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -281,20 +326,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -307,7 +361,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true

--- a/tests/ast/data/col_rbinops.test
+++ b/tests/ast/data/col_rbinops.test
@@ -51,7 +51,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -77,7 +80,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 42
@@ -97,20 +103,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -123,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -147,7 +165,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
                 v: 42
@@ -167,20 +188,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 29
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -193,7 +223,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -217,7 +250,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
                 v: 42
@@ -237,20 +273,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 31
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -263,7 +308,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -287,7 +335,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
                 v: 42
@@ -307,20 +358,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 33
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -333,7 +393,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -357,7 +420,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
                 v: 42
@@ -377,20 +443,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 35
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -403,7 +478,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -427,7 +505,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 37
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
                 v: 42
@@ -447,20 +528,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 37
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -473,7 +563,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -497,7 +590,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
                 v: 42
@@ -517,20 +613,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 39
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -543,7 +648,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -567,7 +675,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
                 v: 42
@@ -587,20 +698,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 41
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
           }
@@ -613,7 +733,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true

--- a/tests/ast/data/col_star.test
+++ b/tests/ast/data/col_star.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -48,7 +51,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 31
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -61,7 +67,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/col_string.test
+++ b/tests/ast/data/col_string.test
@@ -47,7 +47,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -84,14 +87,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -99,14 +108,20 @@ body {
             pattern {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 44
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -119,7 +134,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -154,14 +172,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -169,14 +193,20 @@ body {
             pattern {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 46
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -189,7 +219,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -224,14 +257,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -239,14 +278,20 @@ body {
             prefix {
               string_val {
                 src {
+                  end_column: 50
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 50
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -259,7 +304,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -294,26 +342,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             suffix {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
                 v: "test"
@@ -329,7 +389,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -364,14 +427,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
@@ -390,14 +459,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 35
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 35
                 }
               }
@@ -416,20 +491,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 35
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -442,7 +526,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -477,14 +564,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
@@ -492,14 +585,20 @@ body {
             collation_spec {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 47
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -512,7 +611,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -547,14 +649,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
@@ -562,14 +670,20 @@ body {
             pattern {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 48
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -582,7 +696,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -127,7 +127,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -164,20 +167,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             to {
@@ -193,7 +205,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -228,20 +243,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
             to {
@@ -257,7 +281,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -292,20 +319,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             to {
@@ -321,7 +357,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -356,20 +395,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             to {
@@ -385,7 +433,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -420,20 +471,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
             to {
@@ -452,7 +512,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -487,20 +550,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
             to {
@@ -516,7 +588,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -551,20 +626,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
             to {
@@ -580,7 +664,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -615,20 +702,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
             to {
@@ -644,7 +740,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -679,20 +778,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
             to {
@@ -708,7 +816,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -743,20 +854,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
             to {
@@ -772,7 +892,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -807,20 +930,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
             to {
@@ -836,7 +968,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -871,20 +1006,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
             to {
@@ -904,7 +1048,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -939,20 +1086,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
             to {
@@ -968,7 +1124,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1003,20 +1162,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
             to {
@@ -1039,7 +1207,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -1074,20 +1245,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 55
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 55
             }
             to {
@@ -1116,7 +1296,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
         variadic: true
@@ -1151,20 +1334,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 57
             }
             to {
@@ -1185,7 +1377,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 57
         }
         variadic: true
@@ -1220,20 +1415,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 59
             }
             to {
@@ -1250,7 +1454,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 59
         }
         variadic: true
@@ -1285,20 +1492,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 61
             }
             to {
@@ -1314,7 +1530,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 61
         }
         variadic: true
@@ -1349,20 +1568,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 63
             }
             to {
@@ -1378,7 +1606,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 63
         }
         variadic: true
@@ -1413,20 +1644,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 65
             }
             to {
@@ -1442,7 +1682,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 65
         }
         variadic: true
@@ -1477,20 +1720,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 67
             }
             to {
@@ -1506,7 +1758,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 67
         }
         variadic: true
@@ -1541,20 +1796,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 69
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 69
             }
             to {
@@ -1570,7 +1834,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 69
         }
         variadic: true
@@ -1605,20 +1872,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 71
             }
             to {
@@ -1634,7 +1910,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 71
         }
         variadic: true
@@ -1669,20 +1948,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 73
             }
             to {
@@ -1698,7 +1986,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 73
         }
         variadic: true
@@ -1733,20 +2024,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 75
             }
             to {
@@ -1764,7 +2064,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 75
         }
         variadic: true
@@ -1799,20 +2102,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 77
             }
             to {
@@ -1830,7 +2142,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 77
         }
         variadic: true
@@ -1865,20 +2180,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 79
             }
             to {
@@ -1907,7 +2231,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 79
         }
         variadic: true

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -74,7 +74,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 94
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 29
         }
       }
@@ -97,7 +100,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 v: 1
@@ -106,7 +112,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 v: 2
@@ -115,7 +124,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 v: 3
@@ -129,7 +141,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
       }
@@ -172,27 +187,39 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 34
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 26
                           start_line: 33
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 34
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 33
                     }
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 33
                 }
               }
             }
             name: "ans"
             src {
+              end_column: 46
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 33
             }
             variant_is_as {
@@ -208,7 +235,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         variadic: true
@@ -232,7 +262,10 @@ body {
           bitfield1: 3
         }
         src {
+          end_column: 57
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }
@@ -283,7 +316,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 124
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 37
         }
       }
@@ -317,7 +353,10 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 39
                     }
                     v: "add_two"
@@ -337,27 +376,39 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 46
+                          end_line: 39
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 38
                           start_line: 39
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 46
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 39
                     }
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 39
                 }
               }
             }
             name: "a_Ans"
             src {
+              end_column: 60
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 39
             }
             variant_is_as {
@@ -373,7 +424,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         variadic: true
@@ -397,7 +451,10 @@ body {
           bitfield1: 7
         }
         src {
+          end_column: 71
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -455,7 +512,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 83
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 41
               }
               v: true
@@ -486,7 +546,10 @@ body {
         }
         secure: true
         src {
+          end_column: 83
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 41
         }
         stage_location: "@"
@@ -540,7 +603,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 84
+                end_line: 52
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 48
               }
               v: true
@@ -570,7 +636,10 @@ body {
         }
         secure: true
         src {
+          end_column: 84
+          end_line: 52
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 48
         }
         stage_location: "@"
@@ -613,14 +682,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 54
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 54
                 }
               }
@@ -639,20 +714,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 54
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 54
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 54
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 54
             }
           }
@@ -665,7 +749,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
         variadic: true

--- a/tests/ast/data/col_unary_ops.test
+++ b/tests/ast/data/col_unary_ops.test
@@ -27,7 +27,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -64,20 +67,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 32
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -90,7 +102,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -125,20 +140,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 32
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -151,7 +175,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/df_alias.test
+++ b/tests/ast/data/df_alias.test
@@ -22,7 +22,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -52,7 +55,10 @@ body {
         }
         name: "new_name"
         src {
+          end_column: 33
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }

--- a/tests/ast/data/df_analytics_functions.test
+++ b/tests/ast/data/df_analytics_functions.test
@@ -142,13 +142,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-01"
@@ -157,7 +163,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 101
@@ -166,7 +175,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 200
@@ -177,13 +189,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-02"
@@ -192,7 +210,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 101
@@ -201,7 +222,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 100
@@ -212,13 +236,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-03"
@@ -227,7 +257,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 101
@@ -236,7 +269,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 300
@@ -247,13 +283,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-04"
@@ -262,7 +304,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 102
@@ -271,7 +316,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 250
@@ -282,7 +330,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
       }
@@ -311,7 +362,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
         variadic: true
@@ -343,7 +397,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 36
                 }
               }
@@ -351,14 +408,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 65
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 36
                 }
                 v: 2
               }
             }
             src {
+              end_column: 65
+              end_line: 36
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 36
             }
           }
@@ -372,7 +435,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 36
         }
       }
@@ -405,7 +471,10 @@ body {
         group_by: "PRODUCTKEY"
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 25
           start_line: 38
         }
         window_sizes: 2
@@ -447,7 +516,10 @@ body {
         group_by: "PRODUCTKEY"
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 26
           start_line: 48
         }
         window_sizes: 2
@@ -484,7 +556,10 @@ body {
         is_forward: true
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 29
           start_line: 56
         }
       }
@@ -522,7 +597,10 @@ body {
         is_forward: true
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 72
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 30
           start_line: 66
         }
       }
@@ -543,7 +621,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 74
             }
             v: "SALESAMOUNT"
@@ -561,7 +642,10 @@ body {
         lags: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 26
           start_line: 74
         }
       }
@@ -582,7 +666,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 27
               start_line: 81
             }
             v: "SALESAMOUNT"
@@ -602,7 +689,10 @@ body {
         lags: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 27
           start_line: 81
         }
       }
@@ -623,7 +713,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 94
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 27
               start_line: 89
             }
             v: "SALESAMOUNT"
@@ -641,7 +734,10 @@ body {
         leads: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 94
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 27
           start_line: 89
         }
       }
@@ -662,7 +758,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 102
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 96
             }
             v: "SALESAMOUNT"
@@ -682,7 +781,10 @@ body {
         leads: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 102
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 28
           start_line: 96
         }
       }
@@ -722,13 +824,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 104
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 104
                 }
               }
             }
             src {
+              end_column: 70
+              end_line: 104
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 104
             }
           }
@@ -742,7 +850,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 104
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 104
         }
       }
@@ -775,7 +886,10 @@ body {
         group_by: "PRODUCTKEY"
         sliding_interval: "12H"
         src {
+          end_column: 9
+          end_line: 112
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 30
           start_line: 106
         }
         time_col: "ORDERDATE"
@@ -815,7 +929,10 @@ body {
         group_by: "PRODUCTKEY"
         sliding_interval: "12H"
         src {
+          end_column: 9
+          end_line: 124
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 117
         }
         time_col: "ORDERDATE"

--- a/tests/ast/data/df_col.test
+++ b/tests/ast/data/df_col.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
               }
             }
             src {
+              end_column: 36
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -71,7 +77,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 27
             }
           }
@@ -87,7 +96,10 @@ body {
               }
             }
             src {
+              end_column: 55
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 27
             }
           }
@@ -100,7 +112,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/df_drop.test
+++ b/tests/ast/data/df_drop.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -59,14 +62,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 29
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 21
                     start_line: 27
                   }
                   v: "A"
                 }
               }
               src {
+                end_column: 29
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 27
               }
             }
@@ -81,7 +90,10 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }

--- a/tests/ast/data/df_except.test
+++ b/tests/ast/data/df_except.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -53,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -89,7 +95,10 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/df_first.test
+++ b/tests/ast/data/df_first.test
@@ -48,7 +48,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -79,7 +82,10 @@ body {
         }
         num: -5
         src {
+          end_column: 26
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -115,7 +121,10 @@ body {
         }
         num: 2
         src {
+          end_column: 37
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -151,7 +160,10 @@ body {
         }
         num: 1
         src {
+          end_column: 24
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -186,7 +198,10 @@ body {
         }
         num: 1
         src {
+          end_column: 35
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -220,7 +235,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         statement_params {

--- a/tests/ast/data/df_intersect.test
+++ b/tests/ast/data/df_intersect.test
@@ -27,7 +27,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -54,7 +57,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -90,7 +96,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/df_limit.test
+++ b/tests/ast/data/df_limit.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -55,7 +58,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 31
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -68,7 +74,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -96,7 +105,10 @@ body {
         }
         n: 3
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -118,7 +130,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 31
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -131,7 +146,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -160,7 +178,10 @@ body {
         n: 1
         offset: 1
         src {
+          end_column: 53
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -62,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -91,7 +94,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
         weights: 0.1
@@ -114,7 +120,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
           }
@@ -123,7 +132,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
       }
@@ -144,7 +156,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
             v: 1
@@ -154,7 +169,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
       }
@@ -175,7 +193,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
             v: 2
@@ -185,7 +206,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
       }
@@ -214,7 +238,10 @@ body {
           value: 24
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
         weights: 0.1
@@ -237,7 +264,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 57
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
           }
@@ -246,7 +276,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
       }
@@ -267,7 +300,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 57
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
             v: 1
@@ -277,7 +313,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
       }
@@ -298,7 +337,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 57
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
             v: 2
@@ -308,7 +350,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
       }
@@ -342,14 +387,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 29
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 19
                       start_line: 39
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 29
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 39
                 }
               }
@@ -368,20 +419,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 39
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 32
                       start_line: 39
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 39
             }
           }
@@ -394,7 +454,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         variadic: true
@@ -418,7 +481,10 @@ body {
           bitfield1: 10
         }
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -454,7 +520,10 @@ body {
           value: 24
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
         weights: 0.1
@@ -478,7 +547,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 41
             }
           }
@@ -487,7 +559,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
       }
@@ -507,7 +582,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 41
             }
             v: 1
@@ -517,7 +595,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
       }
@@ -537,7 +618,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 41
             }
             v: 2
@@ -547,7 +631,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
       }
@@ -570,7 +657,10 @@ body {
           bitfield1: 14
         }
         src {
+          end_column: 22
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }

--- a/tests/ast/data/df_sample.test
+++ b/tests/ast/data/df_sample.test
@@ -26,7 +26,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,7 +61,10 @@ body {
           value: 3
         }
         src {
+          end_column: 27
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -87,7 +93,10 @@ body {
           value: 0.5
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }

--- a/tests/ast/data/df_sort.test
+++ b/tests/ast/data/df_sort.test
@@ -42,7 +42,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -82,14 +85,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 27
             }
           }
@@ -103,7 +112,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -139,14 +151,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 29
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 29
             }
           }
@@ -160,7 +178,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }
@@ -205,14 +226,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 31
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 31
             }
           }
@@ -231,14 +258,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 31
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 39
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 31
             }
           }
@@ -252,7 +285,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
       }
@@ -297,14 +333,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 33
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 33
             }
           }
@@ -323,14 +365,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 33
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 39
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 33
             }
           }
@@ -344,7 +392,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
       }
@@ -394,14 +445,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 35
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 35
             }
           }
@@ -420,14 +477,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 35
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 39
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 35
             }
           }
@@ -446,14 +509,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 49
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 v: "C"
               }
             }
             src {
+              end_column: 49
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 35
             }
           }
@@ -467,7 +536,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
       }
@@ -499,14 +571,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 37
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 29
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 37
             }
           }
@@ -520,7 +598,10 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
       }

--- a/tests/ast/data/df_union.test
+++ b/tests/ast/data/df_union.test
@@ -46,7 +46,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -73,7 +76,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -109,7 +115,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -142,7 +151,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -166,7 +178,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
         variant {
@@ -193,7 +208,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variant {
@@ -229,7 +247,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -262,7 +283,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }

--- a/tests/ast/data/functions.test
+++ b/tests/ast/data/functions.test
@@ -1204,7 +1204,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -1239,14 +1242,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 33
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 33
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -1259,7 +1268,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 29
         }
         variadic: true
@@ -1292,7 +1304,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 31
                 }
                 v: "X"
@@ -1301,14 +1316,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 31
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 31
             }
           }
@@ -1321,7 +1342,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 31
         }
         variadic: true
@@ -1354,14 +1378,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 33
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 39
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 33
             }
           }
@@ -1374,7 +1404,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 33
         }
         variadic: true
@@ -1407,14 +1440,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 36
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 35
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 36
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 35
             }
           }
@@ -1427,7 +1466,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 35
         }
         variadic: true
@@ -1460,7 +1502,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 37
                 }
                 v: "X"
@@ -1469,14 +1514,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 37
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 41
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 37
             }
           }
@@ -1489,7 +1540,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 37
         }
         variadic: true
@@ -1522,14 +1576,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 39
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 42
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 39
             }
           }
@@ -1542,7 +1602,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 39
         }
         variadic: true
@@ -1575,14 +1638,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 41
                 }
                 v: 1
               }
             }
             src {
+              end_column: 31
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 41
             }
           }
@@ -1601,14 +1670,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 33
                   start_line: 41
                 }
                 v: "1"
               }
             }
             src {
+              end_column: 41
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 33
               start_line: 41
             }
           }
@@ -1627,14 +1702,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 51
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 41
                 }
                 v: 1.0
               }
             }
             src {
+              end_column: 51
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 41
             }
           }
@@ -1653,14 +1734,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 62
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 41
                 }
                 v: true
               }
             }
             src {
+              end_column: 62
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 41
             }
           }
@@ -1679,14 +1766,20 @@ body {
             pos_args {
               binary_val {
                 src {
+                  end_column: 76
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 41
                 }
                 v: "snow"
               }
             }
             src {
+              end_column: 76
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 41
             }
           }
@@ -1707,14 +1800,20 @@ body {
                 day: 2
                 month: 2
                 src {
+                  end_column: 108
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 41
                 }
                 year: 2023
               }
             }
             src {
+              end_column: 108
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 41
             }
           }
@@ -1733,13 +1832,19 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 121
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 110
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 121
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 110
                       start_line: 41
                     }
                     v: 1
@@ -1748,7 +1853,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 121
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 110
                       start_line: 41
                     }
                     v: 2
@@ -1757,7 +1865,10 @@ body {
               }
             }
             src {
+              end_column: 121
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 110
               start_line: 41
             }
           }
@@ -1779,7 +1890,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 145
+                        end_line: 41
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 123
                         start_line: 41
                       }
                       v: "snow"
@@ -1788,7 +1902,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 145
+                        end_line: 41
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 123
                         start_line: 41
                       }
                       v: "flake"
@@ -1796,13 +1913,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 145
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 123
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 145
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 123
               start_line: 41
             }
           }
@@ -1815,7 +1938,10 @@ body {
           }
         }
         src {
+          end_column: 146
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 41
         }
         variadic: true
@@ -1849,13 +1975,19 @@ body {
               sp_column_sql_expr {
                 sql: "CURRENT_WAREHOUSE()"
                 src {
+                  end_column: 56
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 43
             }
           }
@@ -1868,7 +2000,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 43
         }
         variadic: true
@@ -1899,7 +2034,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 45
             }
           }
@@ -1912,7 +2050,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 45
         }
         variadic: true
@@ -1943,7 +2084,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 47
             }
           }
@@ -1956,7 +2100,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 47
         }
         variadic: true
@@ -1987,7 +2134,10 @@ body {
               }
             }
             src {
+              end_column: 39
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 49
             }
           }
@@ -2000,7 +2150,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 49
         }
         variadic: true
@@ -2031,7 +2184,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 51
             }
           }
@@ -2044,7 +2200,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 51
         }
         variadic: true
@@ -2075,7 +2234,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 53
             }
           }
@@ -2088,7 +2250,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 53
         }
         variadic: true
@@ -2119,7 +2284,10 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 55
             }
           }
@@ -2132,7 +2300,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 55
         }
         variadic: true
@@ -2163,7 +2334,10 @@ body {
               }
             }
             src {
+              end_column: 39
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 57
             }
           }
@@ -2176,7 +2350,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 57
         }
         variadic: true
@@ -2207,7 +2384,10 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 59
             }
           }
@@ -2220,7 +2400,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 59
         }
         variadic: true
@@ -2251,7 +2434,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 61
             }
           }
@@ -2264,7 +2450,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 61
         }
         variadic: true
@@ -2295,7 +2484,10 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 63
             }
           }
@@ -2308,7 +2500,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 63
         }
         variadic: true
@@ -2339,7 +2534,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 65
             }
           }
@@ -2352,7 +2550,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 65
         }
         variadic: true
@@ -2383,7 +2584,10 @@ body {
               }
             }
             src {
+              end_column: 50
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 67
             }
           }
@@ -2396,7 +2600,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 67
         }
         variadic: true
@@ -2440,14 +2647,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 69
                     }
                     v: "d"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 69
                 }
               }
@@ -2455,14 +2668,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 43
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 69
                 }
                 v: 4
               }
             }
             src {
+              end_column: 43
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 69
             }
           }
@@ -2475,7 +2694,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 69
         }
         variadic: true
@@ -2519,14 +2741,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 71
                 }
               }
@@ -2534,14 +2762,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 48
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 71
                 }
                 v: 4
               }
             }
             src {
+              end_column: 48
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 71
             }
           }
@@ -2554,7 +2788,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 71
         }
         variadic: true
@@ -2598,14 +2835,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 73
                 }
               }
@@ -2624,20 +2867,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 73
             }
           }
@@ -2650,7 +2902,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 73
         }
         variadic: true
@@ -2694,20 +2949,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 75
             }
           }
@@ -2737,20 +3001,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 75
             }
           }
@@ -2763,7 +3036,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 75
         }
         variadic: true
@@ -2807,20 +3083,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 77
             }
           }
@@ -2850,20 +3135,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 77
             }
           }
@@ -2893,20 +3187,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 77
             }
           }
@@ -2919,7 +3222,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 77
         }
         variadic: true
@@ -2963,14 +3269,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 79
                 }
               }
@@ -2989,20 +3301,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 79
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 79
             }
           }
@@ -3032,14 +3353,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 79
                 }
               }
@@ -3047,14 +3374,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 76
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 79
                 }
                 v: -10
               }
             }
             src {
+              end_column: 76
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 79
             }
           }
@@ -3084,14 +3417,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 79
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 79
                 }
               }
@@ -3099,14 +3438,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 104
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 79
                 }
                 v: 42
               }
             }
             src {
+              end_column: 104
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 79
             }
           }
@@ -3119,7 +3464,10 @@ body {
           }
         }
         src {
+          end_column: 105
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 79
         }
         variadic: true
@@ -3163,14 +3511,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 81
                 }
               }
@@ -3189,20 +3543,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 81
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 81
             }
           }
@@ -3232,14 +3595,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 81
                 }
               }
@@ -3247,14 +3616,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 78
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 81
                 }
                 v: -10
               }
             }
             src {
+              end_column: 78
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 81
             }
           }
@@ -3284,14 +3659,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 81
                 }
               }
@@ -3299,14 +3680,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 107
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 81
                 }
                 v: 42
               }
             }
             src {
+              end_column: 107
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 80
               start_line: 81
             }
           }
@@ -3319,7 +3706,10 @@ body {
           }
         }
         src {
+          end_column: 108
+          end_line: 81
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 81
         }
         variadic: true
@@ -3352,7 +3742,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 83
                 }
                 v: "A"
@@ -3361,14 +3754,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 83
                 }
                 v: 10
               }
             }
             src {
+              end_column: 46
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 83
             }
           }
@@ -3387,7 +3786,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 62
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 83
                 }
                 v: "A"
@@ -3396,14 +3798,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 83
                 }
                 v: 2
               }
             }
             src {
+              end_column: 62
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 83
             }
           }
@@ -3433,14 +3841,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 79
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 71
                       start_line: 83
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 79
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 83
                 }
               }
@@ -3459,20 +3873,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 83
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 83
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 83
             }
           }
@@ -3485,7 +3908,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 83
         }
         variadic: true
@@ -3529,14 +3955,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 85
                 }
               }
@@ -3555,20 +3987,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 85
             }
           }
@@ -3598,14 +4039,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 85
                 }
               }
@@ -3624,20 +4071,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 89
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 58
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 89
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 85
             }
           }
@@ -3667,14 +4123,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 117
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 85
                 }
               }
@@ -3693,20 +4155,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 117
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 117
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 91
               start_line: 85
             }
           }
@@ -3736,14 +4207,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 144
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 136
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 144
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 136
                   start_line: 85
                 }
               }
@@ -3762,20 +4239,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 154
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 146
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 154
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 146
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 155
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 119
               start_line: 85
             }
           }
@@ -3805,14 +4291,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 187
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 157
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 187
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 157
                   start_line: 85
                 }
               }
@@ -3831,20 +4323,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 187
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 157
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 187
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 157
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 187
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 157
               start_line: 85
             }
           }
@@ -3874,14 +4375,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 220
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 189
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 220
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 189
                   start_line: 85
                 }
               }
@@ -3900,14 +4407,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 220
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 189
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 220
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 189
                   start_line: 85
                 }
               }
@@ -3926,20 +4439,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 220
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 189
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 220
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 189
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 220
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 189
               start_line: 85
             }
           }
@@ -3952,7 +4474,10 @@ body {
           }
         }
         src {
+          end_column: 221
+          end_line: 85
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 85
         }
         variadic: true
@@ -3996,14 +4521,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 87
                     }
                     v: "UTC"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 87
                 }
               }
@@ -4022,20 +4553,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 62
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 87
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 87
             }
           }
@@ -4065,14 +4605,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 124
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 87
                     }
                     v: "Asia/Shanghai"
                   }
                 }
                 src {
+                  end_column: 124
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 87
                 }
               }
@@ -4091,14 +4637,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 87
                     }
                     v: "UTC"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 87
                 }
               }
@@ -4117,20 +4669,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 87
                     }
                     v: "b"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 125
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 87
             }
           }
@@ -4143,7 +4704,10 @@ body {
           }
         }
         src {
+          end_column: 126
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 87
         }
         variadic: true
@@ -4187,20 +4751,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 89
             }
           }
@@ -4230,20 +4803,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 89
             }
           }
@@ -4256,7 +4838,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 89
         }
         variadic: true
@@ -4300,20 +4885,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 91
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 91
             }
           }
@@ -4343,20 +4937,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 91
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 91
             }
           }
@@ -4369,7 +4972,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 91
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 91
         }
         variadic: true
@@ -4413,14 +5019,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 93
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 93
                 }
               }
@@ -4439,20 +5051,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 93
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 93
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 93
             }
           }
@@ -4465,7 +5086,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 93
         }
         variadic: true
@@ -4498,14 +5122,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 95
                 }
                 v: "*"
               }
             }
             src {
+              end_column: 35
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 95
             }
           }
@@ -4524,14 +5154,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 95
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 47
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 95
             }
           }
@@ -4561,20 +5197,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 95
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 95
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 95
             }
           }
@@ -4587,7 +5232,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 95
         }
         variadic: true
@@ -4618,7 +5266,10 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 97
             }
           }
@@ -4638,13 +5289,19 @@ body {
               sp_column_sql_expr {
                 sql: "*"
                 src {
+                  end_column: 66
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 97
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 97
             }
           }
@@ -4663,7 +5320,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "A"
@@ -4672,7 +5332,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "B"
@@ -4681,7 +5344,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "C"
@@ -4690,7 +5356,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "D"
@@ -4710,20 +5379,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 112
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 97
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 112
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 97
                 }
               }
             }
             src {
+              end_column: 113
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 97
             }
           }
@@ -4736,7 +5414,10 @@ body {
           }
         }
         src {
+          end_column: 114
+          end_line: 97
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 97
         }
         variadic: true
@@ -4780,14 +5461,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 99
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 99
                 }
               }
@@ -4806,20 +5493,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 99
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 99
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 99
             }
           }
@@ -4832,7 +5528,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 99
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 99
         }
         variadic: true
@@ -4876,14 +5575,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 101
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 101
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 101
                 }
               }
@@ -4902,20 +5607,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 101
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 101
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 101
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 101
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 101
             }
           }
@@ -4928,7 +5642,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 101
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 101
         }
         variadic: true
@@ -4972,14 +5689,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 103
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 103
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 103
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 103
                 }
               }
@@ -4998,20 +5721,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 103
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 103
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 103
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 103
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 103
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 103
             }
           }
@@ -5024,7 +5756,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 103
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 103
         }
         variadic: true
@@ -5068,14 +5803,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
@@ -5094,14 +5835,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
@@ -5120,14 +5867,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
@@ -5146,20 +5899,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 105
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 105
             }
           }
@@ -5172,7 +5934,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 105
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 105
         }
         variadic: true
@@ -5216,14 +5981,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 107
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 107
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 107
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 107
                 }
               }
@@ -5242,20 +6013,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 107
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 107
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 107
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 107
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 107
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 107
             }
           }
@@ -5268,7 +6048,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 107
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 107
         }
         variadic: true
@@ -5312,14 +6095,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
@@ -5338,14 +6127,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
@@ -5364,14 +6159,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
@@ -5390,20 +6191,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 109
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 109
             }
           }
@@ -5416,7 +6226,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 109
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 109
         }
         variadic: true
@@ -5460,20 +6273,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 111
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 111
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 111
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 111
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 111
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 111
             }
           }
@@ -5486,7 +6308,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 111
         }
         variadic: true
@@ -5520,13 +6345,19 @@ body {
               sp_column_sql_expr {
                 sql: "*"
                 src {
+                  end_column: 33
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 113
             }
           }
@@ -5556,20 +6387,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 113
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 113
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 113
             }
           }
@@ -5599,20 +6439,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 113
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 113
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 113
             }
           }
@@ -5625,7 +6474,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 113
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 113
         }
         variadic: true
@@ -5669,20 +6521,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 115
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 115
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 115
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 115
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 115
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 115
             }
           }
@@ -5695,7 +6556,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 115
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 115
         }
         variadic: true
@@ -5739,20 +6603,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 117
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 117
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 117
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 117
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 117
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 117
             }
           }
@@ -5765,7 +6638,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 117
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 117
         }
         variadic: true
@@ -5809,20 +6685,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 119
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 119
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 119
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 119
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 119
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 119
             }
           }
@@ -5835,7 +6720,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 119
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 119
         }
         variadic: true
@@ -5879,20 +6767,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 121
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 121
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 121
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 121
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 121
             }
           }
@@ -5905,7 +6802,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 121
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 121
         }
         variadic: true
@@ -5949,20 +6849,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 123
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 123
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 123
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 123
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 123
             }
           }
@@ -5975,7 +6884,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 123
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 123
         }
         variadic: true
@@ -6019,20 +6931,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 125
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 125
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 125
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 125
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 125
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 125
             }
           }
@@ -6045,7 +6966,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 125
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 125
         }
         variadic: true
@@ -6089,20 +7013,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 127
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 127
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 127
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 127
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 127
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 127
             }
           }
@@ -6115,7 +7048,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 127
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 127
         }
         variadic: true
@@ -6159,20 +7095,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 129
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 129
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 129
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 129
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 129
             }
           }
@@ -6185,7 +7130,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 129
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 129
         }
         variadic: true
@@ -6229,20 +7177,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 131
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 131
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 131
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 131
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 131
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 131
             }
           }
@@ -6255,7 +7212,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 131
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 131
         }
         variadic: true
@@ -6299,20 +7259,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 133
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 133
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 133
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 133
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 133
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 133
             }
           }
@@ -6325,7 +7294,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 133
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 133
         }
         variadic: true
@@ -6369,20 +7341,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 135
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 135
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 135
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 135
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 135
             }
           }
@@ -6395,7 +7376,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 135
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 135
         }
         variadic: true
@@ -6439,20 +7423,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 137
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 137
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 137
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 137
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 137
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 137
             }
           }
@@ -6465,7 +7458,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 137
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 137
         }
         variadic: true
@@ -6509,20 +7505,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 139
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 139
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 139
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 139
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 139
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 139
             }
           }
@@ -6535,7 +7540,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 139
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 139
         }
         variadic: true
@@ -6579,14 +7587,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 141
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 141
                 }
               }
@@ -6605,20 +7619,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 52
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 141
                     }
                     v: 0.6
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 141
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 141
             }
           }
@@ -6648,14 +7671,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 141
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 141
                 }
               }
@@ -6674,19 +7703,28 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 86
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 141
                     }
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 141
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 141
             }
           }
@@ -6699,7 +7737,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 141
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 141
         }
         variadic: true
@@ -6743,20 +7784,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 143
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 143
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 143
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 143
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 143
             }
           }
@@ -6769,7 +7819,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 143
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 143
         }
         variadic: true
@@ -6813,14 +7866,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 145
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 145
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 145
                 }
               }
@@ -6839,20 +7898,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 61
+                      end_line: 145
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 145
                     }
                     v: 0.3
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 145
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 145
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 145
             }
           }
@@ -6865,7 +7933,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 145
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 145
         }
         variadic: true
@@ -6909,20 +7980,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 147
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 147
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 147
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 147
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 147
             }
           }
@@ -6935,7 +8015,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 147
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 147
         }
         variadic: true
@@ -6979,20 +8062,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 149
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 149
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 149
             }
           }
@@ -7022,14 +8114,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 149
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 149
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 149
                 }
               }
@@ -7048,20 +8146,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 149
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 149
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 149
             }
           }
@@ -7074,7 +8181,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 149
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 149
         }
         variadic: true
@@ -7105,7 +8215,10 @@ body {
               }
             }
             src {
+              end_column: 35
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 151
             }
           }
@@ -7135,14 +8248,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 151
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 151
                 }
               }
@@ -7161,20 +8280,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 63
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 151
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 151
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 151
             }
           }
@@ -7187,7 +8315,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 151
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 151
         }
         variadic: true
@@ -7222,20 +8353,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 153
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 153
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 153
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 153
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 153
             }
           }
@@ -7248,7 +8388,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 153
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 153
         }
         variadic: true
@@ -7283,20 +8426,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 155
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 155
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 155
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 155
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 155
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 155
             }
           }
@@ -7309,7 +8461,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 155
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 155
         }
         variadic: true
@@ -7344,20 +8499,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 157
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 157
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 157
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 157
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 157
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 157
             }
           }
@@ -7370,7 +8534,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 157
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 157
         }
         variadic: true
@@ -7405,20 +8572,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 159
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 159
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 159
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 159
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 159
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 159
             }
           }
@@ -7431,7 +8607,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 159
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 159
         }
         variadic: true
@@ -7462,7 +8641,10 @@ body {
               }
             }
             src {
+              end_column: 33
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 161
             }
           }
@@ -7479,7 +8661,10 @@ body {
               }
             }
             src {
+              end_column: 47
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 161
             }
           }
@@ -7498,14 +8683,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 59
+                  end_line: 161
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 161
                 }
                 v: 10
               }
             }
             src {
+              end_column: 59
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 161
             }
           }
@@ -7518,7 +8709,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 161
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 161
         }
         variadic: true
@@ -7562,14 +8756,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 163
                 }
               }
@@ -7588,14 +8788,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 163
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 163
                 }
               }
@@ -7614,20 +8820,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 163
             }
           }
@@ -7657,14 +8872,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 163
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 163
                 }
               }
@@ -7685,20 +8906,29 @@ body {
                     pos_args {
                       float64_val {
                         src {
+                          end_column: 75
+                          end_line: 163
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 49
                           start_line: 163
                         }
                         v: 13.0
                       }
                     }
                     src {
+                      end_column: 75
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 163
                     }
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 163
                 }
                 to {
@@ -7720,20 +8950,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 163
             }
           }
@@ -7765,20 +9004,29 @@ body {
                     pos_args {
                       float64_val {
                         src {
+                          end_column: 97
+                          end_line: 163
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 77
                           start_line: 163
                         }
                         v: 0.2
                       }
                     }
                     src {
+                      end_column: 97
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 163
                     }
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 163
                 }
                 to {
@@ -7800,14 +9048,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 97
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 163
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 163
                 }
               }
@@ -7826,20 +9080,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 97
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 163
                     }
                     v: 0.2
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 77
               start_line: 163
             }
           }
@@ -7852,7 +9115,10 @@ body {
           }
         }
         src {
+          end_column: 98
+          end_line: 163
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 163
         }
         variadic: true
@@ -7885,13 +9151,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 32
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 165
                 }
               }
             }
             src {
+              end_column: 32
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 165
             }
           }
@@ -7910,14 +9182,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 165
                 }
                 v: 10
               }
             }
             src {
+              end_column: 42
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 34
               start_line: 165
             }
           }
@@ -7936,14 +9214,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 165
                 }
                 v: -10
               }
             }
             src {
+              end_column: 53
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 165
             }
           }
@@ -7956,7 +9240,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 165
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 165
         }
         variadic: true
@@ -7989,14 +9276,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 32
+                  end_line: 167
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 167
                 }
                 v: 1
               }
             }
             src {
+              end_column: 32
+              end_line: 167
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 167
             }
           }
@@ -8009,7 +9302,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 167
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 167
         }
         variadic: true
@@ -8042,14 +9338,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 33
+                  end_line: 169
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 169
                 }
                 v: 12
               }
             }
             src {
+              end_column: 33
+              end_line: 169
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 169
             }
           }
@@ -8062,7 +9364,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 169
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 169
         }
         variadic: true
@@ -8095,14 +9400,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 34
+                  end_line: 171
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 171
                 }
                 v: 324
               }
             }
             src {
+              end_column: 34
+              end_line: 171
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 171
             }
           }
@@ -8115,7 +9426,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 171
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 171
         }
         variadic: true
@@ -8159,14 +9473,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 173
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 173
                 }
               }
@@ -8185,14 +9505,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 47
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 173
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 173
                 }
               }
@@ -8211,20 +9537,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 47
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 173
                     }
                     v: 3
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 173
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 173
             }
           }
@@ -8254,14 +9589,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 68
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 173
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 173
                 }
               }
@@ -8280,14 +9621,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 76
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 173
                     }
                     v: 12
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 173
                 }
               }
@@ -8306,20 +9653,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 76
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 173
                     }
                     v: 3
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 173
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 173
             }
           }
@@ -8332,7 +9688,10 @@ body {
           }
         }
         src {
+          end_column: 77
+          end_line: 173
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 173
         }
         variadic: true
@@ -8376,14 +9735,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 175
                 }
               }
@@ -8391,13 +9756,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 44
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 175
             }
           }
@@ -8416,7 +9787,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 66
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 175
                 }
                 v: "A"
@@ -8425,13 +9799,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 66
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 66
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 175
             }
           }
@@ -8450,7 +9830,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 91
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 175
                 }
                 v: "A"
@@ -8459,14 +9842,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 91
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 175
                 }
                 v: "999.9"
               }
             }
             src {
+              end_column: 91
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 68
               start_line: 175
             }
           }
@@ -8496,14 +9885,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 111
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 103
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 111
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 175
                 }
               }
@@ -8522,20 +9917,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 121
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 113
                       start_line: 175
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 121
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 113
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 122
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 93
               start_line: 175
             }
           }
@@ -8548,7 +9952,10 @@ body {
           }
         }
         src {
+          end_column: 123
+          end_line: 175
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 175
         }
         variadic: true
@@ -8592,13 +9999,19 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 35
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 177
                     }
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 177
                 }
               }
@@ -8617,20 +10030,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 35
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 177
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 177
             }
           }
@@ -8660,14 +10082,20 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 51
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 177
                     }
                     v: 1.2
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 177
                 }
               }
@@ -8686,20 +10114,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 51
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 177
                     }
                     v: 9.3
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 177
             }
           }
@@ -8729,14 +10166,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 67
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 177
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 177
                 }
               }
@@ -8755,20 +10198,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 67
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 177
                     }
                     v: 89.2
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 177
             }
           }
@@ -8798,14 +10250,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 177
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 177
                 }
               }
@@ -8824,20 +10282,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 81
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 177
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 177
             }
           }
@@ -8867,14 +10334,20 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 97
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 177
                     }
                     v: 0.2
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 177
                 }
               }
@@ -8893,20 +10366,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 97
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 177
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 177
             }
           }
@@ -8936,14 +10418,20 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 118
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 99
                       start_line: 177
                     }
                     v: 0.3
                   }
                 }
                 src {
+                  end_column: 118
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 177
                 }
               }
@@ -8962,20 +10450,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 109
                       start_line: 177
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 117
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 109
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 118
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 99
               start_line: 177
             }
           }
@@ -8988,7 +10485,10 @@ body {
           }
         }
         src {
+          end_column: 119
+          end_line: 177
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 177
         }
         variadic: true
@@ -9032,20 +10532,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 179
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 179
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 179
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 179
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 179
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 179
             }
           }
@@ -9058,7 +10567,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 179
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 179
         }
         variadic: true
@@ -9102,20 +10614,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 181
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 181
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 181
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 181
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 181
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 181
             }
           }
@@ -9128,7 +10649,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 181
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 181
         }
         variadic: true
@@ -9172,20 +10696,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 183
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 183
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 183
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 183
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 183
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 183
             }
           }
@@ -9198,7 +10731,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 183
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 183
         }
         variadic: true
@@ -9242,20 +10778,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 185
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 185
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 185
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 185
             }
           }
@@ -9268,7 +10813,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 185
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 185
         }
         variadic: true
@@ -9312,20 +10860,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 187
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 187
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 187
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 187
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 187
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 187
             }
           }
@@ -9338,7 +10895,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 187
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 187
         }
         variadic: true
@@ -9382,14 +10942,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 189
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 189
                 }
               }
@@ -9408,20 +10974,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 189
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 189
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 189
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 189
             }
           }
@@ -9434,7 +11009,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 189
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 189
         }
         variadic: true
@@ -9478,20 +11056,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 191
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 191
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 191
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 191
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 191
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 191
             }
           }
@@ -9504,7 +11091,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 191
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 191
         }
         variadic: true
@@ -9548,20 +11138,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 193
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 193
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 193
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 193
             }
           }
@@ -9574,7 +11173,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 193
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 193
         }
         variadic: true
@@ -9618,20 +11220,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 195
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 195
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 195
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 195
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 195
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 195
             }
           }
@@ -9644,7 +11255,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 195
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 195
         }
         variadic: true
@@ -9688,20 +11302,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 197
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 197
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 197
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 197
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 197
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 197
             }
           }
@@ -9714,7 +11337,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 197
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 197
         }
         variadic: true
@@ -9758,20 +11384,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 199
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 199
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 199
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 199
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 199
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 199
             }
           }
@@ -9784,7 +11419,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 199
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 199
         }
         variadic: true
@@ -9828,20 +11466,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 201
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 201
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 201
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 201
             }
           }
@@ -9854,7 +11501,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 201
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 201
         }
         variadic: true
@@ -9898,14 +11548,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 203
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 203
                 }
               }
@@ -9924,20 +11580,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 203
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 203
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 203
             }
           }
@@ -9967,14 +11632,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 203
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 203
                 }
               }
@@ -9982,14 +11653,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 77
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 203
                 }
                 v: 10
               }
             }
             src {
+              end_column: 77
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 203
             }
           }
@@ -10002,7 +11679,10 @@ body {
           }
         }
         src {
+          end_column: 78
+          end_line: 203
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 203
         }
         variadic: true
@@ -10046,20 +11726,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 205
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 205
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 205
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 205
             }
           }
@@ -10072,7 +11761,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 205
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 205
         }
         variadic: true
@@ -10116,20 +11808,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 207
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 207
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 207
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 207
             }
           }
@@ -10142,7 +11843,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 207
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 207
         }
         variadic: true
@@ -10186,20 +11890,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 209
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 209
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 209
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 209
             }
           }
@@ -10212,7 +11925,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 209
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 209
         }
         variadic: true
@@ -10256,20 +11972,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 211
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 211
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 211
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 211
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 211
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 211
             }
           }
@@ -10282,7 +12007,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 211
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 211
         }
         variadic: true
@@ -10326,20 +12054,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 213
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 213
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 213
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 213
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 213
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 213
             }
           }
@@ -10352,7 +12089,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 213
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 213
         }
         variadic: true
@@ -10396,20 +12136,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 215
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 215
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 215
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 215
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 215
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 215
             }
           }
@@ -10422,7 +12171,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 215
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 215
         }
         variadic: true
@@ -10466,20 +12218,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 217
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 217
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 217
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 217
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 217
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 217
             }
           }
@@ -10492,7 +12253,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 217
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 217
         }
         variadic: true
@@ -10536,20 +12300,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 219
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 219
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 219
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 219
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 219
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 219
             }
           }
@@ -10562,7 +12335,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 219
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 219
         }
         variadic: true
@@ -10606,14 +12382,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 221
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 221
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 221
                 }
               }
@@ -10621,13 +12403,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 221
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 221
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 221
             }
           }
@@ -10657,14 +12445,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 221
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 221
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 221
                 }
               }
@@ -10672,14 +12466,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 58
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 221
                 }
                 v: 224
               }
             }
             src {
+              end_column: 58
+              end_line: 221
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 221
             }
           }
@@ -10692,7 +12492,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 221
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 221
         }
         variadic: true
@@ -10736,13 +12539,19 @@ body {
                 pos_args {
                   null_val {
                     src {
+                      end_column: 39
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 223
                     }
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 223
                 }
               }
@@ -10761,14 +12570,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 223
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 223
                 }
               }
@@ -10787,14 +12602,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 223
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 223
                 }
               }
@@ -10813,20 +12634,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 64
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 223
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 223
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 223
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 223
             }
           }
@@ -10839,7 +12669,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 223
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 223
         }
         variadic: true
@@ -10883,20 +12716,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 225
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 225
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 225
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 225
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 225
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 225
             }
           }
@@ -10909,7 +12751,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 225
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 225
         }
         variadic: true
@@ -10953,20 +12798,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 227
             }
           }
@@ -10996,20 +12850,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 227
             }
           }
@@ -11039,14 +12902,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 227
                 }
               }
@@ -11065,20 +12934,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 227
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 227
             }
           }
@@ -11108,14 +12986,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 227
                 }
               }
@@ -11134,20 +13018,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 107
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 227
                     }
                     v: "123"
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 108
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 79
               start_line: 227
             }
           }
@@ -11160,7 +13053,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 227
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 227
         }
         variadic: true
@@ -11204,20 +13100,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 229
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 229
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 229
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 229
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 229
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 229
             }
           }
@@ -11230,7 +13135,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 229
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 229
         }
         variadic: true
@@ -11274,20 +13182,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 231
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 231
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 231
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 231
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 231
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 231
             }
           }
@@ -11300,7 +13217,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 231
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 231
         }
         variadic: true
@@ -11344,14 +13264,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 233
                 }
               }
@@ -11370,14 +13296,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 233
                 }
               }
@@ -11396,20 +13328,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 233
             }
           }
@@ -11439,14 +13380,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 233
                 }
               }
@@ -11465,14 +13412,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 233
                     }
                     v: 100
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 233
                 }
               }
@@ -11491,20 +13444,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 71
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 233
             }
           }
@@ -11534,14 +13496,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 233
                 }
               }
@@ -11560,14 +13528,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 233
                 }
               }
@@ -11586,20 +13560,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 107
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 73
               start_line: 233
             }
           }
@@ -11612,7 +13595,10 @@ body {
           }
         }
         src {
+          end_column: 108
+          end_line: 233
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 233
         }
         variadic: true
@@ -11656,20 +13642,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 235
             }
           }
@@ -11699,20 +13694,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 235
             }
           }
@@ -11742,14 +13746,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 235
                 }
               }
@@ -11768,20 +13778,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 235
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 235
             }
           }
@@ -11811,14 +13830,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 235
                 }
               }
@@ -11837,20 +13862,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 235
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 103
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 235
             }
           }
@@ -11863,7 +13897,10 @@ body {
           }
         }
         src {
+          end_column: 104
+          end_line: 235
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 235
         }
         variadic: true
@@ -11907,14 +13944,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 237
                 }
               }
@@ -11933,14 +13976,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 237
                 }
               }
@@ -11959,20 +14008,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 237
             }
           }
@@ -12002,14 +14060,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 237
                 }
               }
@@ -12028,14 +14092,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 237
                     }
                     v: 100
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 237
                 }
               }
@@ -12054,20 +14124,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 71
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 237
             }
           }
@@ -12097,14 +14176,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 237
                 }
               }
@@ -12123,14 +14208,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 237
                 }
               }
@@ -12149,20 +14240,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 107
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 73
               start_line: 237
             }
           }
@@ -12175,7 +14275,10 @@ body {
           }
         }
         src {
+          end_column: 108
+          end_line: 237
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 237
         }
         variadic: true
@@ -12219,20 +14322,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 239
             }
           }
@@ -12262,20 +14374,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 239
             }
           }
@@ -12305,14 +14426,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 239
                 }
               }
@@ -12331,20 +14458,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 239
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 239
             }
           }
@@ -12374,14 +14510,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 239
                 }
               }
@@ -12400,20 +14542,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 239
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 103
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 239
             }
           }
@@ -12426,7 +14577,10 @@ body {
           }
         }
         src {
+          end_column: 104
+          end_line: 239
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 239
         }
         variadic: true
@@ -12470,14 +14624,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 241
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 241
                 }
               }
@@ -12496,20 +14656,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 40
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 241
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 241
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 241
             }
           }
@@ -12539,14 +14708,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 241
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 241
                 }
               }
@@ -12565,20 +14740,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 62
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 241
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 241
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 241
             }
           }
@@ -12608,14 +14792,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 241
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 241
                 }
               }
@@ -12634,20 +14824,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 241
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 241
                 }
               }
             }
             src {
+              end_column: 85
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 241
             }
           }
@@ -12660,7 +14859,10 @@ body {
           }
         }
         src {
+          end_column: 86
+          end_line: 241
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 241
         }
         variadic: true
@@ -12704,20 +14906,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 243
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 243
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 243
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 243
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 243
             }
           }
@@ -12730,7 +14941,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 243
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 243
         }
         variadic: true
@@ -12774,20 +14988,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 245
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 245
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 245
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 245
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 245
             }
           }
@@ -12800,7 +15023,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 245
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 245
         }
         variadic: true
@@ -12844,20 +15070,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 247
             }
           }
@@ -12887,20 +15122,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 247
             }
           }
@@ -12930,14 +15174,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 247
                 }
               }
@@ -12956,20 +15206,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 247
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 247
             }
           }
@@ -12999,14 +15258,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 247
                 }
               }
@@ -13025,20 +15290,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 90
                       start_line: 247
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 90
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 99
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 75
               start_line: 247
             }
           }
@@ -13051,7 +15325,10 @@ body {
           }
         }
         src {
+          end_column: 100
+          end_line: 247
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 247
         }
         variadic: true
@@ -13095,20 +15372,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 249
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 31
                       start_line: 249
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 249
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 249
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 249
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 249
             }
           }
@@ -13121,7 +15407,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 249
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 249
         }
         variadic: true
@@ -13165,20 +15454,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 251
             }
           }
@@ -13208,20 +15506,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 251
             }
           }
@@ -13251,14 +15558,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 251
                 }
               }
@@ -13277,20 +15590,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 251
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 81
               start_line: 251
             }
           }
@@ -13320,14 +15642,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 143
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 118
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 143
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 118
                   start_line: 251
                 }
               }
@@ -13346,20 +15674,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 143
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 118
                       start_line: 251
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 143
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 118
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 143
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 118
               start_line: 251
             }
           }
@@ -13372,7 +15709,10 @@ body {
           }
         }
         src {
+          end_column: 144
+          end_line: 251
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 251
         }
         variadic: true
@@ -13405,7 +15745,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 57
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 253
                 }
                 v: "A"
@@ -13425,14 +15768,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 253
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 253
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 253
                 }
               }
@@ -13451,20 +15800,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 253
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 253
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 253
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 253
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 253
             }
           }
@@ -13477,7 +15835,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 253
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 253
         }
         variadic: true
@@ -13521,14 +15882,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 255
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 255
                 }
               }
@@ -13547,20 +15914,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 38
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 255
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 255
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 255
             }
           }
@@ -13590,14 +15966,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 255
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 255
                 }
               }
@@ -13616,20 +15998,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 58
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 255
                     }
                     v: 4.3
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 255
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 255
             }
           }
@@ -13659,14 +16050,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 255
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 255
                 }
               }
@@ -13685,20 +16082,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 255
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 255
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 255
             }
           }
@@ -13711,7 +16117,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 255
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 255
         }
         variadic: true
@@ -13755,14 +16164,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 257
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 257
                 }
               }
@@ -13781,20 +16196,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 38
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 257
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 257
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 257
             }
           }
@@ -13824,14 +16248,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 257
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 257
                 }
               }
@@ -13850,20 +16280,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 58
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 257
                     }
                     v: 4.3
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 257
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 257
             }
           }
@@ -13893,14 +16332,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 257
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 257
                 }
               }
@@ -13919,20 +16364,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 257
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 257
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 257
             }
           }
@@ -13945,7 +16399,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 257
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 257
         }
         variadic: true
@@ -13978,7 +16435,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 36
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 259
                 }
                 v: "A"
@@ -13987,13 +16447,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 259
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 259
             }
           }
@@ -14012,7 +16478,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 259
                 }
                 v: "A"
@@ -14021,13 +16490,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 259
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 259
             }
           }
@@ -14057,14 +16532,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 259
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 259
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 259
                 }
               }
@@ -14072,14 +16553,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 73
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 259
                 }
                 v: 4.7
               }
             }
             src {
+              end_column: 73
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 259
             }
           }
@@ -14092,7 +16579,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 259
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 259
         }
         variadic: true
@@ -14136,20 +16626,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 261
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 261
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 261
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 261
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 261
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 261
             }
           }
@@ -14162,7 +16661,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 261
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 261
         }
         variadic: true
@@ -14206,14 +16708,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 263
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 263
                 }
               }
@@ -14232,20 +16740,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 263
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 263
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 263
             }
           }
@@ -14275,14 +16792,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 263
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 263
                 }
               }
@@ -14301,20 +16824,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 263
                     }
                     v: "asfdg"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 263
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 263
             }
           }
@@ -14327,7 +16859,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 263
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 263
         }
         variadic: true
@@ -14371,14 +16906,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 265
                 }
               }
@@ -14397,14 +16938,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 265
                 }
               }
@@ -14423,20 +16970,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 265
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 265
             }
           }
@@ -14466,14 +17022,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 265
                 }
               }
@@ -14492,13 +17054,19 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 88
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 265
                     }
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 265
                 }
               }
@@ -14517,20 +17085,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 88
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 265
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 265
                 }
               }
             }
             src {
+              end_column: 88
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 265
             }
           }
@@ -14560,14 +17137,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 108
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 108
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 100
                   start_line: 265
                 }
               }
@@ -14586,14 +17169,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 123
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 90
                       start_line: 265
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 123
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 90
                   start_line: 265
                 }
               }
@@ -14612,20 +17201,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 122
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 114
                       start_line: 265
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 122
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 114
                   start_line: 265
                 }
               }
             }
             src {
+              end_column: 123
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 90
               start_line: 265
             }
           }
@@ -14638,7 +17236,10 @@ body {
           }
         }
         src {
+          end_column: 124
+          end_line: 265
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 265
         }
         variadic: true
@@ -14671,7 +17272,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
                 v: "A"
@@ -14680,7 +17284,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
                 v: "abc"
@@ -14689,14 +17296,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 56
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
                 v: 3
               }
             }
             src {
+              end_column: 56
+              end_line: 267
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 267
             }
           }
@@ -14726,14 +17339,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 267
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 267
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 267
                 }
               }
@@ -14752,14 +17371,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 267
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 267
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 267
                 }
               }
@@ -14767,14 +17392,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 96
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 267
                 }
                 v: 2
               }
             }
             src {
+              end_column: 96
+              end_line: 267
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 267
             }
           }
@@ -14787,7 +17418,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 267
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 267
         }
         variadic: true
@@ -14831,14 +17465,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 269
                 }
               }
@@ -14857,14 +17497,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 269
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 269
                 }
               }
@@ -14883,20 +17529,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 269
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 269
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 269
             }
           }
@@ -14926,14 +17581,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 73
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 73
                   start_line: 269
                 }
               }
@@ -14952,14 +17613,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 269
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 269
                 }
               }
@@ -14978,14 +17645,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 269
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 269
                 }
               }
@@ -15004,14 +17677,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 116
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 269
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 269
                 }
               }
@@ -15030,14 +17709,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 116
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 269
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 269
                 }
               }
@@ -15056,20 +17741,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 269
                     }
                     v: "test"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 269
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 269
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 269
             }
           }
@@ -15082,7 +17776,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 269
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 269
         }
         variadic: true
@@ -15115,7 +17812,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 53
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
                 v: "A"
@@ -15124,7 +17824,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 53
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
                 v: "B"
@@ -15133,14 +17836,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
                 v: 2
               }
             }
             src {
+              end_column: 53
+              end_line: 271
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 271
             }
           }
@@ -15153,7 +17862,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 271
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 271
         }
         variadic: true
@@ -15197,14 +17909,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
@@ -15223,14 +17941,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
@@ -15249,13 +17973,19 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
@@ -15274,14 +18004,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 60
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
@@ -15300,19 +18036,28 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 60
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 273
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 273
             }
           }
@@ -15342,14 +18087,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 273
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 273
                 }
               }
@@ -15368,14 +18119,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 273
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 273
                 }
               }
@@ -15394,14 +18151,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 273
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 273
                 }
               }
@@ -15420,14 +18183,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 273
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 273
                 }
               }
@@ -15446,14 +18215,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 125
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 117
                       start_line: 273
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 125
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 117
                   start_line: 273
                 }
               }
@@ -15472,14 +18247,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 135
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 127
                       start_line: 273
                     }
                     v: "F"
                   }
                 }
                 src {
+                  end_column: 135
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 127
                   start_line: 273
                 }
               }
@@ -15498,14 +18279,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 152
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 273
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 152
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 273
                 }
               }
@@ -15524,14 +18311,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 152
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 273
                     }
                     v: "sgh"
                   }
                 }
                 src {
+                  end_column: 152
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 273
                 }
               }
@@ -15550,20 +18343,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 152
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 273
                     }
                     v: 99.9
                   }
                 }
                 src {
+                  end_column: 152
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 273
                 }
               }
             }
             src {
+              end_column: 152
+              end_line: 273
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 273
             }
           }
@@ -15576,7 +18378,10 @@ body {
           }
         }
         src {
+          end_column: 153
+          end_line: 273
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 273
         }
         variadic: true
@@ -15620,14 +18425,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 275
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 275
                 }
               }
@@ -15646,13 +18457,19 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 275
                     }
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 275
                 }
               }
@@ -15671,19 +18488,28 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 275
                     }
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 275
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 275
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 275
             }
           }
@@ -15713,14 +18539,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 79
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 275
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 79
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 275
                 }
               }
@@ -15739,14 +18571,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 79
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 275
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 79
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 275
                 }
               }
@@ -15765,20 +18603,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 79
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 275
                     }
                     v: "ahsgj"
                   }
                 }
                 src {
+                  end_column: 79
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 275
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 275
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 275
             }
           }
@@ -15791,7 +18638,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 275
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 275
         }
         variadic: true
@@ -15835,14 +18685,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 277
                 }
               }
@@ -15861,20 +18717,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 277
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 277
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 277
             }
           }
@@ -15904,14 +18769,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 277
                 }
               }
@@ -15930,20 +18801,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 277
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 277
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 277
             }
           }
@@ -15973,14 +18853,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 107
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 277
                 }
               }
@@ -15999,14 +18885,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 107
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 277
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 277
                 }
               }
@@ -16025,20 +18917,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 107
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 277
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 277
                 }
               }
             }
             src {
+              end_column: 107
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 277
             }
           }
@@ -16068,14 +18969,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 138
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 109
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 138
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 109
                   start_line: 277
                 }
               }
@@ -16094,14 +19001,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 138
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 109
                       start_line: 277
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 138
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 109
                   start_line: 277
                 }
               }
@@ -16120,20 +19033,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 137
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 129
                       start_line: 277
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 137
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 277
                 }
               }
             }
             src {
+              end_column: 138
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 109
               start_line: 277
             }
           }
@@ -16146,7 +19068,10 @@ body {
           }
         }
         src {
+          end_column: 139
+          end_line: 277
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 277
         }
         variadic: true
@@ -16190,14 +19115,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 279
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 279
                 }
               }
@@ -16205,14 +19136,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 55
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 279
                 }
                 v: "sp-upper"
               }
             }
             src {
+              end_column: 55
+              end_line: 279
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 279
             }
           }
@@ -16225,7 +19162,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 279
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 279
         }
         variadic: true
@@ -16269,20 +19209,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 281
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 281
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 281
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 281
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 281
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 281
             }
           }
@@ -16295,7 +19244,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 281
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 281
         }
         variadic: true
@@ -16339,14 +19291,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 283
                 }
               }
@@ -16365,14 +19323,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 283
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 283
                 }
               }
@@ -16391,20 +19355,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 283
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 283
             }
           }
@@ -16421,7 +19394,10 @@ body {
               }
             }
             src {
+              end_column: 62
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 283
             }
           }
@@ -16434,7 +19410,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 283
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 283
         }
         variadic: true
@@ -16478,14 +19457,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 285
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 285
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 285
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 285
                 }
               }
@@ -16504,14 +19489,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 285
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 285
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 285
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 285
                 }
               }
@@ -16530,20 +19521,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 285
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 285
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 285
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 285
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 285
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 285
             }
           }
@@ -16556,7 +19556,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 285
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 285
         }
         variadic: true
@@ -16600,14 +19603,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 287
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 287
                 }
               }
@@ -16626,14 +19635,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 287
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 287
                 }
               }
@@ -16652,20 +19667,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 287
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 287
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 287
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 287
             }
           }
@@ -16695,14 +19719,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 287
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 287
                 }
               }
@@ -16721,14 +19751,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 287
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 287
                 }
               }
@@ -16747,20 +19783,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 93
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 287
                     }
                     v: "ashg"
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 287
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 287
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 287
             }
           }
@@ -16773,7 +19818,10 @@ body {
           }
         }
         src {
+          end_column: 95
+          end_line: 287
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 287
         }
         variadic: true
@@ -16817,14 +19865,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 289
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 289
                 }
               }
@@ -16843,20 +19897,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 289
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 289
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 289
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 289
             }
           }
@@ -16869,7 +19932,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 289
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 289
         }
         variadic: true
@@ -16913,14 +19979,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 291
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 291
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 291
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 291
                 }
               }
@@ -16939,20 +20011,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 291
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 291
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 291
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 291
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 291
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 291
             }
           }
@@ -16965,7 +20046,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 291
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 291
         }
         variadic: true
@@ -17009,14 +20093,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 293
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 293
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 293
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 293
                 }
               }
@@ -17035,20 +20125,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 293
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 293
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 293
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 293
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 293
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 293
             }
           }
@@ -17061,7 +20160,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 293
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 293
         }
         variadic: true
@@ -17105,14 +20207,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 33
                       start_line: 295
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 33
                   start_line: 295
                 }
               }
@@ -17131,14 +20239,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 295
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 295
                 }
               }
@@ -17157,14 +20271,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 295
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 295
                 }
               }
@@ -17183,20 +20303,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 295
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 295
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 295
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 295
             }
           }
@@ -17226,14 +20355,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 295
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 295
                 }
               }
@@ -17252,14 +20387,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 98
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 295
                     }
                     v: 12
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 295
                 }
               }
@@ -17278,14 +20419,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 98
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 295
                     }
                     v: 13
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 295
                 }
               }
@@ -17304,20 +20451,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 97
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 89
                       start_line: 295
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 89
                   start_line: 295
                 }
               }
             }
             src {
+              end_column: 98
+              end_line: 295
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 295
             }
           }
@@ -17330,7 +20486,10 @@ body {
           }
         }
         src {
+          end_column: 99
+          end_line: 295
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 295
         }
         variadic: true
@@ -17374,14 +20533,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 297
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 297
                 }
               }
@@ -17400,20 +20565,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 297
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 297
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 297
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 297
             }
           }
@@ -17443,14 +20617,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 297
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 297
                 }
               }
@@ -17469,20 +20649,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 297
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 65
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 297
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 297
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 297
             }
           }
@@ -17495,7 +20684,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 297
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 297
         }
         variadic: true
@@ -17539,14 +20731,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 299
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 299
                 }
               }
@@ -17565,20 +20763,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 299
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 299
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 299
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 299
             }
           }
@@ -17608,14 +20815,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 62
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 299
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 299
                 }
               }
@@ -17634,20 +20847,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 67
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 299
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 299
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 299
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 299
             }
           }
@@ -17660,7 +20882,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 299
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 299
         }
         variadic: true
@@ -17704,20 +20929,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 301
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 301
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 301
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 301
             }
           }
@@ -17730,7 +20964,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 301
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 301
         }
         variadic: true
@@ -17774,20 +21011,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 303
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 303
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 303
             }
           }
@@ -17817,20 +21063,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 303
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 303
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 303
             }
           }
@@ -17860,14 +21115,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 303
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 303
                 }
               }
@@ -17886,20 +21147,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 303
                     }
                     v: "bcd"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 303
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 303
             }
           }
@@ -17912,7 +21182,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 303
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 303
         }
         variadic: true
@@ -17956,14 +21229,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 305
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 305
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 305
                 }
               }
@@ -17982,20 +21261,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 305
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 305
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 305
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 305
             }
           }
@@ -18014,7 +21302,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 83
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 305
                 }
                 v: "A"
@@ -18023,14 +21314,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 83
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 305
                 }
                 v: "YYYY"
               }
             }
             src {
+              end_column: 83
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 305
             }
           }
@@ -18043,7 +21340,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 305
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 305
         }
         variadic: true
@@ -18087,20 +21387,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 307
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 307
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 307
             }
           }
@@ -18130,14 +21439,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 307
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 307
                 }
               }
@@ -18145,14 +21460,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 60
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 307
                 }
                 v: "YYYY"
               }
             }
             src {
+              end_column: 60
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 307
             }
           }
@@ -18182,14 +21503,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 307
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 307
                 }
               }
@@ -18208,20 +21535,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 307
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 307
                 }
               }
             }
             src {
+              end_column: 89
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 307
             }
           }
@@ -18234,7 +21570,10 @@ body {
           }
         }
         src {
+          end_column: 90
+          end_line: 307
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 307
         }
         variadic: true
@@ -18278,20 +21617,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 309
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 309
             }
           }
@@ -18321,20 +21669,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 68
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 309
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 309
             }
           }
@@ -18364,14 +21721,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 309
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 309
                 }
               }
@@ -18390,20 +21753,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 309
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 70
               start_line: 309
             }
           }
@@ -18416,7 +21788,10 @@ body {
           }
         }
         src {
+          end_column: 103
+          end_line: 309
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 309
         }
         variadic: true
@@ -18449,7 +21824,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 311
                 }
                 v: "A"
@@ -18458,13 +21836,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 47
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 311
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 311
             }
           }
@@ -18494,14 +21878,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 311
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 311
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 311
                 }
               }
@@ -18509,13 +21899,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 81
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 311
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 311
             }
           }
@@ -18534,7 +21930,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 311
                 }
                 v: "A"
@@ -18543,14 +21942,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 311
                 }
                 v: "auto"
               }
             }
             src {
+              end_column: 112
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 311
             }
           }
@@ -18580,14 +21985,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 139
+                      end_line: 311
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 131
                       start_line: 311
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 139
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 131
                   start_line: 311
                 }
               }
@@ -18606,20 +22017,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 149
+                      end_line: 311
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 141
                       start_line: 311
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 149
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 141
                   start_line: 311
                 }
               }
             }
             src {
+              end_column: 150
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 114
               start_line: 311
             }
           }
@@ -18632,7 +22052,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 311
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 311
         }
         variadic: true
@@ -18665,7 +22088,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 313
                 }
                 v: "A"
@@ -18674,13 +22100,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 47
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 313
             }
           }
@@ -18710,14 +22142,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 313
                 }
               }
@@ -18725,13 +22163,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 81
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 313
             }
           }
@@ -18750,7 +22194,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 313
                 }
                 v: "A"
@@ -18759,14 +22206,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 313
                 }
                 v: "auto"
               }
             }
             src {
+              end_column: 112
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 313
             }
           }
@@ -18796,14 +22249,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 139
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 131
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 139
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 131
                   start_line: 313
                 }
               }
@@ -18822,20 +22281,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 149
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 141
                       start_line: 313
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 149
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 141
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 150
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 114
               start_line: 313
             }
           }
@@ -18848,7 +22316,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 313
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 313
         }
         variadic: true
@@ -18881,7 +22352,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 315
                 }
                 v: "A"
@@ -18890,13 +22364,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 46
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 315
             }
           }
@@ -18926,14 +22406,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 315
                 }
               }
@@ -18941,13 +22427,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 79
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 315
             }
           }
@@ -18966,7 +22458,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 109
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 315
                 }
                 v: "A"
@@ -18975,14 +22470,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 109
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 315
                 }
                 v: "auto"
               }
             }
             src {
+              end_column: 109
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 81
               start_line: 315
             }
           }
@@ -19012,14 +22513,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 135
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 127
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 135
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 127
                   start_line: 315
                 }
               }
@@ -19038,20 +22545,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 145
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 137
                       start_line: 315
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 145
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 137
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 146
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 111
               start_line: 315
             }
           }
@@ -19064,7 +22580,10 @@ body {
           }
         }
         src {
+          end_column: 147
+          end_line: 315
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 315
         }
         variadic: true
@@ -19097,7 +22616,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 60
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 317
                 }
                 v: "A"
@@ -19117,20 +22639,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 59
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 317
                     }
                     v: 1234
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 317
             }
           }
@@ -19160,14 +22691,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 89
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 81
                       start_line: 317
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 317
                 }
               }
@@ -19186,20 +22723,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 317
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 100
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 317
             }
           }
@@ -19212,7 +22758,10 @@ body {
           }
         }
         src {
+          end_column: 101
+          end_line: 317
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 317
         }
         variadic: true
@@ -19245,7 +22794,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 319
                 }
                 v: "A"
@@ -19265,20 +22817,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 57
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 319
                     }
                     v: 1234
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 319
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 319
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 319
             }
           }
@@ -19308,14 +22869,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 319
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 319
                 }
               }
@@ -19334,20 +22901,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 319
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 319
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 319
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 319
             }
           }
@@ -19360,7 +22936,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 319
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 319
         }
         variadic: true
@@ -19393,14 +22972,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 321
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 321
             }
           }
@@ -19419,7 +23004,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 62
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 321
                 }
                 v: "A"
@@ -19439,20 +23027,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 321
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 321
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 321
             }
           }
@@ -19482,20 +23079,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 321
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 321
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 87
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 321
             }
           }
@@ -19508,7 +23114,10 @@ body {
           }
         }
         src {
+          end_column: 88
+          end_line: 321
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 321
         }
         variadic: true
@@ -19539,7 +23148,10 @@ body {
               }
             }
             src {
+              end_column: 45
+              end_line: 323
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 323
             }
           }
@@ -19552,7 +23164,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 323
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 323
         }
         variadic: true
@@ -19583,7 +23198,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 325
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 325
             }
           }
@@ -19596,7 +23214,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 325
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 325
         }
         variadic: true
@@ -19627,7 +23248,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 327
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 327
             }
           }
@@ -19640,7 +23264,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 327
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 327
         }
         variadic: true
@@ -19684,20 +23311,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 329
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 329
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 329
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 329
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 329
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 329
             }
           }
@@ -19710,7 +23346,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 329
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 329
         }
         variadic: true
@@ -19754,20 +23393,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 331
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 331
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 331
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 331
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 331
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 331
             }
           }
@@ -19797,20 +23445,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 331
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 331
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 331
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 331
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 331
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 331
             }
           }
@@ -19840,14 +23497,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 331
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 331
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 331
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 331
                 }
               }
@@ -19866,20 +23529,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 331
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 331
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 331
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 331
                 }
               }
             }
             src {
+              end_column: 95
+              end_line: 331
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 67
               start_line: 331
             }
           }
@@ -19909,14 +23581,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 331
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 331
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 331
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 331
                 }
               }
@@ -19935,20 +23613,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 331
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 331
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 331
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 331
                 }
               }
             }
             src {
+              end_column: 115
+              end_line: 331
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 97
               start_line: 331
             }
           }
@@ -19961,7 +23648,10 @@ body {
           }
         }
         src {
+          end_column: 116
+          end_line: 331
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 331
         }
         variadic: true
@@ -20005,20 +23695,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 333
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 333
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 333
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 333
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 333
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 333
             }
           }
@@ -20031,7 +23730,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 333
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 333
         }
         variadic: true
@@ -20075,14 +23777,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 335
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 335
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 335
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 335
                 }
               }
@@ -20090,14 +23798,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 335
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 335
                 }
                 v: "fr"
               }
             }
             src {
+              end_column: 45
+              end_line: 335
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 335
             }
           }
@@ -20127,14 +23841,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 64
+                      end_line: 335
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 335
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 335
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 335
                 }
               }
@@ -20143,13 +23863,19 @@ body {
               sp_column_sql_expr {
                 sql: "\"B\""
                 src {
+                  end_column: 75
+                  end_line: 335
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 335
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 335
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 335
             }
           }
@@ -20162,7 +23888,10 @@ body {
           }
         }
         src {
+          end_column: 76
+          end_line: 335
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 335
         }
         variadic: true
@@ -20206,14 +23935,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 337
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 337
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 337
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 337
                 }
               }
@@ -20221,14 +23956,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 49
+                  end_line: 337
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 337
                 }
                 v: "fr"
               }
             }
             src {
+              end_column: 49
+              end_line: 337
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 337
             }
           }
@@ -20258,14 +23999,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 337
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 337
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 337
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 337
                 }
               }
@@ -20274,13 +24021,19 @@ body {
               sp_column_sql_expr {
                 sql: "\"B\""
                 src {
+                  end_column: 83
+                  end_line: 337
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 337
                 }
               }
             }
             src {
+              end_column: 83
+              end_line: 337
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 337
             }
           }
@@ -20293,7 +24046,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 337
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 337
         }
         variadic: true
@@ -20337,20 +24093,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 339
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 339
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 339
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 339
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 339
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 339
             }
           }
@@ -20363,7 +24128,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 339
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 339
         }
         variadic: true
@@ -20407,20 +24175,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 341
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 341
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 341
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 341
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 341
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 341
             }
           }
@@ -20433,7 +24210,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 341
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 341
         }
         variadic: true
@@ -20477,20 +24257,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 343
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 343
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 343
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 343
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 343
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 343
             }
           }
@@ -20503,7 +24292,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 343
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 343
         }
         variadic: true
@@ -20547,20 +24339,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 345
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 345
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 345
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 345
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 345
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 345
             }
           }
@@ -20573,7 +24374,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 345
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 345
         }
         variadic: true
@@ -20617,20 +24421,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 347
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 347
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 347
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 347
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 347
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 347
             }
           }
@@ -20643,7 +24456,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 347
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 347
         }
         variadic: true
@@ -20674,7 +24490,10 @@ body {
               }
             }
             src {
+              end_column: 35
+              end_line: 349
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 349
             }
           }
@@ -20687,7 +24506,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 349
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 349
         }
         variadic: true
@@ -20731,14 +24553,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 351
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 351
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 351
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 351
                 }
               }
@@ -20757,20 +24585,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 351
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 351
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 351
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 351
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 351
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 351
             }
           }
@@ -20800,14 +24637,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 351
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 351
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 351
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 351
                 }
               }
@@ -20826,20 +24669,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 351
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 351
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 351
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 351
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 351
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 351
             }
           }
@@ -20869,14 +24721,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 351
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 351
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 351
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 351
                 }
               }
@@ -20895,20 +24753,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 351
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 108
                       start_line: 351
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 351
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 108
                   start_line: 351
                 }
               }
             }
             src {
+              end_column: 117
+              end_line: 351
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 351
             }
           }
@@ -20921,7 +24788,10 @@ body {
           }
         }
         src {
+          end_column: 118
+          end_line: 351
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 351
         }
         variadic: true
@@ -20965,20 +24835,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 353
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 353
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 353
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 353
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 353
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 353
             }
           }
@@ -20991,7 +24870,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 353
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 353
         }
         variadic: true
@@ -21035,20 +24917,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 355
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 355
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 355
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 355
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 355
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 355
             }
           }
@@ -21061,7 +24952,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 355
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 355
         }
         variadic: true
@@ -21105,14 +24999,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 357
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 357
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 357
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 357
                 }
               }
@@ -21131,20 +25031,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 357
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 357
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 357
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 357
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 357
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 357
             }
           }
@@ -21174,14 +25083,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 357
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 357
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 357
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 357
                 }
               }
@@ -21200,20 +25115,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 357
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 357
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 357
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 357
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 357
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 357
             }
           }
@@ -21226,7 +25150,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 357
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 357
         }
         variadic: true
@@ -21270,20 +25197,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 359
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 359
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 359
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 359
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 359
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 359
             }
           }
@@ -21296,7 +25232,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 359
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 359
         }
         variadic: true
@@ -21340,14 +25279,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 361
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 361
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 361
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 361
                 }
               }
@@ -21366,20 +25311,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 361
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 361
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 361
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 361
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 361
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 361
             }
           }
@@ -21409,14 +25363,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 361
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 361
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 361
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 361
                 }
               }
@@ -21435,20 +25395,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 93
+                      end_line: 361
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 85
                       start_line: 361
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 361
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 361
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 361
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 361
             }
           }
@@ -21478,14 +25447,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 129
+                      end_line: 361
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 96
                       start_line: 361
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 129
+                  end_line: 361
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 96
                   start_line: 361
                 }
               }
@@ -21504,20 +25479,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 128
+                      end_line: 361
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 120
                       start_line: 361
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 128
+                  end_line: 361
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 120
                   start_line: 361
                 }
               }
             }
             src {
+              end_column: 129
+              end_line: 361
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 96
               start_line: 361
             }
           }
@@ -21530,7 +25514,10 @@ body {
           }
         }
         src {
+          end_column: 130
+          end_line: 361
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 361
         }
         variadic: true
@@ -21563,7 +25550,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 363
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 363
                 }
                 v: "A"
@@ -21572,14 +25562,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 363
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 363
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 48
+              end_line: 363
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 363
             }
           }
@@ -21598,7 +25594,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 83
+                  end_line: 363
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 363
                 }
                 v: "A"
@@ -21618,20 +25617,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 363
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 363
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 363
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 363
                 }
               }
             }
             src {
+              end_column: 83
+              end_line: 363
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 363
             }
           }
@@ -21650,7 +25658,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 114
+                  end_line: 363
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 363
                 }
                 v: "B"
@@ -21659,14 +25670,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 114
+                  end_line: 363
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 363
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 114
+              end_line: 363
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 85
               start_line: 363
             }
           }
@@ -21679,7 +25696,10 @@ body {
           }
         }
         src {
+          end_column: 115
+          end_line: 363
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 363
         }
         variadic: true
@@ -21723,20 +25743,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 365
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 365
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 365
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 365
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 365
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 365
             }
           }
@@ -21749,7 +25778,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 365
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 365
         }
         variadic: true
@@ -21793,20 +25825,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 367
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 367
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 367
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 367
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 367
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 367
             }
           }
@@ -21819,7 +25860,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 367
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 367
         }
         variadic: true
@@ -21863,20 +25907,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 369
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 369
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 369
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 369
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 369
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 369
             }
           }
@@ -21889,7 +25942,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 369
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 369
         }
         variadic: true
@@ -21933,14 +25989,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 371
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 371
                 }
               }
@@ -21959,14 +26021,20 @@ body {
                 pos_args {
                   bool_val {
                     src {
+                      end_column: 41
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 371
                     }
                     v: true
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 371
                 }
               }
@@ -21985,19 +26053,28 @@ body {
                 pos_args {
                   bool_val {
                     src {
+                      end_column: 41
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 371
                     }
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 371
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 371
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 371
             }
           }
@@ -22027,14 +26104,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 64
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 371
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 371
                 }
               }
@@ -22053,14 +26136,20 @@ body {
                 pos_args {
                   bool_val {
                     src {
+                      end_column: 64
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 371
                     }
                     v: true
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 371
                 }
               }
@@ -22079,19 +26168,28 @@ body {
                 pos_args {
                   bool_val {
                     src {
+                      end_column: 64
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 371
                     }
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 371
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 371
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 371
             }
           }
@@ -22121,14 +26219,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 371
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 371
                 }
               }
@@ -22147,13 +26251,19 @@ body {
                 pos_args {
                   bool_val {
                     src {
+                      end_column: 99
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 371
                     }
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 371
                 }
               }
@@ -22172,20 +26282,29 @@ body {
                 pos_args {
                   bool_val {
                     src {
+                      end_column: 99
+                      end_line: 371
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 371
                     }
                     v: true
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 371
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 371
                 }
               }
             }
             src {
+              end_column: 99
+              end_line: 371
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 66
               start_line: 371
             }
           }
@@ -22198,7 +26317,10 @@ body {
           }
         }
         src {
+          end_column: 100
+          end_line: 371
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 371
         }
         variadic: true
@@ -22242,14 +26364,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 373
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 373
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 373
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 373
                 }
               }
@@ -22268,20 +26396,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 373
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 373
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 373
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 373
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 373
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 373
             }
           }
@@ -22311,14 +26448,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 373
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 373
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 373
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 373
                 }
               }
@@ -22337,20 +26480,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 373
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 373
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 373
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 373
                 }
               }
             }
             src {
+              end_column: 85
+              end_line: 373
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 373
             }
           }
@@ -22363,7 +26515,10 @@ body {
           }
         }
         src {
+          end_column: 86
+          end_line: 373
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 373
         }
         variadic: true
@@ -22407,14 +26562,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 375
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 375
                 }
               }
@@ -22433,20 +26594,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 375
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 375
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 375
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 375
             }
           }
@@ -22476,14 +26646,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 58
                       start_line: 375
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 375
                 }
               }
@@ -22502,20 +26678,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 375
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 375
                 }
               }
             }
             src {
+              end_column: 99
+              end_line: 375
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 375
             }
           }
@@ -22545,14 +26730,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 130
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 122
                       start_line: 375
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 130
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 375
                 }
               }
@@ -22571,14 +26762,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 141
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 101
                       start_line: 375
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 141
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 101
                   start_line: 375
                 }
               }
@@ -22597,20 +26794,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 141
+                      end_line: 375
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 101
                       start_line: 375
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 141
+                  end_line: 375
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 101
                   start_line: 375
                 }
               }
             }
             src {
+              end_column: 141
+              end_line: 375
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 101
               start_line: 375
             }
           }
@@ -22623,7 +26829,10 @@ body {
           }
         }
         src {
+          end_column: 142
+          end_line: 375
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 375
         }
         variadic: true
@@ -22656,7 +26865,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 377
                 }
                 v: "A"
@@ -22665,7 +26877,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 377
                 }
                 v: "B"
@@ -22674,13 +26889,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 44
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 377
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 377
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 377
             }
           }
@@ -22699,7 +26920,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 75
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 377
                 }
                 v: "A"
@@ -22719,14 +26943,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 68
+                      end_line: 377
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 377
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 377
                 }
               }
@@ -22734,13 +26964,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 75
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 377
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 377
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 377
             }
           }
@@ -22770,14 +27006,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 377
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 377
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 377
                 }
               }
@@ -22785,7 +27027,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 105
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 377
                 }
                 v: "B"
@@ -22794,14 +27039,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 105
+                  end_line: 377
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 377
                 }
                 v: "C"
               }
             }
             src {
+              end_column: 105
+              end_line: 377
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 77
               start_line: 377
             }
           }
@@ -22814,7 +27065,10 @@ body {
           }
         }
         src {
+          end_column: 106
+          end_line: 377
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 377
         }
         variadic: true
@@ -22847,7 +27101,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 379
                 }
                 v: "A"
@@ -22856,14 +27113,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 379
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 44
+              end_line: 379
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 379
             }
           }
@@ -22882,7 +27145,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 63
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 379
                 }
                 v: "A"
@@ -22891,14 +27157,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 63
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 379
                 }
                 v: 10
               }
             }
             src {
+              end_column: 63
+              end_line: 379
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 379
             }
           }
@@ -22928,14 +27200,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 379
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 379
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 379
                 }
               }
@@ -22943,13 +27221,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 86
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 379
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 379
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 379
             }
           }
@@ -22979,14 +27263,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 379
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 379
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 379
                 }
               }
@@ -23005,20 +27295,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 379
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 379
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 379
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 379
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 379
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 88
               start_line: 379
             }
           }
@@ -23031,7 +27330,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 379
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 379
         }
         variadic: true
@@ -23064,7 +27366,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 381
                 }
                 v: "A"
@@ -23073,14 +27378,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 381
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 44
+              end_line: 381
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 381
             }
           }
@@ -23099,7 +27410,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 63
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 381
                 }
                 v: "A"
@@ -23108,14 +27422,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 63
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 381
                 }
                 v: 10
               }
             }
             src {
+              end_column: 63
+              end_line: 381
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 381
             }
           }
@@ -23145,14 +27465,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 381
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 381
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 381
                 }
               }
@@ -23160,13 +27486,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 86
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 381
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 381
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 381
             }
           }
@@ -23196,14 +27528,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 381
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 381
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 381
                 }
               }
@@ -23222,20 +27560,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 381
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 381
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 381
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 381
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 381
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 88
               start_line: 381
             }
           }
@@ -23248,7 +27595,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 381
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 381
         }
         variadic: true
@@ -23281,7 +27631,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 57
+                  end_line: 383
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 383
                 }
                 v: "year"
@@ -23301,14 +27654,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 383
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 383
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 383
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 383
                 }
               }
@@ -23327,20 +27686,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 383
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 383
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 383
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 383
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 383
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 383
             }
           }
@@ -23359,7 +27727,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 91
+                  end_line: 383
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 383
                 }
                 v: "month"
@@ -23379,14 +27750,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 383
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 383
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 383
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 383
                 }
               }
@@ -23405,20 +27782,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 90
+                      end_line: 383
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 383
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 90
+                  end_line: 383
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 383
                 }
               }
             }
             src {
+              end_column: 91
+              end_line: 383
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 383
             }
           }
@@ -23431,7 +27817,10 @@ body {
           }
         }
         src {
+          end_column: 92
+          end_line: 383
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 383
         }
         variadic: true
@@ -23464,7 +27853,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 385
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 385
                 }
                 v: "A"
@@ -23473,14 +27865,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 385
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 385
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 43
+              end_line: 385
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 385
             }
           }
@@ -23510,14 +27908,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 385
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 385
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 385
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 385
                 }
               }
@@ -23536,20 +27940,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 385
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 63
                       start_line: 385
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 385
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 63
                   start_line: 385
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 385
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 385
             }
           }
@@ -23562,7 +27975,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 385
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 385
         }
         variadic: true
@@ -23595,7 +28011,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 387
                 }
                 v: "A"
@@ -23604,14 +28023,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 387
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 41
+              end_line: 387
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 387
             }
           }
@@ -23641,14 +28066,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 387
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 387
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 387
                 }
               }
@@ -23667,20 +28098,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 387
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 387
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 387
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 387
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 387
             }
           }
@@ -23699,7 +28139,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 84
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 387
                 }
                 v: "A"
@@ -23708,14 +28151,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 84
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 387
                 }
                 v: 10
               }
             }
             src {
+              end_column: 84
+              end_line: 387
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 70
               start_line: 387
             }
           }
@@ -23734,7 +28183,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 387
                 }
                 v: "B"
@@ -23743,14 +28195,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 101
+                  end_line: 387
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 387
                 }
                 v: 7.9
               }
             }
             src {
+              end_column: 101
+              end_line: 387
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 86
               start_line: 387
             }
           }
@@ -23763,7 +28221,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 387
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 387
         }
         variadic: true
@@ -23796,7 +28257,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 389
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 389
                 }
                 v: "year"
@@ -23816,14 +28280,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 389
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 389
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 389
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 389
                 }
               }
@@ -23842,20 +28312,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 389
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 389
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 389
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 389
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 389
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 389
             }
           }
@@ -23874,7 +28353,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 88
+                  end_line: 389
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 389
                 }
                 v: "year"
@@ -23894,14 +28376,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 389
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 389
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 389
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 389
                 }
               }
@@ -23920,20 +28408,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 87
+                      end_line: 389
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 389
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 87
+                  end_line: 389
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 389
                 }
               }
             }
             src {
+              end_column: 88
+              end_line: 389
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 389
             }
           }
@@ -23946,7 +28443,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 389
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 389
         }
         variadic: true
@@ -23979,7 +28479,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 391
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 391
                 }
                 v: "year"
@@ -23999,20 +28502,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 391
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 391
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 391
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 391
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 391
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 391
             }
           }
@@ -24031,7 +28543,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 77
+                  end_line: 391
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 391
                 }
                 v: "year"
@@ -24051,20 +28566,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 391
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 391
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 391
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 391
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 391
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 391
             }
           }
@@ -24077,7 +28601,10 @@ body {
           }
         }
         src {
+          end_column: 78
+          end_line: 391
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 391
         }
         variadic: true
@@ -24110,7 +28637,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 393
                 }
                 v: 10
@@ -24119,7 +28649,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 393
                 }
                 v: 2
@@ -24128,14 +28661,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 393
                 }
                 v: 1
               }
             }
             src {
+              end_column: 51
+              end_line: 393
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 393
             }
           }
@@ -24154,7 +28693,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 80
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 393
                 }
                 v: 10
@@ -24163,7 +28705,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 80
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 393
                 }
                 v: "A"
@@ -24172,14 +28717,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 80
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 393
                 }
                 v: 1
               }
             }
             src {
+              end_column: 80
+              end_line: 393
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 393
             }
           }
@@ -24198,7 +28749,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 393
                 }
                 v: "A"
@@ -24207,7 +28761,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 393
                 }
                 v: "B"
@@ -24216,14 +28773,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 393
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 112
+              end_line: 393
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 82
               start_line: 393
             }
           }
@@ -24242,7 +28805,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 146
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 114
                   start_line: 393
                 }
                 v: 10
@@ -24262,14 +28828,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 142
+                      end_line: 393
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 134
                       start_line: 393
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 142
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 134
                   start_line: 393
                 }
               }
@@ -24277,14 +28849,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 146
+                  end_line: 393
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 114
                   start_line: 393
                 }
                 v: 1
               }
             }
             src {
+              end_column: 146
+              end_line: 393
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 114
               start_line: 393
             }
           }
@@ -24297,7 +28875,10 @@ body {
           }
         }
         src {
+          end_column: 147
+          end_line: 393
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 393
         }
         variadic: true
@@ -24330,7 +28911,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 49
+                  end_line: 395
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 395
                 }
                 v: "year"
@@ -24350,20 +28934,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 395
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 395
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 395
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 395
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 395
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 395
             }
           }
@@ -24382,7 +28975,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 79
+                  end_line: 395
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 395
                 }
                 v: "year"
@@ -24402,20 +28998,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 395
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 395
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 395
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 395
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 395
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 395
             }
           }
@@ -24428,7 +29033,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 395
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 395
         }
         variadic: true
@@ -24472,20 +29080,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 397
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 397
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 397
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 397
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 397
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 397
             }
           }
@@ -24498,7 +29115,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 397
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 397
         }
         variadic: true
@@ -24542,20 +29162,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 399
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 399
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 399
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 399
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 399
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 399
             }
           }
@@ -24568,7 +29197,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 399
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 399
         }
         variadic: true
@@ -24612,20 +29244,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 401
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 401
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 401
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 401
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 401
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 401
             }
           }
@@ -24638,7 +29279,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 401
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 401
         }
         variadic: true
@@ -24682,20 +29326,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 403
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 403
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 403
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 403
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 403
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 403
             }
           }
@@ -24708,7 +29361,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 403
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 403
         }
         variadic: true
@@ -24752,20 +29408,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 405
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 405
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 405
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 405
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 405
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 405
             }
           }
@@ -24778,7 +29443,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 405
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 405
         }
         variadic: true
@@ -24822,20 +29490,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 407
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 407
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 407
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 407
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 407
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 407
             }
           }
@@ -24848,7 +29525,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 407
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 407
         }
         variadic: true
@@ -24892,20 +29572,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 409
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 409
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 409
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 409
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 409
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 409
             }
           }
@@ -24918,7 +29607,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 409
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 409
         }
         variadic: true
@@ -24962,20 +29654,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 411
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 411
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 411
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 411
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 411
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 411
             }
           }
@@ -24988,7 +29689,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 411
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 411
         }
         variadic: true
@@ -25032,20 +29736,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 413
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 413
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 413
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 413
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 413
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 413
             }
           }
@@ -25058,7 +29771,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 413
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 413
         }
         variadic: true
@@ -25102,20 +29818,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 415
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 415
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 415
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 415
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 415
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 415
             }
           }
@@ -25128,7 +29853,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 415
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 415
         }
         variadic: true
@@ -25172,20 +29900,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 417
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 417
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 417
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 417
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 417
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 417
             }
           }
@@ -25198,7 +29935,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 417
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 417
         }
         variadic: true
@@ -25242,20 +29982,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 419
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 419
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 419
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 419
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 419
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 419
             }
           }
@@ -25268,7 +30017,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 419
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 419
         }
         variadic: true
@@ -25312,20 +30064,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 421
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 421
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 421
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 421
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 421
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 421
             }
           }
@@ -25338,7 +30099,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 421
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 421
         }
         variadic: true
@@ -25382,20 +30146,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 423
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 423
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 423
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 423
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 423
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 423
             }
           }
@@ -25408,7 +30181,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 423
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 423
         }
         variadic: true
@@ -25452,20 +30228,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 425
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 425
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 425
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 425
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 425
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 425
             }
           }
@@ -25478,7 +30263,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 425
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 425
         }
         variadic: true
@@ -25522,20 +30310,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 427
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 427
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 427
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 427
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 427
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 427
             }
           }
@@ -25548,7 +30345,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 427
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 427
         }
         variadic: true
@@ -25592,20 +30392,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 429
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 429
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 429
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 429
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 429
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 429
             }
           }
@@ -25618,7 +30427,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 429
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 429
         }
         variadic: true
@@ -25662,20 +30474,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 431
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 431
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 431
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 431
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 431
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 431
             }
           }
@@ -25688,7 +30509,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 431
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 431
         }
         variadic: true
@@ -25732,20 +30556,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 433
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 433
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 433
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 433
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 433
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 433
             }
           }
@@ -25758,7 +30591,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 433
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 433
         }
         variadic: true
@@ -25791,7 +30627,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 50
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 435
                 }
                 v: 1
@@ -25800,7 +30639,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 50
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 435
                 }
                 v: 2
@@ -25809,7 +30651,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 50
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 435
                 }
                 v: 3
@@ -25818,13 +30663,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 50
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 435
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 435
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 435
             }
           }
@@ -25843,7 +30694,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 435
                 }
                 v: "A"
@@ -25852,7 +30706,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 435
                 }
                 v: "B"
@@ -25861,7 +30718,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 435
                 }
                 v: "A"
@@ -25870,13 +30730,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 82
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 435
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 435
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 435
             }
           }
@@ -25895,7 +30761,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 117
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 435
                 }
                 v: 1
@@ -25904,7 +30773,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 117
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 435
                 }
                 v: "A"
@@ -25924,14 +30796,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 435
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 108
                       start_line: 435
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 108
                   start_line: 435
                 }
               }
@@ -25939,13 +30817,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 117
+                  end_line: 435
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 435
                 }
               }
             }
             src {
+              end_column: 117
+              end_line: 435
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 435
             }
           }
@@ -25958,7 +30842,10 @@ body {
           }
         }
         src {
+          end_column: 118
+          end_line: 435
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 435
         }
         variadic: true
@@ -25991,7 +30878,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 437
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 437
                 }
                 v: "A"
@@ -26000,14 +30890,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 437
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 437
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 56
+              end_line: 437
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 437
             }
           }
@@ -26037,14 +30933,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 87
+                      end_line: 437
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 437
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 87
+                  end_line: 437
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 437
                 }
               }
@@ -26052,14 +30954,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 93
+                  end_line: 437
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 437
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 93
+              end_line: 437
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 437
             }
           }
@@ -26089,14 +30997,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 124
+                      end_line: 437
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 116
                       start_line: 437
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 124
+                  end_line: 437
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 116
                   start_line: 437
                 }
               }
@@ -26115,20 +31029,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 134
+                      end_line: 437
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 126
                       start_line: 437
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 134
+                  end_line: 437
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 126
                   start_line: 437
                 }
               }
             }
             src {
+              end_column: 135
+              end_line: 437
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 95
               start_line: 437
             }
           }
@@ -26141,7 +31064,10 @@ body {
           }
         }
         src {
+          end_column: 136
+          end_line: 437
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 437
         }
         variadic: true
@@ -26174,7 +31100,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 439
                 }
                 v: 2000
@@ -26183,7 +31112,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 439
                 }
                 v: 12
@@ -26192,7 +31124,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 439
                 }
               }
@@ -26200,7 +31135,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 439
                 }
                 v: 12
@@ -26209,7 +31147,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 439
                 }
                 v: 3
@@ -26218,14 +31159,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 439
                 }
                 v: 1
               }
             }
             src {
+              end_column: 69
+              end_line: 439
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 439
             }
           }
@@ -26244,7 +31191,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
                 v: 2000
@@ -26253,7 +31203,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
                 v: 12
@@ -26262,7 +31215,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
               }
@@ -26270,7 +31226,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
                 v: 12
@@ -26279,7 +31238,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
                 v: 3
@@ -26288,7 +31250,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
                 v: 1
@@ -26297,13 +31262,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 120
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 439
                 }
               }
             }
             src {
+              end_column: 120
+              end_line: 439
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 71
               start_line: 439
             }
           }
@@ -26322,7 +31293,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
                 v: 2000
@@ -26331,7 +31305,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
                 v: 12
@@ -26340,7 +31317,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
               }
@@ -26348,7 +31328,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
                 v: 12
@@ -26357,7 +31340,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
                 v: 3
@@ -26366,7 +31352,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
                 v: 1
@@ -26375,7 +31364,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
               }
@@ -26383,13 +31375,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 177
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 439
                 }
               }
             }
             src {
+              end_column: 177
+              end_line: 439
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 122
               start_line: 439
             }
           }
@@ -26408,7 +31406,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
                 v: 2000
@@ -26417,7 +31418,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
                 v: 12
@@ -26426,7 +31430,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
               }
@@ -26434,7 +31441,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
                 v: 12
@@ -26443,7 +31453,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
                 v: 3
@@ -26452,7 +31465,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
                 v: 1
@@ -26461,7 +31477,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
               }
@@ -26469,14 +31488,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 234
+                  end_line: 439
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 439
                 }
                 v: "us"
               }
             }
             src {
+              end_column: 234
+              end_line: 439
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 179
               start_line: 439
             }
           }
@@ -26489,7 +31514,10 @@ body {
           }
         }
         src {
+          end_column: 235
+          end_line: 439
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 439
         }
         variadic: true
@@ -26522,7 +31550,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 441
                 }
                 v: "year"
@@ -26531,7 +31562,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 441
                 }
                 v: "month"
@@ -26540,7 +31574,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 441
                 }
                 v: "day"
@@ -26549,7 +31586,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 441
                 }
                 v: "hour"
@@ -26558,7 +31598,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 441
                 }
                 v: "minute"
@@ -26567,14 +31610,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 441
                 }
                 v: "second"
               }
             }
             src {
+              end_column: 98
+              end_line: 441
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 441
             }
           }
@@ -26604,14 +31653,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 136
+                      end_line: 441
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 121
                       start_line: 441
                     }
                     v: "date"
                   }
                 }
                 src {
+                  end_column: 136
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 121
                   start_line: 441
                 }
               }
@@ -26641,26 +31696,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 153
+                          end_line: 441
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 138
                           start_line: 441
                         }
                         v: "time"
                       }
                     }
                     src {
+                      end_column: 153
+                      end_line: 441
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 138
                       start_line: 441
                     }
                   }
                 }
                 src {
+                  end_column: 153
+                  end_line: 441
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 138
                   start_line: 441
                 }
               }
             }
             src {
+              end_column: 154
+              end_line: 441
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 100
               start_line: 441
             }
           }
@@ -26673,7 +31740,10 @@ body {
           }
         }
         src {
+          end_column: 155
+          end_line: 441
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 441
         }
         variadic: true
@@ -26706,7 +31776,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
                 v: 2000
@@ -26715,7 +31788,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
                 v: 12
@@ -26724,7 +31800,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
               }
@@ -26732,7 +31811,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
                 v: 12
@@ -26741,7 +31823,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
                 v: 3
@@ -26750,7 +31835,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
                 v: 1
@@ -26759,13 +31847,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 73
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 443
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 443
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 443
             }
           }
@@ -26784,7 +31878,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
                 v: 2000
@@ -26793,7 +31890,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
                 v: 12
@@ -26802,7 +31902,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
               }
@@ -26810,7 +31913,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
                 v: 12
@@ -26819,7 +31925,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
                 v: 3
@@ -26828,7 +31937,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
                 v: 1
@@ -26837,13 +31949,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 128
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 443
                 }
               }
             }
             src {
+              end_column: 128
+              end_line: 443
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 75
               start_line: 443
             }
           }
@@ -26862,7 +31980,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
                 v: 2000
@@ -26871,7 +31992,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
                 v: 12
@@ -26880,7 +32004,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
               }
@@ -26888,7 +32015,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
                 v: 12
@@ -26897,7 +32027,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
                 v: 3
@@ -26906,7 +32039,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
                 v: 1
@@ -26915,13 +32051,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 183
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 443
                 }
               }
             }
             src {
+              end_column: 183
+              end_line: 443
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 130
               start_line: 443
             }
           }
@@ -26940,7 +32082,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
                 v: 2000
@@ -26949,7 +32094,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
                 v: 12
@@ -26958,7 +32106,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
               }
@@ -26966,7 +32117,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
                 v: 12
@@ -26975,7 +32129,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
                 v: 3
@@ -26984,7 +32141,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
                 v: 1
@@ -26993,14 +32153,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 443
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 443
                 }
                 v: 12
               }
             }
             src {
+              end_column: 236
+              end_line: 443
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 185
               start_line: 443
             }
           }
@@ -27013,7 +32179,10 @@ body {
           }
         }
         src {
+          end_column: 237
+          end_line: 443
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 443
         }
         variadic: true
@@ -27046,7 +32215,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 445
                 }
                 v: 2000
@@ -27055,7 +32227,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 445
                 }
                 v: 12
@@ -27064,7 +32239,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 445
                 }
               }
@@ -27072,7 +32250,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 445
                 }
                 v: 12
@@ -27081,7 +32262,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 445
                 }
                 v: 3
@@ -27090,14 +32274,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 445
                 }
                 v: 1
               }
             }
             src {
+              end_column: 73
+              end_line: 445
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 445
             }
           }
@@ -27116,7 +32306,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
                 v: 2000
@@ -27125,7 +32318,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
                 v: 12
@@ -27134,7 +32330,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
               }
@@ -27142,7 +32341,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
                 v: 12
@@ -27151,7 +32353,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
                 v: 3
@@ -27160,7 +32365,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
                 v: 1
@@ -27180,20 +32388,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 127
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 445
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 127
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 445
                 }
               }
             }
             src {
+              end_column: 127
+              end_line: 445
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 75
               start_line: 445
             }
           }
@@ -27212,7 +32429,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 445
                 }
                 v: 2000
@@ -27221,7 +32441,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 445
                 }
                 v: 12
@@ -27230,7 +32453,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 445
                 }
               }
@@ -27238,7 +32464,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 445
                 }
                 v: 12
@@ -27247,7 +32476,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 445
                 }
                 v: 3
@@ -27256,7 +32488,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 445
                 }
                 v: 1
@@ -27276,7 +32511,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                     v: 2000
@@ -27285,7 +32523,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                     v: 12
@@ -27294,7 +32535,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                   }
@@ -27302,7 +32546,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                     v: 12
@@ -27311,7 +32558,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                     v: 3
@@ -27320,7 +32570,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                     v: 1
@@ -27329,20 +32582,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 445
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 445
                     }
                     v: 12
                   }
                 }
                 src {
+                  end_column: 228
+                  end_line: 445
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 177
                   start_line: 445
                 }
               }
             }
             src {
+              end_column: 229
+              end_line: 445
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 129
               start_line: 445
             }
           }
@@ -27355,7 +32617,10 @@ body {
           }
         }
         src {
+          end_column: 230
+          end_line: 445
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 445
         }
         variadic: true
@@ -27388,7 +32653,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
                 v: 2000
@@ -27397,7 +32665,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
                 v: 12
@@ -27406,7 +32677,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
               }
@@ -27414,7 +32688,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
                 v: 12
@@ -27423,7 +32700,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
                 v: 3
@@ -27432,7 +32712,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
                 v: 1
@@ -27441,7 +32724,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
               }
@@ -27449,13 +32735,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 72
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 447
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 447
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 447
             }
           }
@@ -27474,7 +32766,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
                 v: 2000
@@ -27483,7 +32778,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
                 v: 12
@@ -27492,7 +32790,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
               }
@@ -27500,7 +32801,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
                 v: 12
@@ -27509,7 +32813,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
                 v: 3
@@ -27518,7 +32825,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
                 v: 1
@@ -27527,7 +32837,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
               }
@@ -27535,13 +32848,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 126
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 447
                 }
               }
             }
             src {
+              end_column: 126
+              end_line: 447
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 74
               start_line: 447
             }
           }
@@ -27560,7 +32879,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
                 v: 2000
@@ -27569,7 +32891,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
                 v: 12
@@ -27578,7 +32903,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
               }
@@ -27586,7 +32914,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
                 v: 12
@@ -27595,7 +32926,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
                 v: 3
@@ -27604,7 +32938,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
                 v: 1
@@ -27613,7 +32950,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
               }
@@ -27621,13 +32961,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 186
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 447
                 }
               }
             }
             src {
+              end_column: 186
+              end_line: 447
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 128
               start_line: 447
             }
           }
@@ -27646,7 +32992,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
                 v: 2000
@@ -27655,7 +33004,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
                 v: 12
@@ -27664,7 +33016,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
               }
@@ -27672,7 +33027,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
                 v: 12
@@ -27681,7 +33039,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
                 v: 3
@@ -27690,7 +33051,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
                 v: 1
@@ -27699,7 +33063,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
               }
@@ -27707,14 +33074,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 246
+                  end_line: 447
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 447
                 }
                 v: "us"
               }
             }
             src {
+              end_column: 246
+              end_line: 447
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 188
               start_line: 447
             }
           }
@@ -27727,7 +33100,10 @@ body {
           }
         }
         src {
+          end_column: 247
+          end_line: 447
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 447
         }
         variadic: true
@@ -27771,20 +33147,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 449
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 449
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 449
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 449
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 449
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 449
             }
           }
@@ -27797,7 +33182,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 449
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 449
         }
         variadic: true
@@ -27841,20 +33229,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 451
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 451
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 451
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 451
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 451
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 451
             }
           }
@@ -27867,7 +33264,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 451
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 451
         }
         variadic: true
@@ -27911,20 +33311,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 453
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 453
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 453
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 453
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 453
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 453
             }
           }
@@ -27937,7 +33346,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 453
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 453
         }
         variadic: true
@@ -27981,20 +33393,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 455
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 455
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 455
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 455
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 455
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 455
             }
           }
@@ -28007,7 +33428,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 455
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 455
         }
         variadic: true
@@ -28051,14 +33475,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 457
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 457
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 457
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 457
                 }
               }
@@ -28077,20 +33507,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 457
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 457
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 457
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 457
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 457
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 457
             }
           }
@@ -28120,14 +33559,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 457
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 457
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 457
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 457
                 }
               }
@@ -28146,20 +33591,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 457
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 457
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 457
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 457
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 457
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 457
             }
           }
@@ -28189,14 +33643,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 135
+                      end_line: 457
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 127
                       start_line: 457
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 135
+                  end_line: 457
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 127
                   start_line: 457
                 }
               }
@@ -28215,20 +33675,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 141
+                      end_line: 457
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 457
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 141
+                  end_line: 457
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 457
                 }
               }
             }
             src {
+              end_column: 141
+              end_line: 457
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 104
               start_line: 457
             }
           }
@@ -28241,7 +33710,10 @@ body {
           }
         }
         src {
+          end_column: 142
+          end_line: 457
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 457
         }
         variadic: true
@@ -28285,20 +33757,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 459
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 459
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 459
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 459
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 459
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 459
             }
           }
@@ -28311,7 +33792,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 459
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 459
         }
         variadic: true
@@ -28355,20 +33839,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 461
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 461
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 461
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 461
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 461
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 461
             }
           }
@@ -28381,7 +33874,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 461
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 461
         }
         variadic: true
@@ -28425,20 +33921,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 463
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 463
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 463
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 463
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 463
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 463
             }
           }
@@ -28451,7 +33956,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 463
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 463
         }
         variadic: true
@@ -28495,20 +34003,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 465
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 465
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 465
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 465
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 465
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 465
             }
           }
@@ -28538,20 +34055,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 465
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 465
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 465
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 465
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 465
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 465
             }
           }
@@ -28564,7 +34090,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 465
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 465
         }
         variadic: true
@@ -28608,14 +34137,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 467
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 467
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 467
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 467
                 }
               }
@@ -28634,20 +34169,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 50
+                      end_line: 467
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 467
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 467
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 467
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 467
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 467
             }
           }
@@ -28677,14 +34221,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 467
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 467
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 467
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 467
                 }
               }
@@ -28703,20 +34253,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 467
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 467
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 467
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 467
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 467
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 467
             }
           }
@@ -28746,14 +34305,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 467
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 90
                       start_line: 467
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 467
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 90
                   start_line: 467
                 }
               }
@@ -28772,20 +34337,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 108
+                      end_line: 467
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 467
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 108
+                  end_line: 467
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 100
                   start_line: 467
                 }
               }
             }
             src {
+              end_column: 109
+              end_line: 467
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 77
               start_line: 467
             }
           }
@@ -28798,7 +34372,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 467
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 467
         }
         variadic: true
@@ -28842,14 +34419,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 469
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 469
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 469
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 469
                 }
               }
@@ -28868,20 +34451,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 47
+                      end_line: 469
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 469
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 469
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 469
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 469
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 469
             }
           }
@@ -28911,14 +34503,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 469
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 469
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 469
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 469
                 }
               }
@@ -28937,20 +34535,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 469
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 469
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 469
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 469
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 469
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 469
             }
           }
@@ -28980,14 +34587,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 89
+                      end_line: 469
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 81
                       start_line: 469
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 469
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 469
                 }
               }
@@ -29006,20 +34619,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 469
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 469
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 469
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 469
                 }
               }
             }
             src {
+              end_column: 100
+              end_line: 469
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 71
               start_line: 469
             }
           }
@@ -29032,7 +34654,10 @@ body {
           }
         }
         src {
+          end_column: 101
+          end_line: 469
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 469
         }
         variadic: true
@@ -29076,20 +34701,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 471
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 471
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 471
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 471
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 471
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 471
             }
           }
@@ -29102,7 +34736,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 471
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 471
         }
         variadic: true
@@ -29133,7 +34770,10 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 473
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 473
             }
           }
@@ -29163,20 +34803,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 65
+                      end_line: 473
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 473
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 65
+                  end_line: 473
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 473
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 473
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 473
             }
           }
@@ -29206,14 +34855,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 89
+                      end_line: 473
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 473
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 473
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 473
                 }
               }
@@ -29232,14 +34887,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 473
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 473
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 473
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 473
                 }
               }
@@ -29258,20 +34919,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 473
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 96
                       start_line: 473
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 473
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 96
                   start_line: 473
                 }
               }
             }
             src {
+              end_column: 105
+              end_line: 473
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 67
               start_line: 473
             }
           }
@@ -29284,7 +34954,10 @@ body {
           }
         }
         src {
+          end_column: 106
+          end_line: 473
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 473
         }
         variadic: true
@@ -29315,7 +34988,10 @@ body {
               }
             }
             src {
+              end_column: 51
+              end_line: 475
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 475
             }
           }
@@ -29345,20 +35021,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 475
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 475
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 475
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 475
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 475
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 475
             }
           }
@@ -29388,14 +35073,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 113
+                      end_line: 475
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 475
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 113
+                  end_line: 475
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 475
                 }
               }
@@ -29414,14 +35105,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 129
+                      end_line: 475
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 475
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 129
+                  end_line: 475
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 475
                 }
               }
@@ -29440,20 +35137,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 128
+                      end_line: 475
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 120
                       start_line: 475
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 128
+                  end_line: 475
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 120
                   start_line: 475
                 }
               }
             }
             src {
+              end_column: 129
+              end_line: 475
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 475
             }
           }
@@ -29466,7 +35172,10 @@ body {
           }
         }
         src {
+          end_column: 130
+          end_line: 475
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 475
         }
         variadic: true
@@ -29510,14 +35219,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 477
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 477
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 477
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 477
                 }
               }
@@ -29536,20 +35251,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 477
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 477
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 477
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 477
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 477
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 477
             }
           }
@@ -29579,14 +35303,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 477
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 477
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 477
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 477
                 }
               }
@@ -29605,20 +35335,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 477
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 477
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 477
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 477
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 477
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 477
             }
           }
@@ -29631,7 +35370,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 477
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 477
         }
         variadic: true
@@ -29675,14 +35417,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 479
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 479
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 479
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 479
                 }
               }
@@ -29701,14 +35449,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 479
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 479
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 479
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 479
                 }
               }
@@ -29727,20 +35481,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 479
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 479
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 479
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 479
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 479
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 479
             }
           }
@@ -29770,14 +35533,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 479
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 479
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 479
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 479
                 }
               }
@@ -29796,14 +35565,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 479
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 479
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 479
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 479
                 }
               }
@@ -29822,20 +35597,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 479
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 479
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 479
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 479
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 479
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 479
             }
           }
@@ -29848,7 +35632,10 @@ body {
           }
         }
         src {
+          end_column: 98
+          end_line: 479
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 479
         }
         variadic: true
@@ -29892,14 +35679,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 481
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 481
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 481
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 481
                 }
               }
@@ -29918,20 +35711,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 481
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 481
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 481
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 481
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 481
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 481
             }
           }
@@ -29961,14 +35763,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 481
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 481
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 481
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 481
                 }
               }
@@ -29987,19 +35795,28 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 481
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 481
                     }
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 481
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 481
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 481
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 481
             }
           }
@@ -30012,7 +35829,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 481
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 481
         }
         variadic: true
@@ -30056,14 +35876,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 483
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 483
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 483
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 483
                 }
               }
@@ -30082,20 +35908,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 483
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 483
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 483
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 483
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 483
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 483
             }
           }
@@ -30125,14 +35960,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 483
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 483
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 483
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 483
                 }
               }
@@ -30151,20 +35992,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 483
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 483
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 483
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 483
                 }
               }
             }
             src {
+              end_column: 89
+              end_line: 483
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 483
             }
           }
@@ -30177,7 +36027,10 @@ body {
           }
         }
         src {
+          end_column: 90
+          end_line: 483
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 483
         }
         variadic: true
@@ -30221,20 +36074,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 485
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 485
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 485
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 485
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 485
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 485
             }
           }
@@ -30247,7 +36109,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 485
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 485
         }
         variadic: true
@@ -30291,14 +36156,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 487
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 487
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 487
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 487
                 }
               }
@@ -30317,14 +36188,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 487
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 487
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 487
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 487
                 }
               }
@@ -30343,20 +36220,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 487
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 487
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 487
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 487
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 487
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 487
             }
           }
@@ -30386,14 +36272,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 487
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 487
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 487
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 487
                 }
               }
@@ -30412,14 +36304,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 487
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 487
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 487
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 487
                 }
               }
@@ -30438,20 +36336,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 487
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 487
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 487
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 487
                 }
               }
             }
             src {
+              end_column: 95
+              end_line: 487
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 487
             }
           }
@@ -30464,7 +36371,10 @@ body {
           }
         }
         src {
+          end_column: 96
+          end_line: 487
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 487
         }
         variadic: true
@@ -30508,14 +36418,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 489
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 489
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 489
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 489
                 }
               }
@@ -30534,20 +36450,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 489
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 489
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 489
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 489
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 489
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 489
             }
           }
@@ -30577,14 +36502,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 489
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 489
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 489
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 489
                 }
               }
@@ -30603,20 +36534,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 87
+                      end_line: 489
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 489
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 87
+                  end_line: 489
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 489
                 }
               }
             }
             src {
+              end_column: 88
+              end_line: 489
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 489
             }
           }
@@ -30629,7 +36569,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 489
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 489
         }
         variadic: true
@@ -30673,20 +36616,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 491
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 491
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 491
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 491
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 491
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 491
             }
           }
@@ -30699,7 +36651,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 491
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 491
         }
         variadic: true
@@ -30743,14 +36698,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 493
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 493
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 493
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 493
                 }
               }
@@ -30769,20 +36730,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 493
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 493
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 493
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 493
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 493
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 493
             }
           }
@@ -30812,14 +36782,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 493
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 493
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 493
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 493
                 }
               }
@@ -30838,20 +36814,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 493
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 493
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 493
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 493
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 493
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 493
             }
           }
@@ -30864,7 +36849,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 493
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 493
         }
         variadic: true
@@ -30895,7 +36883,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 495
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 495
             }
           }
@@ -30925,14 +36916,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 495
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 63
                       start_line: 495
                     }
                     v: "k"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 495
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 63
                   start_line: 495
                 }
               }
@@ -30951,20 +36948,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 495
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 73
                       start_line: 495
                     }
                     v: "v"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 495
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 73
                   start_line: 495
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 495
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 495
             }
           }
@@ -30994,14 +37000,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 495
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 495
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 495
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 495
                 }
               }
@@ -31020,14 +37032,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 495
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 495
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 495
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 495
                 }
               }
@@ -31046,14 +37064,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 495
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 495
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 495
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 495
                 }
               }
@@ -31072,20 +37096,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 495
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 495
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 495
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 495
                 }
               }
             }
             src {
+              end_column: 120
+              end_line: 495
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 495
             }
           }
@@ -31098,7 +37131,10 @@ body {
           }
         }
         src {
+          end_column: 121
+          end_line: 495
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 495
         }
         variadic: true
@@ -31129,7 +37165,10 @@ body {
               }
             }
             src {
+              end_column: 54
+              end_line: 497
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 497
             }
           }
@@ -31159,14 +37198,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 497
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 497
                     }
                     v: "k"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 497
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 497
                 }
               }
@@ -31185,20 +37230,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 497
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 497
                     }
                     v: "v"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 497
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 497
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 497
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 497
             }
           }
@@ -31228,14 +37282,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 497
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 497
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 497
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 497
                 }
               }
@@ -31254,14 +37314,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 497
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 497
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 497
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 497
                 }
               }
@@ -31280,14 +37346,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 497
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 497
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 497
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 497
                 }
               }
@@ -31306,20 +37378,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 497
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 497
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 497
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 497
                 }
               }
             }
             src {
+              end_column: 150
+              end_line: 497
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 104
               start_line: 497
             }
           }
@@ -31332,7 +37413,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 497
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 497
         }
         variadic: true
@@ -31376,14 +37460,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 499
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 499
                 }
               }
@@ -31402,20 +37492,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 499
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 499
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 499
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 499
             }
           }
@@ -31445,14 +37544,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 499
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 499
                 }
               }
@@ -31471,14 +37576,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 499
                     }
                     v: "k1"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 499
                 }
               }
@@ -31497,14 +37608,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 499
                     }
                     v: "k2"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 499
                 }
               }
@@ -31523,14 +37640,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 499
                     }
                     v: "k3"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 499
                 }
               }
@@ -31549,20 +37672,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 499
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 499
                     }
                     v: "k4"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 499
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 499
                 }
               }
             }
             src {
+              end_column: 98
+              end_line: 499
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 499
             }
           }
@@ -31575,7 +37707,10 @@ body {
           }
         }
         src {
+          end_column: 99
+          end_line: 499
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 499
         }
         variadic: true
@@ -31619,14 +37754,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 501
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 501
                 }
               }
@@ -31645,14 +37786,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 501
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 501
                 }
               }
@@ -31671,20 +37818,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 501
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 501
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 501
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 501
             }
           }
@@ -31714,14 +37870,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 501
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 501
                 }
               }
@@ -31740,14 +37902,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 86
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 501
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 501
                 }
               }
@@ -31766,14 +37934,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 95
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 501
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 501
                 }
               }
@@ -31792,20 +37966,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 501
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 501
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 501
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 501
                 }
               }
             }
             src {
+              end_column: 101
+              end_line: 501
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 501
             }
           }
@@ -31818,7 +38001,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 501
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 501
         }
         variadic: true
@@ -31862,14 +38048,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 503
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 503
                 }
               }
@@ -31888,20 +38080,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 503
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 503
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 503
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 503
             }
           }
@@ -31931,14 +38132,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 503
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 503
                 }
               }
@@ -31957,14 +38164,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 503
                     }
                     v: "k1"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 503
                 }
               }
@@ -31983,14 +38196,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 503
                     }
                     v: "k2"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 503
                 }
               }
@@ -32009,14 +38228,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 503
                     }
                     v: "k3"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 503
                 }
               }
@@ -32035,20 +38260,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 503
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 503
                     }
                     v: "k4"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 503
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 503
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 503
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 503
             }
           }
@@ -32061,7 +38295,10 @@ body {
           }
         }
         src {
+          end_column: 95
+          end_line: 503
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 503
         }
         variadic: true
@@ -32105,14 +38342,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 505
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 505
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 505
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 505
                 }
               }
@@ -32131,20 +38374,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 505
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 505
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 505
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 505
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 505
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 505
             }
           }
@@ -32157,7 +38409,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 505
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 505
         }
         variadic: true
@@ -32201,14 +38456,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 507
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 507
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 507
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 507
                 }
               }
@@ -32227,20 +38488,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 507
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 507
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 507
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 507
                 }
               }
             }
             src {
+              end_column: 59
+              end_line: 507
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 507
             }
           }
@@ -32253,7 +38523,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 507
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 507
         }
         variadic: true
@@ -32297,14 +38570,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 509
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 509
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 509
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 509
                 }
               }
@@ -32323,20 +38602,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 509
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 509
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 509
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 509
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 509
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 509
             }
           }
@@ -32349,7 +38637,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 509
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 509
         }
         variadic: true
@@ -32382,14 +38673,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 34
+                  end_line: 511
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 511
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 34
+              end_line: 511
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 511
             }
           }
@@ -32402,7 +38699,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 511
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 511
         }
         variadic: true
@@ -32435,14 +38735,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 513
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 513
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 46
+              end_line: 513
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 513
             }
           }
@@ -32455,7 +38761,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 513
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 513
         }
         variadic: true
@@ -32488,14 +38797,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 515
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 515
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 45
+              end_line: 515
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 515
             }
           }
@@ -32508,7 +38823,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 515
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 515
         }
         variadic: true
@@ -32541,14 +38859,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 517
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 517
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 35
+              end_line: 517
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 517
             }
           }
@@ -32561,7 +38885,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 517
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 517
         }
         variadic: true
@@ -32594,14 +38921,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 519
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 519
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 47
+              end_line: 519
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 519
             }
           }
@@ -32614,7 +38947,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 519
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 519
         }
         variadic: true
@@ -32647,14 +38983,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 521
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 521
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 46
+              end_line: 521
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 521
             }
           }
@@ -32667,7 +39009,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 521
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 521
         }
         variadic: true
@@ -32711,20 +39056,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 523
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 523
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 523
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 523
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 523
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 523
             }
           }
@@ -32737,7 +39091,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 523
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 523
         }
         variadic: true
@@ -32781,20 +39138,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 525
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 525
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 525
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 525
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 525
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 525
             }
           }
@@ -32807,7 +39173,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 525
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 525
         }
         variadic: true
@@ -32851,20 +39220,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 527
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 527
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 527
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 527
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 527
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 527
             }
           }
@@ -32877,7 +39255,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 527
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 527
         }
         variadic: true
@@ -32921,20 +39302,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 529
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 529
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 529
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 529
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 529
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 529
             }
           }
@@ -32947,7 +39337,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 529
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 529
         }
         variadic: true
@@ -32991,20 +39384,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 531
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 531
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 531
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 531
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 531
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 531
             }
           }
@@ -33017,7 +39419,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 531
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 531
         }
         variadic: true
@@ -33050,7 +39455,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 533
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 533
                 }
                 v: "A"
@@ -33059,14 +39467,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 533
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 533
                 }
                 v: "int"
               }
             }
             src {
+              end_column: 42
+              end_line: 533
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 533
             }
           }
@@ -33085,7 +39499,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 65
+                  end_line: 533
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 533
                 }
                 v: "A"
@@ -33097,13 +39514,19 @@ body {
                   sp_long_type: true
                 }
                 src {
+                  end_column: 65
+                  end_line: 533
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 533
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 533
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 533
             }
           }
@@ -33116,7 +39539,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 533
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 533
         }
         variadic: true
@@ -33149,7 +39575,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 535
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 535
                 }
                 v: "A"
@@ -33158,14 +39587,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 535
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 535
                 }
                 v: "int"
               }
             }
             src {
+              end_column: 46
+              end_line: 535
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 535
             }
           }
@@ -33184,7 +39619,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 73
+                  end_line: 535
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 535
                 }
                 v: "A"
@@ -33196,13 +39634,19 @@ body {
                   sp_long_type: true
                 }
                 src {
+                  end_column: 73
+                  end_line: 535
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 535
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 535
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 535
             }
           }
@@ -33215,7 +39659,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 535
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 535
         }
         variadic: true
@@ -33248,7 +39695,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 537
                 }
                 v: "A"
@@ -33257,7 +39707,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 41
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 537
                 }
               }
@@ -33265,13 +39718,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 41
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 537
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 537
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 537
             }
           }
@@ -33290,7 +39749,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 64
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 537
                 }
                 v: "A"
@@ -33299,7 +39761,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 64
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 537
                 }
               }
@@ -33307,13 +39772,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 64
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 537
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 537
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 537
             }
           }
@@ -33332,7 +39803,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 85
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 537
                 }
                 v: "A"
@@ -33341,7 +39815,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 85
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 537
                 }
                 v: 10
@@ -33350,13 +39827,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 85
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 537
                 }
               }
             }
             src {
+              end_column: 85
+              end_line: 537
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 66
               start_line: 537
             }
           }
@@ -33386,14 +39869,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 537
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 537
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 537
                 }
               }
@@ -33401,7 +39890,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 114
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 537
                 }
                 v: 10
@@ -33410,14 +39902,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 114
+                  end_line: 537
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 537
                 }
                 v: 2
               }
             }
             src {
+              end_column: 114
+              end_line: 537
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 87
               start_line: 537
             }
           }
@@ -33430,7 +39928,10 @@ body {
           }
         }
         src {
+          end_column: 115
+          end_line: 537
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 537
         }
         variadic: true
@@ -33463,7 +39964,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 539
                 }
                 v: "A"
@@ -33472,7 +39976,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 40
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 539
                 }
               }
@@ -33480,13 +39987,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 40
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 539
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 539
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 539
             }
           }
@@ -33505,7 +40018,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 62
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 539
                 }
                 v: "A"
@@ -33514,7 +40030,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 62
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 539
                 }
               }
@@ -33522,13 +40041,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 62
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 539
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 539
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 539
             }
           }
@@ -33547,7 +40072,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 539
                 }
                 v: "A"
@@ -33556,7 +40084,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 82
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 539
                 }
                 v: 10
@@ -33565,13 +40096,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 82
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 539
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 539
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 539
             }
           }
@@ -33601,14 +40138,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 539
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 539
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 539
                 }
               }
@@ -33616,7 +40159,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 110
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 539
                 }
                 v: 10
@@ -33625,14 +40171,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 110
+                  end_line: 539
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 539
                 }
                 v: 2
               }
             }
             src {
+              end_column: 110
+              end_line: 539
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 539
             }
           }
@@ -33645,7 +40197,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 539
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 539
         }
         variadic: true
@@ -33689,20 +40244,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 541
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 541
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 541
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 541
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 541
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 541
             }
           }
@@ -33715,7 +40279,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 541
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 541
         }
         variadic: true
@@ -33759,20 +40326,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 543
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 543
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 543
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 543
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 543
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 543
             }
           }
@@ -33785,7 +40361,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 543
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 543
         }
         variadic: true
@@ -33829,20 +40408,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 545
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 545
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 545
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 545
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 545
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 545
             }
           }
@@ -33855,7 +40443,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 545
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 545
         }
         variadic: true
@@ -33899,20 +40490,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 547
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 547
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 547
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 547
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 547
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 547
             }
           }
@@ -33925,7 +40525,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 547
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 547
         }
         variadic: true
@@ -33969,20 +40572,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 549
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 549
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 549
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 549
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 549
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 549
             }
           }
@@ -33995,7 +40607,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 549
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 549
         }
         variadic: true
@@ -34039,20 +40654,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 551
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 551
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 551
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 551
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 551
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 551
             }
           }
@@ -34065,7 +40689,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 551
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 551
         }
         variadic: true
@@ -34109,20 +40736,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 553
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 553
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 553
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 553
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 553
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 553
             }
           }
@@ -34135,7 +40771,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 553
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 553
         }
         variadic: true
@@ -34179,20 +40818,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 555
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 555
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 555
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 555
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 555
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 555
             }
           }
@@ -34205,7 +40853,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 555
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 555
         }
         variadic: true
@@ -34249,20 +40900,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 557
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 557
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 557
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 557
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 557
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 557
             }
           }
@@ -34292,14 +40952,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 66
+                      end_line: 557
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 557
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 66
+                  end_line: 557
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 557
                 }
               }
@@ -34307,14 +40973,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 66
+                  end_line: 557
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 557
                 }
                 v: "BASE64"
               }
             }
             src {
+              end_column: 66
+              end_line: 557
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 557
             }
           }
@@ -34344,14 +41016,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 557
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 557
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 557
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 557
                 }
               }
@@ -34359,14 +41037,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 96
+                  end_line: 557
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 557
                 }
                 v: "UTF-8"
               }
             }
             src {
+              end_column: 96
+              end_line: 557
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 68
               start_line: 557
             }
           }
@@ -34379,7 +41063,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 557
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 557
         }
         variadic: true
@@ -34423,20 +41110,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 559
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 559
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 559
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 559
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 559
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 559
             }
           }
@@ -34449,7 +41145,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 559
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 559
         }
         variadic: true
@@ -34493,20 +41192,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 561
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 561
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 561
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 561
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 561
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 561
             }
           }
@@ -34519,7 +41227,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 561
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 561
         }
         variadic: true
@@ -34563,20 +41274,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 563
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 563
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 563
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 563
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 563
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 563
             }
           }
@@ -34589,7 +41309,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 563
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 563
         }
         variadic: true
@@ -34633,20 +41356,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 565
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 565
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 565
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 565
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 565
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 565
             }
           }
@@ -34659,7 +41391,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 565
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 565
         }
         variadic: true
@@ -34703,20 +41438,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 567
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 567
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 567
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 567
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 567
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 567
             }
           }
@@ -34729,7 +41473,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 567
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 567
         }
         variadic: true
@@ -34773,14 +41520,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 569
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 569
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 569
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 569
                 }
               }
@@ -34799,20 +41552,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 569
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 569
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 569
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 569
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 569
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 569
             }
           }
@@ -34825,7 +41587,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 569
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 569
         }
         variadic: true
@@ -34869,20 +41634,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 571
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 571
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 571
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 571
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 571
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 571
             }
           }
@@ -34895,7 +41669,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 571
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 571
         }
         variadic: true
@@ -34939,14 +41716,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 573
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 573
                 }
               }
@@ -34965,14 +41748,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 573
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 573
                 }
               }
@@ -34980,13 +41769,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 573
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 573
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 573
             }
           }
@@ -35016,14 +41811,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 573
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 573
                 }
               }
@@ -35042,14 +41843,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 573
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 573
                 }
               }
@@ -35057,13 +41864,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 63
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 573
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 573
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 573
             }
           }
@@ -35093,14 +41906,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 573
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 573
                 }
               }
@@ -35119,14 +41938,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 573
                     }
                     v: "123"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 573
                 }
               }
@@ -35145,20 +41970,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 573
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 573
                 }
               }
             }
             src {
+              end_column: 103
+              end_line: 573
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 573
             }
           }
@@ -35188,14 +42022,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 105
                       start_line: 573
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 105
                   start_line: 573
                 }
               }
@@ -35214,14 +42054,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 105
                       start_line: 573
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 105
                   start_line: 573
                 }
               }
@@ -35240,20 +42086,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 573
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 105
                       start_line: 573
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 573
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 105
                   start_line: 573
                 }
               }
             }
             src {
+              end_column: 126
+              end_line: 573
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 105
               start_line: 573
             }
           }
@@ -35266,7 +42121,10 @@ body {
           }
         }
         src {
+          end_column: 127
+          end_line: 573
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 573
         }
         variadic: true
@@ -35310,14 +42168,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 575
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 575
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 575
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 575
                 }
               }
@@ -35336,20 +42200,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 575
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 575
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 575
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 575
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 575
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 575
             }
           }
@@ -35362,7 +42235,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 575
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 575
         }
         variadic: true
@@ -35395,7 +42271,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 577
                 }
                 v: 1
@@ -35404,14 +42283,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 577
                 }
                 v: 2
               }
             }
             src {
+              end_column: 35
+              end_line: 577
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 577
             }
           }
@@ -35441,14 +42326,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 577
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 577
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 577
                 }
               }
@@ -35456,14 +42347,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 48
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 577
                 }
                 v: 2
               }
             }
             src {
+              end_column: 48
+              end_line: 577
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 577
             }
           }
@@ -35482,7 +42379,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 61
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 577
                 }
                 v: 3
@@ -35502,20 +42402,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 577
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 577
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 577
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 577
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 577
             }
           }
@@ -35545,14 +42454,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 577
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 577
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 577
                 }
               }
@@ -35560,14 +42475,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 79
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 63
                   start_line: 577
                 }
                 v: 2
               }
             }
             src {
+              end_column: 79
+              end_line: 577
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 63
               start_line: 577
             }
           }
@@ -35597,14 +42518,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 93
+                      end_line: 577
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 85
                       start_line: 577
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 577
                 }
               }
@@ -35623,20 +42550,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 577
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 95
                       start_line: 577
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 577
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 95
                   start_line: 577
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 577
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 81
               start_line: 577
             }
           }
@@ -35649,7 +42585,10 @@ body {
           }
         }
         src {
+          end_column: 103
+          end_line: 577
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 577
         }
         variadic: true
@@ -35689,14 +42628,20 @@ body {
                           pos_args {
                             string_val {
                               src {
+                                end_column: 39
+                                end_line: 579
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 31
                                 start_line: 579
                               }
                               v: "a"
                             }
                           }
                           src {
+                            end_column: 39
+                            end_line: 579
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 31
                             start_line: 579
                           }
                         }
@@ -35704,14 +42649,20 @@ body {
                       rhs {
                         int64_val {
                           src {
+                            end_column: 43
+                            end_line: 579
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 31
                             start_line: 579
                           }
                           v: 2
                         }
                       }
                       src {
+                        end_column: 43
+                        end_line: 579
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 31
                         start_line: 579
                       }
                     }
@@ -35719,19 +42670,28 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 48
+                        end_line: 579
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 31
                         start_line: 579
                       }
                     }
                   }
                   src {
+                    end_column: 48
+                    end_line: 579
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 31
                     start_line: 579
                   }
                 }
               }
               src {
+                end_column: 62
+                end_line: 579
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 26
                 start_line: 579
               }
               value {
@@ -35748,21 +42708,30 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 61
+                        end_line: 579
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 50
                         start_line: 579
                       }
                       v: "even"
                     }
                   }
                   src {
+                    end_column: 61
+                    end_line: 579
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 50
                     start_line: 579
                   }
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 579
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 579
             }
           }
@@ -35775,7 +42744,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 579
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 579
         }
         variadic: true
@@ -35823,14 +42795,20 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 38
+                              end_line: 581
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 30
                               start_line: 581
                             }
                             v: "a"
                           }
                         }
                         src {
+                          end_column: 38
+                          end_line: 581
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 30
                           start_line: 581
                         }
                       }
@@ -35838,14 +42816,20 @@ body {
                     rhs {
                       int64_val {
                         src {
+                          end_column: 42
+                          end_line: 581
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 30
                           start_line: 581
                         }
                         v: 2
                       }
                     }
                     src {
+                      end_column: 42
+                      end_line: 581
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 581
                     }
                   }
@@ -35853,13 +42837,19 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 47
+                      end_line: 581
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 581
                     }
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 581
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 581
                 }
               }
@@ -35878,14 +42868,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 581
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 581
                     }
                     v: "even"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 581
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 581
                 }
               }
@@ -35904,20 +42900,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 581
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 581
                     }
                     v: "odd"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 581
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 581
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 581
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 581
             }
           }
@@ -35930,7 +42935,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 581
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 581
         }
         variadic: true
@@ -35963,13 +42971,19 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 33
+                  end_line: 583
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 583
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 583
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 583
             }
           }
@@ -35988,7 +43002,10 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 60
+                  end_line: 583
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 583
                 }
                 vs {
@@ -36005,14 +43022,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 48
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 40
                           start_line: 583
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 48
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 583
                     }
                   }
@@ -36020,7 +43043,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 583
                     }
                     v: "B"
@@ -36029,7 +43055,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 583
                     }
                     v: "A"
@@ -36038,7 +43067,10 @@ body {
               }
             }
             src {
+              end_column: 60
+              end_line: 583
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 583
             }
           }
@@ -36057,7 +43089,10 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 115
+                  end_line: 583
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 583
                 }
                 vs {
@@ -36074,14 +43109,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 78
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 67
                           start_line: 583
                         }
                         v: "col1"
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 583
                     }
                   }
@@ -36100,14 +43141,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 91
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 80
                           start_line: 583
                         }
                         v: "col2"
                       }
                     }
                     src {
+                      end_column: 91
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 583
                     }
                   }
@@ -36117,19 +43164,28 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 115
+                  end_line: 583
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 583
                 }
                 vs {
                   list_val {
                     src {
+                      end_column: 115
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 583
                     }
                     vs {
                       int64_val {
                         src {
+                          end_column: 115
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 583
                         }
                         v: 1
@@ -36138,7 +43194,10 @@ body {
                     vs {
                       string_val {
                         src {
+                          end_column: 115
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 583
                         }
                         v: "a"
@@ -36149,13 +43208,19 @@ body {
                 vs {
                   list_val {
                     src {
+                      end_column: 115
+                      end_line: 583
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 583
                     }
                     vs {
                       int64_val {
                         src {
+                          end_column: 115
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 583
                         }
                         v: 2
@@ -36164,7 +43229,10 @@ body {
                     vs {
                       string_val {
                         src {
+                          end_column: 115
+                          end_line: 583
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 583
                         }
                         v: "b"
@@ -36175,7 +43243,10 @@ body {
               }
             }
             src {
+              end_column: 115
+              end_line: 583
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 583
             }
           }
@@ -36188,7 +43259,10 @@ body {
           }
         }
         src {
+          end_column: 116
+          end_line: 583
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 583
         }
         variadic: true
@@ -36219,7 +43293,10 @@ body {
               }
             }
             src {
+              end_column: 37
+              end_line: 585
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 585
             }
           }
@@ -36232,7 +43309,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 585
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 585
         }
         variadic: true
@@ -36263,7 +43343,10 @@ body {
               }
             }
             src {
+              end_column: 32
+              end_line: 587
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 587
             }
           }
@@ -36276,7 +43359,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 587
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 587
         }
         variadic: true
@@ -36307,7 +43393,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 589
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 589
             }
           }
@@ -36320,7 +43409,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 589
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 589
         }
         variadic: true
@@ -36351,7 +43443,10 @@ body {
               }
             }
             src {
+              end_column: 38
+              end_line: 591
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 591
             }
           }
@@ -36364,7 +43459,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 591
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 591
         }
         variadic: true
@@ -36395,7 +43493,10 @@ body {
               }
             }
             src {
+              end_column: 38
+              end_line: 593
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 593
             }
           }
@@ -36408,7 +43509,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 593
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 593
         }
         variadic: true
@@ -36441,7 +43545,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 34
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 595
                 }
                 v: "A"
@@ -36450,7 +43557,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 34
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 595
                 }
                 v: 1
@@ -36459,7 +43569,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 34
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 595
                 }
               }
@@ -36467,13 +43580,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 34
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 595
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 595
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 595
             }
           }
@@ -36503,14 +43622,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 595
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 595
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 595
                 }
               }
@@ -36518,7 +43643,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 49
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 595
                 }
                 v: 1
@@ -36527,7 +43655,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 49
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 595
                 }
               }
@@ -36535,13 +43666,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 49
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 595
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 595
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 36
               start_line: 595
             }
           }
@@ -36560,7 +43697,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 74
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 595
                 }
                 v: "A"
@@ -36569,7 +43709,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 74
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 595
                 }
                 v: 1
@@ -36578,7 +43721,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 74
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 595
                 }
               }
@@ -36586,14 +43732,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 74
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 595
                 }
                 v: true
               }
             }
             src {
+              end_column: 74
+              end_line: 595
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 595
             }
           }
@@ -36612,7 +43764,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 97
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 595
                 }
                 v: "A"
@@ -36621,7 +43776,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 97
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 595
                 }
                 v: 1
@@ -36641,14 +43799,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 595
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 595
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 595
                 }
               }
@@ -36656,13 +43820,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 97
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 595
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 595
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 76
               start_line: 595
             }
           }
@@ -36681,7 +43851,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 125
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 595
                 }
                 v: "A"
@@ -36690,7 +43863,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 125
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 595
                 }
                 v: 2
@@ -36710,14 +43886,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 118
+                      end_line: 595
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 111
                       start_line: 595
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 118
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 111
                   start_line: 595
                 }
               }
@@ -36725,14 +43907,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 125
+                  end_line: 595
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 595
                 }
                 v: true
               }
             }
             src {
+              end_column: 125
+              end_line: 595
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 99
               start_line: 595
             }
           }
@@ -36745,7 +43933,10 @@ body {
           }
         }
         src {
+          end_column: 126
+          end_line: 595
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 595
         }
         variadic: true
@@ -36778,7 +43969,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 597
                 }
                 v: "A"
@@ -36787,7 +43981,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 597
                 }
                 v: 1
@@ -36796,7 +43993,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 35
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 597
                 }
               }
@@ -36804,13 +44004,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 35
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 597
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 597
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 597
             }
           }
@@ -36840,14 +44046,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 597
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 597
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 597
                 }
               }
@@ -36855,7 +44067,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 597
                 }
                 v: 1
@@ -36864,7 +44079,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 51
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 597
                 }
               }
@@ -36872,13 +44090,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 51
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 597
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 597
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 597
             }
           }
@@ -36897,7 +44121,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 77
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 597
                 }
                 v: "A"
@@ -36906,7 +44133,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 77
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 597
                 }
                 v: 1
@@ -36915,7 +44145,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 77
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 597
                 }
               }
@@ -36923,14 +44156,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 77
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 597
                 }
                 v: true
               }
             }
             src {
+              end_column: 77
+              end_line: 597
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 597
             }
           }
@@ -36949,7 +44188,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 597
                 }
                 v: "A"
@@ -36958,7 +44200,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 101
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 597
                 }
                 v: 1
@@ -36978,14 +44223,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 100
+                      end_line: 597
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 92
                       start_line: 597
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 100
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 92
                   start_line: 597
                 }
               }
@@ -36993,13 +44244,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 101
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 597
                 }
               }
             }
             src {
+              end_column: 101
+              end_line: 597
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 79
               start_line: 597
             }
           }
@@ -37018,7 +44275,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 130
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 597
                 }
                 v: "A"
@@ -37027,7 +44287,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 130
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 597
                 }
                 v: 2
@@ -37047,14 +44310,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 123
+                      end_line: 597
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 116
                       start_line: 597
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 123
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 116
                   start_line: 597
                 }
               }
@@ -37062,14 +44331,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 130
+                  end_line: 597
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 597
                 }
                 v: true
               }
             }
             src {
+              end_column: 130
+              end_line: 597
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 103
               start_line: 597
             }
           }
@@ -37082,7 +44357,10 @@ body {
           }
         }
         src {
+          end_column: 131
+          end_line: 597
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 597
         }
         variadic: true
@@ -37115,7 +44393,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 599
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 599
                 }
                 v: "A"
@@ -37124,13 +44405,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 41
+                  end_line: 599
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 599
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 599
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 599
             }
           }
@@ -37149,7 +44436,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 64
+                  end_line: 599
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 599
                 }
                 v: "A"
@@ -37158,14 +44448,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 64
+                  end_line: 599
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 599
                 }
                 v: true
               }
             }
             src {
+              end_column: 64
+              end_line: 599
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 599
             }
           }
@@ -37195,14 +44491,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 599
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 599
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 599
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 599
                 }
               }
@@ -37210,13 +44512,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 93
+                  end_line: 599
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 599
                 }
               }
             }
             src {
+              end_column: 93
+              end_line: 599
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 66
               start_line: 599
             }
           }
@@ -37229,7 +44537,10 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 599
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 599
         }
         variadic: true
@@ -37262,7 +44573,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 601
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 601
                 }
                 v: "A"
@@ -37271,13 +44585,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 42
+                  end_line: 601
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 601
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 601
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 601
             }
           }
@@ -37296,7 +44616,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 66
+                  end_line: 601
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 601
                 }
                 v: "A"
@@ -37305,14 +44628,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 66
+                  end_line: 601
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 601
                 }
                 v: true
               }
             }
             src {
+              end_column: 66
+              end_line: 601
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 601
             }
           }
@@ -37342,14 +44671,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 601
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 601
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 601
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 601
                 }
               }
@@ -37357,13 +44692,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 96
+                  end_line: 601
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 601
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 601
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 68
               start_line: 601
             }
           }
@@ -37376,7 +44717,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 601
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 601
         }
         variadic: true
@@ -37409,14 +44753,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 603
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 603
                 }
                 v: 10
               }
             }
             src {
+              end_column: 35
+              end_line: 603
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 603
             }
           }
@@ -37446,20 +44796,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 603
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 603
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 603
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 603
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 603
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 603
             }
           }
@@ -37489,20 +44848,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 603
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 603
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 603
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 603
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 603
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 603
             }
           }
@@ -37515,7 +44883,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 603
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 603
         }
         variadic: true
@@ -37548,14 +44919,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 46
+                  end_line: 605
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 605
                 }
                 v: 0.4
               }
             }
             src {
+              end_column: 46
+              end_line: 605
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 605
             }
           }
@@ -37568,7 +44945,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 605
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 605
         }
         variadic: true
@@ -37599,7 +44979,10 @@ body {
               }
             }
             src {
+              end_column: 36
+              end_line: 607
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 607
             }
           }
@@ -37629,20 +45012,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 607
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 607
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 607
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 607
             }
           }
@@ -37672,14 +45064,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 607
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 607
                 }
               }
@@ -37698,20 +45096,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 607
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 607
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 607
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 607
             }
           }
@@ -37741,14 +45148,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 607
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 607
                 }
               }
@@ -37767,14 +45180,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 607
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 607
                 }
               }
@@ -37793,14 +45212,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 607
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 607
                 }
               }
@@ -37819,14 +45244,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 607
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 607
                 }
               }
@@ -37845,14 +45276,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 607
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 607
                 }
               }
@@ -37871,20 +45308,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 607
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 607
                     }
                     v: "F"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 607
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 607
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 607
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 607
             }
           }
@@ -37897,7 +45343,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 607
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 607
         }
         variadic: true
@@ -37928,7 +45377,10 @@ body {
               }
             }
             src {
+              end_column: 33
+              end_line: 609
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 609
             }
           }
@@ -37958,20 +45410,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 609
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 609
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 609
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 609
             }
           }
@@ -38001,14 +45462,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 609
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 609
                 }
               }
@@ -38027,20 +45494,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 609
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 609
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 609
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 609
             }
           }
@@ -38070,14 +45546,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 609
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 609
                 }
               }
@@ -38096,14 +45578,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 609
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 609
                 }
               }
@@ -38122,14 +45610,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 609
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 609
                 }
               }
@@ -38148,14 +45642,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 609
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 609
                 }
               }
@@ -38174,14 +45674,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 609
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 609
                 }
               }
@@ -38200,20 +45706,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 609
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 609
                     }
                     v: "F"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 609
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 609
                 }
               }
             }
             src {
+              end_column: 104
+              end_line: 609
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 609
             }
           }
@@ -38226,7 +45741,10 @@ body {
           }
         }
         src {
+          end_column: 105
+          end_line: 609
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 609
         }
         variadic: true
@@ -38259,7 +45777,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 611
                 }
                 v: "A"
@@ -38268,7 +45789,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 611
                 }
               }
@@ -38276,13 +45800,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 38
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 611
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 611
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 611
             }
           }
@@ -38312,14 +45842,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 611
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 611
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 611
                 }
               }
@@ -38327,7 +45863,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 57
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 611
                 }
               }
@@ -38335,13 +45874,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 57
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 611
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 611
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 611
             }
           }
@@ -38360,7 +45905,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 76
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 611
                 }
                 v: "A"
@@ -38369,7 +45917,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 76
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 611
                 }
                 v: ","
@@ -38378,13 +45929,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 76
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 611
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 611
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 611
             }
           }
@@ -38403,7 +45960,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 611
                 }
                 v: "A"
@@ -38412,7 +45972,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 611
                 }
                 v: "|"
@@ -38421,14 +45984,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 101
+                  end_line: 611
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 611
                 }
                 v: true
               }
             }
             src {
+              end_column: 101
+              end_line: 611
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 611
             }
           }
@@ -38441,7 +46010,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 611
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 611
         }
         variadic: true
@@ -38474,14 +46046,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 613
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 613
                 }
                 v: "name"
               }
             }
             src {
+              end_column: 42
+              end_line: 613
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 613
             }
           }
@@ -38500,7 +46078,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 79
+                  end_line: 613
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 613
                 }
                 v: "test"
@@ -38520,14 +46101,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 613
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 613
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 613
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 613
                 }
               }
@@ -38546,20 +46133,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 78
+                      end_line: 613
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 71
                       start_line: 613
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 613
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 613
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 613
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 613
             }
           }
@@ -38572,7 +46168,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 613
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 613
         }
         variadic: true
@@ -38605,7 +46204,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 615
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 615
                 }
                 v: "A"
@@ -38614,13 +46216,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 45
+                  end_line: 615
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 615
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 615
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 615
             }
           }
@@ -38639,7 +46247,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 72
+                  end_line: 615
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 615
                 }
                 v: "A"
@@ -38648,13 +46259,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 72
+                  end_line: 615
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 615
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 615
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 615
             }
           }
@@ -38684,14 +46301,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 97
+                      end_line: 615
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 89
                       start_line: 615
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 615
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 89
                   start_line: 615
                 }
               }
@@ -38710,20 +46333,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 110
+                      end_line: 615
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 99
                       start_line: 615
                     }
                     v: "YYYY"
                   }
                 }
                 src {
+                  end_column: 110
+                  end_line: 615
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 615
                 }
               }
             }
             src {
+              end_column: 111
+              end_line: 615
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 74
               start_line: 615
             }
           }
@@ -38736,7 +46368,10 @@ body {
           }
         }
         src {
+          end_column: 112
+          end_line: 615
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 615
         }
         variadic: true
@@ -38780,14 +46415,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 617
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 617
                     }
                     v: "needle"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 617
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 617
                 }
               }
@@ -38806,14 +46447,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 617
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 617
                     }
                     v: "expr"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 617
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 617
                 }
               }
@@ -38832,20 +46479,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 55
+                      end_line: 617
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 617
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 617
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 617
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 617
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 617
             }
           }
@@ -38875,14 +46531,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 617
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 617
                     }
                     v: "needle"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 617
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 617
                 }
               }
@@ -38901,14 +46563,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 617
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 617
                     }
                     v: "test string"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 617
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 617
                 }
               }
@@ -38927,20 +46595,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 617
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 617
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 617
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 617
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 617
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 617
             }
           }
@@ -38953,7 +46630,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 617
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 617
         }
         variadic: true
@@ -38997,20 +46677,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 619
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 31
                       start_line: 619
                     }
                     v: "expr"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 619
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 619
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 619
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 619
             }
           }
@@ -39029,14 +46718,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 54
+                  end_line: 619
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 619
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 54
+              end_line: 619
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 619
             }
           }
@@ -39049,7 +46744,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 619
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 619
         }
         variadic: true

--- a/tests/ast/data/interval.test
+++ b/tests/ast/data/interval.test
@@ -85,7 +85,10 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 13
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 27
                 }
                 vs {
@@ -93,7 +96,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -110,7 +116,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -127,7 +136,10 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 13
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 27
                 }
                 vs {
@@ -135,7 +147,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -152,7 +167,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -175,7 +193,10 @@ body {
           }
         }
         src {
+          end_column: 13
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -206,7 +227,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 20
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 12
                   start_line: 36
                 }
               }
@@ -227,7 +251,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 2
@@ -239,7 +266,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 2
@@ -251,7 +281,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 4
@@ -263,7 +296,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 3
@@ -275,7 +311,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 3
@@ -287,7 +326,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 1
@@ -299,7 +341,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 4
@@ -311,7 +356,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 1
@@ -323,7 +371,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 3
@@ -335,7 +386,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 2
@@ -343,13 +397,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 13
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 13
+              end_line: 48
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 36
             }
           }
@@ -362,7 +422,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variadic: true
@@ -394,7 +457,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 51
                 }
               }
@@ -415,7 +481,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 55
+                        end_line: 51
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 51
                       }
                       v: 1234
@@ -423,13 +492,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 51
             }
           }
@@ -442,7 +517,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
         variadic: true
@@ -474,7 +552,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 20
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 12
                   start_line: 54
                 }
               }
@@ -495,7 +576,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 4
@@ -507,7 +591,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 5
@@ -519,7 +606,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 6
@@ -531,7 +621,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 2
@@ -543,7 +636,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 1
@@ -555,7 +651,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 7
@@ -567,7 +666,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 3
@@ -575,13 +677,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 13
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 13
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 54
             }
           }
@@ -594,7 +702,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 64
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 53
         }
         variadic: true
@@ -626,7 +737,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 20
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 12
                   start_line: 67
                 }
               }
@@ -647,7 +761,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 4
@@ -659,7 +776,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 5
@@ -671,7 +791,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 9
@@ -683,7 +806,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 8
@@ -695,7 +821,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 6
@@ -707,7 +836,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 2
@@ -719,7 +851,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 10
@@ -731,7 +866,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 7
@@ -743,7 +881,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 3
@@ -755,7 +896,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 1
@@ -763,13 +907,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 13
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 68
                 }
               }
             }
             src {
+              end_column: 13
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 67
             }
           }
@@ -782,7 +932,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 80
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 66
         }
         variadic: true
@@ -814,7 +967,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 82
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 82
                 }
               }
@@ -835,7 +991,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 67
+                        end_line: 82
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 82
                       }
                     }
@@ -846,7 +1005,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 67
+                        end_line: 82
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 82
                       }
                       v: 21
@@ -854,13 +1016,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 82
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 82
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 82
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 82
             }
           }
@@ -873,7 +1041,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 82
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 82
         }
         variadic: true

--- a/tests/ast/data/select.test
+++ b/tests/ast/data/select.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,14 +61,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 39
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 27
             }
           }
@@ -84,14 +93,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 27
             }
           }
@@ -104,7 +119,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -50,13 +50,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 25
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 25
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -78,13 +84,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
           }
         }
         src {
+          end_column: 59
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -106,13 +118,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
         }
         src {
+          end_column: 55
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -134,13 +152,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
           }
         }
         src {
+          end_column: 61
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -162,13 +186,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -190,13 +220,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -224,19 +260,28 @@ body {
                 reader {
                   sp_dataframe_reader_init {
                     src {
+                      end_column: 26
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 value {
                   bool_val {
                     src {
+                      end_column: 55
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: true
@@ -245,13 +290,19 @@ body {
               }
             }
             src {
+              end_column: 84
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
             value {
               bool_val {
                 src {
+                  end_column: 84
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 v: true
@@ -260,7 +311,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -286,7 +340,10 @@ body {
               _2 {
                 bool_val {
                   src {
+                    end_column: 80
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: true
@@ -298,7 +355,10 @@ body {
               _2 {
                 bool_val {
                   src {
+                    end_column: 80
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: true
@@ -308,19 +368,28 @@ body {
             reader {
               sp_dataframe_reader_init {
                 src {
+                  end_column: 26
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 80
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
           }
         }
         src {
+          end_column: 106
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -358,14 +427,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 72
+                            end_line: 43
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 41
                             start_line: 43
                           }
                           v: "METADATA$FILE_ROW_NUMBER"
                         }
                       }
                       src {
+                        end_column: 72
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 41
                         start_line: 43
                       }
                     }
@@ -373,7 +448,10 @@ body {
                   args {
                     string_val {
                       src {
+                        end_column: 104
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 43
                       }
                       v: "METADATA$FILE_LAST_MODIFIED"
@@ -384,13 +462,19 @@ body {
                 reader {
                   sp_dataframe_reader_init {
                     src {
+                      end_column: 26
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 43
                 }
               }
@@ -428,13 +512,19 @@ body {
               }
             }
             src {
+              end_column: 124
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 43
             }
           }
         }
         src {
+          end_column: 150
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
       }

--- a/tests/ast/data/session.sql.test
+++ b/tests/ast/data/session.sql.test
@@ -22,7 +22,10 @@ body {
       sp_sql {
         query: "select 42"
         src {
+          end_column: 37
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -43,7 +46,10 @@ body {
         params {
           int64_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: 1
@@ -52,7 +58,10 @@ body {
         params {
           string_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "a"
@@ -61,7 +70,10 @@ body {
         params {
           int64_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: 2
@@ -70,7 +82,10 @@ body {
         params {
           string_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "b"
@@ -78,7 +93,10 @@ body {
         }
         query: "select * from values (?, ?), (?, ?)"
         src {
+          end_column: 89
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -98,7 +116,10 @@ body {
       sp_sql {
         query: "select 42"
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/session_generator.test
+++ b/tests/ast/data/session_generator.test
@@ -36,14 +36,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 40
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 27
             }
           }
@@ -62,20 +68,29 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 50
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 27
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 50
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 27
             }
           }
         }
         src {
+          end_column: 51
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variadic: true
@@ -108,14 +123,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 39
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 29
                 }
                 v: 1
               }
             }
             src {
+              end_column: 39
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 29
             }
           }
@@ -145,14 +166,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 29
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
@@ -171,14 +198,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 29
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
@@ -197,27 +230,39 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 29
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 29
             }
           }
         }
         row_count: 3
         src {
+          end_column: 71
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -250,13 +295,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 39
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 31
             }
           }
@@ -286,14 +337,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 31
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 31
                 }
               }
@@ -312,14 +369,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 31
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 31
                 }
               }
@@ -338,26 +401,38 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 31
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 31
             }
           }
         }
         src {
+          end_column: 72
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         time_limit_seconds: 1

--- a/tests/ast/data/session_range.test
+++ b/tests/ast/data/session_range.test
@@ -29,7 +29,10 @@ body {
     expr {
       sp_range {
         src {
+          end_column: 29
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 25
         }
         start: 10
@@ -55,7 +58,10 @@ body {
           value: 10
         }
         src {
+          end_column: 32
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 27
         }
         start: 1
@@ -81,7 +87,10 @@ body {
           value: 10
         }
         src {
+          end_column: 35
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 29
         }
         start: 1
@@ -104,7 +113,10 @@ body {
     expr {
       sp_range {
         src {
+          end_column: 34
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 31
         }
         start: 1
@@ -127,7 +139,10 @@ body {
     expr {
       sp_range {
         src {
+          end_column: 37
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 33
         }
         start: 1

--- a/tests/ast/data/session_table_dq_abs_l.test
+++ b/tests/ast/data/session_table_dq_abs_l.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 88
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,14 +61,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -78,7 +87,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_abs_s.test
+++ b/tests/ast/data/session_table_dq_abs_s.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rs_l.test
+++ b/tests/ast/data/session_table_dq_rs_l.test
@@ -22,7 +22,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -57,14 +60,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -77,7 +86,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rs_s.test
+++ b/tests/ast/data/session_table_dq_rs_s.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rt_l.test
+++ b/tests/ast/data/session_table_dq_rt_l.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rt_s.test
+++ b/tests/ast/data/session_table_dq_rt_s.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_abs_l.test
+++ b/tests/ast/data/session_table_uq_abs_l.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,14 +61,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -78,7 +87,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_abs_s.test
+++ b/tests/ast/data/session_table_uq_abs_s.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 72
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rs_l.test
+++ b/tests/ast/data/session_table_uq_rs_l.test
@@ -22,7 +22,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -57,14 +60,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -77,7 +86,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rs_s.test
+++ b/tests/ast/data/session_table_uq_rs_s.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rt_l.test
+++ b/tests/ast/data/session_table_uq_rt_l.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rt_s.test
+++ b/tests/ast/data/session_table_uq_rt_s.test
@@ -21,7 +21,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -56,14 +59,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -76,7 +85,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -36,7 +36,10 @@ body {
         parallel: 4
         quote_identifiers: true
         src {
+          end_column: 53
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         table_name {
@@ -81,7 +84,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 260
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 31
               }
               v: 90
@@ -92,7 +98,10 @@ body {
         overwrite: true
         parallel: 10
         src {
+          end_column: 260
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 31
         }
         table_name {

--- a/tests/ast/data/shadowed_local_name.test
+++ b/tests/ast/data/shadowed_local_name.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -68,14 +71,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 57
+                    end_line: 25
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 47
                     start_line: 25
                   }
                   v: "NUM"
                 }
               }
               src {
+                end_column: 57
+                end_line: 25
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 47
                 start_line: 25
               }
             }
@@ -90,7 +99,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -116,7 +128,10 @@ body {
           }
         }
         src {
+          end_column: 27
+          end_line: 28
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 28
         }
       }
@@ -144,7 +159,10 @@ body {
         input {
           string_val {
             src {
+              end_column: 52
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
             v: "STR"
@@ -158,7 +176,10 @@ body {
           value: "path"
         }
         src {
+          end_column: 52
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -233,7 +233,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 114
+          end_line: 42
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 42
         }
       }
@@ -253,7 +256,10 @@ body {
       sp_sql {
         query: "create or replace temp table test_from(test_str varchar) as select randstr(20, random()) from table (generator(rowCount => 100))"
         src {
+          end_column: 155
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 43
         }
       }
@@ -277,7 +283,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 165
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 43
         }
       }
@@ -307,7 +316,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 46
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 46
                 }
                 v: 1
@@ -316,7 +328,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 46
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 46
                 }
                 v: 2
@@ -325,7 +340,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 46
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 46
                 }
                 v: 3
@@ -339,7 +357,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 46
         }
       }
@@ -365,7 +386,10 @@ body {
           }
         }
         src {
+          end_column: 21
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
       }
@@ -391,7 +415,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 90
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
         table_name {
@@ -427,7 +454,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 64
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 48
                 }
                 v: -1
@@ -436,7 +466,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 64
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 48
                 }
                 v: -2
@@ -450,7 +483,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 48
         }
       }
@@ -476,7 +512,10 @@ body {
           }
         }
         src {
+          end_column: 19
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 49
         }
       }
@@ -502,7 +541,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 86
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 49
         }
         table_name {
@@ -535,7 +577,10 @@ body {
       sp_sql {
         query: "call my_copy_sp(\'test_from\', \'test_to\', 10)"
         src {
+          end_column: 66
+          end_line: 50
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 50
         }
       }
@@ -558,7 +603,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 76
+          end_line: 50
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 50
         }
       }
@@ -589,7 +637,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
         variant {
@@ -614,7 +665,10 @@ body {
           bitfield1: 16
         }
         src {
+          end_column: 40
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
       }
@@ -641,7 +695,10 @@ body {
       sp_sql {
         query: "drop table if exists test_to"
         src {
+          end_column: 55
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 54
         }
       }
@@ -665,7 +722,10 @@ body {
           bitfield1: 19
         }
         src {
+          end_column: 65
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 54
         }
       }
@@ -704,7 +764,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_from"
@@ -713,7 +776,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_to"
@@ -722,14 +788,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: 10
           }
         }
         src {
+          end_column: 62
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -756,7 +828,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_from"
@@ -765,7 +840,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_to"
@@ -774,14 +852,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: 10
           }
         }
         src {
+          end_column: 62
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -804,7 +888,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
         variant {
@@ -833,7 +920,10 @@ body {
         }
         n: 10
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
       }
@@ -858,7 +948,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
       }
@@ -884,7 +977,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 122
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
         table_name {
@@ -929,7 +1025,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
         variant {
@@ -954,7 +1053,10 @@ body {
           bitfield1: 30
         }
         src {
+          end_column: 40
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1000,7 +1102,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 59
         }
       }
@@ -1028,14 +1133,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 21
+              end_line: 66
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 66
             }
             v: 1
           }
         }
         src {
+          end_column: 21
+          end_line: 66
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 66
         }
       }
@@ -1054,7 +1165,10 @@ body {
       sp_sql {
         query: "select 1 + 1"
         src {
+          end_column: 63
+          end_line: 60
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 32
           start_line: 60
         }
       }
@@ -1077,7 +1191,10 @@ body {
           bitfield1: 35
         }
         src {
+          end_column: 73
+          end_line: 60
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 32
           start_line: 60
         }
       }
@@ -1112,7 +1229,10 @@ body {
       sp_sql {
         query: "select 1 + 2"
         src {
+          end_column: 52
+          end_line: 70
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 70
         }
       }
@@ -1135,7 +1255,10 @@ body {
           bitfield1: 39
         }
         src {
+          end_column: 62
+          end_line: 70
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 70
         }
       }
@@ -1162,7 +1285,10 @@ body {
       sp_sql {
         query: "create or replace temp stage mystage"
         src {
+          end_column: 63
+          end_line: 74
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 74
         }
       }
@@ -1186,7 +1312,10 @@ body {
           bitfield1: 42
         }
         src {
+          end_column: 73
+          end_line: 74
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 74
         }
       }
@@ -1242,7 +1371,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 75
         }
         stage_location: "@mystage"
@@ -1263,7 +1395,10 @@ body {
       sp_sql {
         query: "call mul_sp(5, 6)"
         src {
+          end_column: 40
+          end_line: 84
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 84
         }
       }
@@ -1286,7 +1421,10 @@ body {
           bitfield1: 46
         }
         src {
+          end_column: 50
+          end_line: 84
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 84
         }
       }
@@ -1342,7 +1480,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 87
         }
         stage_location: "@mystage"
@@ -1363,7 +1504,10 @@ body {
       sp_sql {
         query: "call mul_sp(5, 6)"
         src {
+          end_column: 40
+          end_line: 96
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 96
         }
       }
@@ -1386,7 +1530,10 @@ body {
           bitfield1: 50
         }
         src {
+          end_column: 50
+          end_line: 96
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 96
         }
       }
@@ -1451,7 +1598,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 110
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 99
         }
         stage_location: "@mystage"
@@ -1473,7 +1623,10 @@ body {
       sp_sql {
         query: "call mul_sp(5, 6)"
         src {
+          end_column: 40
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 111
         }
       }
@@ -1496,7 +1649,10 @@ body {
           bitfield1: 54
         }
         src {
+          end_column: 50
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 111
         }
       }
@@ -1544,8 +1700,11 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 112
+          end_line: 114
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 115
+          start_column: 9
+          start_line: 114
         }
         statement_params {
           _1: "SF_PARTNER"
@@ -1575,14 +1734,20 @@ body {
         pos_args {
           float64_val {
             src {
+              end_column: 29
+              end_line: 117
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 117
             }
             v: 1.5707963267948966
           }
         }
         src {
+          end_column: 29
+          end_line: 117
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 117
         }
       }
@@ -1650,8 +1815,11 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 150
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 121
+          start_column: 9
+          start_line: 120
         }
       }
     }
@@ -1677,7 +1845,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 123
             }
             v: 1
@@ -1686,14 +1857,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 123
             }
             v: 2
           }
         }
         src {
+          end_column: 23
+          end_line: 123
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 123
         }
       }
@@ -1712,7 +1889,10 @@ body {
       sp_sql {
         query: "SELECT 1 as A, 2 as B"
         src {
+          end_column: 61
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 122
         }
       }
@@ -1778,8 +1958,11 @@ body {
           }
         }
         src {
+          end_column: 123
+          end_line: 126
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 127
+          start_column: 9
+          start_line: 126
         }
       }
     }
@@ -1805,7 +1988,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 129
             }
             v: 1
@@ -1814,14 +2000,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 129
             }
             v: 2
           }
         }
         src {
+          end_column: 23
+          end_line: 129
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 129
         }
       }
@@ -1840,7 +2032,10 @@ body {
       sp_sql {
         query: "SELECT 1 as A, 2 as B"
         src {
+          end_column: 61
+          end_line: 128
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 128
         }
       }
@@ -1907,8 +2102,11 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 14
+          end_line: 132
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 133
+          start_column: 9
+          start_line: 132
         }
       }
     }
@@ -1934,7 +2132,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 135
             }
             v: 1
@@ -1943,14 +2144,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 135
             }
             v: 2
           }
         }
         src {
+          end_column: 23
+          end_line: 135
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 135
         }
       }
@@ -1969,7 +2176,10 @@ body {
       sp_sql {
         query: "SELECT 1 as A, 2 as B"
         src {
+          end_column: 61
+          end_line: 134
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 134
         }
       }

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -125,7 +125,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 45
               }
             }
@@ -142,7 +145,10 @@ body {
           sp_integer_type: true
         }
         src {
+          end_column: 9
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 45
         }
       }
@@ -165,13 +171,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 1
@@ -180,7 +192,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 3
@@ -191,13 +206,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 1
@@ -206,7 +227,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 4
@@ -217,13 +241,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 2
@@ -232,7 +262,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 5
@@ -243,13 +276,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 2
@@ -258,7 +297,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 6
@@ -269,7 +311,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
       }
@@ -297,7 +342,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -336,14 +384,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 28
+                    end_line: 55
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 55
                   }
                   v: "a"
                 }
               }
               src {
+                end_column: 28
+                end_line: 55
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 55
               }
             }
@@ -351,7 +405,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 29
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -374,7 +431,10 @@ body {
           bitfield1: 4
         }
         src {
+          end_column: 39
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -429,7 +489,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 90
+                end_line: 108
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 13
                 start_line: 105
               }
             }
@@ -440,7 +503,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 90
+                end_line: 108
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 13
                 start_line: 105
               }
               v: true
@@ -467,7 +533,10 @@ body {
           _2: "f"
         }
         src {
+          end_column: 90
+          end_line: 108
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 105
         }
         stage_location {
@@ -516,14 +585,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 22
+                    end_line: 110
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 110
                   }
                   v: "a"
                 }
               }
               src {
+                end_column: 22
+                end_line: 110
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 110
               }
             }
@@ -531,7 +606,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 23
+          end_line: 110
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 110
         }
       }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -68,7 +68,8 @@ foo = udtf(Foo,  output_schema= ["a", "b"],
 
 df = session.create_dataframe(
     [(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)]
-).to_df(["a", "b", "c"])
+)
+df = df.to_df(["a", "b", "c"])
 
 class TwoXUDTF:
     def process(self, n: int):
@@ -116,17 +117,17 @@ foo = udtf("Foo", output_schema=StructType([StructField("a", LongType(), nullabl
 
 df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
 
-res11 = df.to_df(["a", "b", "c"])
+df = df.to_df(["a", "b", "c"])
 
 twox_udtf = udtf("TwoXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
-res11.select((twox_udtf("a"))).collect()
+df.select((twox_udtf("a"))).collect()
 
 twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
-res11.select(res11["a"], (twoxsix_udtf(res11["a"]))).collect()
+df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 
-res11.select(col("a"), (twoxsix_udtf("a").alias("double", "six_x")), col("c")).collect()
+df.select(col("a"), (twoxsix_udtf("a").alias("double", "six_x")), col("c")).collect()
 
 ## EXPECTED ENCODED AST
 
@@ -1173,15 +1174,16 @@ body {
           }
         }
         src {
-          end_column: 32
-          end_line: 93
+          end_column: 38
+          end_line: 94
           file: "SRC_POSITION_TEST_MODE"
-          start_column: 10
-          start_line: 93
+          start_column: 13
+          start_line: 94
         }
       }
     }
     symbol {
+      value: "df"
     }
     uid: 19
     var_id {
@@ -1213,10 +1215,10 @@ body {
             bool_val {
               src {
                 end_column: 9
-                end_line: 103
+                end_line: 104
                 file: "SRC_POSITION_TEST_MODE"
                 start_column: 20
-                start_line: 99
+                start_line: 100
               }
             }
           }
@@ -1241,10 +1243,10 @@ body {
         parallel: 4
         src {
           end_column: 9
-          end_line: 103
+          end_line: 104
           file: "SRC_POSITION_TEST_MODE"
           start_column: 20
-          start_line: 99
+          start_line: 100
         }
       }
     }
@@ -1272,20 +1274,20 @@ body {
           string_val {
             src {
               end_column: 32
-              end_line: 105
+              end_line: 106
               file: "SRC_POSITION_TEST_MODE"
               start_column: 18
-              start_line: 105
+              start_line: 106
             }
             v: "a"
           }
         }
         src {
           end_column: 32
-          end_line: 105
+          end_line: 106
           file: "SRC_POSITION_TEST_MODE"
           start_column: 18
-          start_line: 105
+          start_line: 106
         }
       }
     }
@@ -1312,10 +1314,10 @@ body {
             }
             src {
               end_column: 33
-              end_line: 105
+              end_line: 106
               file: "SRC_POSITION_TEST_MODE"
               start_column: 8
-              start_line: 105
+              start_line: 106
             }
           }
         }
@@ -1328,10 +1330,10 @@ body {
         }
         src {
           end_column: 33
-          end_line: 105
+          end_line: 106
           file: "SRC_POSITION_TEST_MODE"
           start_column: 8
-          start_line: 105
+          start_line: 106
         }
         variadic: true
       }
@@ -1355,10 +1357,10 @@ body {
         }
         src {
           end_column: 43
-          end_line: 105
+          end_line: 106
           file: "SRC_POSITION_TEST_MODE"
           start_column: 8
-          start_line: 105
+          start_line: 106
         }
       }
     }
@@ -1402,10 +1404,10 @@ body {
             bool_val {
               src {
                 end_column: 9
-                end_line: 117
+                end_line: 118
                 file: "SRC_POSITION_TEST_MODE"
                 start_column: 23
-                start_line: 111
+                start_line: 112
               }
             }
           }
@@ -1439,10 +1441,10 @@ body {
         parallel: 4
         src {
           end_column: 9
-          end_line: 117
+          end_line: 118
           file: "SRC_POSITION_TEST_MODE"
           start_column: 23
-          start_line: 111
+          start_line: 112
         }
       }
     }
@@ -1478,19 +1480,19 @@ body {
             }
             src {
               end_column: 41
-              end_line: 119
+              end_line: 120
               file: "SRC_POSITION_TEST_MODE"
               start_column: 37
-              start_line: 119
+              start_line: 120
             }
           }
         }
         src {
           end_column: 42
-          end_line: 119
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
           start_column: 24
-          start_line: 119
+          start_line: 120
         }
       }
     }
@@ -1518,10 +1520,10 @@ body {
             }
             src {
               end_column: 22
-              end_line: 119
+              end_line: 120
               file: "SRC_POSITION_TEST_MODE"
               start_column: 18
-              start_line: 119
+              start_line: 120
             }
           }
         }
@@ -1536,10 +1538,10 @@ body {
             }
             src {
               end_column: 43
-              end_line: 119
+              end_line: 120
               file: "SRC_POSITION_TEST_MODE"
               start_column: 8
-              start_line: 119
+              start_line: 120
             }
           }
         }
@@ -1552,10 +1554,10 @@ body {
         }
         src {
           end_column: 43
-          end_line: 119
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
           start_column: 8
-          start_line: 119
+          start_line: 120
         }
         variadic: true
       }
@@ -1579,10 +1581,10 @@ body {
         }
         src {
           end_column: 53
-          end_line: 119
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
           start_column: 8
-          start_line: 119
+          start_line: 120
         }
       }
     }
@@ -1611,10 +1613,10 @@ body {
             string_val {
               src {
                 end_column: 65
-                end_line: 121
+                end_line: 122
                 file: "SRC_POSITION_TEST_MODE"
                 start_column: 23
-                start_line: 121
+                start_line: 122
               }
               v: "double"
             }
@@ -1623,10 +1625,10 @@ body {
             string_val {
               src {
                 end_column: 65
-                end_line: 121
+                end_line: 122
                 file: "SRC_POSITION_TEST_MODE"
                 start_column: 23
-                start_line: 121
+                start_line: 122
               }
               v: "six_x"
             }
@@ -1646,29 +1648,29 @@ body {
               string_val {
                 src {
                   end_column: 40
-                  end_line: 121
+                  end_line: 122
                   file: "SRC_POSITION_TEST_MODE"
                   start_column: 23
-                  start_line: 121
+                  start_line: 122
                 }
                 v: "a"
               }
             }
             src {
               end_column: 40
-              end_line: 121
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
               start_column: 23
-              start_line: 121
+              start_line: 122
             }
           }
         }
         src {
           end_column: 65
-          end_line: 121
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
           start_column: 23
-          start_line: 121
+          start_line: 122
         }
       }
     }
@@ -1699,20 +1701,20 @@ body {
               string_val {
                 src {
                   end_column: 71
-                  end_line: 121
+                  end_line: 122
                   file: "SRC_POSITION_TEST_MODE"
                   start_column: 8
-                  start_line: 121
+                  start_line: 122
                 }
                 v: "a"
               }
             }
             src {
               end_column: 71
-              end_line: 121
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
               start_column: 8
-              start_line: 121
+              start_line: 122
             }
           }
         }
@@ -1727,10 +1729,10 @@ body {
             }
             src {
               end_column: 71
-              end_line: 121
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
               start_column: 8
-              start_line: 121
+              start_line: 122
             }
           }
         }
@@ -1749,20 +1751,20 @@ body {
               string_val {
                 src {
                   end_column: 71
-                  end_line: 121
+                  end_line: 122
                   file: "SRC_POSITION_TEST_MODE"
                   start_column: 8
-                  start_line: 121
+                  start_line: 122
                 }
                 v: "c"
               }
             }
             src {
               end_column: 71
-              end_line: 121
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
               start_column: 8
-              start_line: 121
+              start_line: 122
             }
           }
         }
@@ -1775,10 +1777,10 @@ body {
         }
         src {
           end_column: 71
-          end_line: 121
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
           start_column: 8
-          start_line: 121
+          start_line: 122
         }
         variadic: true
       }
@@ -1802,10 +1804,10 @@ body {
         }
         src {
           end_column: 81
-          end_line: 121
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
           start_column: 8
-          start_line: 121
+          start_line: 122
         }
       }
     }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -116,17 +116,17 @@ foo = udtf("Foo", output_schema=StructType([StructField("a", LongType(), nullabl
 
 df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
 
-df = df.to_df(["a", "b", "c"])
+res11 = df.to_df(["a", "b", "c"])
 
 twox_udtf = udtf("TwoXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
-df.select((twox_udtf("a"))).collect()
+res11.select((twox_udtf("a"))).collect()
 
 twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
-df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
+res11.select(res11["a"], (twoxsix_udtf(res11["a"]))).collect()
 
-df.select(col("a"), (twoxsix_udtf("a").alias("double", "six_x")), col("c")).collect()
+res11.select(col("a"), (twoxsix_udtf("a").alias("double", "six_x")), col("c")).collect()
 
 ## EXPECTED ENCODED AST
 
@@ -152,7 +152,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 132
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 46
               }
             }
@@ -177,7 +180,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 132
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 46
         }
       }
@@ -216,20 +222,29 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 49
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 48
                 }
                 v: 20
               }
             }
             src {
+              end_column: 49
+              end_line: 48
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 48
             }
           }
         }
         src {
+          end_column: 50
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 48
         }
       }
@@ -256,13 +271,19 @@ body {
               }
             }
             src {
+              end_column: 51
+              end_line: 48
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 48
             }
           }
         }
         src {
+          end_column: 51
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 48
         }
       }
@@ -285,7 +306,10 @@ body {
           bitfield1: 3
         }
         src {
+          end_column: 61
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 48
         }
       }
@@ -332,8 +356,11 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 39
+                end_line: 50
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 51
+                start_column: 9
+                start_line: 50
               }
             }
           }
@@ -357,8 +384,11 @@ body {
         }
         parallel: 4
         src {
+          end_column: 39
+          end_line: 50
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 51
+          start_column: 9
+          start_line: 50
         }
       }
     }
@@ -379,13 +409,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 74
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 55
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 1
@@ -394,7 +430,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 2
@@ -405,13 +444,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 74
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 55
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 3
@@ -420,7 +465,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 4
@@ -437,7 +485,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
       }
@@ -475,7 +526,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 56
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 56
                 }
               }
@@ -491,13 +545,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 56
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 56
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 56
             }
           }
@@ -511,7 +571,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -539,7 +602,10 @@ body {
               }
             }
             src {
+              end_column: 63
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 56
             }
           }
@@ -553,7 +619,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -614,7 +683,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 139
+                end_line: 63
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 63
               }
             }
@@ -639,7 +711,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 139
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 25
           start_line: 63
         }
       }
@@ -678,20 +753,29 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 52
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 65
                 }
                 v: 3
               }
             }
             src {
+              end_column: 52
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 65
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 65
         }
       }
@@ -718,13 +802,19 @@ body {
               }
             }
             src {
+              end_column: 54
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 65
             }
           }
         }
         src {
+          end_column: 54
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 65
         }
       }
@@ -747,7 +837,10 @@ body {
           bitfield1: 14
         }
         src {
+          end_column: 64
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 65
         }
       }
@@ -811,7 +904,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 40
+                end_line: 89
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 72
               }
             }
@@ -822,7 +918,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 40
+                end_line: 89
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 72
               }
               v: true
@@ -869,7 +968,10 @@ body {
         }
         secure: true
         src {
+          end_column: 40
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 72
         }
         stage_location: "@"
@@ -898,13 +1000,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 91
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 1
@@ -913,7 +1021,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: "one o one"
@@ -922,7 +1033,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 10
@@ -933,13 +1047,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 91
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 2
@@ -948,7 +1068,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: "twenty two"
@@ -957,7 +1080,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 20
@@ -968,13 +1094,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 91
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 3
@@ -983,7 +1115,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: "thirty three"
@@ -992,7 +1127,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 30
@@ -1003,7 +1141,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 91
         }
       }
@@ -1032,13 +1173,15 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 91
+          start_column: 10
+          start_line: 93
         }
       }
     }
     symbol {
-      value: "df"
     }
     uid: 19
     var_id {
@@ -1069,7 +1212,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 103
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 99
               }
             }
@@ -1094,7 +1240,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 9
+          end_line: 103
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 99
         }
       }
@@ -1122,14 +1271,20 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 32
+              end_line: 105
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 105
             }
             v: "a"
           }
         }
         src {
+          end_column: 32
+          end_line: 105
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 105
         }
       }
@@ -1156,7 +1311,10 @@ body {
               }
             }
             src {
+              end_column: 33
+              end_line: 105
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 105
             }
           }
@@ -1169,7 +1327,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 105
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 105
         }
         variadic: true
@@ -1193,7 +1354,10 @@ body {
           bitfield1: 22
         }
         src {
+          end_column: 43
+          end_line: 105
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 105
         }
       }
@@ -1237,7 +1401,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 117
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 111
               }
             }
@@ -1271,7 +1438,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 9
+          end_line: 117
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 23
           start_line: 111
         }
       }
@@ -1307,13 +1477,19 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 119
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 119
             }
           }
         }
         src {
+          end_column: 42
+          end_line: 119
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 119
         }
       }
@@ -1341,7 +1517,10 @@ body {
               }
             }
             src {
+              end_column: 22
+              end_line: 119
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 119
             }
           }
@@ -1356,7 +1535,10 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 119
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 119
             }
           }
@@ -1369,7 +1551,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 119
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 119
         }
         variadic: true
@@ -1393,7 +1578,10 @@ body {
           bitfield1: 27
         }
         src {
+          end_column: 53
+          end_line: 119
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 119
         }
       }
@@ -1422,7 +1610,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 65
+                end_line: 121
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 121
               }
               v: "double"
@@ -1431,7 +1622,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 65
+                end_line: 121
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 121
               }
               v: "six_x"
@@ -1451,20 +1645,29 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 121
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 121
                 }
                 v: "a"
               }
             }
             src {
+              end_column: 40
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 121
             }
           }
         }
         src {
+          end_column: 65
+          end_line: 121
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 23
           start_line: 121
         }
       }
@@ -1495,14 +1698,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 71
+                  end_line: 121
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 121
                 }
                 v: "a"
               }
             }
             src {
+              end_column: 71
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 121
             }
           }
@@ -1517,7 +1726,10 @@ body {
               }
             }
             src {
+              end_column: 71
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 121
             }
           }
@@ -1536,14 +1748,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 71
+                  end_line: 121
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 121
                 }
                 v: "c"
               }
             }
             src {
+              end_column: 71
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 121
             }
           }
@@ -1556,7 +1774,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 121
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 121
         }
         variadic: true
@@ -1580,7 +1801,10 @@ body {
           bitfield1: 31
         }
         src {
+          end_column: 81
+          end_line: 121
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 121
         }
       }

--- a/tests/ast/data/windows.test
+++ b/tests/ast/data/windows.test
@@ -90,7 +90,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variant {
@@ -127,21 +130,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             name: "key"
             src {
+              end_column: 44
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             variant_is_as {
@@ -165,21 +177,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 31
                     }
                     v: "STR"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 31
                 }
               }
             }
             name: "value"
             src {
+              end_column: 69
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 31
             }
             variant_is_as {
@@ -195,7 +216,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -243,26 +267,38 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 36
+                              end_line: 37
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 24
                               start_line: 37
                             }
                             v: "value"
                           }
                         }
                         src {
+                          end_column: 36
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 37
                         }
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 37
                     }
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 37
                 }
                 window_spec {
@@ -272,7 +308,10 @@ body {
                         n {
                           int64_val {
                             src {
+                              end_column: 98
+                              end_line: 33
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 33
                             }
                             v: 2
@@ -281,7 +320,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 98
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 33
                     }
                     start {
@@ -303,20 +345,29 @@ body {
                             pos_args {
                               string_val {
                                 src {
+                                  end_column: 62
+                                  end_line: 33
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 18
                                   start_line: 33
                                 }
                                 v: "key"
                               }
                             }
                             src {
+                              end_column: 62
+                              end_line: 33
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 33
                             }
                           }
                         }
                         src {
+                          end_column: 62
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 18
                           start_line: 33
                         }
                         wnd {
@@ -335,26 +386,38 @@ body {
                                 pos_args {
                                   string_val {
                                     src {
+                                      end_column: 46
+                                      end_line: 33
                                       file: "SRC_POSITION_TEST_MODE"
+                                      start_column: 18
                                       start_line: 33
                                     }
                                     v: "value"
                                   }
                                 }
                                 src {
+                                  end_column: 46
+                                  end_line: 33
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 18
                                   start_line: 33
                                 }
                               }
                             }
                             src {
+                              end_column: 46
+                              end_line: 33
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 33
                             }
                             wnd {
                               sp_window_spec_empty {
                                 src {
+                                  end_column: 46
+                                  end_line: 33
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 18
                                   start_line: 33
                                 }
                               }
@@ -369,7 +432,10 @@ body {
             }
             name: "window1"
             src {
+              end_column: 65
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
             variant_is_as {
@@ -406,26 +472,38 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 79
+                              end_line: 37
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 67
                               start_line: 37
                             }
                             v: "value"
                           }
                         }
                         src {
+                          end_column: 79
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 67
                           start_line: 37
                         }
                       }
                     }
                     src {
+                      end_column: 79
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 37
                     }
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 37
                 }
                 window_spec {
@@ -434,7 +512,10 @@ body {
                       sp_window_relative_position__unbounded_following: true
                     }
                     src {
+                      end_column: 122
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 35
                     }
                     start {
@@ -458,32 +539,47 @@ body {
                                 pos_args {
                                   string_val {
                                     src {
+                                      end_column: 44
+                                      end_line: 35
                                       file: "SRC_POSITION_TEST_MODE"
+                                      start_column: 34
                                       start_line: 35
                                     }
                                     v: "key"
                                   }
                                 }
                                 src {
+                                  end_column: 44
+                                  end_line: 35
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 34
                                   start_line: 35
                                 }
                               }
                             }
                             src {
+                              end_column: 51
+                              end_line: 35
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 34
                               start_line: 35
                             }
                           }
                         }
                         src {
+                          end_column: 52
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 18
                           start_line: 35
                         }
                         wnd {
                           sp_window_spec_empty {
                             src {
+                              end_column: 52
+                              end_line: 35
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 35
                             }
                           }
@@ -496,7 +592,10 @@ body {
             }
             name: "window2"
             src {
+              end_column: 108
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 67
               start_line: 37
             }
             variant_is_as {
@@ -512,7 +611,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
         variadic: true
@@ -558,26 +660,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 39
+                          end_line: 39
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 39
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 39
                     }
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 39
             }
             window_spec {
@@ -596,26 +710,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 66
+                          end_line: 39
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 45
                           start_line: 39
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 66
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 39
                     }
                   }
                 }
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 39
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 66
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 39
                     }
                   }
@@ -632,7 +758,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
         variadic: true
@@ -678,26 +807,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 39
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 41
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 41
                     }
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 41
             }
             window_spec {
@@ -716,14 +857,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 76
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 45
                           start_line: 41
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 76
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 41
                     }
                   }
@@ -742,26 +889,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 76
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 45
                           start_line: 41
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 76
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 41
                     }
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 41
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 76
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 41
                     }
                   }
@@ -778,7 +937,10 @@ body {
           }
         }
         src {
+          end_column: 78
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
         variadic: true
@@ -824,26 +986,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 43
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 43
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 43
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 43
             }
             window_spec {
@@ -862,26 +1036,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 67
+                          end_line: 43
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 43
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 67
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 43
                     }
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 43
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 67
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 43
                     }
                   }
@@ -898,7 +1084,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
         variadic: true
@@ -944,26 +1133,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 45
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 45
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 45
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 45
             }
             window_spec {
@@ -982,26 +1183,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 68
+                          end_line: 45
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 45
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 68
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 45
                     }
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 45
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 68
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 45
                     }
                   }
@@ -1018,7 +1231,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 45
         }
         variadic: true
@@ -1064,26 +1280,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 47
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 47
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 47
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 47
             }
             window_spec {
@@ -1093,7 +1321,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 47
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 47
                         }
                         v: 2
@@ -1102,7 +1333,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 47
                 }
                 start {
@@ -1110,7 +1344,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 47
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 47
                         }
                       }
@@ -1120,7 +1357,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 67
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 47
                     }
                   }
@@ -1137,7 +1377,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 47
         }
         variadic: true
@@ -1183,26 +1426,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 49
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 49
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 49
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 49
             }
             window_spec {
@@ -1212,7 +1467,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 49
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 49
                         }
                         v: 2
@@ -1221,7 +1479,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 49
                 }
                 start {
@@ -1229,7 +1490,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 49
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 49
                         }
                         v: 1
@@ -1240,7 +1504,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 68
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 49
                     }
                   }
@@ -1257,7 +1524,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 49
         }
         variadic: true
@@ -1303,26 +1573,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 51
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 51
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 51
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 51
             }
             window_spec {
@@ -1332,7 +1614,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 51
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 51
                         }
                         v: 2
@@ -1341,7 +1626,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 51
                 }
                 start {
@@ -1349,7 +1637,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 51
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 51
                         }
                       }
@@ -1359,7 +1650,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 67
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 51
                     }
                   }
@@ -1376,7 +1670,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 51
         }
         variadic: true
@@ -1422,26 +1719,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 53
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 53
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 53
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 53
             }
             window_spec {
@@ -1451,7 +1760,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 53
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 53
                         }
                         v: 2
@@ -1460,7 +1772,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 53
                 }
                 start {
@@ -1468,7 +1783,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 53
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 53
                         }
                         v: 1
@@ -1479,7 +1797,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 68
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 53
                     }
                   }
@@ -1496,7 +1817,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 53
         }
         variadic: true
@@ -1542,26 +1866,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 55
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 55
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 55
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 111
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 55
             }
             window_spec {
@@ -1570,7 +1906,10 @@ body {
                   sp_window_relative_position__unbounded_following: true
                 }
                 src {
+                  end_column: 110
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 55
                 }
                 start {
@@ -1579,7 +1918,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 110
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 55
                     }
                   }
@@ -1596,7 +1938,10 @@ body {
           }
         }
         src {
+          end_column: 112
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 55
         }
         variadic: true
@@ -1642,26 +1987,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 57
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 57
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 57
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 110
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 57
             }
             window_spec {
@@ -1670,7 +2027,10 @@ body {
                   sp_window_relative_position__unbounded_preceding: true
                 }
                 src {
+                  end_column: 109
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 57
                 }
                 start {
@@ -1679,7 +2039,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 109
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 57
                     }
                   }
@@ -1696,7 +2059,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 57
         }
         variadic: true
@@ -1742,26 +2108,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 59
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 59
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 59
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 110
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 59
             }
             window_spec {
@@ -1770,7 +2148,10 @@ body {
                   sp_window_relative_position__unbounded_following: true
                 }
                 src {
+                  end_column: 109
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 59
                 }
                 start {
@@ -1779,7 +2160,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 109
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 59
                     }
                   }
@@ -1796,7 +2180,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 59
         }
         variadic: true
@@ -1842,26 +2229,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 61
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 61
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 61
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 109
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 61
             }
             window_spec {
@@ -1870,7 +2269,10 @@ body {
                   sp_window_relative_position__unbounded_preceding: true
                 }
                 src {
+                  end_column: 108
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 61
                 }
                 start {
@@ -1879,7 +2281,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 108
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 61
                     }
                   }
@@ -1896,7 +2301,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 61
         }
         variadic: true
@@ -1942,26 +2350,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 63
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 63
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 63
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 63
             }
           }
@@ -1974,7 +2394,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 63
         }
         variadic: true
@@ -2022,33 +2445,48 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 37
+                              end_line: 65
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 25
                               start_line: 65
                             }
                             v: "value"
                           }
                         }
                         src {
+                          end_column: 37
+                          end_line: 65
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 65
                         }
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 65
                     }
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 65
                 }
               }
             }
             name: "window1"
             src {
+              end_column: 59
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 65
             }
             variant_is_as {
@@ -2064,7 +2502,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 65
         }
         variadic: true

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -22,6 +22,7 @@ from dateutil.tz import tzlocal
 from snowflake.snowpark._internal.ast.utils import (
     ClearTempTables,
     base64_lines_to_textproto,
+    clear_line_no_in_request,
     textproto_to_request,
 )
 from snowflake.snowpark._internal.utils import global_counter
@@ -188,6 +189,7 @@ def test_ast(session, tables, test_case):
     actual, base64_str = run_test(
         session, tables, test_case.filename.replace(".", "_"), test_case.source
     )
+
     if pytest.update_expectations:
         assert pytest.unparser_jar, (
             "Can only update expectations with unparser jar set. Either run the test with --unparser-jar=<path> or"
@@ -223,6 +225,12 @@ def test_ast(session, tables, test_case):
             # Similarly, for create_dataframe with temporary tables clear them as they may differ from session to session.
             ClearTempTables(actual_message)
             ClearTempTables(expected_message)
+
+            # If this is not python 3.9, then for the purposes of the expectation tests we will ignore the line_no
+            # information since it can be different based on various python bug fixes.
+            if sys.version_info.major != 3 or sys.version_info.minor != 9:
+                clear_line_no_in_request(actual_message)
+                clear_line_no_in_request(expected_message)
 
             det_actual_message = actual_message.SerializeToString(deterministic=True)
             det_expected_message = expected_message.SerializeToString(

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -228,7 +228,7 @@ def test_ast(session, tables, test_case):
 
             # If this is not python 3.11+, then for the purposes of the expectation tests we will ignore the line_no
             # information since it can be different based on various python bug fixes.
-            if sys.version_info.major != 3 or sys.version_info.minor <= 10:
+            if sys.version_info.minor <= 10:
                 clear_line_no_in_request(actual_message)
                 clear_line_no_in_request(expected_message)
 

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -228,7 +228,7 @@ def test_ast(session, tables, test_case):
 
             # If this is not python 3.9, then for the purposes of the expectation tests we will ignore the line_no
             # information since it can be different based on various python bug fixes.
-            if sys.version_info.major != 3 or sys.version_info.minor != 9:
+            if sys.version_info.major != 3 or sys.version_info.minor != 11:
                 clear_line_no_in_request(actual_message)
                 clear_line_no_in_request(expected_message)
 

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -226,9 +226,9 @@ def test_ast(session, tables, test_case):
             ClearTempTables(actual_message)
             ClearTempTables(expected_message)
 
-            # If this is not python 3.9, then for the purposes of the expectation tests we will ignore the line_no
+            # If this is not python 3.11+, then for the purposes of the expectation tests we will ignore the line_no
             # information since it can be different based on various python bug fixes.
-            if sys.version_info.major != 3 or sys.version_info.minor != 11:
+            if sys.version_info.major != 3 or sys.version_info.minor <= 10:
                 clear_line_no_in_request(actual_message)
                 clear_line_no_in_request(expected_message)
 


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
Fixes[SNOW-1842459](https://snowflakecomputing.atlassian.net/browse/SNOW-1842459)

2. Fill out the following pre-review checklist:

- [ ] I am adding a new automated test(s) to verify correctness of my new code
- [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
- [ ] I am adding new logging messages
- [ ] I am adding a new telemetry message
- [ ] I am adding new credentials
- [ ] I am adding a new dependency
- [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
- [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

The frame_info line information differs across python versions for chained operations, so to mitigate we only compare line no information for python 3.9 and not other versions.