### PR TITLE
SNOW-1866086: Fix test_dt_accessor.py::test_strftime in Windows

### DIFF
--- a/tests/integ/modin/series/test_dt_accessor.py
+++ b/tests/integ/modin/series/test_dt_accessor.py
@@ -13,6 +13,7 @@ import pytz
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import create_test_series, eval_snowpark_pandas_result
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from tests.utils import IS_WINDOWS
 
 dt_properties = pytest.mark.parametrize(
     "property_name",
@@ -447,6 +448,11 @@ def test_days_in_month(property):
     ],
 )
 def test_strftime(date_format):
+    if IS_WINDOWS and date_format == "abc%":
+        pytest.skip(
+            "Windows test shows that native pandas leaves the input value unchanged when date_format='abc%'"
+        )
+
     datetime_index = native_pd.DatetimeIndex(
         [
             "2014-04-04 23:56:01.000000001",


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1866086

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Fix test_dt_accessor.py::test_strftime in Windows.
