### PR TITLE
SNOW-1871175: Add support for specifying a schema string for `DataFrame.create_dataframe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   - `try_to_binary`
 
 - Added `Catalog` class to manage snowflake objects. It can be accessed via `Session.catalog`.
+- Added support for specifying a schema string (including implicit struct syntax) when calling `DataFrame.create_dataframe`.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -993,8 +993,8 @@ def get_string_length(type_str: str) -> Optional[int]:
 
 def extract_bracket_content(type_str: str, keyword: str) -> str:
     """
-    Given a string that starts with e.g. 'array<', returns the content inside the top-level <...>.
-    e.g., "array<int>" => "int"
+    Given a string that starts with e.g. "array<", returns the content inside the top-level <...>.
+    e.g., "array<int>" => "int". It also parses the nested array like "array<array<...>>".
     Raises ValueError on mismatched or missing bracket.
     """
     prefix_pattern = rf"(?i)^\s*{keyword}\s*<"

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -969,6 +969,15 @@ DECIMAL_RE = re.compile(
 STRING_RE = re.compile(r"^\s*(varchar|string|text)\s*\(\s*(\d*)\s*\)\s*$")
 # support type string format like "  string  (  23  )  "
 
+ARRAY_RE = re.compile(r"(?i)^\s*array\s*<")
+# support type string format like starting with "array<..."
+
+MAP_RE = re.compile(r"(?i)^\s*map\s*<")
+# support type string format like starting with "map<..."
+
+STRUCT_RE = re.compile(r"(?i)^\s*struct\s*<")
+# support type string format like starting with "array<..." starting with "struct<..."
+
 
 def get_number_precision_scale(type_str: str) -> Optional[Tuple[int, int]]:
     decimal_matches = DECIMAL_RE.match(type_str)
@@ -982,7 +991,147 @@ def get_string_length(type_str: str) -> Optional[int]:
         return int(string_matches.group(2))
 
 
+def extract_bracket_content(type_str: str, keyword: str) -> str:
+    """
+    Given a string that starts with e.g. 'array<', returns the content inside the top-level <...>.
+    e.g., "array<int>" => "int"
+    Raises ValueError on mismatched or missing bracket.
+    """
+    prefix_pattern = rf"(?i)^\s*{keyword}\s*<"
+    match = re.match(prefix_pattern, type_str)
+    if not match:
+        raise ValueError(
+            f"'{type_str}' does not match expected '{keyword}<...>' syntax."
+        )
+
+    start_index = match.end() - 1  # position at '<'
+    bracket_depth = 0
+    inside_chars: List[str] = []
+    i = start_index
+    while i < len(type_str):
+        c = type_str[i]
+        if c == "<":
+            bracket_depth += 1
+            # we don't store the opening bracket in 'inside_chars'
+            # if bracket_depth was 0 -> 1, to skip the outer bracket
+            if bracket_depth > 1:
+                inside_chars.append(c)
+        elif c == ">":
+            bracket_depth -= 1
+            if bracket_depth < 0:
+                raise ValueError(f"Mismatched '>' in '{type_str}'")
+            if bracket_depth == 0:
+                if i != len(type_str) - 1:
+                    raise ValueError(
+                        f"Unexpected characters after closing '>' in '{type_str}'"
+                    )
+                # done
+                return "".join(inside_chars).strip()
+            inside_chars.append(c)
+        else:
+            inside_chars.append(c)
+        i += 1
+
+    raise ValueError(f"Missing closing '>' in '{type_str}'.")
+
+
+def parse_struct_field_list(fields_str: str) -> StructType:
+    """
+    Parse something like "a: int, b: string, c: array<int>"
+    into StructType([StructField('a', IntegerType()), ...]).
+    """
+    fields = []
+    field_defs = split_top_level_comma_fields(fields_str)
+    for field_def in field_defs:
+        # Try splitting on colon first, else whitespace
+        if ":" in field_def:
+            left, right = field_def.split(":", 1)
+        else:
+            parts = field_def.split(None, 1)
+            if len(parts) != 2:
+                raise ValueError(f"Cannot parse struct field definition: '{field_def}'")
+            left, right = parts[0], parts[1]
+
+        field_name = left.strip()
+        type_part = right.strip()
+        if not field_name:
+            raise ValueError(f"Struct field missing name in '{field_def}'")
+
+        field_type = type_string_to_type_object(type_part)
+        fields.append(StructField(field_name, field_type, nullable=True))
+
+    return StructType(fields)
+
+
+def split_top_level_comma_fields(s: str) -> List[str]:
+    """
+    Splits 's' by commas not enclosed in matching brackets.
+    Example: "int, array<long>, decimal(10,2)" => ["int", "array<long>", "decimal(10,2)"].
+    """
+    parts = []
+    bracket_depth = 0
+    start_idx = 0
+    for i, c in enumerate(s):
+        if c in ["<", "("]:
+            bracket_depth += 1
+        elif c in [">", ")"]:
+            bracket_depth -= 1
+            if bracket_depth < 0:
+                raise ValueError(f"Mismatched bracket in '{s}'.")
+        elif c == "," and bracket_depth == 0:
+            parts.append(s[start_idx:i].strip())
+            start_idx = i + 1
+    parts.append(s[start_idx:].strip())
+    return parts
+
+
+def is_likely_struct(s: str) -> bool:
+    """
+    Heuristic: If there's a top-level comma or colon outside brackets,
+    treat it like a struct with multiple fields, e.g. "a: int, b: string".
+    """
+    bracket_depth = 0
+    for c in s:
+        if c in ["<", "("]:
+            bracket_depth += 1
+        elif c in [">", ")"]:
+            bracket_depth -= 1
+        elif (c in [":", ","]) and bracket_depth == 0:
+            return True
+    return False
+
+
 def type_string_to_type_object(type_str: str) -> DataType:
+    type_str = type_str.strip()
+    if not type_str:
+        raise ValueError("Empty type string")
+
+    # First check if this might be a top-level multi-field struct
+    #    (e.g. "a: int, b: string") even if not written as "struct<...>"
+    if is_likely_struct(type_str):
+        return parse_struct_field_list(type_str)
+
+    # Check for array<...>
+    if ARRAY_RE.match(type_str):
+        inner = extract_bracket_content(type_str, "array")
+        element_type = type_string_to_type_object(inner)
+        return ArrayType(element_type)
+
+    # Check for map<key, value>
+    if MAP_RE.match(type_str):
+        inner = extract_bracket_content(type_str, "map")
+        parts = split_top_level_comma_fields(inner)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid map type definition: '{type_str}'")
+        key_type = type_string_to_type_object(parts[0])
+        val_type = type_string_to_type_object(parts[1])
+        return MapType(key_type, val_type)
+
+    # Check for explicit struct<...>
+    if STRUCT_RE.match(type_str):
+        inner = extract_bracket_content(type_str, "struct")
+        return parse_struct_field_list(inner)
+
     precision_scale = get_number_precision_scale(type_str)
     if precision_scale:
         return DecimalType(*precision_scale)

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -976,7 +976,7 @@ MAP_RE = re.compile(r"(?i)^\s*map\s*<")
 # support type string format like starting with "map<..."
 
 STRUCT_RE = re.compile(r"(?i)^\s*struct\s*<")
-# support type string format like starting with "array<..." starting with "struct<..."
+# support type string format like starting with "struct<..."
 
 
 def get_number_precision_scale(type_str: str) -> Optional[Tuple[int, int]]:

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -997,6 +997,7 @@ def extract_bracket_content(type_str: str, keyword: str) -> str:
     e.g., "array<int>" => "int". It also parses the nested array like "array<array<...>>".
     Raises ValueError on mismatched or missing bracket.
     """
+    type_str = type_str.strip()
     prefix_pattern = rf"(?i)^\s*{keyword}\s*<"
     match = re.match(prefix_pattern, type_str)
     if not match:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -3174,7 +3174,7 @@ class Session:
                     f"Invalid schema string: {schema}. "
                     f"You should provide a valid schema string representing a struct type."
                 )
-        if isinstance(schema, (StructType, str)):
+        if isinstance(schema, StructType):
             new_schema = schema
             # SELECT query has an undefined behavior for nullability, so if the schema requires non-nullable column and
             # all columns are primitive type columns, we use a temp table to lock in the nullabilities.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -95,6 +95,7 @@ from snowflake.snowpark._internal.type_utils import (
     infer_schema,
     infer_type,
     merge_type,
+    type_string_to_type_object,
 )
 from snowflake.snowpark._internal.udf_utils import generate_call_python_sp_sql
 from snowflake.snowpark._internal.utils import (
@@ -3029,7 +3030,7 @@ class Session:
     def create_dataframe(
         self,
         data: Union[List, Tuple, "pandas.DataFrame"],
-        schema: Optional[Union[StructType, Iterable[str]]] = None,
+        schema: Optional[Union[StructType, Iterable[str], str]] = None,
         _emit_ast: bool = True,
     ) -> DataFrame:
         """Creates a new DataFrame containing the specified values from the local data.
@@ -3046,9 +3047,15 @@ class Session:
                 ``data`` will constitute a row in the DataFrame.
             schema: A :class:`~snowflake.snowpark.types.StructType` containing names and
                 data types of columns, or a list of column names, or ``None``.
-                When ``schema`` is a list of column names or ``None``, the schema of the
-                DataFrame will be inferred from the data across all rows. To improve
-                performance, provide a schema. This avoids the need to infer data types
+
+                - When passing a **string**, it can be either an *explicit* struct
+                  (e.g. ``"struct<a: int, b: string>"``) or an *implicit* struct
+                  (e.g. ``"a: int, b: string"``). Internally, the string is parsed and
+                  converted into a :class:`StructType` using Snowpark's type parsing.
+                - When ``schema`` is a list of column names or ``None``, the schema of the
+                  DataFrame will be inferred from the data across all rows.
+
+                To improve performance, provide a schema. This avoids the need to infer data types
                 with large data sets.
 
         Examples::
@@ -3077,6 +3084,10 @@ class Session:
             >>> import pandas as pd
             >>> session.create_dataframe(pd.DataFrame([(1, 2, 3, 4)], columns=["a", "b", "c", "d"])).collect()
             [Row(a=1, b=2, c=3, d=4)]
+
+            >>> # create a dataframe using an implicit struct schema string
+            >>> session.create_dataframe([[10, 20], [30, 40]], schema="x: int, y: int").collect()
+            [Row(X=10, Y=20), Row(X=30, Y=40)]
 
         Note:
             When `data` is a pandas DataFrame, `snowflake.connector.pandas_tools.write_pandas` is called, which
@@ -3156,7 +3167,14 @@ class Session:
         # infer the schema based on the data
         names = None
         schema_query = None
-        if isinstance(schema, StructType):
+        if isinstance(schema, str):
+            schema = type_string_to_type_object(schema)
+            if not isinstance(schema, StructType):
+                raise ValueError(
+                    f"Invalid schema string: {schema}. "
+                    f"You should provide a valid schema string representing a struct type."
+                )
+        if isinstance(schema, (StructType, str)):
             new_schema = schema
             # SELECT query has an undefined behavior for nullability, so if the schema requires non-nullable column and
             # all columns are primitive type columns, we use a temp table to lock in the nullabilities.

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -43,6 +43,11 @@ from snowflake.snowpark._internal.type_utils import (
     retrieve_func_defaults_from_source,
     retrieve_func_type_hints_from_source,
     snow_type_to_dtype_str,
+    type_string_to_type_object,
+    is_likely_struct,
+    parse_struct_field_list,
+    split_top_level_comma_fields,
+    extract_bracket_content,
 )
 from snowflake.snowpark.types import (
     ArrayType,
@@ -1457,3 +1462,390 @@ def test_maptype_alias():
 
     assert tpe.valueType == tpe.value_type
     assert tpe.keyType == tpe.key_type
+
+
+def test_type_string_to_type_object_basic_int():
+    dt = type_string_to_type_object("int")
+    assert isinstance(dt, IntegerType), f"Expected IntegerType, got {dt}"
+
+
+def test_type_string_to_type_object_smallint():
+    dt = type_string_to_type_object("smallint")
+    assert isinstance(dt, ShortType), f"Expected ShortType, got {dt}"
+
+
+def test_type_string_to_type_object_byteint():
+    dt = type_string_to_type_object("byteint")
+    assert isinstance(dt, ByteType), f"Expected ByteType, got {dt}"
+
+
+def test_type_string_to_type_object_bigint():
+    dt = type_string_to_type_object("bigint")
+    assert isinstance(dt, LongType), f"Expected LongType, got {dt}"
+
+
+def test_type_string_to_type_object_number_decimal():
+    # For number(precision, scale) => DecimalType
+    dt = type_string_to_type_object("number(10,2)")
+    assert isinstance(dt, DecimalType), f"Expected DecimalType, got {dt}"
+    assert dt.precision == 10, f"Expected precision=10, got {dt.precision}"
+    assert dt.scale == 2, f"Expected scale=2, got {dt.scale}"
+
+
+def test_type_string_to_type_object_numeric_decimal():
+    dt = type_string_to_type_object("numeric(20, 5)")
+    assert isinstance(dt, DecimalType), f"Expected DecimalType, got {dt}"
+    assert dt.precision == 20, f"Expected precision=20, got {dt.precision}"
+    assert dt.scale == 5, f"Expected scale=5, got {dt.scale}"
+
+
+def test_type_string_to_type_object_decimal_spaces():
+    # Check spaces inside parentheses
+    dt = type_string_to_type_object("  decimal  (  2  ,  1  )  ")
+    assert isinstance(dt, DecimalType), f"Expected DecimalType, got {dt}"
+    assert dt.precision == 2, f"Expected precision=2, got {dt.precision}"
+    assert dt.scale == 1, f"Expected scale=1, got {dt.scale}"
+
+
+def test_type_string_to_type_object_string_with_length():
+    dt = type_string_to_type_object("string(50)")
+    assert isinstance(dt, StringType), f"Expected StringType, got {dt}"
+    # Snowpark's StringType typically doesn't store length internally,
+    # but here, you're returning StringType(50) in your code, so let's check
+    if hasattr(dt, "length"):
+        assert dt.length == 50, f"Expected length=50, got {dt.length}"
+
+
+def test_type_string_to_type_object_text_with_length():
+    dt = type_string_to_type_object("text(100)")
+    assert isinstance(dt, StringType), f"Expected StringType, got {dt}"
+    if hasattr(dt, "length"):
+        assert dt.length == 100, f"Expected length=100, got {dt.length}"
+
+
+def test_type_string_to_type_object_array_of_int():
+    dt = type_string_to_type_object("array<int>")
+    assert isinstance(dt, ArrayType), f"Expected ArrayType, got {dt}"
+    assert isinstance(
+        dt.element_type, IntegerType
+    ), f"Expected element_type=IntegerType, got {dt.element_type}"
+
+
+def test_type_string_to_type_object_array_of_decimal():
+    dt = type_string_to_type_object("array<decimal(10,2)>")
+    assert isinstance(dt, ArrayType), f"Expected ArrayType, got {dt}"
+    assert isinstance(
+        dt.element_type, DecimalType
+    ), f"Expected element_type=DecimalType, got {dt.element_type}"
+    assert dt.element_type.precision == 10
+    assert dt.element_type.scale == 2
+
+
+def test_type_string_to_type_object_map_of_int_string():
+    dt = type_string_to_type_object("map<int, string>")
+    assert isinstance(dt, MapType), f"Expected MapType, got {dt}"
+    assert isinstance(
+        dt.key_type, IntegerType
+    ), f"Expected key_type=IntegerType, got {dt.key_type}"
+    assert isinstance(
+        dt.value_type, StringType
+    ), f"Expected value_type=StringType, got {dt.value_type}"
+
+
+def test_type_string_to_type_object_map_of_array_decimal():
+    dt = type_string_to_type_object("map< array<int>, decimal(12,5)>")
+    assert isinstance(dt, MapType), f"Expected MapType, got {dt}"
+    assert isinstance(
+        dt.key_type, ArrayType
+    ), f"Expected key_type=ArrayType, got {dt.key_type}"
+    assert isinstance(
+        dt.key_type.element_type, IntegerType
+    ), f"Expected key_type.element_type=IntegerType, got {dt.key_type.element_type}"
+    assert isinstance(
+        dt.value_type, DecimalType
+    ), f"Expected value_type=DecimalType, got {dt.value_type}"
+    assert dt.value_type.precision == 12
+    assert dt.value_type.scale == 5
+
+
+def test_type_string_to_type_object_explicit_struct_simple():
+    dt = type_string_to_type_object("struct<a: int, b: string>")
+    assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
+    assert len(dt.fields) == 2, f"Expected 2 fields, got {len(dt.fields)}"
+
+    # Now assert exact StructField matches
+    expected_field_a = StructField("a", IntegerType(), nullable=True)
+    expected_field_b = StructField("b", StringType(), nullable=True)
+    assert (
+        dt.fields[0] == expected_field_a
+    ), f"Expected {expected_field_a}, got {dt.fields[0]}"
+    assert (
+        dt.fields[1] == expected_field_b
+    ), f"Expected {expected_field_b}, got {dt.fields[1]}"
+
+
+def test_type_string_to_type_object_explicit_struct_nested():
+    dt = type_string_to_type_object(
+        "struct<x: array<int>, y: map<string, decimal(5,2)>>"
+    )
+    assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
+    assert len(dt.fields) == 2, f"Expected 2 fields, got {len(dt.fields)}"
+
+    # Check each field directly against StructField(...)
+    expected_field_x = StructField("x", ArrayType(IntegerType()), nullable=True)
+    expected_field_y = StructField(
+        "y", MapType(StringType(), DecimalType(5, 2)), nullable=True
+    )
+
+    assert (
+        dt.fields[0] == expected_field_x
+    ), f"Expected {expected_field_x}, got {dt.fields[0]}"
+    assert (
+        dt.fields[1] == expected_field_y
+    ), f"Expected {expected_field_y}, got {dt.fields[1]}"
+
+
+def test_type_string_to_type_object_unknown_type():
+    try:
+        type_string_to_type_object("unknown_type")
+        raise AssertionError("Expected ValueError for unknown type")
+    except ValueError as ex:
+        assert "unknown_type" in str(
+            ex
+        ), f"Error message doesn't mention 'unknown_type': {ex}"
+
+
+def test_type_string_to_type_object_mismatched_bracket_array():
+    try:
+        type_string_to_type_object("array<int")
+        raise AssertionError("Expected ValueError for mismatched bracket")
+    except ValueError as ex:
+        assert "Missing closing" in str(ex) or "Mismatched" in str(
+            ex
+        ), f"Expected bracket mismatch error, got: {ex}"
+
+
+def test_type_string_to_type_object_mismatched_bracket_map():
+    try:
+        print(type_string_to_type_object("map<int, string>>"))
+        raise AssertionError("Expected ValueError for mismatched bracket")
+    except ValueError as ex:
+        assert "Unexpected characters after closing '>' in" in str(
+            ex
+        ), f"Expected Unexpected characters after closing '>' error, got: {ex}"
+
+
+def test_type_string_to_type_object_bad_decimal():
+    try:
+        type_string_to_type_object("decimal(10,2,5)")
+        raise AssertionError("Expected ValueError for a malformed decimal argument")
+    except ValueError:
+        # "decimal(10,2,5)" doesn't match the DECIMAL_RE regex => unknown type => ValueError
+        pass
+
+
+def test_type_string_to_type_object_bad_struct_syntax():
+    try:
+        type_string_to_type_object("struct<x int, y: string")
+        raise AssertionError(
+            "Expected ValueError for mismatched bracket or parse error"
+        )
+    except ValueError as ex:
+        assert (
+            "Missing closing" in str(ex)
+            or "Mismatched" in str(ex)
+            or "syntax" in str(ex).lower()
+        ), f"Expected bracket or parse syntax error, got: {ex}"
+
+
+def test_type_string_to_type_object_implicit_struct_simple():
+    """
+    Verify that a comma-separated list of 'name: type' fields parses as a StructType,
+    even without 'struct<...>'.
+    """
+    dt = type_string_to_type_object("a: int, b: string")
+    assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
+    assert len(dt.fields) == 2, f"Expected 2 fields, got {len(dt.fields)}"
+
+    expected_field_a = StructField("a", IntegerType(), nullable=True)
+    expected_field_b = StructField("b", StringType(), nullable=True)
+
+    assert (
+        dt.fields[0] == expected_field_a
+    ), f"Expected {expected_field_a}, got {dt.fields[0]}"
+    assert (
+        dt.fields[1] == expected_field_b
+    ), f"Expected {expected_field_b}, got {dt.fields[1]}"
+
+
+def test_type_string_to_type_object_implicit_struct_single_field():
+    """
+    Even a single 'name: type' with no commas should parse to StructType
+    if your parser logic treats it as an implicit struct.
+    """
+    dt = type_string_to_type_object("c: decimal(10,2)")
+    assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
+    assert len(dt.fields) == 1, f"Expected 1 field, got {len(dt.fields)}"
+
+    expected_field_c = StructField("c", DecimalType(10, 2), nullable=True)
+    assert (
+        dt.fields[0] == expected_field_c
+    ), f"Expected {expected_field_c}, got {dt.fields[0]}"
+
+
+def test_type_string_to_type_object_implicit_struct_nested():
+    """
+    Test an implicit struct with multiple fields,
+    including nested array/map types.
+    """
+    dt = type_string_to_type_object("arr: array<int>, kv: map<string, decimal(5,2)>")
+    assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
+    assert len(dt.fields) == 2, f"Expected 2 fields, got {len(dt.fields)}"
+
+    expected_field_arr = StructField("arr", ArrayType(IntegerType()), nullable=True)
+    expected_field_kv = StructField(
+        "kv", MapType(StringType(), DecimalType(5, 2)), nullable=True
+    )
+
+    assert (
+        dt.fields[0] == expected_field_arr
+    ), f"Expected {expected_field_arr}, got {dt.fields[0]}"
+    assert (
+        dt.fields[1] == expected_field_kv
+    ), f"Expected {expected_field_kv}, got {dt.fields[1]}"
+
+
+def test_type_string_to_type_object_implicit_struct_with_spaces():
+    """
+    Test spacing variations. E.g. "  col1  :   int  ,  col2  :  map< string , decimal(5,2) >  ".
+    """
+    dt = type_string_to_type_object(
+        "  col1 :  int  ,  col2 :   map< string , decimal(5,2) > "
+    )
+    assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
+    assert len(dt.fields) == 2, f"Expected 2 fields, got {len(dt.fields)}"
+
+    expected_field_col1 = StructField("col1", IntegerType(), nullable=True)
+    expected_field_col2 = StructField(
+        "col2", MapType(StringType(), DecimalType(5, 2)), nullable=True
+    )
+
+    assert (
+        dt.fields[0] == expected_field_col1
+    ), f"Expected {expected_field_col1}, got {dt.fields[0]}"
+    assert (
+        dt.fields[1] == expected_field_col2
+    ), f"Expected {expected_field_col2}, got {dt.fields[1]}"
+
+
+def test_type_string_to_type_object_implicit_struct_error():
+    """
+    Check a malformed implicit struct that should raise ValueError
+    (e.g. trailing comma or missing bracket for nested).
+    """
+    try:
+        type_string_to_type_object("a: int, b:")
+        raise AssertionError("Expected ValueError for malformed struct (b: )")
+    except ValueError as ex:
+        # We expect an error message about Empty type string
+        assert "Empty type string" in str(
+            ex
+        ), f"Expected error 'Empty type string', got: {ex}"
+
+    try:
+        type_string_to_type_object("arr: array<int, b: string")
+        raise AssertionError("Expected ValueError for mismatched bracket")
+    except ValueError as ex:
+        # We expect an error about bracket mismatch or missing '>'
+        assert "Missing closing" in str(
+            ex
+        ), f"Expected Missing closing error, got: {ex}"
+
+
+def test_extract_bracket_content_array_ok():
+    s = "array<int>"
+    # We expect to extract "int" from inside <...>
+    content = extract_bracket_content(s, keyword="array")
+    assert content == "int", f"Expected 'int', got {content}"
+
+
+def test_extract_bracket_content_map_spaces():
+    s = " map< int , string >"
+    content = extract_bracket_content(s, keyword="map")
+    assert content == "int , string", f"Expected 'int , string', got {content}"
+
+
+def test_extract_bracket_content_missing_closing():
+    s = "array<int"
+    try:
+        extract_bracket_content(s, keyword="array")
+        raise AssertionError("Expected ValueError for missing '>'")
+    except ValueError as ex:
+        assert (
+            "Missing closing" in str(ex) or "mismatched" in str(ex).lower()
+        ), f"Error does not mention missing bracket: {ex}"
+
+
+def test_extract_bracket_content_mismatched_extra_close():
+    s = "struct<a: int>>"
+    try:
+        extract_bracket_content(s, keyword="struct")
+        raise AssertionError("Expected ValueError for extra '>'")
+    except ValueError as ex:
+        assert "Unexpected characters after closing '>' in" in str(
+            ex
+        ), f"Error does not mention Unexpected characters after closing '>' in: {ex}"
+
+
+def test_split_top_level_comma_fields_no_brackets():
+    s = "int, string, decimal(10,2)"
+    parts = split_top_level_comma_fields(s)
+    assert parts == ["int", "string", "decimal(10,2)"], f"Got unexpected parts: {parts}"
+
+
+def test_split_top_level_comma_fields_nested_brackets():
+    s = "int, array<long>, decimal(10,2), map<int, array<string>>"
+    parts = split_top_level_comma_fields(s)
+    assert parts == [
+        "int",
+        "array<long>",
+        "decimal(10,2)",
+        "map<int, array<string>>",
+    ], f"Got unexpected parts: {parts}"
+
+
+def test_parse_struct_field_list_simple():
+    s = "a: int, b: string"
+    struct_type = parse_struct_field_list(s)
+    assert (
+        len(struct_type.fields) == 2
+    ), f"Expected 2 fields, got {len(struct_type.fields)}"
+    # Direct equality checks on each StructField
+    from snowflake.snowpark.types import StructField, IntegerType, StringType
+
+    assert struct_type.fields[0] == StructField("a", IntegerType(), nullable=True)
+    assert struct_type.fields[1] == StructField("b", StringType(), nullable=True)
+
+
+def test_parse_struct_field_list_malformed():
+    s = "col1: int, col2"
+    try:
+        parse_struct_field_list(s)
+        raise AssertionError("Expected ValueError for missing type in 'col2'")
+    except ValueError as ex:
+        assert (
+            "Cannot parse struct field definition" in str(ex)
+            or "missing" in str(ex).lower()
+        ), f"Unexpected error message: {ex}"
+
+
+def test_is_likely_struct_true():
+    # top-level colon => likely struct
+    s = "a: int, b: string"
+    assert is_likely_struct(s) is True, "Expected True for struct-like string"
+
+
+def test_is_likely_struct_false():
+    # No top-level colon or comma => not a struct
+    s = "array<int>"
+    assert is_likely_struct(s) is False, "Expected False for non-struct string"

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1540,6 +1540,14 @@ def test_type_string_to_type_object_array_of_decimal():
     assert dt.element_type.precision == 10
     assert dt.element_type.scale == 2
 
+    try:
+        type_string_to_type_object("array<decimal(10,2>")
+        raise AssertionError("Expected ValueError for not a supported type")
+    except ValueError as ex:
+        assert "is not a supported type" in str(
+            ex
+        ), f"Expected not a supported type, got: {ex}"
+
 
 def test_type_string_to_type_object_map_of_int_string():
     dt = type_string_to_type_object("map<int, string>")
@@ -1720,7 +1728,7 @@ def test_type_string_to_type_object_implicit_struct_with_spaces():
     Test spacing variations. E.g. "  col1  :   int  ,  col2  :  map< string , decimal(5,2) >  ".
     """
     dt = type_string_to_type_object(
-        "  col1 :  int  ,  col2 :   map< string , decimal(5,2) > "
+        "  col1 :  int  ,  col2 :   map< string , decimal( 5 , 2 ) > "
     )
     assert isinstance(dt, StructType), f"Expected StructType, got {dt}"
     assert len(dt.fields) == 2, f"Expected 2 fields, got {len(dt.fields)}"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1871175

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Support schema string 
