### PR TITLE
SNOW-1844280: fix stored proc pytest option issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,10 @@ def pytest_addoption(parser, pluginmanager):
         "--disable_multithreading_mode", action="store_true", default=False
     )
     parser.addoption("--skip_sql_count_check", action="store_true", default=False)
+    if not any(
+        "--local_testing_mode" in opt.names() for opt in parser._anonymous.options
+    ):
+        parser.addoption("--local_testing_mode", action="store_true", default=False)
     parser.addoption("--enable_ast", action="store_true", default=False)
     parser.addoption("--validate_ast", action="store_true", default=False)
     parser.addoption(
@@ -74,10 +78,6 @@ def pytest_addoption(parser, pluginmanager):
         type=str,
         help="Path to the Unparser JAR built in the monorepo. To build it, run `sbt assembly` from the unparser directory.",
     )
-    if not any(
-        "--local_testing_mode" in opt.names() for opt in parser._anonymous.options
-    ):
-        parser.addoption("--local_testing_mode", action="store_true", default=False)
 
 
 def pytest_collection_modifyitems(items) -> None:
@@ -115,7 +115,7 @@ def sql_simplifier_enabled(pytestconfig):
 
 @pytest.fixture(scope="session")
 def local_testing_mode(pytestconfig):
-    return pytestconfig.getoption("local_testing_mode")
+    return pytestconfig.getoption("local_testing_mode", False)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,17 +58,13 @@ def is_excluded_frontend_file(path):
     return False
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser, pluginmanager):
     parser.addoption("--disable_sql_simplifier", action="store_true", default=False)
     parser.addoption("--disable_cte_optimization", action="store_true", default=False)
     parser.addoption(
         "--disable_multithreading_mode", action="store_true", default=False
     )
     parser.addoption("--skip_sql_count_check", action="store_true", default=False)
-    if not any(
-        "--local_testing_mode" in opt.names() for opt in parser._anonymous.options
-    ):
-        parser.addoption("--local_testing_mode", action="store_true", default=False)
     parser.addoption("--enable_ast", action="store_true", default=False)
     parser.addoption("--validate_ast", action="store_true", default=False)
     parser.addoption(
@@ -78,6 +74,10 @@ def pytest_addoption(parser):
         type=str,
         help="Path to the Unparser JAR built in the monorepo. To build it, run `sbt assembly` from the unparser directory.",
     )
+    if not any(
+        "--local_testing_mode" in opt.names() for opt in parser._anonymous.options
+    ):
+        parser.addoption("--local_testing_mode", action="store_true", default=False)
 
 
 def pytest_collection_modifyitems(items) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,7 @@ def sql_simplifier_enabled(pytestconfig):
 
 @pytest.fixture(scope="session")
 def local_testing_mode(pytestconfig):
+    # SNOW-1845413 we have a default value here unlike other options to bypass test in stored procedure
     return pytestconfig.getoption("local_testing_mode", False)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def is_excluded_frontend_file(path):
     return False
 
 
-def pytest_addoption(parser, pluginmanager):
+def pytest_addoption(parser):
     parser.addoption("--disable_sql_simplifier", action="store_true", default=False)
     parser.addoption("--disable_cte_optimization", action="store_true", default=False)
     parser.addoption(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

in stored proc it's unable to find pytest option "local_testing_mode".
giving a default value resolves the issue, however, it's still unknown why this doesn't happen before but happen after the IR PR merge.
probably because the fixture is referenced somewhere by the new tests. for now let's fix the issue to unblock release

successful running sproc precommit test job: 1490
