### PR TITLE
SNOW-1782778: Fix Function available memory exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Added support for `Series.str.center`.
 - Added support for `Series.str.pad`.
 
+#### Bug Fixes
+
+- Fixed a bug that `DataFrame.show` incorrectly fetch all data of the dataframe.
 
 ## 1.26.0 (2024-12-05)
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -491,7 +491,6 @@ class ServerConnection:
         async_post_actions: Optional[List[Query]] = None,
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncJob]:
-        show_limit = kwargs.pop("show_limit", None)
         try:
             # Set SNOWPARK_SKIP_TXN_COMMIT_IN_DDL to True to avoid DDL commands to commit the open transaction
             if is_ddl_on_temp_object:
@@ -528,7 +527,6 @@ class ServerConnection:
                 results_cursor=results_cursor,
                 to_pandas=to_pandas,
                 to_iter=to_iter,
-                show_limit=show_limit,
             )
         else:
             return AsyncJob(
@@ -548,10 +546,7 @@ class ServerConnection:
         results_cursor: SnowflakeCursor,
         to_pandas: bool = False,
         to_iter: bool = False,
-        show_limit: int = None,
     ) -> Dict[str, Any]:
-        if show_limit is not None:
-            to_iter = True
         qid = results_cursor.sfqid
         if to_iter:
             new_cursor = results_cursor.connection.cursor()
@@ -587,15 +582,6 @@ class ServerConnection:
             data_or_iter = (
                 iter(results_cursor) if to_iter else results_cursor.fetchall()
             )
-        # return limit number of rows
-        if show_limit is not None:
-            data_or_iter_result = []
-            for i, d in enumerate(data_or_iter):
-                if i >= show_limit:
-                    break
-                else:
-                    data_or_iter_result.append(d)
-            return {"data": data_or_iter_result, "sfqid": qid}
 
         return {"data": data_or_iter, "sfqid": qid}
 
@@ -784,8 +770,9 @@ class ServerConnection:
     def get_result_and_metadata(
         self, plan: SnowflakePlan, **kwargs
     ) -> Tuple[List[Row], List[Attribute]]:
-        result_set, result_meta = self.get_result_set(plan, **kwargs)
-        result = result_set_to_rows(result_set["data"])
+        show_limit = kwargs.pop("show_limit", None)
+        result_set, result_meta = self.get_result_set(plan, to_iter=True, **kwargs)
+        result = result_set_to_rows(result_set["data"], show_limit=show_limit)
         attributes = convert_result_meta_to_attribute(result_meta, self.max_string_size)
         return result, attributes
 

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -768,11 +768,13 @@ class ServerConnection:
         return result, result_meta
 
     def get_result_and_metadata(
-        self, plan: SnowflakePlan, **kwargs
+        self, plan: SnowflakePlan, limit: Optional[int] = None, **kwargs
     ) -> Tuple[List[Row], List[Attribute]]:
-        show_limit = kwargs.pop("show_limit", None)
-        result_set, result_meta = self.get_result_set(plan, to_iter=True, **kwargs)
-        result = result_set_to_rows(result_set["data"], show_limit=show_limit)
+        if limit is not None:
+            result_set, result_meta = self.get_result_set(plan, to_iter=True, **kwargs)
+        else:
+            result_set, result_meta = self.get_result_set(plan, **kwargs)
+        result = result_set_to_rows(result_set["data"], limit=limit)
         attributes = convert_result_meta_to_attribute(result_meta, self.max_string_size)
         return result, attributes
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -702,6 +702,7 @@ def result_set_to_rows(
     result_set: List[Any],
     result_meta: Optional[Union[List[ResultMetadata], List["ResultMetadataV2"]]] = None,
     case_sensitive: bool = True,
+    show_limit: int = None,
 ) -> List[Row]:
     col_names = [col.name for col in result_meta] if result_meta else None
     rows = []
@@ -710,7 +711,9 @@ def result_set_to_rows(
         row_struct = (
             Row._builder.build(*col_names).set_case_sensitive(case_sensitive).to_row()
         )
-    for data in result_set:
+    for i, data in enumerate(result_set):
+        if show_limit is not None and i >= show_limit:
+            break
         if data is None:
             raise ValueError("Result returned from Python connector is None")
         row = row_struct(*data)

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -702,7 +702,7 @@ def result_set_to_rows(
     result_set: List[Any],
     result_meta: Optional[Union[List[ResultMetadata], List["ResultMetadataV2"]]] = None,
     case_sensitive: bool = True,
-    show_limit: int = None,
+    limit: Optional[int] = None,
 ) -> List[Row]:
     col_names = [col.name for col in result_meta] if result_meta else None
     rows = []
@@ -712,7 +712,7 @@ def result_set_to_rows(
             Row._builder.build(*col_names).set_case_sensitive(case_sensitive).to_row()
         )
     for i, data in enumerate(result_set):
-        if show_limit is not None and i >= show_limit:
+        if limit is not None and i >= limit:
             break
         if data is None:
             raise ValueError("Result returned from Python connector is None")

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4368,7 +4368,7 @@ class DataFrame:
             )
         else:
             res, meta = self._session._conn.get_result_and_metadata(
-                self._plan, show_limit=n, **kwargs
+                self._plan, limit=n, **kwargs
             )
             result = res[:n]
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4367,6 +4367,7 @@ class DataFrame:
                 self.limit(n, _emit_ast=False)._plan, **kwargs
             )
         else:
+            kwargs["show_limit"] = n
             res, meta = self._session._conn.get_result_and_metadata(
                 self._plan, **kwargs
             )

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4367,9 +4367,8 @@ class DataFrame:
                 self.limit(n, _emit_ast=False)._plan, **kwargs
             )
         else:
-            kwargs["show_limit"] = n
             res, meta = self._session._conn.get_result_and_metadata(
-                self._plan, **kwargs
+                self._plan, show_limit=n, **kwargs
             )
             result = res[:n]
 

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -755,7 +755,7 @@ class MockServerConnection:
         )
 
     def get_result_and_metadata(
-        self, plan: SnowflakePlan, **kwargs
+        self, plan: SnowflakePlan, limit: Optional[int] = None, **kwargs
     ) -> Tuple[List[Row], List[Attribute]]:
         res = execute_mock_plan(plan, plan.expr_to_alias)
         attrs = [
@@ -772,6 +772,8 @@ class MockServerConnection:
 
         rows = []
         for i in range(len(res)):
+            if limit is not None and i >= limit:
+                break
             values = []
             for j, attr in enumerate(attrs):
                 value = res.iloc[i, j]

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -301,11 +301,6 @@ def test_show(session):
     )
 
 
-@pytest.mark.xfail(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="SQL query not supported",
-    run=False,
-)
 def test_show_non_select_statement(session):
     df = session.create_dataframe([[1, 2, 3, 4] for _ in range(100)]).to_df(
         ['"col1"', "col2_a", "col2_b", "col3"]

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -307,7 +307,7 @@ def test_show(session):
     run=False,
 )
 def test_show_non_select_statement(session):
-    df = session.create_dataframe([[1, 2, 3, 4] for i in range(100)]).to_df(
+    df = session.create_dataframe([[1, 2, 3, 4] for _ in range(100)]).to_df(
         ['"col1"', "col2_a", "col2_b", "col3"]
     )
     with mock.patch(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1782778

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   We hit this issue because when it is not a select statement, we do not have a limit on the query results, while regex is always not reliable enough to decide whether it is a select statement. Thus leading to accidental consume of huge queries.
This PR is meant to add a limit even if it is not select statement, we did this by consume it with iterator and return limited rows, which avoid this issue
