### PR TITLE
SNOW-981562: Expose is_temp_table_for_cleanup to Session.table

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2253,7 +2253,7 @@ class Session:
                 )
 
     @publicapi
-    def table(self, name: Union[str, Iterable[str]], _emit_ast: bool = True) -> Table:
+    def table(self, name: Union[str, Iterable[str]], is_temp_table_for_cleanup: bool = False, _emit_ast: bool = True) -> Table:
         """
         Returns a Table that points the specified table.
 
@@ -2287,13 +2287,14 @@ class Session:
             elif isinstance(name, Iterable):
                 ast.name.sp_table_name_structured.name.extend(name)
             ast.variant.sp_session_table = True
+            ast.is_temp_table_for_cleanup = is_temp_table_for_cleanup
         else:
             stmt = None
 
         if not isinstance(name, str) and isinstance(name, Iterable):
             name = ".".join(name)
         validate_object_name(name)
-        t = Table(name, session=self, _ast_stmt=stmt, _emit_ast=_emit_ast)
+        t = Table(name, session=self, is_temp_table_for_cleanup=is_temp_table_for_cleanup, _ast_stmt=stmt, _emit_ast=_emit_ast)
         # Replace API call origin for table
         set_api_call_source(t, "Session.table")
         return t

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2253,7 +2253,12 @@ class Session:
                 )
 
     @publicapi
-    def table(self, name: Union[str, Iterable[str]], is_temp_table_for_cleanup: bool = False, _emit_ast: bool = True) -> Table:
+    def table(
+        self,
+        name: Union[str, Iterable[str]],
+        is_temp_table_for_cleanup: bool = False,
+        _emit_ast: bool = True,
+    ) -> Table:
         """
         Returns a Table that points the specified table.
 
@@ -2294,7 +2299,13 @@ class Session:
         if not isinstance(name, str) and isinstance(name, Iterable):
             name = ".".join(name)
         validate_object_name(name)
-        t = Table(name, session=self, is_temp_table_for_cleanup=is_temp_table_for_cleanup, _ast_stmt=stmt, _emit_ast=_emit_ast)
+        t = Table(
+            name,
+            session=self,
+            is_temp_table_for_cleanup=is_temp_table_for_cleanup,
+            _ast_stmt=stmt,
+            _emit_ast=_emit_ast,
+        )
         # Replace API call origin for table
         set_api_call_source(t, "Session.table")
         return t

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -2,8 +2,16 @@
 
 df1 = session.table(f"mock_schema.{tables.table1}", is_temp_table_for_cleanup=True)
 df2 = session.table(f"mock_schema.{tables.table1}", is_temp_table_for_cleanup=False)
-df = df1.union_all(df2)
+df = df1.union_all(df2).select("num")
 
 ## EXPECTED UNPARSER OUTPUT
+
+df1 = session.table("mock_schema.table1", is_temp_table_for_cleanup=True)
+
+df2 = session.table("mock_schema.table1")
+
+df = df1.union_all(df2)
+
+df = df.select(col("num"))
 
 ## EXPECTED ENCODED AST

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -1,0 +1,9 @@
+## TEST CASE
+
+df1 = session.table(f"mock_schema.{tables.table1}", is_temp_table_for_cleanup=True)
+df2 = session.table(f"mock_schema.{tables.table1}", is_temp_table_for_cleanup=False)
+df = df1.union_all(df2)
+
+## EXPECTED UNPARSER OUTPUT
+
+## EXPECTED ENCODED AST

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -15,3 +15,160 @@ df = df1.union_all(df2)
 df = df.select(col("num"))
 
 ## EXPECTED ENCODED AST
+
+body {
+  assign {
+    expr {
+      sp_table {
+        is_temp_table_for_cleanup: true
+        name {
+          sp_table_name_flat {
+            name: "mock_schema.table1"
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 25
+        }
+        variant {
+          sp_session_table: true
+        }
+      }
+    }
+    symbol {
+      value: "df1"
+    }
+    uid: 1
+    var_id {
+      bitfield1: 1
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_table {
+        name {
+          sp_table_name_flat {
+            name: "mock_schema.table1"
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 26
+        }
+        variant {
+          sp_session_table: true
+        }
+      }
+    }
+    symbol {
+      value: "df2"
+    }
+    uid: 2
+    var_id {
+      bitfield1: 2
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_union_all {
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        other {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 27
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 3
+    var_id {
+      bitfield1: 3
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_select__columns {
+        cols {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  fn_name_flat {
+                    name: "col"
+                  }
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_line: 27
+                }
+                v: "num"
+              }
+            }
+            src {
+              file: "SRC_POSITION_TEST_MODE"
+              start_line: 27
+            }
+          }
+        }
+        df {
+          sp_dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
+        }
+        src {
+          file: "SRC_POSITION_TEST_MODE"
+          start_line: 27
+        }
+        variadic: true
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 4
+    var_id {
+      bitfield1: 4
+    }
+  }
+}
+client_ast_version: 1
+client_language {
+  python_language {
+    version {
+      label: "final"
+      major: 3
+      minor: 9
+      patch: 1
+    }
+  }
+}
+client_version {
+  major: 1
+  minor: 26
+}


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-981562

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Expose `is_temp_table_for_cleanup` to `Session.table` API
