### PR TITLE
SNOW-1794377: Add support for Dataframe.toJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
   - `collect_list` an alias of `array_agg`.
   - `substring` makes `len` argument optional.
 - Added parameter `ast_enabled` to session for internal usage (default: `False`).
+- Added support for `Dataframe.toJSON`
 
 #### Improvements
 

--- a/docs/source/snowpark/dataframe.rst
+++ b/docs/source/snowpark/dataframe.rst
@@ -81,6 +81,7 @@ DataFrame
     DataFrame.subtract
     DataFrame.take
     DataFrame.toDF
+    DataFrame.toJSON
     DataFrame.toLocalIterator
     DataFrame.toPandas
     DataFrame.to_df

--- a/docs/source/snowpark/dataframe.rst
+++ b/docs/source/snowpark/dataframe.rst
@@ -86,6 +86,7 @@ DataFrame
     DataFrame.toPandas
     DataFrame.to_df
     DataFrame.to_local_iterator
+    DataFrame.to_json
     DataFrame.to_pandas
     DataFrame.to_pandas_batches
     DataFrame.to_snowpark_pandas

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -5623,7 +5623,7 @@ Query List:
             >>> df = session.create_dataframe([(1, "a"), (2, "b")], schema=["a", "b"])
             >>> df.to_json().show()
             -------------------
-            |"TO_JSON"         |
+            |"TO_JSON"        |
             -------------------
             |{"A":1,"B":"a"}  |
             |{"A":2,"B":"b"}  |

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -5615,22 +5615,22 @@ Query List:
         ]
         return dtypes
 
-    def toJSON(self) -> "DataFrame":
+    def to_json(self) -> "DataFrame":
         """
         Converts each row of the DataFrame into a JSON string.
 
         Example:
             >>> df = session.create_dataframe([(1, "a"), (2, "b")], schema=["a", "b"])
-            >>> df.toJSON().show()
+            >>> df.to_json().show()
             -------------------
-            |"TOJSON"         |
+            |"TO_JSON"         |
             -------------------
             |{"A":1,"B":"a"}  |
             |{"A":2,"B":"b"}  |
             -------------------
             <BLANKLINE>
         """
-        return self.select(to_json(object_construct_keep_null("*")).alias("TOJSON"))
+        return self.select(to_json(object_construct_keep_null("*")).alias("TO_JSON"))
 
     def _with_plan(self, plan, _ast_stmt=None) -> "DataFrame":
         """
@@ -5809,6 +5809,7 @@ Query List:
     order_by = sort
     orderBy = order_by
     printSchema = print_schema
+    toJSON = to_json
 
     # These methods are not needed for code migration. So no aliases for them.
     # groupByGrouping_sets = group_by_grouping_sets

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -178,6 +178,8 @@ from snowflake.snowpark.functions import (
     sql_expr,
     stddev,
     to_char,
+    to_json,
+    object_construct_keep_null,
 )
 from snowflake.snowpark.mock._select_statement import MockSelectStatement
 from snowflake.snowpark.row import Row
@@ -5612,6 +5614,23 @@ Query List:
             for name, field in zip(self.schema.names, self.schema.fields)
         ]
         return dtypes
+
+    def toJSON(self) -> "DataFrame":
+        """
+        Converts each row of the DataFrame into a JSON string.
+
+        Example:
+            >>> df = session.create_dataframe([(1, "a"), (2, "b")], schema=["a", "b"])
+            >>> df.toJSON().show()
+            -------------------
+            |"TOJSON"         |
+            -------------------
+            |{"A":1,"B":"a"}  |
+            |{"A":2,"B":"b"}  |
+            -------------------
+            <BLANKLINE>
+        """
+        return self.select(to_json(object_construct_keep_null("*")).alias("TOJSON"))
 
     def _with_plan(self, plan, _ast_stmt=None) -> "DataFrame":
         """


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1794377

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR adds an approximation of pysparks Dataframe.toJSON method. Notably Snowpark does not support RDDs so instead we return a Dataframe. Additionally Snowflake JSON methods don't support the `use_unicode` flag that pyspark provides so that is left out as well. We could add it as a dummy value for compatibility, but I think we should stick to what the Snowflake API can provide.