### PR TITLE
SNOW-1801330: Map numpy functions in df.apply to builtin functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Improve performance of `DataFrame.map`, `Series.apply` and `Series.map` methods by mapping numpy functions to snowpark functions if possible.
 - Updated integration testing for `session.lineage.trace` to exclude deleted objects
 - Added documentation for `DataFrame.map`.
+- Improve performance of `DataFrame.apply` by mapping numpy functions to snowpark functions if possible.
 
 ## 1.26.0 (2024-12-05)
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -8783,17 +8783,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 )
             return self._apply_snowpark_python_function_to_columns(func, kwargs)
 
-        # Check if the function is a known numpy function that can be translated to Snowflake function.
+        # TODO SNOW-1739034: remove pragma no cover when apply tests are enabled in CI
+        # Check if the function is a known numpy function that can be translated to
+        # Snowflake function.
         sf_func = NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION.get(func)
-        if sf_func is not None:
-            # TODO SNOW-1739034: remove pragma no cover when apply tests are enabled in CI
-            return self._apply_snowpark_python_function_to_columns(
-                sf_func, kwargs
-            )  # pragma: no cover
+        if sf_func is not None:  # pragma: no cover
+            return self._apply_snowpark_python_function_to_columns(sf_func, kwargs)
 
-        if func in (np.sum, np.min, np.max):
+        if func in (np.sum, np.min, np.max):  # pragma: no cover
             # Aggregate functions applied element-wise to columns are no-op.
-            return self  # pragma: no cover
+            return self
 
         # Currently, NULL values are always passed into the udtf even if strict=True,
         # which is a bug on the server side SNOW-880105.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -373,7 +373,7 @@ from snowflake.snowpark.modin.plugin.utils.error_message import ErrorMessage
 from snowflake.snowpark.modin.plugin.utils.warning_message import WarningMessage
 from snowflake.snowpark.modin.utils import MODIN_UNNAMED_SERIES_LABEL
 from snowflake.snowpark.modin.plugin.utils.numpy_to_pandas import (
-    NUMPY_FUNCTION_TO_SNOWFLAKE_FUNCTION,
+    NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION,
 )
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.types import (
@@ -8435,6 +8435,30 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 )
             return self._apply_snowpark_python_function_to_columns(func, kwargs)
 
+        # TODO SNOW-1739034: remove 'no cover' when apply tests are enabled in CI
+        sf_func = NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION.get(
+            func
+        )  # pragma: no cover
+        if sf_func is not None:  # pragma: no cover
+            return self._apply_snowpark_python_function_to_columns(sf_func, kwargs)
+
+        if get_snowflake_agg_func(func, {}, axis) is not None:  # pragma: no cover
+            # np.std and np.var 'ddof' parameter defaults to 0 but
+            # df.std and df.var 'ddof' parameter defaults to 1.
+            # Set it here explicitly to 0 if not provided.
+            if func in (np.std, np.var) and "ddof" not in kwargs:
+                kwargs["ddof"] = 0
+            # np.median return NaN if any value is NaN while df.median skips NaN values.
+            # Set 'skipna' to false to match behavior.
+            if func == np.median:
+                kwargs["skipna"] = False
+            qc = self.agg(func, axis, None, kwargs)
+            if axis == 1:
+                # agg method populates series name with aggregation function name but
+                # in apply we need unnamed series.
+                qc = qc.set_columns([MODIN_UNNAMED_SERIES_LABEL])
+            return qc
+
         if axis == 0:
             frame = self._modin_frame
 
@@ -8760,12 +8784,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             return self._apply_snowpark_python_function_to_columns(func, kwargs)
 
         # Check if the function is a known numpy function that can be translated to Snowflake function.
-        sf_func = NUMPY_FUNCTION_TO_SNOWFLAKE_FUNCTION.get(func)
+        sf_func = NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION.get(func)
         if sf_func is not None:
             # TODO SNOW-1739034: remove pragma no cover when apply tests are enabled in CI
             return self._apply_snowpark_python_function_to_columns(
                 sf_func, kwargs
             )  # pragma: no cover
+
+        if func in (np.sum, np.min, np.max):
+            # Aggregate functions applied element-wise to columns are no-op.
+            return self  # pragma: no cover
 
         # Currently, NULL values are always passed into the udtf even if strict=True,
         # which is a bug on the server side SNOW-880105.

--- a/src/snowflake/snowpark/modin/plugin/utils/numpy_to_pandas.py
+++ b/src/snowflake/snowpark/modin/plugin/utils/numpy_to_pandas.py
@@ -291,7 +291,8 @@ numpy_to_pandas_universal_func_map = {
 }
 
 
-NUMPY_FUNCTION_TO_SNOWFLAKE_FUNCTION = {
+# Map numpy universal (element-wise) function to Snowflake function
+NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION = {
     # Math operations
     np.absolute: sp_func.abs,
     np.sign: sp_func.sign,
@@ -308,10 +309,6 @@ NUMPY_FUNCTION_TO_SNOWFLAKE_FUNCTION = {
     np.log2: sp_func._log2,
     np.log10: sp_func._log10,
     np.log1p: lambda col: sp_func.ln(col + 1),
-    # Aggregate functions translate to identity functions when applied element wise
-    np.sum: lambda col: col,
-    np.min: lambda col: col,
-    np.max: lambda col: col,
     # Trigonometric functions
     np.sin: sp_func.sin,
     np.cos: sp_func.cos,

--- a/src/snowflake/snowpark/modin/plugin/utils/numpy_to_pandas.py
+++ b/src/snowflake/snowpark/modin/plugin/utils/numpy_to_pandas.py
@@ -291,7 +291,11 @@ numpy_to_pandas_universal_func_map = {
 }
 
 
-# Map numpy universal (element-wise) function to Snowflake function
+# Map from numpy universal (element-wise) function to Snowflake function.
+# This is used to map numpy functions to builtin sql functions when numpy function is
+# passed in apply and map methods. For example: df.apply(np.<func>)
+# Using native SQL functions instead of creating UDF/UDTF provides significant
+# better performance.
 NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION = {
     # Math operations
     np.absolute: sp_func.abs,

--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -88,11 +88,12 @@ def test_axis_0_basic_types_without_type_hints(data, func, return_type):
     # this test processes functions without type hints and invokes the UDTF solution.
     native_df = native_pd.DataFrame(data, columns=["A", "b"])
     snow_df = pd.DataFrame(data, columns=["A", "b"])
+    # np.min is mapped to builtin function so no UDTF is required.
     with SqlCounter(
-        query_count=11,
-        join_count=2,
-        udtf_count=2,
-        high_count_expected=True,
+        query_count=1 if func == np.min else 11,
+        join_count=0 if func == np.min else 2,
+        udtf_count=0 if func == np.min else 2,
+        high_count_expected=func != np.min,
         high_count_reason="SNOW-1650644 & SNOW-1345395: Avoid extra caching and repeatedly creating same temp function",
     ):
         eval_snowpark_pandas_result(snow_df, native_df, lambda x: x.apply(func, axis=0))


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1801330

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Map numpy universal functions (element-wise functions) and aggregate functions in df.apply to sql builtin functions. 
