### PR TITLE
SNOW-1830501 Column APIs implemented in decoder: `in`, `between`, `try_cast`, `literal`, `__getitem__`

### DIFF
--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -6,7 +6,7 @@ df = df.select(col("NUM").in_(1, 2, 3))
 
 df = df.select(col("NUM").in_(df))
 
-df = df.select(col("NUM").in_([1, 2, 3]))
+df = df.select(col("NUM").in_([1]))
 
 ## EXPECTED UNPARSER OUTPUT
 
@@ -16,7 +16,7 @@ df = df.select(col("NUM").in_(1, 2, 3))
 
 df = df.select(col("NUM").in_(df))
 
-df = df.select(col("NUM").in_([1, 2, 3]))
+df = df.select(col("NUM").in_([1]))
 
 ## EXPECTED ENCODED AST
 
@@ -240,24 +240,6 @@ body {
                       start_line: 31
                     }
                     v: 1
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 31
-                    }
-                    v: 2
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 31
-                    }
-                    v: 3
                   }
                 }
               }

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -228,16 +228,8 @@ def compare_base64_results(
     if sys.version_info.minor <= 10 or exclude_symbols_and_src:
         clear_line_no_in_request(actual_message)
         clear_line_no_in_request(expected_message)
-
-    if not exclude_symbols_and_src:
-        actual_message = actual_message.SerializeToString(deterministic=True)
-        expected_message = expected_message.SerializeToString(deterministic=True)
-    else:
-        from google.protobuf.text_format import MessageToString
-
-        print("actual_message", MessageToString(actual_message))
-        actual_message = MessageToString(actual_message)
-        expected_message = MessageToString(expected_message)
+    actual_message = actual_message.SerializeToString(deterministic=True)
+    expected_message = expected_message.SerializeToString(deterministic=True)
 
     assert actual_message == expected_message
 

--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -228,8 +228,16 @@ def compare_base64_results(
     if sys.version_info.minor <= 10 or exclude_symbols_and_src:
         clear_line_no_in_request(actual_message)
         clear_line_no_in_request(expected_message)
-    actual_message = actual_message.SerializeToString(deterministic=True)
-    expected_message = expected_message.SerializeToString(deterministic=True)
+
+    if not exclude_symbols_and_src:
+        actual_message = actual_message.SerializeToString(deterministic=True)
+        expected_message = expected_message.SerializeToString(deterministic=True)
+    else:
+        from google.protobuf.text_format import MessageToString
+
+        print("actual_message", MessageToString(actual_message))
+        actual_message = MessageToString(actual_message)
+        expected_message = MessageToString(expected_message)
 
     assert actual_message == expected_message
 


### PR DESCRIPTION

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1830501, SNOW-1830503 (for try_cast)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Added decoder logic for Column APIs `in`, `between`, `try_cast`, `literal`, `__getitem__`.
`try_cast` is from ticket SNOW-1830503 (cast and alias are already implemented).

I had to modify the `col_in.test` to be logically correct (was taking in a list that was too long initially).
