### PR TITLE
SNOW-1847626: Add support for value_contains_null to MapType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,26 +67,7 @@
 - Added support for `DataFrame.map`.
 - Added support for `DataFrame.from_dict` and `DataFrame.from_records`.
 - Added support for mixed case field names in struct type columns.
-- Added support for `SeriesGroupBy.unique`
-- Added support for `Series.dt.strftime` with the following directives:
-  - %d: Day of the month as a zero-padded decimal number.
-  - %m: Month as a zero-padded decimal number.
-  - %Y: Year with century as a decimal number.
-  - %H: Hour (24-hour clock) as a zero-padded decimal number.
-  - %M: Minute as a zero-padded decimal number.
-  - %S: Second as a zero-padded decimal number.
-  - %f: Microsecond as a decimal number, zero-padded to 6 digits.
-  - %j: Day of the year as a zero-padded decimal number.
-  - %X: Locale’s appropriate time representation.
-  - %%: A literal '%' character.
-- Added support for `Series.between`.
-- Added support for `include_groups=False` in `DataFrameGroupBy.apply`.
-- Added support for `expand=True` in `Series.str.split`.
-- Added support for `DataFrame.pop` and `Series.pop`.
-
-#### Bug Fixes
-
-- Fixed a bug that system function called through `session.call` have incorrect type conversion.
+- Added support for `value_contains_null` parameter to MapType.
 
 #### Improvements
 - Improve performance of `DataFrame.map`, `Series.apply` and `Series.map` methods by mapping numpy functions to snowpark functions if possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 - Updated README.md to include instructions on how to verify package signatures using `cosign`.
 - Added an option `keep_column_order` for keeping original column order in `DataFrame.with_column` and `DataFrame.with_columns`.
+- Added support for `value_contains_null` parameter to MapType.
 
 #### Bug Fixes
 
@@ -67,7 +68,26 @@
 - Added support for `DataFrame.map`.
 - Added support for `DataFrame.from_dict` and `DataFrame.from_records`.
 - Added support for mixed case field names in struct type columns.
-- Added support for `value_contains_null` parameter to MapType.
+- Added support for `SeriesGroupBy.unique`
+- Added support for `Series.dt.strftime` with the following directives:
+  - %d: Day of the month as a zero-padded decimal number.
+  - %m: Month as a zero-padded decimal number.
+  - %Y: Year with century as a decimal number.
+  - %H: Hour (24-hour clock) as a zero-padded decimal number.
+  - %M: Minute as a zero-padded decimal number.
+  - %S: Second as a zero-padded decimal number.
+  - %f: Microsecond as a decimal number, zero-padded to 6 digits.
+  - %j: Day of the year as a zero-padded decimal number.
+  - %X: Locale’s appropriate time representation.
+  - %%: A literal '%' character.
+- Added support for `Series.between`.
+- Added support for `include_groups=False` in `DataFrameGroupBy.apply`.
+- Added support for `expand=True` in `Series.str.split`.
+- Added support for `DataFrame.pop` and `Series.pop`.
+
+#### Bug Fixes
+
+- Fixed a bug that system function called through `session.call` have incorrect type conversion.
 
 #### Improvements
 - Improve performance of `DataFrame.map`, `Series.apply` and `Series.map` methods by mapping numpy functions to snowpark functions if possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Updated README.md to include instructions on how to verify package signatures using `cosign`.
 - Added an option `keep_column_order` for keeping original column order in `DataFrame.with_column` and `DataFrame.with_columns`.
 - Added support for `contains_null` parameter to ArrayType.
+- Added support for `value_contains_null` parameter to MapType.
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1542,7 +1542,7 @@ def attribute_to_schema_string(attributes: List[Attribute]) -> str:
     return COMMA.join(
         attr.name
         + SPACE
-        + convert_sp_to_sf_type(attr.datatype)
+        + convert_sp_to_sf_type(attr.datatype, attr.nullable)
         + (NOT_NULL if not attr.nullable else EMPTY_STRING)
         for attr in attributes
     )

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -272,10 +272,12 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
         return "to_array(0)"
     if isinstance(data_type, MapType):
         if data_type.structured:
-            assert isinstance(data_type.key_type, DataType)
-            assert isinstance(data_type.value_type, DataType)
-            key = schema_expression(data_type.key_type, is_nullable)
-            value = schema_expression(data_type.value_type, is_nullable)
+            # Key values can never be null
+            key = schema_expression(data_type.key_type, False)
+            # Value nullability is variable. Defaults to True
+            value = schema_expression(
+                data_type.value_type, data_type.value_contains_null
+            )
             return f"object_construct_keep_null({key}, {value}) :: {convert_sp_to_sf_type(data_type)}"
         return "to_object(parse_json('0'))"
     if isinstance(data_type, StructType):

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -272,6 +272,7 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
         return "to_array(0)"
     if isinstance(data_type, MapType):
         if data_type.structured:
+            assert data_type.key_type is not None and data_type.value_type is not None
             # Key values can never be null
             key = schema_expression(data_type.key_type, False)
             # Value nullability is variable. Defaults to True

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -248,7 +248,7 @@ def convert_sf_to_sp_type(
     )
 
 
-def convert_sp_to_sf_type(datatype: DataType) -> str:
+def convert_sp_to_sf_type(datatype: DataType, nullable_override=None) -> str:
     if isinstance(datatype, DecimalType):
         return f"NUMBER({datatype.precision}, {datatype.scale})"
     if isinstance(datatype, IntegerType):
@@ -295,7 +295,9 @@ def convert_sp_to_sf_type(datatype: DataType) -> str:
             return "ARRAY"
     if isinstance(datatype, MapType):
         if datatype.structured:
-            nullable = "" if datatype.value_contains_null else " NOT NULL"
+            nullable = (
+                "" if datatype.value_contains_null or nullable_override else " NOT NULL"
+            )
             return f"MAP({convert_sp_to_sf_type(datatype.key_type)}, {convert_sp_to_sf_type(datatype.value_type)}{nullable})"
         else:
             return "OBJECT"

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -151,6 +151,7 @@ def convert_metadata_to_sp_type(
                 convert_metadata_to_sp_type(metadata.fields[0], max_string_size),
                 convert_metadata_to_sp_type(metadata.fields[1], max_string_size),
                 structured=True,
+                value_contains_null=metadata.fields[1]._is_nullable,
             )
         else:
             assert all(
@@ -294,7 +295,8 @@ def convert_sp_to_sf_type(datatype: DataType) -> str:
             return "ARRAY"
     if isinstance(datatype, MapType):
         if datatype.structured:
-            return f"MAP({convert_sp_to_sf_type(datatype.key_type)}, {convert_sp_to_sf_type(datatype.value_type)})"
+            nullable = "" if datatype.value_contains_null else " NOT NULL"
+            return f"MAP({convert_sp_to_sf_type(datatype.key_type)}, {convert_sp_to_sf_type(datatype.value_type)}{nullable})"
         else:
             return "OBJECT"
     if isinstance(datatype, StructType):

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -398,24 +398,13 @@ class MapType(DataType):
         self,
         key_type: Optional[DataType] = None,
         value_type: Optional[DataType] = None,
-        structured: Optional[bool] = None,
+        structured: bool = False,
+        value_contains_null: bool = True,
     ) -> None:
-        if context._should_use_structured_type_semantics():
-            if (key_type is None and value_type is not None) or (
-                key_type is not None and value_type is None
-            ):
-                raise ValueError(
-                    "Must either set both key_type and value_type or leave both unset."
-                )
-            self.structured = (
-                structured if structured is not None else key_type is not None
-            )
-            self.key_type = key_type
-            self.value_type = value_type
-        else:
-            self.structured = structured or False
-            self.key_type = key_type if key_type else StringType()
-            self.value_type = value_type if value_type else StringType()
+        self.structured = structured
+        self.key_type = key_type if key_type else StringType()
+        self.value_type = value_type if value_type else StringType()
+        self.value_contains_null = value_contains_null
 
     def __repr__(self) -> str:
         type_str = ""

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -398,12 +398,25 @@ class MapType(DataType):
         self,
         key_type: Optional[DataType] = None,
         value_type: Optional[DataType] = None,
-        structured: bool = False,
+        structured: Optional[bool] = None,
         value_contains_null: bool = True,
     ) -> None:
-        self.structured = structured
-        self.key_type = key_type if key_type else StringType()
-        self.value_type = value_type if value_type else StringType()
+        if context._should_use_structured_type_semantics():
+            if (key_type is None and value_type is not None) or (
+                key_type is not None and value_type is None
+            ):
+                raise ValueError(
+                    "Must either set both key_type and value_type or leave both unset."
+                )
+            self.structured = (
+                structured if structured is not None else key_type is not None
+            )
+            self.key_type = key_type
+            self.value_type = value_type
+        else:
+            self.structured = structured or False
+            self.key_type = key_type if key_type else StringType()
+            self.value_type = value_type if value_type else StringType()
         self.value_contains_null = value_contains_null
 
     def __repr__(self) -> str:

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1364,13 +1364,12 @@ def test_structured_type_schema_expression(
         assert table.union(table).schema == expected_schema
         # Functions used in schema generation don't respect nested nullability so compare query string instead
         non_null_union = non_null_table.union(non_null_table)
-        # __import__('pdb').set_trace()
         assert non_null_union._plan.schema_query == (
-            "( SELECT object_construct_keep_null('a' ::  STRING (16777216), 0 :: DOUBLE) :: "
+            "( SELECT object_construct_keep_null('a' ::  STRING (16777216), NULL :: DOUBLE) :: "
             'MAP(STRING(16777216), DOUBLE) AS "MAP", to_array(NULL :: DOUBLE) :: ARRAY(DOUBLE) AS "ARR",'
             " object_construct_keep_null('FIELD1', 'a' ::  STRING (16777216), 'FIELD2', 0 :: "
             'DOUBLE) :: OBJECT(FIELD1 STRING(16777216), FIELD2 DOUBLE) AS "OBJ") UNION ( SELECT '
-            "object_construct_keep_null('a' ::  STRING (16777216), 0 :: DOUBLE) :: "
+            "object_construct_keep_null('a' ::  STRING (16777216), NULL :: DOUBLE) :: "
             'MAP(STRING(16777216), DOUBLE) AS "MAP", to_array(NULL :: DOUBLE) :: ARRAY(DOUBLE) AS "ARR", '
             "object_construct_keep_null('FIELD1', 'a' ::  STRING (16777216), 'FIELD2', 0 :: "
             'DOUBLE) :: OBJECT(FIELD1 STRING(16777216), FIELD2 DOUBLE) AS "OBJ")'

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1189,6 +1189,72 @@ def test_structured_array_contains_null(
     "config.getoption('local_testing_mode', default=False)",
     reason="local testing does not fully support structured types yet.",
 )
+def test_structured_map_value_contains_null(
+    structured_type_session, structured_type_support
+):
+    if not structured_type_support:
+        pytest.skip("Test requires structured type support.")
+
+    array_df = structured_type_session.sql(
+        "select {'test' : 'test'} :: MAP(STRING, STRING NOT NULL) AS M, {'test' : 'test'} :: MAP(STRING, STRING) AS M_N"
+    )
+    expected_schema = StructType(
+        [
+            StructField(
+                "M",
+                MapType(
+                    StringType(),
+                    StringType(),
+                    structured=True,
+                    value_contains_null=False,
+                ),
+            ),
+            StructField(
+                "M_N",
+                MapType(
+                    StringType(),
+                    StringType(),
+                    structured=True,
+                    value_contains_null=True,
+                ),
+            ),
+        ]
+    )
+    assert array_df.schema == expected_schema
+
+    table_name = f"snowpark_structured_map_contains_null_{uuid.uuid4().hex[:5]}".upper()
+    try:
+        # Create table from select statement
+        non_null_df = structured_type_session.create_dataframe(
+            [
+                ({"a": "b"},),
+            ],
+            schema=StructType(
+                [
+                    StructField(
+                        "A",
+                        MapType(StringType(), StringType(), value_contains_null=False),
+                        nullable=False,
+                    )
+                ]
+            ),
+        )
+        non_null_df.write.save_as_table(table_name)
+        save_ddl = structured_type_session._run_query(
+            f"select get_ddl('table', '{table_name}')"
+        )
+        # Not null dropped because dataframe created from select cannot maintain nullability
+        assert save_ddl[0][0] == (
+            f"create or replace TABLE {table_name.upper()} (\n\tA MAP(VARCHAR(16777216), VARCHAR(16777216))\n);"
+        )
+    finally:
+        Utils.drop_table(structured_type_session, table_name)
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="local testing does not fully support structured types yet.",
+)
 def test_structured_type_schema_expression(
     structured_type_session, local_testing_mode, structured_type_support
 ):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -965,6 +965,18 @@ def test_convert_sp_to_sf_type():
     assert convert_sp_to_sf_type(BinaryType()) == "BINARY"
     assert convert_sp_to_sf_type(ArrayType()) == "ARRAY"
     assert convert_sp_to_sf_type(MapType()) == "OBJECT"
+    assert (
+        convert_sp_to_sf_type(MapType(StringType(), StringType(), structured=True))
+        == "MAP(STRING, STRING)"
+    )
+    assert (
+        convert_sp_to_sf_type(
+            MapType(
+                StringType(), StringType(), structured=True, value_contains_null=False
+            )
+        )
+        == "MAP(STRING, STRING NOT NULL)"
+    )
     assert convert_sp_to_sf_type(StructType()) == "OBJECT"
     assert convert_sp_to_sf_type(VariantType()) == "VARIANT"
     assert convert_sp_to_sf_type(GeographyType()) == "GEOGRAPHY"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1847626

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

This PR adds support for value_contains_null to DictType objects. Structured map type columns never have nullable keys, but can have nullable values. This adds a parameter to the initializer that allows specifying.