### PR TITLE
SNOW-1847174: Support include_groups=False in groupby.apply.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   - %X: Locale’s appropriate time representation.
   - %%: A literal '%' character.
 - Added support for `Series.between`.
+- Added support for `include_groups=False` in `DataFrameGroupBy.apply`.
 
 #### Bug Fixes
 

--- a/docs/source/modin/supported/groupby_supported.rst
+++ b/docs/source/modin/supported/groupby_supported.rst
@@ -39,8 +39,8 @@ Function application
 +-----------------------------+---------------------------------+----------------------------------+----------------------------------------------------+
 | ``apply``                   | P                               | ``axis`` other than 0 is not     | ``Y`` if the following are true, otherwise ``N``:  |
 |                             |                                 | implemented.                     |   - ``func`` is a callable that always returns     |
-|                             |                                 | ``include_groups = False`` is    |     either a pandas DataFrame, a pandas Series, or |
-|                             |                                 | not implemented.                 |     objects that are neither DataFrame nor Series. |
+|                             |                                 |                                  |     either a pandas DataFrame, a pandas Series, or |
+|                             |                                 |                                  |     objects that are neither DataFrame nor Series. |
 |                             |                                 |                                  |   - grouping on axis=0                             |
 |                             |                                 |                                  |   - Not applying transform to a dataframe with a   |
 |                             |                                 |                                  |     non-unique index                               |

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -4003,7 +4003,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             series_groupby:
                 Whether we are performing a SeriesGroupBy.apply() instead of a DataFrameGroupBy.apply()
             include_groups:
-                When True, will apply func to the groupings in the case that
+                When True, will include grouping keys when calling func in the case that
                 they are columns of the DataFrame.
             force_single_group:
                 Force single group (empty set of group by labels) useful for DataFrame.apply() with axis=0

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -4066,7 +4066,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 if series_groupby
                 else (
                     # For DataFrameGroupBy, if include_groups, we apply the
-                    # function to all data columnns. Otherwise, we exclude
+                    # function to all data columns. Otherwise, we exclude
                     # data columns that we are grouping by.
                     include_groups
                     or identifier not in by_snowflake_quoted_identifiers_list

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3979,6 +3979,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         agg_args: Any,
         agg_kwargs: dict[str, Any],
         series_groupby: bool,
+        include_groups: bool,
         force_single_group: bool = False,
         force_list_like_to_series: bool = False,
     ) -> "SnowflakeQueryCompiler":
@@ -4001,6 +4002,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 Keyword arguments to pass to agg_func when applying it to each group.
             series_groupby:
                 Whether we are performing a SeriesGroupBy.apply() instead of a DataFrameGroupBy.apply()
+            include_groups:
+                When True, will apply func to the groupings in the case that
+                they are columns of the DataFrame.
             force_single_group:
                 Force single group (empty set of group by labels) useful for DataFrame.apply() with axis=0
             force_list_like_to_series:
@@ -4018,14 +4022,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 f"No support for groupby.apply with parameters by={by}, "
                 + f"level={level}, and axis={axis}"
             )
-
-        if "include_groups" in agg_kwargs:
-            # exclude "include_groups" from the apply function kwargs
-            include_groups = agg_kwargs.pop("include_groups")
-            if not include_groups:
-                ErrorMessage.not_implemented(
-                    f"No support for groupby.apply with include_groups = {include_groups}"
-                )
 
         sort = groupby_kwargs.get("sort", True)
         as_index = groupby_kwargs.get("as_index", True)
@@ -4051,17 +4047,36 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
         snowflake_type_map = self._modin_frame.quoted_identifier_to_snowflake_type()
-
-        # For DataFrameGroupBy, `func` operates on this frame in its entirety.
-        # For SeriesGroupBy, this frame may also include some grouping columns
-        # that `func` should not take as input. In that case, the only column
-        # that `func` takes as input is the last data column, so grab just that
-        # column with a slice starting at index -1 and ending at None.
-        input_data_column_identifiers = (
-            self._modin_frame.data_column_snowflake_quoted_identifiers[
-                slice(-1, None) if series_groupby else slice(None)
-            ]
-        )
+        input_data_column_positions = [
+            i
+            for i, identifier in enumerate(
+                self._modin_frame.data_column_snowflake_quoted_identifiers
+            )
+            if (
+                (
+                    # For SeriesGroupBy, this frame may also include some
+                    # grouping columns that `func` should not take as input. In
+                    # that case, the only column that `func` takes as input is
+                    # the last data column, so take just that column.
+                    # include_groups has no effect.
+                    i
+                    == len(self._modin_frame.data_column_snowflake_quoted_identifiers)
+                    - 1
+                )
+                if series_groupby
+                else (
+                    # For DataFrameGroupBy, if include_groups, we apply the
+                    # function to all data columnns. Otherwise, we exclude
+                    # data columns that we are grouping by.
+                    include_groups
+                    or identifier not in by_snowflake_quoted_identifiers_list
+                )
+            )
+        ]
+        input_data_column_identifiers = [
+            self._modin_frame.data_column_snowflake_quoted_identifiers[i]
+            for i in input_data_column_positions
+        ]
 
         # TODO(SNOW-1210489): When type hints show that `agg_func` returns a
         # scalar, we can use a vUDF instead of a vUDTF and we can skip the
@@ -4070,7 +4085,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             agg_func,
             agg_args,
             agg_kwargs,
-            data_column_index=self._modin_frame.data_columns_index,
+            data_column_index=self._modin_frame.data_columns_index[
+                input_data_column_positions
+            ],
             index_column_names=self._modin_frame.index_column_pandas_labels,
             input_data_column_types=[
                 snowflake_type_map[quoted_identifier]
@@ -8514,6 +8531,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     series_groupby=True,
                     force_single_group=True,
                     force_list_like_to_series=True,
+                    include_groups=True,
                 )
 
                 data_col_result_frame = data_col_qc._modin_frame

--- a/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
@@ -1079,6 +1079,11 @@ class DataFrameGroupBy:
             A callable that takes a dataframe or series as its first argument, and
             returns a dataframe, a series or a scalar. In addition the
             callable may take positional and keyword arguments.
+        include_groups : bool, default True
+            When True, will apply ``func`` to the groups in the case that they
+            are columns of the DataFrame. If this raises a TypeError, the
+            result will be computed with the groupings excluded. When False,
+            the groupings will be excluded when applying ``func``.
         args, kwargs : tuple and dict
             Optional positional and keyword arguments to pass to ``func``.
 

--- a/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
@@ -1081,9 +1081,7 @@ class DataFrameGroupBy:
             callable may take positional and keyword arguments.
         include_groups : bool, default True
             When True, will apply ``func`` to the groups in the case that they
-            are columns of the DataFrame. If this raises a TypeError, the
-            result will be computed with the groupings excluded. When False,
-            the groupings will be excluded when applying ``func``.
+            are columns of the DataFrame.
         args, kwargs : tuple and dict
             Optional positional and keyword arguments to pass to ``func``.
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/groupby_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/groupby_overrides.py
@@ -238,7 +238,7 @@ class DataFrameGroupBy(metaclass=TelemetryMeta):
     # Function application
     ###########################################################################
 
-    def apply(self, func, *args, **kwargs):
+    def apply(self, func, *args, include_groups=True, **kwargs):
         # TODO: SNOW-1063349: Modin upgrade - modin.pandas.groupby.DataFrameGroupBy functions
         # TODO: SNOW-1244717: Explore whether window function are performant and can be used
         #       whenever `func` is an aggregation function.
@@ -253,6 +253,7 @@ class DataFrameGroupBy(metaclass=TelemetryMeta):
                 agg_args=args,
                 agg_kwargs=kwargs,
                 series_groupby=False,
+                include_groups=include_groups,
             )
         )
         if dataframe_result.columns.equals(pandas.Index([MODIN_UNNAMED_SERIES_LABEL])):
@@ -1445,7 +1446,7 @@ class SeriesGroupBy(DataFrameGroupBy):
     # Function application
     ###########################################################################
 
-    def apply(self, func, *args, **kwargs):
+    def apply(self, func, *args, include_groups=True, **kwargs):
         # TODO: SNOW-1063349: Modin upgrade - modin.pandas.groupby.SeriesGroupBy functions
         if not callable(func):
             raise NotImplementedError("No support for non-callable `func`")
@@ -1457,6 +1458,7 @@ class SeriesGroupBy(DataFrameGroupBy):
                 groupby_kwargs=self._kwargs,
                 agg_args=args,
                 agg_kwargs=kwargs,
+                include_groups=include_groups,
                 # TODO(https://github.com/modin-project/modin/issues/7096):
                 # upstream the series_groupby param to Modin
                 series_groupby=True,

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -1302,6 +1302,11 @@ class TestCallableWithMixedReturnTypes:
         )
 
 
+@sql_count_checker(
+    query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+    join_count=JOIN_COUNT,
+    udtf_count=UDTF_COUNT,
+)
 def test_include_groups_default_value(grouping_dfs_with_multiindexes):
     """
     Test that the default value behavior include_groups matches pandas.

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -80,7 +80,7 @@ def transform_that_changes_columns(df: native_pd.DataFrame) -> native_pd.DataFra
     return native_pd.DataFrame(
         {
             "custom_sum": df["int_col"].cumsum() + df["int_col"].max(),
-            "custom_string": df["string_col_1"].astype("object").cumsum()
+            "custom_string": (df["string_col_2"].astype("object").cumsum())
             + df["string_col_2"].str.cat(sep="-"),
         }
     )
@@ -171,25 +171,31 @@ JOIN_COUNT = 1
 UDTF_COUNT = 1
 
 
+@pytest.mark.parametrize(
+    "include_groups", [True, False], ids=lambda v: f"include_groups_{v}"
+)
 class TestFuncReturnsDataFrame:
     @pytest.mark.parametrize(
         "func",
         [
             normalize_numeric_columns_by_sum,
             param(
-                lambda df: df.iloc[:, [2, 2, 0, 1]],
+                lambda df: df.iloc[:, [1, 0]],
                 id="different_columns_but_same_index",
             ),
             param(
                 lambda df: (
                     native_pd.DataFrame(
-                        [["k0_grouped", 0, 1], ["k0_grouped", 2, 2]],
+                        [
+                            list(range(0, len(df.columns))),
+                            list(range(1, 1 + len(df.columns))),
+                        ],
                         index=native_pd.Index([None, 3], name="new_index"),
                         columns=df.columns,
                     )
-                    if df[("a", "string_col_1")].iloc[0] == "k0"
+                    if df.index[0][0] == "i1"
                     else native_pd.DataFrame(
-                        [["other_key_grouped", 100, 101]],
+                        [list(range(2, 2 + len(df.columns)))],
                         index=native_pd.Index([None, 3], name="new_index"),
                         columns=df.columns,
                     )
@@ -205,13 +211,13 @@ class TestFuncReturnsDataFrame:
         join_count=JOIN_COUNT,
     )
     def test_group_by_one_column_and_one_level_with_default_kwargs(
-        self, grouping_dfs_with_multiindexes, func
+        self, grouping_dfs_with_multiindexes, func, include_groups
     ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby(
                 ["level_0", ("a", "string_col_1")],
-            ).apply(func),
+            ).apply(func, include_groups=include_groups),
         )
 
     @sql_count_checker(
@@ -219,12 +225,14 @@ class TestFuncReturnsDataFrame:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_df_with_default_index(self, grouping_dfs_with_multiindexes):
+    def test_df_with_default_index(
+        self, grouping_dfs_with_multiindexes, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.reset_index(drop=True)
             .groupby(("a", "string_col_1"))
-            .apply(normalize_numeric_columns_by_sum),
+            .apply(normalize_numeric_columns_by_sum, include_groups=include_groups),
         )
 
     @sql_count_checker(
@@ -232,11 +240,12 @@ class TestFuncReturnsDataFrame:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_func_returns_empty_frame(self):
+    def test_func_returns_empty_frame(self, include_groups):
         eval_snowpark_pandas_result(
             *create_test_dfs([[1, 2], [3, 4]]),
             lambda df: df.groupby(0).apply(
-                lambda df: native_pd.DataFrame(index=[1, 3], columns=[4, 5])
+                lambda df: native_pd.DataFrame(index=[1, 3], columns=[4, 5]),
+                include_groups=include_groups,
             ),
         )
 
@@ -245,13 +254,15 @@ class TestFuncReturnsDataFrame:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_args_and_kwargs(self, grouping_dfs_with_multiindexes):
+    def test_args_and_kwargs(self, grouping_dfs_with_multiindexes, include_groups):
         def func(df, num1, str1):
             return df.applymap(lambda x: "_".join((str(x), num1, str1)))
 
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
-            lambda df: df.groupby("level_0").apply(func, "0.3", str1="str1"),
+            lambda df: df.groupby("level_0").apply(
+                func, "0.3", str1="str1", include_groups=include_groups
+            ),
         )
 
     @pytest.mark.parametrize(
@@ -271,13 +282,17 @@ class TestFuncReturnsDataFrame:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_group_by_level(self, grouping_dfs_with_multiindexes, level):
+    def test_group_by_level(
+        self, grouping_dfs_with_multiindexes, level, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
-            lambda df: df.groupby(level=level).apply(lambda df: df.iloc[::-1, ::-1]),
+            lambda df: df.groupby(level=level).apply(
+                lambda df: df.iloc[::-1, ::-1], include_groups=include_groups
+            ),
         )
 
-    def test_dropna_false(self, grouping_dfs_with_multiindexes):
+    def test_dropna_false(self, grouping_dfs_with_multiindexes, include_groups):
         snow_df, pandas_df = grouping_dfs_with_multiindexes
         # check that we are going to group by a column that has nulls.
         assert pandas_df[("a", "string_col_1")].isna().sum() > 0
@@ -286,7 +301,7 @@ class TestFuncReturnsDataFrame:
             return df.groupby(
                 ("a", "string_col_1"),
                 dropna=False,
-            ).apply(normalize_numeric_columns_by_sum)
+            ).apply(normalize_numeric_columns_by_sum, include_groups=include_groups)
 
         with SqlCounter(
             # When dropna=False, we can skip the dropna query
@@ -334,10 +349,14 @@ class TestFuncReturnsDataFrame:
             np.nan,
         ],
     )
-    def test_group_dataframe_with_column_of_all_nulls_snow_1233832(self, null_value):
+    def test_group_dataframe_with_column_of_all_nulls_snow_1233832(
+        self, null_value, include_groups
+    ):
         eval_snowpark_pandas_result(
             *create_test_dfs({"null_col": [null_value], "int_col": [1]}),
-            lambda df: df.groupby("int_col").apply(lambda x: x),
+            lambda df: df.groupby("int_col").apply(
+                lambda x: x, include_groups=include_groups
+            ),
         )
 
     @sql_count_checker(
@@ -352,11 +371,11 @@ class TestFuncReturnsDataFrame:
             ("a", "string_col_1"),
         ],
     )
-    def test_sort_false(self, grouping_dfs_with_multiindexes, by):
+    def test_sort_false(self, grouping_dfs_with_multiindexes, by, include_groups):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby(by, sort=False).apply(
-                normalize_numeric_columns_by_sum
+                normalize_numeric_columns_by_sum, include_groups=include_groups
             ),
         )
 
@@ -373,10 +392,14 @@ class TestFuncReturnsDataFrame:
         # behavior depends on whether the function is a transform.
         [normalize_numeric_columns_by_sum, duplicate_df_rowwise],
     )
-    def test_as_index_false(self, grouping_dfs_with_multiindexes, by, func):
+    def test_as_index_false(
+        self, grouping_dfs_with_multiindexes, by, func, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
-            lambda df: df.groupby(by=by, as_index=False).apply(func),
+            lambda df: df.groupby(by=by, as_index=False).apply(
+                func, include_groups=include_groups
+            ),
         )
 
     @pytest.mark.parametrize(
@@ -392,23 +415,25 @@ class TestFuncReturnsDataFrame:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_group_keys_false(self, grouping_dfs_with_multiindexes, as_index):
+    def test_group_keys_false(
+        self, grouping_dfs_with_multiindexes, as_index, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby(
                 by=["level_0", ("a", "string_col_1")],
                 as_index=as_index,
                 group_keys=False,
-            ).apply(normalize_numeric_columns_by_sum),
+            ).apply(normalize_numeric_columns_by_sum, include_groups=include_groups),
         )
 
     @sql_count_checker(query_count=0)
     @pytest.mark.xfail(strict=True, raises=NotImplementedError)
-    def test_axis_one(self, grouping_dfs_with_multiindexes):
+    def test_axis_one(self, grouping_dfs_with_multiindexes, include_groups):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby(level=0, axis=1).apply(
-                normalize_numeric_columns_by_sum
+                normalize_numeric_columns_by_sum, include_groups=include_groups
             ),
         )
 
@@ -463,7 +488,7 @@ class TestFuncReturnsDataFrame:
         ],
     )
     def test_df_with_single_level_labels(
-        self, by, as_index, func, group_keys, dfs_kwargs
+        self, by, as_index, func, group_keys, dfs_kwargs, include_groups
     ):
         mdf, pdf = create_test_dfs(**dfs_kwargs)
 
@@ -472,7 +497,7 @@ class TestFuncReturnsDataFrame:
                 by=by,
                 group_keys=group_keys,
                 as_index=as_index,
-            ).apply(func)
+            ).apply(func, include_groups=include_groups)
 
         pandas_result = operation(pdf)
         with SqlCounter(
@@ -509,7 +534,7 @@ class TestFuncReturnsDataFrame:
                         native_pd.DataFrame(
                             {
                                 "custom_sum": [26, 30, 30, 46],
-                                "custom_string": ["k0e", "k1d-b", "k0c", "k1k0d-b"],
+                                "custom_string": ["ee", "dd-b", "cc", "dbd-b"],
                             },
                             index=native_pd.Index(
                                 ["i0", "i1", "i2", "i1"], name="index"
@@ -524,10 +549,10 @@ class TestFuncReturnsDataFrame:
                             {
                                 "custom_sum": [29, 28, 44, 60],
                                 "custom_string": [
-                                    "k0e-c-b",
-                                    "k1d",
-                                    "k0k0e-c-b",
-                                    "k0k0k0e-c-b",
+                                    "ee-c-b",
+                                    "dd",
+                                    "ece-c-b",
+                                    "ecbe-c-b",
                                 ],
                             },
                             index=native_pd.Index(
@@ -548,14 +573,14 @@ class TestFuncReturnsDataFrame:
         udtf_count=UDTF_COUNT,
     )
     def test_apply_transfform_to_subset(
-        self, grouping_dfs_with_multiindexes, set_sql_simplifier
+        self, grouping_dfs_with_multiindexes, set_sql_simplifier, include_groups
     ):
         """Test a bug where groupby.apply on a subset of columns was giving a syntax error only if sql simplifier was off."""
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby("level_0", group_keys=False)[
                 [("b", "int_col"), ("b", "string_col_2")]
-            ].apply(normalize_numeric_columns_by_sum),
+            ].apply(normalize_numeric_columns_by_sum, include_groups=include_groups),
         )
 
     @pytest.mark.parametrize(
@@ -580,10 +605,14 @@ class TestFuncReturnsDataFrame:
         join_count=JOIN_COUNT,
         udtf_count=UDTF_COUNT,
     )
-    def test_numpy_ints_in_result(self, grouping_dfs_with_multiindexes, result):
+    def test_numpy_ints_in_result(
+        self, grouping_dfs_with_multiindexes, result, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
-            lambda df: df.groupby(level=0).apply(lambda grp: result),
+            lambda df: df.groupby(level=0).apply(
+                lambda grp: result, include_groups=include_groups
+            ),
         )
 
     @pytest.mark.xfail(
@@ -591,13 +620,16 @@ class TestFuncReturnsDataFrame:
         raises=NotImplementedError,
         reason="No support for applying a function that returns two dataframes that have different labels for the column at a given position",
     )
-    def test_mismatched_data_column_positions(self, grouping_dfs_with_multiindexes):
+    def test_mismatched_data_column_positions(
+        self, grouping_dfs_with_multiindexes, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby("level_0").apply(
                 lambda df: native_pd.DataFrame([0], columns=["a"])
                 if df.iloc[0, 1] == 13
-                else native_pd.DataFrame([1], columns=["b"])
+                else native_pd.DataFrame([1], columns=["b"]),
+                include_groups=include_groups,
             ),
         )
 
@@ -606,7 +638,9 @@ class TestFuncReturnsDataFrame:
         raises=NotImplementedError,
         reason="No support for applying a function that returns two dataframes that have different names for a given index level",
     )
-    def test_mismatched_index_column_positions(self, grouping_dfs_with_multiindexes):
+    def test_mismatched_index_column_positions(
+        self, grouping_dfs_with_multiindexes, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby("level_0").apply(
@@ -618,11 +652,12 @@ class TestFuncReturnsDataFrame:
                 else native_pd.DataFrame(
                     [0],
                     index=native_pd.Index([0], name="b"),
-                )
+                ),
+                include_groups=include_groups,
             ),
         )
 
-    def test_duplicate_index_groupby_mismatch_with_pandas(self):
+    def test_duplicate_index_groupby_mismatch_with_pandas(self, include_groups):
         # use a frame that has duplicates in its index to reproduce https://github.com/pandas-dev/pandas/issues/57906
         # this bug is fixed in snowpark pandas but not in pandas.
         snow_df, pandas_df = create_test_dfs(
@@ -642,7 +677,7 @@ class TestFuncReturnsDataFrame:
         def groupby_apply_without_sort(df):
             return df.groupby("index", sort=False, dropna=False, group_keys=False)[
                 "int_col"
-            ].apply(lambda v: v)
+            ].apply(lambda v: v, include_groups=include_groups)
 
         # Assertion fails because index order is different due to pandas issue
         # 57906.
@@ -673,6 +708,9 @@ class TestFuncReturnsDataFrame:
             )
 
 
+@pytest.mark.parametrize(
+    "include_groups", [True, False], ids=lambda v: f"include_groups_{v}"
+)
 class TestFuncReturnsScalar:
     @pytest.mark.parametrize("sort", [True, False], ids=lambda v: f"sort_{v}")
     @pytest.mark.parametrize("as_index", [True, False], ids=lambda v: f"as_index_{v}")
@@ -685,7 +723,9 @@ class TestFuncReturnsScalar:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_volume_from_brazil_per_year(self, sort, dropna, group_keys, as_index):
+    def test_volume_from_brazil_per_year(
+        self, sort, dropna, group_keys, as_index, include_groups
+    ):
         """Test an example that a user provided here: https://snowflake.slack.com/archives/C05RX90ETGU/p1707126781811689"""
         # TODO: group_keys should have no impact when func: df -> scalar
         # (normally it tells whether to include group keys in the index)
@@ -714,7 +754,9 @@ class TestFuncReturnsScalar:
                 group_keys=group_keys,
                 dropna=dropna,
             ).apply(
-                lambda grp: grp[grp.country == "brazil"].volume.sum() / grp.volume.sum()
+                lambda grp: grp[grp.country == "brazil"].volume.sum()
+                / grp.volume.sum(),
+                include_groups=include_groups,
             ),
         )
 
@@ -723,7 +765,7 @@ class TestFuncReturnsScalar:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_root_mean_squared_error(self):
+    def test_root_mean_squared_error(self, include_groups):
         """Test an example that a user provided here: https://groups.google.com/a/snowflake.com/g/snowpark-pandas-api-customer-adoption-DL/c/0PDdj9-p5Hs/m/pRJ-I08dBAAJ"""
         eval_snowpark_pandas_result(
             *create_test_dfs(
@@ -734,7 +776,8 @@ class TestFuncReturnsScalar:
                 }
             ),
             lambda df: df.groupby("customer_id").apply(
-                lambda grp: np.sqrt((grp.actual - grp.expected) ** 2).mean()
+                lambda grp: np.sqrt((grp.actual - grp.expected) ** 2).mean(),
+                include_groups=include_groups,
             ),
         )
 
@@ -748,14 +791,15 @@ class TestFuncReturnsScalar:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_multiindex_df(self, grouping_dfs_with_multiindexes, by, sort, as_index):
+    def test_multiindex_df(
+        self, grouping_dfs_with_multiindexes, by, sort, as_index, include_groups
+    ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
-            lambda df: df.groupby(
-                by,
-                sort=sort,
-                as_index=as_index,
-            ).apply(lambda df: df.astype(str).astype(object).sum().sum()),
+            lambda df: df.groupby(by, sort=sort, as_index=as_index,).apply(
+                lambda df: df.astype(str).astype(object).sum().sum(),
+                include_groups=include_groups,
+            ),
         )
 
     @pytest.mark.parametrize(
@@ -785,13 +829,15 @@ class TestFuncReturnsScalar:
         join_count=JOIN_COUNT,
     )
     def test_non_series_or_dataframe_return_types(
-        self, return_value, grouping_dfs_with_multiindexes
+        self, return_value, grouping_dfs_with_multiindexes, include_groups
     ):
         """These return types are scalars in the sense that they are not pandas Series or DataFrames."""
         snow_df, pandas_df = grouping_dfs_with_multiindexes
 
         def operation(df):
-            return df.groupby(level=0).apply(lambda df: return_value)
+            return df.groupby(level=0).apply(
+                lambda df: return_value, include_groups=include_groups
+            )
 
         if return_value is None:
             # this is a pandas bug: https://github.com/pandas-dev/pandas/issues/57775
@@ -814,7 +860,7 @@ class TestFuncReturnsScalar:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_group_apply_return_df_from_lambda(self):
+    def test_group_apply_return_df_from_lambda(self, include_groups):
         diamonds_path = (
             pathlib.Path(__file__).parent.parent.parent.parent
             / "resources"
@@ -830,25 +876,17 @@ class TestFuncReturnsScalar:
                 lambda x: x.sort_values(
                     "price", ascending=False, kind="mergesort"
                 ).head(5),
-                include_groups=True,
+                include_groups=include_groups,
             ),
         )
 
-        with pytest.raises(
-            NotImplementedError,
-            match="No support for groupby.apply with include_groups = False",
-        ):
-            pd.DataFrame(diamonds_pd).groupby("cut").apply(
-                lambda x: x.sort_values("price", ascending=False).head(5),
-                include_groups=False,
-            )
-
     @pytest.mark.xfail(strict=True, raises=AssertionError, reason="SNOW-1619940")
-    def test_return_timedelta(self):
+    def test_return_timedelta(self, include_groups):
         eval_snowpark_pandas_result(
             *create_test_dfs([[1, 2]]),
             lambda df: df.groupby(0).apply(
-                lambda df: native_pd.Timedelta(df.sum().sum())
+                lambda df: native_pd.Timedelta(df.sum().sum()),
+                include_groups=include_groups,
             ),
         )
 
@@ -869,12 +907,16 @@ class TestFuncReturnsScalar:
             ),
         ],
     )
-    def test_timedelta_input(self, pandas_df):
+    def test_timedelta_input(self, pandas_df, include_groups):
         eval_snowpark_pandas_result(
-            *create_test_dfs(pandas_df), lambda df: df.groupby(0).apply(lambda df: 1)
+            *create_test_dfs(pandas_df),
+            lambda df: df.groupby(0).apply(lambda df: 1, include_groups=include_groups),
         )
 
 
+@pytest.mark.parametrize(
+    "include_groups", [True, False], ids=lambda v: f"include_groups_{v}"
+)
 class TestFuncReturnsSeries:
     @pytest.mark.parametrize(
         "by,level",
@@ -898,7 +940,14 @@ class TestFuncReturnsSeries:
         join_count=JOIN_COUNT,
     )
     def test_return_series_with_two_columns(
-        self, grouping_dfs_with_multiindexes, by, level, as_index, sort, group_keys
+        self,
+        grouping_dfs_with_multiindexes,
+        by,
+        level,
+        as_index,
+        sort,
+        group_keys,
+        include_groups,
     ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
@@ -909,11 +958,12 @@ class TestFuncReturnsSeries:
                     {
                         "custom_sum": group[("b", "int_col")].sum()
                         + group[("b", "int_col")].max(),
-                        "custom_string": group[("a", "string_col_1")].str.cat(sep="-")
+                        "custom_string": group[("b", "string_col_2")].str.cat(sep="-")
                         + group[("b", "string_col_2")].str.cat(sep="_"),
                     },
                     name="custom_metrics",
-                )
+                ),
+                include_groups=include_groups,
             ),
         )
 
@@ -922,7 +972,7 @@ class TestFuncReturnsSeries:
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
-    def test_args_and_kwargs(self, grouping_dfs_with_multiindexes):
+    def test_args_and_kwargs(self, grouping_dfs_with_multiindexes, include_groups):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby(level=0).apply(
@@ -938,6 +988,7 @@ class TestFuncReturnsSeries:
                 ),
                 7,
                 kwarg1="x",
+                include_groups=include_groups,
             ),
         )
 
@@ -949,7 +1000,7 @@ class TestFuncReturnsSeries:
         join_count=JOIN_COUNT + 1,
     )
     @pytest.mark.parametrize("index", [[2.0, np.nan, 2.0, 1.0], [np.nan] * 4])
-    def test_dropna(self, dropna, index):
+    def test_dropna(self, dropna, index, include_groups):
         pandas_index = native_pd.Index(index, name="index")
         if dropna and pandas_index.isna().all():
             pytest.xfail(
@@ -980,7 +1031,8 @@ class TestFuncReturnsSeries:
                         + group["string_col_2"].str.cat(sep="_"),
                     },
                     name="custom_metrics",
-                )
+                ),
+                include_groups=include_groups,
             ),
         )
 
@@ -991,7 +1043,7 @@ class TestFuncReturnsSeries:
         join_count=JOIN_COUNT,
     )
     def test_returning_series_with_different_names(
-        self, grouping_dfs_with_multiindexes
+        self, grouping_dfs_with_multiindexes, include_groups
     ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
@@ -1001,8 +1053,9 @@ class TestFuncReturnsSeries:
                         "int_sum": group[("b", "int_col")].sum(),
                         "string_sum": group[("b", "string_col_2")].astype(object).sum(),
                     },
-                    name="name_" + group[("a", "string_col_1")].iloc[0],
-                )
+                    name="name_" + str(group.iloc[0, 0]),
+                ),
+                include_groups=include_groups,
             ),
         )
 
@@ -1013,22 +1066,21 @@ class TestFuncReturnsSeries:
         join_count=JOIN_COUNT,
     )
     def test_returning_series_with_conflicting_indexes(
-        self, grouping_dfs_with_multiindexes
+        self, grouping_dfs_with_multiindexes, include_groups
     ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,
             lambda df: df.groupby(("a", "string_col_1")).apply(
                 lambda group: native_pd.Series(
                     {
-                        # Since we are grouping by ("a", "string_col_1"), the
-                        # series we return for each group will have a different index.
-                        group[("a", "string_col_1")]
-                        .iloc[0]: group[("b", "int_col")]
-                        .sum(),
-                        group[("a", "string_col_1")].iloc[0]
-                        + "_2": group[("b", "string_col_2")].astype(object).sum(),
+                        str(group[("b", "int_col")].iloc[0]): group[
+                            ("b", "int_col")
+                        ].sum(),
+                        str(group[("b", "int_col")].iloc[0])
+                        + "_2": group[("b", "int_col")].astype(object).sum(),
                     },
-                )
+                ),
+                include_groups=include_groups,
             ),
         )
 
@@ -1046,9 +1098,14 @@ class TestFuncReturnsSeries:
 @pytest.mark.parametrize("group_keys", [True, False], ids=lambda v: f"group_keys_{v}")
 @pytest.mark.parametrize("sort", [True, False], ids=lambda v: f"sort_{v}")
 @pytest.mark.parametrize("dropna", [True, False], ids=lambda v: f"dropna_{v}")
+@pytest.mark.parametrize(
+    "include_groups", [True, False], ids=lambda v: f"include_groups_{v}"
+)
 class TestSeriesGroupBy:
     @pytest.mark.parametrize("by", ["string_col_1", ["index", "string_col_1"], "index"])
-    def test_dataframe_groupby_getitem(self, by, func, dropna, group_keys, sort):
+    def test_dataframe_groupby_getitem(
+        self, by, func, dropna, group_keys, sort, include_groups
+    ):
         """Test apply() on a SeriesGroupBy that we get by DataFrameGroupBy.__getitem__"""
         qc = (
             QUERY_COUNT_WITH_TRANSFORM_CHECK
@@ -1083,22 +1140,32 @@ class TestSeriesGroupBy:
                     ),
                 ),
                 lambda df: df.groupby(
-                    by, dropna=dropna, group_keys=group_keys, sort=sort
-                )["int_col"].apply(func),
+                    by,
+                    dropna=dropna,
+                    group_keys=group_keys,
+                    sort=sort,
+                )["int_col"].apply(func, include_groups=include_groups),
             )
 
     @pytest.mark.xfail(strict=True, raises=NotImplementedError, reason="SNOW-1238546")
-    def test_grouping_series_by_self(self, func, dropna, group_keys, sort):
+    def test_grouping_series_by_self(
+        self, func, dropna, group_keys, sort, include_groups
+    ):
         """Test apply() on a SeriesGroupBy that we get by grouping a series by itself."""
         eval_snowpark_pandas_result(
             *create_test_series([0, 1, 2]),
             lambda s: s.groupby(
-                s, dropna=dropna, group_keys=group_keys, sort=sort
-            ).apply(func),
+                s,
+                dropna=dropna,
+                group_keys=group_keys,
+                sort=sort,
+            ).apply(func, include_groups=include_groups),
         )
 
     @pytest.mark.xfail(strict=True, raises=NotImplementedError, reason="SNOW-1238546")
-    def test_grouping_series_by_external_by(self, func, dropna, group_keys, sort):
+    def test_grouping_series_by_external_by(
+        self, func, dropna, group_keys, sort, include_groups
+    ):
         """Test apply() on a SeriesGroupBy that we get by grouping a series by its index."""
         # This example is from pandas SeriesGroupBy apply docstring.
         eval_snowpark_pandas_result(
@@ -1108,7 +1175,7 @@ class TestSeriesGroupBy:
                 dropna=dropna,
                 group_keys=group_keys,
                 sort=sort,
-            ).apply(func),
+            ).apply(func, include_groups=include_groups),
         )
 
 
@@ -1233,3 +1300,16 @@ class TestCallableWithMixedReturnTypes:
                 else native_pd.DataFrame([[2, 4], [5, 6]])
             ),
         )
+
+
+def test_include_groups_default_value(grouping_dfs_with_multiindexes):
+    """
+    Test that the default value behavior include_groups matches pandas.
+
+    We don't test the default include_groups value for all test cases
+    because that would substantially increase the size of the test suite.
+    """
+    eval_snowpark_pandas_result(
+        *grouping_dfs_with_multiindexes,
+        lambda df: df.groupby(("a", "string_col_1")).apply(lambda df: df.count()),
+    )


### PR DESCRIPTION
Support include_groups=False in groupby.apply.

When include_groups=False, we exclude grouping columns from the inputs to the user-supplied `func`.

This commit changes `func` in some groupby.apply tests where `func` assumes that the grouping columns are in the inputs.

Fixes SNOW-1847174
