### PR TITLE
SNOW-1853342: Add support for contains_null to ArrayType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,26 +67,7 @@
 - Added support for `DataFrame.map`.
 - Added support for `DataFrame.from_dict` and `DataFrame.from_records`.
 - Added support for mixed case field names in struct type columns.
-- Added support for `SeriesGroupBy.unique`
-- Added support for `Series.dt.strftime` with the following directives:
-  - %d: Day of the month as a zero-padded decimal number.
-  - %m: Month as a zero-padded decimal number.
-  - %Y: Year with century as a decimal number.
-  - %H: Hour (24-hour clock) as a zero-padded decimal number.
-  - %M: Minute as a zero-padded decimal number.
-  - %S: Second as a zero-padded decimal number.
-  - %f: Microsecond as a decimal number, zero-padded to 6 digits.
-  - %j: Day of the year as a zero-padded decimal number.
-  - %X: Locale’s appropriate time representation.
-  - %%: A literal '%' character.
-- Added support for `Series.between`.
-- Added support for `include_groups=False` in `DataFrameGroupBy.apply`.
-- Added support for `expand=True` in `Series.str.split`.
-- Added support for `DataFrame.pop` and `Series.pop`.
-
-#### Bug Fixes
-
-- Fixed a bug that system function called through `session.call` have incorrect type conversion.
+- Added support for `contains_null` parameter to ArrayType.
 
 #### Improvements
 - Improve performance of `DataFrame.map`, `Series.apply` and `Series.map` methods by mapping numpy functions to snowpark functions if possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 - Updated README.md to include instructions on how to verify package signatures using `cosign`.
 - Added an option `keep_column_order` for keeping original column order in `DataFrame.with_column` and `DataFrame.with_columns`.
+- Added support for `contains_null` parameter to ArrayType.
 
 #### Bug Fixes
 
@@ -67,7 +68,26 @@
 - Added support for `DataFrame.map`.
 - Added support for `DataFrame.from_dict` and `DataFrame.from_records`.
 - Added support for mixed case field names in struct type columns.
-- Added support for `contains_null` parameter to ArrayType.
+- Added support for `SeriesGroupBy.unique`
+- Added support for `Series.dt.strftime` with the following directives:
+  - %d: Day of the month as a zero-padded decimal number.
+  - %m: Month as a zero-padded decimal number.
+  - %Y: Year with century as a decimal number.
+  - %H: Hour (24-hour clock) as a zero-padded decimal number.
+  - %M: Minute as a zero-padded decimal number.
+  - %S: Second as a zero-padded decimal number.
+  - %f: Microsecond as a decimal number, zero-padded to 6 digits.
+  - %j: Day of the year as a zero-padded decimal number.
+  - %X: Locale’s appropriate time representation.
+  - %%: A literal '%' character.
+- Added support for `Series.between`.
+- Added support for `include_groups=False` in `DataFrameGroupBy.apply`.
+- Added support for `expand=True` in `Series.str.split`.
+- Added support for `DataFrame.pop` and `Series.pop`.
+
+#### Bug Fixes
+
+- Fixed a bug that system function called through `session.call` have incorrect type conversion.
 
 #### Improvements
 - Improve performance of `DataFrame.map`, `Series.apply` and `Series.map` methods by mapping numpy functions to snowpark functions if possible.

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1542,7 +1542,7 @@ def attribute_to_schema_string(attributes: List[Attribute]) -> str:
     return COMMA.join(
         attr.name
         + SPACE
-        + convert_sp_to_sf_type(attr.datatype)
+        + convert_sp_to_sf_type(attr.datatype, attr.nullable)
         + (NOT_NULL if not attr.nullable else EMPTY_STRING)
         for attr in attributes
     )

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -266,8 +266,7 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
             return "to_timestamp('2020-09-16 06:30:00')"
     if isinstance(data_type, ArrayType):
         if data_type.structured:
-            assert isinstance(data_type.element_type, DataType)
-            element = schema_expression(data_type.element_type, is_nullable)
+            element = schema_expression(data_type.element_type, data_type.contains_null)
             return f"to_array({element}) :: {convert_sp_to_sf_type(data_type)}"
         return "to_array(0)"
     if isinstance(data_type, MapType):

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -266,6 +266,7 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
             return "to_timestamp('2020-09-16 06:30:00')"
     if isinstance(data_type, ArrayType):
         if data_type.structured:
+            assert data_type.element_type is not None
             element = schema_expression(data_type.element_type, data_type.contains_null)
             return f"to_array({element}) :: {convert_sp_to_sf_type(data_type)}"
         return "to_array(0)"

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -248,7 +248,7 @@ def convert_sf_to_sp_type(
     )
 
 
-def convert_sp_to_sf_type(datatype: DataType) -> str:
+def convert_sp_to_sf_type(datatype: DataType, nullable_override=None) -> str:
     if isinstance(datatype, DecimalType):
         return f"NUMBER({datatype.precision}, {datatype.scale})"
     if isinstance(datatype, IntegerType):
@@ -290,7 +290,9 @@ def convert_sp_to_sf_type(datatype: DataType) -> str:
         return "BINARY"
     if isinstance(datatype, ArrayType):
         if datatype.structured:
-            nullable = "" if datatype.contains_null else " NOT NULL"
+            nullable = (
+                "" if datatype.contains_null or nullable_override else " NOT NULL"
+            )
             return f"ARRAY({convert_sp_to_sf_type(datatype.element_type)}{nullable})"
         else:
             return "ARRAY"

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -142,6 +142,7 @@ def convert_metadata_to_sp_type(
             return ArrayType(
                 convert_metadata_to_sp_type(metadata.fields[0], max_string_size),
                 structured=True,
+                contains_null=metadata.fields[0]._is_nullable,
             )
         elif column_type_name == "MAP":
             assert (
@@ -289,7 +290,8 @@ def convert_sp_to_sf_type(datatype: DataType) -> str:
         return "BINARY"
     if isinstance(datatype, ArrayType):
         if datatype.structured:
-            return f"ARRAY({convert_sp_to_sf_type(datatype.element_type)})"
+            nullable = "" if datatype.contains_null else " NOT NULL"
+            return f"ARRAY({convert_sp_to_sf_type(datatype.element_type)}{nullable})"
         else:
             return "ARRAY"
     if isinstance(datatype, MapType):

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -334,16 +334,12 @@ class ArrayType(DataType):
     def __init__(
         self,
         element_type: Optional[DataType] = None,
-        structured: Optional[bool] = None,
+        structured: bool = False,
+        contains_null: bool = True,
     ) -> None:
-        if context._should_use_structured_type_semantics():
-            self.structured = (
-                structured if structured is not None else element_type is not None
-            )
-            self.element_type = element_type
-        else:
-            self.structured = structured or False
-            self.element_type = element_type if element_type else StringType()
+        self.structured = structured
+        self.element_type = element_type if element_type else StringType()
+        self.contains_null = contains_null
 
     def __repr__(self) -> str:
         return f"ArrayType({repr(self.element_type) if self.element_type else ''})"

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -334,11 +334,17 @@ class ArrayType(DataType):
     def __init__(
         self,
         element_type: Optional[DataType] = None,
-        structured: bool = False,
+        structured: Optional[bool] = None,
         contains_null: bool = True,
     ) -> None:
-        self.structured = structured
-        self.element_type = element_type if element_type else StringType()
+        if context._should_use_structured_type_semantics():
+            self.structured = (
+                structured if structured is not None else element_type is not None
+            )
+            self.element_type = element_type
+        else:
+            self.structured = structured or False
+            self.element_type = element_type if element_type else StringType()
         self.contains_null = contains_null
 
     def __repr__(self) -> str:
@@ -350,7 +356,7 @@ class ArrayType(DataType):
         element_type = self.element_type
         if isinstance(element_type, (ArrayType, MapType, StructType)):
             element_type = element_type._as_nested()
-        return ArrayType(element_type, self.structured)
+        return ArrayType(element_type, self.structured, self.contains_null)
 
     def is_primitive(self):
         return False
@@ -362,7 +368,8 @@ class ArrayType(DataType):
                 json_dict["elementType"]
                 if "elementType" in json_dict
                 else json_dict["element_type"]
-            )
+            ),
+            contains_null=json_dict.get("contains_null", True),
         )
 
     def simple_string(self) -> str:
@@ -372,6 +379,7 @@ class ArrayType(DataType):
         return {
             "type": self.type_name(),
             "element_type": self.element_type.json_value(),
+            "contains_null": self.contains_null,
         }
 
     simpleString = simple_string

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1271,11 +1271,11 @@ def test_structured_type_schema_expression(
         non_null_union = non_null_table.union(non_null_table)
         assert non_null_union._plan.schema_query == (
             "( SELECT object_construct_keep_null('a' ::  STRING (16777216), 0 :: DOUBLE) :: "
-            'MAP(STRING(16777216), DOUBLE) AS "MAP", to_array(0 :: DOUBLE) :: ARRAY(DOUBLE) AS "ARR",'
+            'MAP(STRING(16777216), DOUBLE) AS "MAP", to_array(NULL :: DOUBLE) :: ARRAY(DOUBLE) AS "ARR",'
             " object_construct_keep_null('FIELD1', 'a' ::  STRING (16777216), 'FIELD2', 0 :: "
             'DOUBLE) :: OBJECT(FIELD1 STRING(16777216), FIELD2 DOUBLE) AS "OBJ") UNION ( SELECT '
             "object_construct_keep_null('a' ::  STRING (16777216), 0 :: DOUBLE) :: "
-            'MAP(STRING(16777216), DOUBLE) AS "MAP", to_array(0 :: DOUBLE) :: ARRAY(DOUBLE) AS "ARR", '
+            'MAP(STRING(16777216), DOUBLE) AS "MAP", to_array(NULL :: DOUBLE) :: ARRAY(DOUBLE) AS "ARR", '
             "object_construct_keep_null('FIELD1', 'a' ::  STRING (16777216), 'FIELD2', 0 :: "
             'DOUBLE) :: OBJECT(FIELD1 STRING(16777216), FIELD2 DOUBLE) AS "OBJ")'
         )

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1133,6 +1133,33 @@ def test_structured_type_print_schema(
     "config.getoption('local_testing_mode', default=False)",
     reason="local testing does not fully support structured types yet.",
 )
+def test_structured_array_contains_null(
+    structured_type_session, structured_type_support
+):
+    if not structured_type_support:
+        pytest.skip("Test requires structured type support.")
+
+    # SNOW-1862947 create DDL test once save as table supported
+    array_df = structured_type_session.sql(
+        "select [1, 2, 3] :: ARRAY(INT NOT NULL) as A, [1, 2, 3] :: ARRAY(INT) as A_N"
+    )
+    expected_schema = StructType(
+        [
+            StructField(
+                "A", ArrayType(LongType(), structured=True, contains_null=False)
+            ),
+            StructField(
+                "A_N", ArrayType(LongType(), structured=True, contains_null=True)
+            ),
+        ]
+    )
+    assert array_df.schema == expected_schema
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="local testing does not fully support structured types yet.",
+)
 def test_structured_type_schema_expression(
     structured_type_session, local_testing_mode, structured_type_support
 ):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -964,6 +964,15 @@ def test_convert_sp_to_sf_type():
     )
     assert convert_sp_to_sf_type(BinaryType()) == "BINARY"
     assert convert_sp_to_sf_type(ArrayType()) == "ARRAY"
+    assert (
+        convert_sp_to_sf_type(ArrayType(IntegerType(), structured=True)) == "ARRAY(INT)"
+    )
+    assert (
+        convert_sp_to_sf_type(
+            ArrayType(IntegerType(), structured=True, contains_null=False)
+        )
+        == "ARRAY(INT NOT NULL)"
+    )
     assert convert_sp_to_sf_type(MapType()) == "OBJECT"
     assert convert_sp_to_sf_type(StructType()) == "OBJECT"
     assert convert_sp_to_sf_type(VariantType()) == "VARIANT"

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1133,9 +1133,10 @@ def test_snow_type_to_dtype_str():
         (
             ArrayType(IntegerType()),
             "array<int>",
-            '{"element_type":"integer","type":"array"}',
+            '{"contains_null":true,"element_type":"integer","type":"array"}',
             "array",
             {
+                "contains_null": True,
                 "element_type": "integer",
                 "type": "array",
             },
@@ -1143,10 +1144,15 @@ def test_snow_type_to_dtype_str():
         (
             ArrayType(ArrayType(IntegerType())),
             "array<array<int>>",
-            '{"element_type":{"element_type":"integer","type":"array"},"type":"array"}',
+            '{"contains_null":true,"element_type":{"contains_null":true,"element_type":"integer","type":"array"},"type":"array"}',
             "array",
             {
-                "element_type": {"element_type": "integer", "type": "array"},
+                "contains_null": True,
+                "element_type": {
+                    "contains_null": True,
+                    "element_type": "integer",
+                    "type": "array",
+                },
                 "type": "array",
             },
         ),
@@ -1255,7 +1261,7 @@ def test_snow_type_to_dtype_str():
                 [ArrayType(ArrayType(IntegerType())), IntegerType(), FloatType()]
             ),
             "pandas<array<array<int>>,int,float>",
-            '{"fields":[{"name":"","type":{"element_type":{"element_type":"integer","type":"array"},"type":"array"}},{"name":"","type":"integer"},{"name":"","type":"float"}],"type":"pandas_dataframe"}',
+            '{"fields":[{"name":"","type":{"contains_null":true,"element_type":{"contains_null":true,"element_type":"integer","type":"array"},"type":"array"}},{"name":"","type":"integer"},{"name":"","type":"float"}],"type":"pandas_dataframe"}',
             "pandas_dataframe",
             {
                 "type": "pandas_dataframe",
@@ -1263,8 +1269,10 @@ def test_snow_type_to_dtype_str():
                     {
                         "name": "",
                         "type": {
+                            "contains_null": True,
                             "type": "array",
                             "element_type": {
+                                "contains_null": True,
                                 "type": "array",
                                 "element_type": "integer",
                             },


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1853342

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR adds support for the `contains_null` parameter to structured ArrayType objects. By default semi-structured and structured array columns allow null values. By setting contains_null in the ArrayType initilization we can specify that no elements of the array are null.

  Note that Snowflake cannot create a table with a schema like `arr ARRAY(INT NOT NULL)` the column also has to be non-nullable like so `arr ARRAY(INT NOT NULL) NOT NULL`. Because of this and the fact that Snowpark uses select statements that are nullable by default, the nullability of a column and therefore the array is most likely overridden with True in many scenarios. The only case I can find where this flag could be false is when operating on an existing table. Spark seems to have a similar limitation when operating on iceberg tables so I don't think this is an issue for SAS compatibility.