### PR TITLE
Disable python 3.8 incompatible doctest

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -538,13 +538,9 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
         # only run doctest for macos on aws
-      - name: Check Resources
-        run: |
-          df -h
-          free
       - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
         name: Run Snowpark pandas API doctests
-        run: python -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci"
+        run: python -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci" -vvvvv
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -552,7 +552,7 @@ jobs:
         # do not run other tests for macos on aws
       - if: ${{ !(matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws') }}
         name: Run Snowpark pandas API tests (excluding doctests)
-        run: python -m tox -e "py${PYTHON_VERSION/\./}-snowparkpandasnotdoctest-modin-ci"
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-snowparkpandasnotdoctest-modin-ci" -vvvvv
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -540,7 +540,7 @@ jobs:
         # only run doctest for macos on aws
       - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
         name: Run Snowpark pandas API doctests
-        run: python -u -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci" -vvvvv
+        run: python -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
@@ -552,7 +552,7 @@ jobs:
         # do not run other tests for macos on aws
       - if: ${{ !(matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws') }}
         name: Run Snowpark pandas API tests (excluding doctests)
-        run: python -u -m tox -e "py${PYTHON_VERSION/\./}-snowparkpandasnotdoctest-modin-ci" -vvvvv
+        run: python -m tox -e "py${PYTHON_VERSION/\./}-snowparkpandasnotdoctest-modin-ci"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -538,6 +538,10 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
         # only run doctest for macos on aws
+      - name: Check Resources
+        run: |
+          df -h
+          free
       - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
         name: Run Snowpark pandas API doctests
         run: python -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci"

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -540,7 +540,7 @@ jobs:
         # only run doctest for macos on aws
       - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
         name: Run Snowpark pandas API doctests
-        run: python -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci" -vvvvv
+        run: python -u -m tox -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci" -vvvvv
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}
@@ -552,7 +552,7 @@ jobs:
         # do not run other tests for macos on aws
       - if: ${{ !(matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws') }}
         name: Run Snowpark pandas API tests (excluding doctests)
-        run: python -m tox -e "py${PYTHON_VERSION/\./}-snowparkpandasnotdoctest-modin-ci" -vvvvv
+        run: python -u -m tox -e "py${PYTHON_VERSION/\./}-snowparkpandasnotdoctest-modin-ci" -vvvvv
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -41,6 +41,27 @@ def pytest_runtest_makereport(item, call):
     return tr
 
 
+# These tests require python packages that are no longer built for python 3.8
+PYTHON_38_SKIPS = {
+    "snowpark.session.Session.replicate_local_environment",
+    "snowpark.session.Session.table_function",
+}
+
+DocTestFinder = doctest.DocTestFinder
+
+
+class CustomDocTestFinder(DocTestFinder):
+    def _find(self, tests, obj, name, module, source_lines, globs, seen):
+        if name in PYTHON_38_SKIPS and sys.version_info < (3, 9):
+            return
+        return DocTestFinder._find(
+            self, tests, obj, name, module, source_lines, globs, seen
+        )
+
+
+doctest.DocTestFinder = CustomDocTestFinder
+
+
 # scope is module so that we ensure we delete the session before
 # moving onto running the tests in the tests dir. Having only one
 # session is important to certain UDF tests to pass , since they


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Two of the doctests for snowflake.snowpark.Session require packages that are not available anymore for python 3.8 which causes a failure in our daily precommit tests. To fix this there are a few options:
   
1 Skip the doctests entirely.
2 Add some code in the doctest that skips it conditionally.
3 Intercept the doctest finder so that it does not include those tests when running in python 3.8.

I've opted for option 3 so that the tests can still be run on other python versions and there isn't code that might be confusing to readers in the examples.