### PR TITLE
SNOW-1853194: Avoid disabling sql simplifier in integ/test_cte.py

### DIFF
--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -970,40 +970,34 @@ def test_select_with_column_expr_alias(session):
     )
 
 
-@pytest.mark.parametrize("enable_sql_simplifier", [True, False])
-def test_time_series_aggregation_grouping(session, enable_sql_simplifier):
-    original_sql_simplifier_enabled = session.sql_simplifier_enabled
-    try:
-        session.sql_simplifier_enabled = enable_sql_simplifier
-        data = [
-            ["2024-02-01 00:00:00", "product_A", "transaction_1", 10],
-            ["2024-02-15 00:00:00", "product_A", "transaction_2", 15],
-            ["2024-02-15 08:00:00", "product_A", "transaction_3", 7],
-            ["2024-02-17 00:00:00", "product_A", "transaction_4", 3],
-        ]
-        df = session.create_dataframe(data).to_df(
-            "TS", "PRODUCT_ID", "TRANSACTION_ID", "QUANTITY"
-        )
+def test_time_series_aggregation_grouping(session):
+    data = [
+        ["2024-02-01 00:00:00", "product_A", "transaction_1", 10],
+        ["2024-02-15 00:00:00", "product_A", "transaction_2", 15],
+        ["2024-02-15 08:00:00", "product_A", "transaction_3", 7],
+        ["2024-02-17 00:00:00", "product_A", "transaction_4", 3],
+    ]
+    df = session.create_dataframe(data).to_df(
+        "TS", "PRODUCT_ID", "TRANSACTION_ID", "QUANTITY"
+    )
 
-        res = df.analytics.time_series_agg(
-            time_col="TS",
-            group_by=["PRODUCT_ID"],
-            aggs={"QUANTITY": ["SUM"]},
-            windows=["-1D", "-7D"],
-            sliding_interval="1D",
-        )
-        check_result(
-            session,
-            res,
-            expect_cte_optimized=True,
-            query_count=1,
-            describe_count=0,
-            union_count=0,
-            join_count=8,
-            cte_join_count=4,
-        )
-    finally:
-        session.sql_simplifier_enabled = original_sql_simplifier_enabled
+    res = df.analytics.time_series_agg(
+        time_col="TS",
+        group_by=["PRODUCT_ID"],
+        aggs={"QUANTITY": ["SUM"]},
+        windows=["-1D", "-7D"],
+        sliding_interval="1D",
+    )
+    check_result(
+        session,
+        res,
+        expect_cte_optimized=True,
+        query_count=1,
+        describe_count=0,
+        union_count=0,
+        join_count=8,
+        cte_join_count=4,
+    )
 
 
 def test_table_select_cte(session):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1853194

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Avoid disabling sql simplifier in integ/test_cte.py. 
   In our daily test, we already run all test cases with sql simplifier disabled.
   We also want to make all test cte cases consistent. Most of them do not explicitly disable sql simplifier.
