### PR TITLE
[Test Fix] Skip test_structured_type_schema_expression in unsupportd accounts

### DIFF
--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -979,7 +979,12 @@ def test_structured_type_print_schema(
 def test_structured_type_schema_expression(
     structured_type_session, local_testing_mode, structured_type_support
 ):
-    if not structured_type_support:
+    # Test does not require iceberg support, but does require FDN table structured type support
+    # which is enabled in the same accounts as iceberg.
+    if not (
+        structured_type_support
+        and iceberg_supported(structured_type_session, local_testing_mode)
+    ):
         pytest.skip("Test requires structured type support.")
 
     table_name = f"snowpark_schema_expresion_test_{uuid.uuid4().hex[:5]}".upper()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   FDN structured type support is not enabled in all accounts that support structured types in results. The overlap is the same as iceberg support so gate on that.