### PR TITLE
SNOW-1830505 Add column null/nan functions logic

### DIFF
--- a/tests/ast/decoder.py
+++ b/tests/ast/decoder.py
@@ -615,6 +615,15 @@ class Decoder:
                 to_dtype = self.decode_data_type_expr(expr.sp_column_cast.to)
                 return col.cast(to_dtype)
 
+            case "sp_column_equal_nan":
+                col = self.decode_expr(expr.sp_column_equal_nan.col)
+                return col.equal_nan()
+
+            case "sp_column_equal_null":
+                lhs = self.decode_expr(expr.sp_column_equal_null.lhs)
+                rhs = self.decode_expr(expr.sp_column_equal_null.rhs)
+                return lhs.equal_null(rhs)
+
             case "sp_column_in__seq":
                 col = self.decode_expr(expr.sp_column_in__seq.col)
                 if isinstance(expr.sp_column_in__seq.values, Iterable):
@@ -625,6 +634,14 @@ class Decoder:
                 else:
                     # The list case should be taken care of in this branch.
                     return col.in_(self.decode_expr(expr.sp_column_in__seq.values))
+
+            case "sp_column_is_not_null":
+                col = self.decode_expr(expr.sp_column_is_not_null.col)
+                return col.is_not_null()
+
+            case "sp_column_is_null":
+                col = self.decode_expr(expr.sp_column_is_null.col)
+                return col.is_null()
 
             case "sp_column_sql_expr":
                 return expr.sp_column_sql_expr.sql


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1830505

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Decoder logic for `equal_null`, `equal_nan`, `is_null`, `is_not_null`