### PR TITLE
SNOW-1869367: Avoid CTE on SnowflakeValuesStatement

### DIFF
--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -1011,11 +1011,13 @@ def test_time_series_aggregation_grouping(session):
     )
 
 
-def test_table_select_cte(session):
-    table_name = random_name_for_temp_object(TempObjectType.TABLE)
+@pytest.mark.parametrize("from_table", [True, False])
+def test_table_avoid_cte_on_select_and_values(session, from_table):
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
-    df.write.save_as_table(table_name, table_type="temp")
-    df = session.table(table_name)
+    if from_table:
+        table_name = random_name_for_temp_object(TempObjectType.TABLE)
+        df.write.save_as_table(table_name, table_type="temp")
+        df = session.table(table_name)
     df_result = df.with_column("add_one", col("a") + 1).union(
         df.with_column("add_two", col("a") + 2)
     )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1869367

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Today repeated subquery elimination will create withQueryBlocks on top of snowflake values statement. Since snowflake values statement are generally leaf nodes, this optimization seems unnecessary.
