### PR TITLE
SNOW-1867961: Fix from_json not working the TimestampType that contains tzinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 - Updated README.md to include instructions on how to verify package signatures using `cosign`.
 
+#### Bug Fixes
+
+- Fixed a bug in StructField.from_json that prevented TimestampTypes with tzinfo from being parsed correctly.
+
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -943,10 +943,20 @@ _atomic_types: List[Type[DataType]] = [
     IntegerType,
     LongType,
     DateType,
-    TimestampType,
     NullType,
 ]
+
+_timestamp_types: List[DataType] = [
+    TimestampType(),
+    TimestampType(timezone=TimestampTimeZone.NTZ),
+    TimestampType(timezone=TimestampTimeZone.LTZ),
+    TimestampType(timezone=TimestampTimeZone.TZ),
+]
+
 _all_atomic_types: Dict[str, Type[DataType]] = {t.typeName(): t for t in _atomic_types}
+_all_timestamp_types: Dict[str, DataType] = {
+    t.json_value(): t for t in _timestamp_types
+}
 
 _complex_types: List[Type[Union[ArrayType, MapType, StructType]]] = [
     ArrayType,
@@ -964,8 +974,10 @@ _FIXED_DECIMAL_PATTERN = re.compile(r"decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)")
 
 def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
     if not isinstance(json_value, dict):
-        if json_value in _all_atomic_types.keys():
+        if json_value in _all_atomic_types:
             return _all_atomic_types[json_value]()
+        if json_value in _all_timestamp_types:
+            return TimestampType(timezone=_all_timestamp_types[json_value].tz)
         elif json_value == "decimal":
             return DecimalType()
         elif _FIXED_DECIMAL_PATTERN.match(json_value):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1431,6 +1431,23 @@ def test_from_json_wrong_data_type():
         StructField.from_json(wrong_json)
 
 
+def test_timestamp_json_round_trip():
+    timestamp_types = [
+        "timestamp",
+        "timestamp_tz",
+        "timestamp_ntz",
+        "timestamp_ltz",
+    ]
+
+    for ts in timestamp_types:
+        assert (
+            StructField.from_json(
+                {"name": "TS", "type": ts, "nullable": True}
+            ).json_value()["type"]
+            == ts
+        )
+
+
 def test_maptype_alias():
     expected_key = StringType()
     expected_value = IntegerType()


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1867961

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

    This PR fixes a bug in `_parse_datatype_json_value` that failed to parse timestamp types that had timezone information. Previously the type strings for `timestamp_ntz`, `timestamp_ltz`, and `timestamp_tz` were not recognized as valid timezone types.
   