### PR TITLE
SNOW-1854327: fix test to exclude deleted nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 #### Improvements
 - Improve performance of `DataFrame.map`, `Series.apply` and `Series.map` methods by mapping numpy functions to snowpark functions if possible.
+- Updated integration testing for `session.lineage.trace` to exclude deleted objects
 
 ## 1.26.0 (2024-12-05)
 

--- a/tests/integ/test_lineage.py
+++ b/tests/integ/test_lineage.py
@@ -200,19 +200,10 @@ def test_lineage_trace(session):
     df = remove_created_on_field(df.to_pandas())
 
     expected_data = {
-        "SOURCE_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "DELETED"},
-        ],
-        "TARGET_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "DELETED"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V4", "status": "ACTIVE"},
-        ],
-        "DIRECTION": [
-            "Downstream",
-            "Downstream",
-        ],
-        "DISTANCE": [1, 2],
+        "SOURCE_OBJECT": [],
+        "TARGET_OBJECT": [],
+        "DIRECTION": [],
+        "DISTANCE": [],
     }
 
     expected_df = pd.DataFrame(expected_data)


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1854327

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

We have a new commit in snowflakedb (https://github.com/snowflakedb/snowflake/pull/230405) where we stop showing deleted nodes. This test relies on old behavior where we do show deleted nodes. The fix is to update the test to not expect deleted nodes.