### PR TITLE
SNOW-1865904 fix query gen when nested cte node is partitioned

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/large_query_breakdown.py
+++ b/src/snowflake/snowpark/_internal/compiler/large_query_breakdown.py
@@ -565,19 +565,14 @@ class LargeQueryBreakdown:
         temp_table_selectable.post_actions = [drop_table_query]
 
         parents = self._parent_map[child]
-        updated_nodes = set()
         for parent in parents:
             replace_child(parent, child, temp_table_selectable, self._query_generator)
 
         nodes_to_reset = list(parents)
         while nodes_to_reset:
             node = nodes_to_reset.pop()
-            if node in updated_nodes:
-                # Skip if the node is already updated.
-                continue
 
             update_resolvable_node(node, self._query_generator)
-            updated_nodes.add(node)
 
             parents = self._parent_map[node]
             nodes_to_reset.extend(parents)

--- a/src/snowflake/snowpark/_internal/compiler/plan_compiler.py
+++ b/src/snowflake/snowpark/_internal/compiler/plan_compiler.py
@@ -185,7 +185,6 @@ class PlanCompiler:
                     error_type=type(e).__name__,
                     error_message=str(e),
                 )
-                pass
 
         return self.replace_temp_obj_placeholders(queries)
 

--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -218,11 +218,10 @@ class QueryGenerator(Analyzer):
 
         elif isinstance(logical_plan, WithQueryBlock):
             resolved_child = resolved_children[logical_plan.children[0]]
-            # record the CTE definition of the current block
-            if logical_plan.name not in self.resolved_with_query_block:
-                self.resolved_with_query_block[
-                    logical_plan.name
-                ] = resolved_child.queries[-1]
+            # record/update the CTE definition of the current block
+            self.resolved_with_query_block[logical_plan.name] = resolved_child.queries[
+                -1
+            ]
 
             resolved_plan = self.plan_builder.with_query_block(
                 logical_plan,

--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -218,7 +218,8 @@ class QueryGenerator(Analyzer):
 
         elif isinstance(logical_plan, WithQueryBlock):
             resolved_child = resolved_children[logical_plan.children[0]]
-            # record/update the CTE definition of the current block
+            # record the CTE definition of the current block and update the query when
+            # the child is re-resolved during optimization stage.
             self.resolved_with_query_block[logical_plan.name] = resolved_child.queries[
                 -1
             ]

--- a/src/snowflake/snowpark/_internal/compiler/query_generator.py
+++ b/src/snowflake/snowpark/_internal/compiler/query_generator.py
@@ -218,7 +218,7 @@ class QueryGenerator(Analyzer):
 
         elif isinstance(logical_plan, WithQueryBlock):
             resolved_child = resolved_children[logical_plan.children[0]]
-            # record the CTE definition of the current block and update the query when
+            # record the CTE definition of the current block or update the query when
             # the child is re-resolved during optimization stage.
             self.resolved_with_query_block[logical_plan.name] = resolved_child.queries[
                 -1

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -764,15 +764,14 @@ def test_large_query_breakdown_with_nested_cte(session):
 
     with SqlCounter(query_count=1, describe_count=0):
         queries = final_df.queries
-        # TODO: update when to_selectable memoization is merged
-        assert len(queries["queries"]) == 3
-        assert len(queries["post_actions"]) == 2
+        assert len(queries["queries"]) == 2
+        assert len(queries["post_actions"]) == 1
         match = re.search(r"SNOWPARK_TEMP_CTE_[\w]+", queries["queries"][0])
         assert match is not None
         cte_name_for_first_partition = match.group()
         # assert that query for upper cte node is re-written and does not
         # contain the cte name for the first partition
-        assert cte_name_for_first_partition not in queries["queries"][2]
+        assert cte_name_for_first_partition not in queries["queries"][1]
 
     check_result_with_and_without_breakdown(session, final_df)
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1865904

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Update query generation for with query block where cte query is updated if the child plan is re-resolved during optimization process.
