### PR TITLE
SNOW-1873529: Add support for empty semi-structured StructType and ArrayType to ast

### DIFF
--- a/scripts/copy-remote-ast.sh
+++ b/scripts/copy-remote-ast.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # This script assumes the target Cloud Workspace specified as the command-line argument has the build target.
 # To make sure this is the case, run bazel build //Snowpark/ast:ast_proto and bazel build //Snowpark/unparser.

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -281,7 +281,7 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
     if isinstance(data_type, StructType):
         if data_type.structured:
             schema_strings = []
-            for field in data_type.fields:
+            for field in data_type.fields or []:
                 # Even if nulls are allowed the cast will fail due to schema mismatch when passed a null field.
                 schema_strings += [
                     f"'{field.name}'",

--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -339,7 +339,7 @@ def build_proto_from_struct_type(
 
     expr.structured = schema.structured
     for field in schema.fields:
-        ast_field = expr.fields.add()
+        ast_field = expr.fields.list.add()
         field.column_identifier._fill_ast(ast_field.column_identifier)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "ColumnIdentifier" has no attribute "_fill_ast"
         field.datatype._fill_ast(ast_field.data_type)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
         ast_field.nullable = field.nullable

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -89,7 +89,7 @@ message PythonTimeZone {
   int64 offset_seconds = 2;
 }
 
-// sp-type.ir:70
+// sp-type.ir:71
 message SpCallable {
   int64 id = 1;
   string name = 2;
@@ -136,71 +136,71 @@ message SpDataType {
   }
 }
 
-// sp-type.ir:27
+// sp-type.ir:28
 message SpArrayType {
   bool structured = 1;
   SpDataType ty = 2;
 }
 
-// sp-type.ir:31
+// sp-type.ir:32
 message SpColumnIdentifier {
   string name = 1;
 }
 
-// sp-type.ir:33
+// sp-type.ir:34
 message SpDecimalType {
   int64 precision = 1;
   int64 scale = 2;
 }
 
-// sp-type.ir:40
+// sp-type.ir:41
 message SpMapType {
   SpDataType key_ty = 1;
   bool structured = 2;
   SpDataType value_ty = 3;
 }
 
-// sp-type.ir:43
+// sp-type.ir:44
 message SpStringType {
   google.protobuf.Int64Value length = 1;
 }
 
-// sp-type.ir:44
+// sp-type.ir:45
 message SpStructField {
   SpColumnIdentifier column_identifier = 1;
   SpDataType data_type = 2;
   bool nullable = 3;
 }
 
-// sp-type.ir:45
+// sp-type.ir:46
 message SpStructType {
   repeated SpStructField fields = 1;
   bool structured = 2;
 }
 
-// sp-type.ir:47
+// sp-type.ir:48
 message SpTimestampType {
   SpTimestampTimeZone time_zone = 1;
 }
 
-// sp-type.ir:49
+// sp-type.ir:50
 message SpVectorType {
   int64 dimension = 1;
   SpDataType ty = 2;
 }
 
-// sp-type.ir:51
+// sp-type.ir:52
 message SpPandasSeriesType {
   SpDataType el_ty = 1;
 }
 
-// sp-type.ir:52
+// sp-type.ir:53
 message SpPandasDataFrameType {
   repeated string col_names = 1;
   repeated SpDataType col_types = 2;
 }
 
-// sp-type.ir:59
+// sp-type.ir:60
 message SpDataframeData {
   oneof sealed_value {
     SpDataframeData_List sp_dataframe_data__list = 1;
@@ -209,22 +209,22 @@ message SpDataframeData {
   }
 }
 
-// sp-type.ir:60
+// sp-type.ir:61
 message SpDataframeData_List {
   repeated Expr vs = 1;
 }
 
-// sp-type.ir:61
+// sp-type.ir:62
 message SpDataframeData_Tuple {
   repeated Expr vs = 1;
 }
 
-// sp-type.ir:62
+// sp-type.ir:63
 message SpDataframeData_Pandas {
   StagedPandasDataframe v = 1;
 }
 
-// sp-type.ir:65
+// sp-type.ir:66
 message SpDataframeSchema {
   oneof sealed_value {
     SpDataframeSchema_List sp_dataframe_schema__list = 1;
@@ -232,12 +232,12 @@ message SpDataframeSchema {
   }
 }
 
-// sp-type.ir:66
+// sp-type.ir:67
 message SpDataframeSchema_List {
   repeated string vs = 1;
 }
 
-// sp-type.ir:67
+// sp-type.ir:68
 message SpDataframeSchema_Struct {
   SpStructType v = 1;
 }
@@ -292,7 +292,7 @@ message SpNullOrder {
   }
 }
 
-// sp-type.ir:82
+// sp-type.ir:83
 message SpPivotValue {
   oneof sealed_value {
     SpPivotValue_Dataframe sp_pivot_value__dataframe = 1;
@@ -300,12 +300,12 @@ message SpPivotValue {
   }
 }
 
-// sp-type.ir:83
+// sp-type.ir:84
 message SpPivotValue_Expr {
   Expr v = 1;
 }
 
-// sp-type.ir:84
+// sp-type.ir:85
 message SpPivotValue_Dataframe {
   SpDataframeRef v = 1;
 }
@@ -363,7 +363,7 @@ message SrcPosition {
   int64 start_line = 5;
 }
 
-// sp-type.ir:55
+// sp-type.ir:56
 message StagedPandasDataframe {
   SpNameRef temp_table = 1;
 }

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -22,6 +22,10 @@ message List_SpDataType {
   repeated SpDataType list = 1;
 }
 
+message List_SpStructField {
+  repeated SpStructField list = 1;
+}
+
 message List_String {
   repeated string list = 1;
 }
@@ -89,7 +93,7 @@ message PythonTimeZone {
   int64 offset_seconds = 2;
 }
 
-// sp-type.ir:71
+// sp-type.ir:72
 message SpCallable {
   int64 id = 1;
   string name = 2;
@@ -172,35 +176,35 @@ message SpStructField {
   bool nullable = 3;
 }
 
-// sp-type.ir:46
+// sp-type.ir:47
 message SpStructType {
-  repeated SpStructField fields = 1;
+  List_SpStructField fields = 1;
   bool structured = 2;
 }
 
-// sp-type.ir:48
+// sp-type.ir:49
 message SpTimestampType {
   SpTimestampTimeZone time_zone = 1;
 }
 
-// sp-type.ir:50
+// sp-type.ir:51
 message SpVectorType {
   int64 dimension = 1;
   SpDataType ty = 2;
 }
 
-// sp-type.ir:52
+// sp-type.ir:53
 message SpPandasSeriesType {
   SpDataType el_ty = 1;
 }
 
-// sp-type.ir:53
+// sp-type.ir:54
 message SpPandasDataFrameType {
   repeated string col_names = 1;
   repeated SpDataType col_types = 2;
 }
 
-// sp-type.ir:60
+// sp-type.ir:61
 message SpDataframeData {
   oneof sealed_value {
     SpDataframeData_List sp_dataframe_data__list = 1;
@@ -209,22 +213,22 @@ message SpDataframeData {
   }
 }
 
-// sp-type.ir:61
+// sp-type.ir:62
 message SpDataframeData_List {
   repeated Expr vs = 1;
 }
 
-// sp-type.ir:62
+// sp-type.ir:63
 message SpDataframeData_Tuple {
   repeated Expr vs = 1;
 }
 
-// sp-type.ir:63
+// sp-type.ir:64
 message SpDataframeData_Pandas {
   StagedPandasDataframe v = 1;
 }
 
-// sp-type.ir:66
+// sp-type.ir:67
 message SpDataframeSchema {
   oneof sealed_value {
     SpDataframeSchema_List sp_dataframe_schema__list = 1;
@@ -232,12 +236,12 @@ message SpDataframeSchema {
   }
 }
 
-// sp-type.ir:67
+// sp-type.ir:68
 message SpDataframeSchema_List {
   repeated string vs = 1;
 }
 
-// sp-type.ir:68
+// sp-type.ir:69
 message SpDataframeSchema_Struct {
   SpStructType v = 1;
 }
@@ -292,7 +296,7 @@ message SpNullOrder {
   }
 }
 
-// sp-type.ir:83
+// sp-type.ir:84
 message SpPivotValue {
   oneof sealed_value {
     SpPivotValue_Dataframe sp_pivot_value__dataframe = 1;
@@ -300,12 +304,12 @@ message SpPivotValue {
   }
 }
 
-// sp-type.ir:84
+// sp-type.ir:85
 message SpPivotValue_Expr {
   Expr v = 1;
 }
 
-// sp-type.ir:85
+// sp-type.ir:86
 message SpPivotValue_Dataframe {
   SpDataframeRef v = 1;
 }
@@ -363,7 +367,7 @@ message SrcPosition {
   int64 start_line = 5;
 }
 
-// sp-type.ir:56
+// sp-type.ir:57
 message StagedPandasDataframe {
   SpNameRef temp_table = 1;
 }

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -93,7 +93,7 @@ message PythonTimeZone {
   int64 offset_seconds = 2;
 }
 
-// sp-type.ir:72
+// sp-type.ir:71
 message SpCallable {
   int64 id = 1;
   string name = 2;
@@ -176,35 +176,35 @@ message SpStructField {
   bool nullable = 3;
 }
 
-// sp-type.ir:47
+// sp-type.ir:46
 message SpStructType {
   List_SpStructField fields = 1;
   bool structured = 2;
 }
 
-// sp-type.ir:49
+// sp-type.ir:48
 message SpTimestampType {
   SpTimestampTimeZone time_zone = 1;
 }
 
-// sp-type.ir:51
+// sp-type.ir:50
 message SpVectorType {
   int64 dimension = 1;
   SpDataType ty = 2;
 }
 
-// sp-type.ir:53
+// sp-type.ir:52
 message SpPandasSeriesType {
   SpDataType el_ty = 1;
 }
 
-// sp-type.ir:54
+// sp-type.ir:53
 message SpPandasDataFrameType {
   repeated string col_names = 1;
   repeated SpDataType col_types = 2;
 }
 
-// sp-type.ir:61
+// sp-type.ir:60
 message SpDataframeData {
   oneof sealed_value {
     SpDataframeData_List sp_dataframe_data__list = 1;
@@ -213,22 +213,22 @@ message SpDataframeData {
   }
 }
 
-// sp-type.ir:62
+// sp-type.ir:61
 message SpDataframeData_List {
   repeated Expr vs = 1;
 }
 
-// sp-type.ir:63
+// sp-type.ir:62
 message SpDataframeData_Tuple {
   repeated Expr vs = 1;
 }
 
-// sp-type.ir:64
+// sp-type.ir:63
 message SpDataframeData_Pandas {
   StagedPandasDataframe v = 1;
 }
 
-// sp-type.ir:67
+// sp-type.ir:66
 message SpDataframeSchema {
   oneof sealed_value {
     SpDataframeSchema_List sp_dataframe_schema__list = 1;
@@ -236,12 +236,12 @@ message SpDataframeSchema {
   }
 }
 
-// sp-type.ir:68
+// sp-type.ir:67
 message SpDataframeSchema_List {
   repeated string vs = 1;
 }
 
-// sp-type.ir:69
+// sp-type.ir:68
 message SpDataframeSchema_Struct {
   SpStructType v = 1;
 }
@@ -296,7 +296,7 @@ message SpNullOrder {
   }
 }
 
-// sp-type.ir:84
+// sp-type.ir:83
 message SpPivotValue {
   oneof sealed_value {
     SpPivotValue_Dataframe sp_pivot_value__dataframe = 1;
@@ -304,12 +304,12 @@ message SpPivotValue {
   }
 }
 
-// sp-type.ir:85
+// sp-type.ir:84
 message SpPivotValue_Expr {
   Expr v = 1;
 }
 
-// sp-type.ir:86
+// sp-type.ir:85
 message SpPivotValue_Dataframe {
   SpDataframeRef v = 1;
 }
@@ -367,7 +367,7 @@ message SrcPosition {
   int64 start_line = 5;
 }
 
-// sp-type.ir:57
+// sp-type.ir:56
 message StagedPandasDataframe {
   SpNameRef temp_table = 1;
 }

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -188,15 +188,18 @@ def convert_sf_to_sp_type(
     max_string_size: int,
 ) -> DataType:
     """Convert the Snowflake logical type to the Snowpark type."""
-    semi_structured_fill = (
-        None if context._should_use_structured_type_semantics() else StringType()
-    )
+    new_semantics = context._should_use_structured_type_semantics()
+    semi_structured_fill = None if new_semantics else StringType()
     if column_type_name == "ARRAY":
         return ArrayType(semi_structured_fill)
     if column_type_name == "VARIANT":
         return VariantType()
-    if column_type_name in {"OBJECT", "MAP"}:
+    if column_type_name == "MAP" or (
+        column_type_name == "OBJECT" and not new_semantics
+    ):
         return MapType(semi_structured_fill, semi_structured_fill)
+    if column_type_name == "OBJECT" and new_semantics:
+        return StructType()
     if column_type_name == "GEOGRAPHY":
         return GeographyType()
     if column_type_name == "GEOMETRY":

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -672,6 +672,12 @@ def python_type_to_snow_type(
             if tp_args
             else None
         )
+        if (
+            key_type is None
+            and value_type is None
+            and context._should_use_structured_type_semantics()
+        ):
+            return StructType(), False
         return MapType(key_type, value_type), False
 
     if installed_pandas:

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1261,6 +1261,7 @@ def create_python_udf_or_sp(
     if replace and if_not_exists:
         raise ValueError("options replace and if_not_exists are incompatible")
     if isinstance(return_type, StructType) and not return_type.structured:
+        # sprocs can return tables without columns defined, but other udxfs expect the return type to be OBJECT in these cases
         if return_type.fields is None and object_type is not TempObjectType.PROCEDURE:
             return_sql = "RETURNS OBJECT"
         else:

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -398,7 +398,11 @@ class MapType(DataType):
         structured: Optional[bool] = None,
     ) -> None:
         if context._should_use_structured_type_semantics():
-            self.structured = True  # Snowflake has no unstructured MapTypes
+            if key_type is None or value_type is None:
+                raise ValueError(
+                    "MapType requires both key and value type be defined. For semi-structured OBJECT use StructType()"
+                )
+            self.structured = True  # Snowflake has no unstructured MAP
         else:
             self.structured = structured or False
         self.key_type = key_type if key_type else StringType()
@@ -773,8 +777,8 @@ class StructType(DataType):
 
     def _fill_ast(self, ast: proto.SpDataType) -> None:
         ast.sp_struct_type.structured = self.structured
-        for field in self.fields:
-            field._fill_ast(ast.sp_struct_type.fields.add())
+        for field in self.fields or []:
+            field._fill_ast(ast.sp_struct_type.fields.list.add())
 
 
 class VariantType(DataType):

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -384,10 +384,6 @@ class ArrayType(DataType):
 
     def _fill_ast(self, ast: proto.SpDataType) -> None:
         ast.sp_array_type.structured = self.structured
-        if self.element_type is None:
-            raise NotImplementedError(
-                "SNOW-1862700: AST does not support empty element_type."
-            )
         self.element_type._fill_ast(ast.sp_array_type.ty)
 
 
@@ -401,15 +397,9 @@ class MapType(DataType):
         structured: Optional[bool] = None,
     ) -> None:
         if context._should_use_structured_type_semantics():
-            if (key_type is None and value_type is not None) or (
-                key_type is not None and value_type is None
-            ):
-                raise ValueError(
-                    "Must either set both key_type and value_type or leave both unset."
-                )
-            self.structured = (
-                structured if structured is not None else key_type is not None
-            )
+            if key_type is None or value_type is None:
+                raise ValueError("MapType requires both a key and value type be set.")
+            self.structured = True  # Snowflake has no unstructured MapTypes
             self.key_type = key_type
             self.value_type = value_type
         else:
@@ -473,10 +463,6 @@ class MapType(DataType):
 
     def _fill_ast(self, ast: proto.SpDataType) -> None:
         ast.sp_map_type.structured = self.structured
-        if self.key_type is None or self.value_type is None:
-            raise NotImplementedError(
-                "SNOW-1862700: AST does not support empty key or value type."
-            )
         self.key_type._fill_ast(ast.sp_map_type.key_ty)
         self.value_type._fill_ast(ast.sp_map_type.value_ty)
 

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -402,7 +402,7 @@ class MapType(DataType):
                 raise ValueError(
                     "MapType requires both key and value type be defined. For semi-structured OBJECT use StructType()"
                 )
-            self.structured = True  # Snowflake has no unstructured MAP
+            self.structured = True  # Snowflake has no semi-structured MAP
         else:
             self.structured = structured or False
         self.key_type = key_type if key_type else StringType()

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import snowflake.snowpark
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
+import snowflake.snowpark.context as context
 from snowflake.connector import ProgrammingError
 from snowflake.snowpark._internal.analyzer.expression import Expression, SnowflakeUDF
 from snowflake.snowpark._internal.ast.utils import (
@@ -717,7 +718,10 @@ class UDAFRegistration:
                     "_do_register_udaf",
                     "Snowflake does not support structured maps as return type for UDAFs. Downcasting to semi-structured object.",
                 )
-                return_type = StructType()
+                if context._should_use_structured_type_semantics():
+                    return_type = StructType()
+                else:
+                    return_type = MapType()
 
         # Capture original parameters.
         if _emit_ast:

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -40,7 +40,7 @@ from snowflake.snowpark._internal.utils import (
     warning,
 )
 from snowflake.snowpark.column import Column
-from snowflake.snowpark.types import DataType, MapType
+from snowflake.snowpark.types import DataType, MapType, StructType
 
 # Python 3.8 needs to use typing.Iterable because collections.abc.Iterable is not subscriptable
 # Python 3.9 can use both
@@ -717,7 +717,7 @@ class UDAFRegistration:
                     "_do_register_udaf",
                     "Snowflake does not support structured maps as return type for UDAFs. Downcasting to semi-structured object.",
                 )
-                return_type = MapType()
+                return_type = StructType()
 
         # Capture original parameters.
         if _emit_ast:

--- a/tests/ast/data/DataFrame.agg.test
+++ b/tests/ast/data/DataFrame.agg.test
@@ -31,13 +31,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 82
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 1
@@ -46,7 +52,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 2
@@ -57,13 +66,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 82
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 3
@@ -72,7 +87,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 4
@@ -83,13 +101,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 82
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 1
@@ -98,7 +122,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 27
                     }
                     v: 4
@@ -115,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 82
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -170,20 +200,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 36
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 29
                       }
                       v: "a"
                     }
                   }
                   src {
+                    end_column: 36
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 37
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 29
               }
             }
@@ -217,20 +256,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 58
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 50
                         start_line: 29
                       }
                       v: "a"
                     }
                   }
                   src {
+                    end_column: 58
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 50
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 59
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 39
                 start_line: 29
               }
             }
@@ -238,7 +286,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 60
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -267,13 +318,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 48
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "a"
@@ -282,7 +339,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "min"
@@ -293,13 +353,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 48
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "b"
@@ -308,7 +374,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 48
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 31
                   }
                   v: "max"
@@ -319,7 +388,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 48
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -351,7 +423,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "a"
@@ -360,7 +435,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "count"
@@ -371,7 +449,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "b"
@@ -380,7 +461,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: "sum"
@@ -388,7 +472,10 @@ body {
                 }
               }
               src {
+                end_column: 48
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
             }
@@ -396,7 +483,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }

--- a/tests/ast/data/DataFrame.collect.test
+++ b/tests/ast/data/DataFrame.collect.test
@@ -48,7 +48,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -75,7 +78,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 20
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -105,7 +111,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 31
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -136,7 +145,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 67
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {
@@ -170,7 +182,10 @@ body {
         }
         log_on_exception: true
         src {
+          end_column: 125
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {
@@ -205,7 +220,10 @@ body {
         }
         no_wait: true
         src {
+          end_column: 27
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
       }
@@ -236,7 +254,10 @@ body {
         }
         no_wait: true
         src {
+          end_column: 74
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 37
         }
         statement_params {
@@ -271,7 +292,10 @@ body {
         log_on_exception: true
         no_wait: true
         src {
+          end_column: 119
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         statement_params {

--- a/tests/ast/data/DataFrame.count.test
+++ b/tests/ast/data/DataFrame.count.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -58,7 +61,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 18
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -87,7 +93,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 29
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -116,7 +125,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 78
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -62,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 28
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 28
         }
       }
@@ -85,7 +88,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 18
+          end_line: 30
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 30
         }
       }
@@ -114,7 +120,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 29
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 32
         }
       }
@@ -143,7 +152,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 78
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 34
         }
         statement_params {

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -37,26 +37,28 @@ body {
           sp_dataframe_schema__struct {
             v {
               fields {
-                column_identifier {
-                  name: "\"A\""
-                }
-                data_type {
-                  sp_string_type {
-                    length {
-                      value: 16777216
+                list {
+                  column_identifier {
+                    name: "\"A\""
+                  }
+                  data_type {
+                    sp_string_type {
+                      length {
+                        value: 16777216
+                      }
                     }
                   }
+                  nullable: true
                 }
-                nullable: true
-              }
-              fields {
-                column_identifier {
-                  name: "\"B\""
+                list {
+                  column_identifier {
+                    name: "\"B\""
+                  }
+                  data_type {
+                    sp_long_type: true
+                  }
+                  nullable: true
                 }
-                data_type {
-                  sp_long_type: true
-                }
-                nullable: true
               }
             }
           }

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -70,7 +70,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -111,7 +114,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -143,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 79
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         statement_params {
@@ -185,7 +194,10 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -218,7 +230,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {
@@ -244,7 +259,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: true
@@ -265,7 +283,10 @@ body {
           _2 {
             string_val {
               src {
+                end_column: 9
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: "GZIP"
@@ -277,7 +298,10 @@ body {
           _2 {
             string_val {
               src {
+                end_column: 9
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: "|"
@@ -288,7 +312,10 @@ body {
           value: "[A-Z]+"
         }
         src {
+          end_column: 9
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         statement_params {
@@ -324,14 +351,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 45
                     }
                     v: "n"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 45
                 }
               }
@@ -339,14 +372,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 45
                 }
                 v: 10
               }
             }
             src {
+              end_column: 42
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 45
             }
           }
@@ -367,14 +406,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 54
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 45
                 }
                 v: "str"
               }
             }
             src {
+              end_column: 54
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 45
             }
           }
@@ -412,7 +457,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
       }
@@ -438,7 +486,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
       }
@@ -464,7 +515,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 53
         }
         statement_params {
@@ -494,7 +548,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 53
         }
       }
@@ -534,7 +591,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
         warehouse: "test_wh"

--- a/tests/ast/data/DataFrame.cross_join.lsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.lsuffix.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -96,7 +102,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -117,7 +126,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 54
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -130,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.cross_join.rsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.rsuffix.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -96,7 +102,10 @@ body {
           value: "_t2"
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -117,7 +126,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 54
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -130,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.cross_join.suffix.test
+++ b/tests/ast/data/DataFrame.cross_join.suffix.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -99,7 +105,10 @@ body {
           value: "_t2"
         }
         src {
+          end_column: 57
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -120,7 +129,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 69
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -133,7 +145,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.describe.test
+++ b/tests/ast/data/DataFrame.describe.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -64,7 +67,10 @@ body {
           }
         }
         src {
+          end_column: 27
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -86,7 +92,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 32
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -102,7 +111,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -124,7 +136,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 39
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "STR"
@@ -133,7 +148,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 39
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -149,7 +167,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }

--- a/tests/ast/data/DataFrame.flatten.test
+++ b/tests/ast/data/DataFrame.flatten.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
         input {
           string_val {
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "STR"
@@ -73,7 +79,10 @@ body {
           value: "path"
         }
         src {
+          end_column: 52
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -114,14 +123,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: "NUM"
               }
             }
             src {
+              end_column: 35
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -131,7 +146,10 @@ body {
         }
         recursive: true
         src {
+          end_column: 66
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/DataFrame.indexers.test
+++ b/tests/ast/data/DataFrame.indexers.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -64,7 +67,10 @@ body {
               }
             }
             src {
+              end_column: 37
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 27
             }
           }
@@ -77,7 +83,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 27
         }
         variadic: true
@@ -107,7 +116,10 @@ body {
               }
             }
             src {
+              end_column: 34
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -120,7 +132,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 29
         }
         variadic: true
@@ -150,7 +165,10 @@ body {
               }
             }
             src {
+              end_column: 37
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 31
             }
           }
@@ -163,7 +181,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.column.test
+++ b/tests/ast/data/DataFrame.join.inner.column.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -83,7 +89,10 @@ body {
         join_expr {
           string_val {
             src {
+              end_column: 34
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
             v: "num"
@@ -107,7 +116,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -138,7 +150,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 29
                 }
               }
@@ -148,7 +163,10 @@ body {
             }
             name: "n1"
             src {
+              end_column: 61
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 29
             }
           }
@@ -164,7 +182,10 @@ body {
               }
             }
             src {
+              end_column: 70
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 63
               start_line: 29
             }
           }
@@ -180,7 +201,10 @@ body {
               }
             }
             src {
+              end_column: 79
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 72
               start_line: 29
             }
           }
@@ -193,7 +217,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.column_list.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -85,7 +91,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "num"
@@ -94,7 +103,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "str"
@@ -120,7 +132,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -142,7 +157,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 55
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -155,7 +173,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -95,7 +101,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 29
                     }
                   }
@@ -111,13 +120,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 49
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 29
                 }
               }
@@ -135,7 +150,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 64
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 29
                     }
                   }
@@ -151,19 +169,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -186,7 +213,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -217,7 +247,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 29
                 }
               }
@@ -227,7 +260,10 @@ body {
             }
             name: "num_1"
             src {
+              end_column: 111
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 88
               start_line: 29
             }
           }
@@ -245,7 +281,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 123
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 113
                   start_line: 29
                 }
               }
@@ -255,7 +294,10 @@ body {
             }
             name: "str_1"
             src {
+              end_column: 136
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 113
               start_line: 29
             }
           }
@@ -268,7 +310,10 @@ body {
           }
         }
         src {
+          end_column: 137
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -93,7 +99,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 29
                 }
               }
@@ -109,13 +118,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -138,7 +153,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -169,7 +187,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 29
                 }
               }
@@ -179,7 +200,10 @@ body {
             }
             name: "num1"
             src {
+              end_column: 76
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 29
             }
           }
@@ -197,7 +221,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 29
                 }
               }
@@ -207,7 +234,10 @@ body {
             }
             name: "num2"
             src {
+              end_column: 99
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 29
             }
           }
@@ -223,7 +253,10 @@ body {
               }
             }
             src {
+              end_column: 108
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 101
               start_line: 29
             }
           }
@@ -236,7 +269,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -95,7 +101,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 29
                     }
                   }
@@ -111,13 +120,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 52
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 29
                 }
               }
@@ -135,7 +150,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 67
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 29
                     }
                   }
@@ -151,19 +169,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 81
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 71
                       start_line: 29
                     }
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -189,7 +216,10 @@ body {
           value: "_2"
         }
         src {
+          end_column: 97
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -211,7 +241,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 109
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -224,7 +257,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.left_outer.column.test
+++ b/tests/ast/data/DataFrame.join.left_outer.column.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -85,7 +91,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "num"
@@ -94,7 +103,10 @@ body {
             vs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 29
                 }
                 v: "str"
@@ -120,7 +132,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -142,7 +157,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 63
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -155,7 +173,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.join.right_outer.predicate.test
+++ b/tests/ast/data/DataFrame.join.right_outer.predicate.test
@@ -30,7 +30,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -59,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -93,7 +99,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 29
                 }
               }
@@ -109,13 +118,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 29
             }
           }
@@ -138,7 +153,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -160,7 +178,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 73
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
@@ -173,7 +194,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.natural_join.test
+++ b/tests/ast/data/DataFrame.natural_join.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -96,7 +102,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -117,7 +126,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 41
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -130,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/DataFrame.pivot.test
+++ b/tests/ast/data/DataFrame.pivot.test
@@ -44,13 +44,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -59,7 +65,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 10000
@@ -68,7 +77,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -79,13 +91,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -94,7 +112,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 400
@@ -103,7 +124,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -114,13 +138,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -129,7 +159,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 4500
@@ -138,7 +171,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -149,13 +185,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -164,7 +206,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 35000
@@ -173,7 +218,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "JAN"
@@ -184,13 +232,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -199,7 +253,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 5000
@@ -208,7 +265,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "FEB"
@@ -219,13 +279,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -234,7 +300,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 3000
@@ -243,7 +312,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "FEB"
@@ -254,13 +326,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -269,7 +347,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 200
@@ -278,7 +359,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 36
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "FEB"
@@ -296,7 +380,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -317,7 +404,10 @@ body {
         default_on_null {
           null_val {
             src {
+              end_column: 44
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
           }
@@ -332,14 +422,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 44
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
             v: "mo"
           }
         }
         src {
+          end_column: 44
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
         values {
@@ -347,13 +443,19 @@ body {
             v {
               list_val {
                 src {
+                  end_column: 44
+                  end_line: 38
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 38
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 38
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 38
                     }
                     v: "JAN"
@@ -362,7 +464,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 38
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 38
                     }
                     v: "FEB"
@@ -392,7 +497,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 53
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 38
               }
               v: "t"
@@ -408,7 +516,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
       }
@@ -429,7 +540,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 63
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
             v: "k"
@@ -444,7 +558,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
       }
@@ -465,7 +582,10 @@ body {
         default_on_null {
           string_val {
             src {
+              end_column: 78
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "Nothing"
@@ -481,14 +601,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 78
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "mo"
           }
         }
         src {
+          end_column: 78
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
         values {
@@ -496,13 +622,19 @@ body {
             v {
               list_val {
                 src {
+                  end_column: 78
+                  end_line: 40
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 40
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 40
                     }
                     v: "JAN"
@@ -511,7 +643,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 40
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 40
                     }
                     v: "FEB"
@@ -541,7 +676,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 87
+                end_line: 40
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 40
               }
               v: "t"
@@ -557,7 +695,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
       }
@@ -578,7 +719,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 97
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "k"
@@ -593,7 +737,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
       }

--- a/tests/ast/data/DataFrame.select_expr.test
+++ b/tests/ast/data/DataFrame.select_expr.test
@@ -37,7 +37,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -67,7 +70,10 @@ body {
         }
         exprs: "$1"
         src {
+          end_column: 33
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -95,7 +101,10 @@ body {
         }
         exprs: "$1"
         src {
+          end_column: 35
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }
@@ -127,7 +136,10 @@ body {
         exprs: "MAX $5"
         exprs: "COUNT DISTINCT $6"
         src {
+          end_column: 100
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -160,7 +172,10 @@ body {
         exprs: "MAX $5"
         exprs: "COUNT DISTINCT $6"
         src {
+          end_column: 102
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
       }

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -82,7 +82,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -106,7 +109,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 51
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "NUM"
@@ -117,7 +123,10 @@ body {
         }
         percentile: 0.5
         src {
+          end_column: 51
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -146,7 +155,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 96
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
             v: "NUM"
@@ -155,7 +167,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 96
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
             v: "NUM"
@@ -168,7 +183,10 @@ body {
         percentile: 0.2
         percentile: 0.4
         src {
+          end_column: 96
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         statement_params {
@@ -203,13 +221,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 94
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.1
@@ -218,7 +242,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.5
@@ -229,13 +256,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 94
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.2
@@ -244,7 +277,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.6
@@ -255,13 +291,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 94
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.3
@@ -270,7 +312,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 94
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 31
                     }
                     v: 0.7
@@ -287,7 +332,10 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
       }
@@ -308,7 +356,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 35
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
             v: "a"
@@ -317,7 +368,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 35
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
             v: "b"
@@ -327,7 +381,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 35
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -356,7 +413,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 63
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
             v: "a"
@@ -365,7 +425,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 63
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
             v: "b"
@@ -375,7 +438,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 63
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         statement_params {
@@ -408,7 +474,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 36
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
             v: "a"
@@ -417,7 +486,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 36
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
             v: "b"
@@ -427,7 +499,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 36
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -456,7 +531,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 64
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
             v: "a"
@@ -465,7 +543,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 64
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
             v: "b"
@@ -475,7 +556,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 64
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
         statement_params {
@@ -510,13 +594,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 1
@@ -525,59 +615,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 1
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 41
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 1
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 2
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 41
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 41
-                    }
-                    v: 2
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 1
@@ -588,13 +629,54 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 1
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 120
+                  end_line: 41
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 41
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 2
@@ -603,7 +685,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 1
@@ -614,13 +699,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 2
@@ -629,7 +720,45 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 120
+                  end_line: 41
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 41
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 41
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 120
+                      end_line: 41
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -640,13 +769,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -655,7 +790,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 2
@@ -666,13 +804,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 120
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -681,7 +825,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 120
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 41
                     }
                     v: 3
@@ -698,7 +845,10 @@ body {
           }
         }
         src {
+          end_column: 120
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
       }
@@ -719,7 +869,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 45
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 43
             }
             v: "key"
@@ -728,7 +881,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 45
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 43
             }
             v: "value"
@@ -738,7 +894,10 @@ body {
           bitfield1: 15
         }
         src {
+          end_column: 45
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
       }
@@ -759,7 +918,10 @@ body {
         col1 {
           string_val {
             src {
+              end_column: 74
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 45
             }
             v: "key"
@@ -768,7 +930,10 @@ body {
         col2 {
           string_val {
             src {
+              end_column: 74
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 45
             }
             v: "value"
@@ -778,7 +943,10 @@ body {
           bitfield1: 15
         }
         src {
+          end_column: 74
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 45
         }
         statement_params {
@@ -805,13 +973,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Bob"
@@ -820,7 +994,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 17
@@ -831,13 +1008,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Alice"
@@ -846,7 +1029,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 10
@@ -857,13 +1043,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Nico"
@@ -872,7 +1064,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 8
@@ -883,13 +1078,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 117
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 47
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: "Bob"
@@ -898,7 +1099,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 117
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 47
                     }
                     v: 12
@@ -915,7 +1119,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
       }
@@ -936,7 +1143,10 @@ body {
         col {
           string_val {
             src {
+              end_column: 56
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 20
               start_line: 51
             }
             v: "name"
@@ -953,7 +1163,10 @@ body {
           _1 {
             string_val {
               src {
+                end_column: 56
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 51
               }
               v: "Bob"
@@ -965,7 +1178,10 @@ body {
           _1 {
             string_val {
               src {
+                end_column: 56
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 51
               }
               v: "Nico"
@@ -974,7 +1190,10 @@ body {
           _2: 1.0
         }
         src {
+          end_column: 56
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 51
         }
       }

--- a/tests/ast/data/DataFrame.to_df.test
+++ b/tests/ast/data/DataFrame.to_df.test
@@ -29,7 +29,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,7 +63,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 27
         }
         variadic: true
@@ -89,7 +95,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 23
           start_line: 29
         }
       }

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -49,7 +49,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -76,7 +79,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 27
         }
       }
@@ -106,7 +112,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 64
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 29
         }
       }
@@ -135,7 +144,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 45
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 31
             }
           }
@@ -148,7 +160,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 31
         }
         variadic: true
@@ -173,7 +188,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 65
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 31
         }
       }
@@ -204,7 +222,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 100
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 33
         }
         statement_params {
@@ -246,7 +267,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
               }
@@ -254,14 +278,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 54
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 v: 1
               }
             }
             src {
+              end_column: 54
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 35
             }
           }
@@ -274,7 +304,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 35
         }
       }
@@ -297,7 +330,10 @@ body {
           bitfield1: 11
         }
         src {
+          end_column: 86
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 35
         }
       }
@@ -327,7 +363,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 122
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 37
         }
         statement_params {

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -36,7 +36,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,7 +65,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 22
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -91,7 +97,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 33
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -121,7 +130,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 69
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {
@@ -154,7 +166,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 82
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {

--- a/tests/ast/data/DataFrame.to_pandas_batch.test
+++ b/tests/ast/data/DataFrame.to_pandas_batch.test
@@ -36,7 +36,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,7 +65,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 30
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -91,7 +97,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -121,7 +130,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 77
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         statement_params {
@@ -154,7 +166,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 90
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         statement_params {

--- a/tests/ast/data/DataFrame.unpivot.test
+++ b/tests/ast/data/DataFrame.unpivot.test
@@ -23,13 +23,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 28
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -38,7 +44,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "electronics"
@@ -47,7 +56,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 100
@@ -56,7 +68,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 200
@@ -67,13 +82,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 28
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -82,7 +103,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: "clothes"
@@ -91,7 +115,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 100
@@ -100,7 +127,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 28
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 300
@@ -119,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 28
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -140,7 +173,10 @@ body {
         column_list {
           string_val {
             src {
+              end_column: 57
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 29
             }
             v: "jan"
@@ -149,7 +185,10 @@ body {
         column_list {
           string_val {
             src {
+              end_column: 57
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 29
             }
             v: "feb"
@@ -164,7 +203,10 @@ body {
         }
         name_column: "month"
         src {
+          end_column: 57
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         value_column: "sales"

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -80,7 +80,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -109,7 +112,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -132,7 +138,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 45
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
         table_name {
@@ -175,7 +184,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 16
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -198,7 +210,10 @@ body {
           bitfield1: 5
         }
         src {
+          end_column: 87
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
         table_name {
@@ -242,7 +257,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 16
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }
@@ -268,7 +286,10 @@ body {
           sp_save_mode_ignore: true
         }
         src {
+          end_column: 102
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         table_name {
@@ -312,7 +333,10 @@ body {
           sp_save_mode_truncate: true
         }
         src {
+          end_column: 16
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
       }
@@ -334,7 +358,10 @@ body {
           list {
             string_val {
               src {
+                end_column: 231
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 35
               }
               v: "STR"
@@ -356,14 +383,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 173
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 162
                     start_line: 35
                   }
                   v: "num1"
                 }
               }
               src {
+                end_column: 173
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 162
                 start_line: 35
               }
             }
@@ -377,7 +410,10 @@ body {
           bitfield1: 11
         }
         src {
+          end_column: 231
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
         statement_params {
@@ -416,7 +452,10 @@ body {
       sp_sql {
         query: "create temp stage if not exists test_stage"
         src {
+          end_column: 88
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 37
         }
       }
@@ -440,7 +479,10 @@ body {
           bitfield1: 14
         }
         src {
+          end_column: 98
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 37
         }
       }
@@ -473,7 +515,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -496,7 +541,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 72
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -529,7 +577,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -552,7 +603,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 123
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               v: true
@@ -564,7 +618,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 123
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               v: true
@@ -580,7 +637,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 123
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -613,7 +673,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 45
         }
       }
@@ -635,7 +698,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 181
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 45
               }
               v: true
@@ -647,7 +713,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 181
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 45
               }
             }
@@ -665,7 +734,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 181
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 45
         }
       }
@@ -698,7 +770,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
       }
@@ -720,7 +795,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 207
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 47
               }
               v: true
@@ -732,7 +810,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 207
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 47
               }
             }
@@ -754,7 +835,10 @@ body {
         }
         location: "@test_stage/copied_from_dataframe"
         src {
+          end_column: 207
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
       }
@@ -787,7 +871,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
       }
@@ -810,7 +897,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 125
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 51
               }
               v: true
@@ -822,7 +912,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 125
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 51
               }
               v: true
@@ -839,7 +932,10 @@ body {
         }
         location: "@test_stage/test.csv"
         src {
+          end_column: 125
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
       }
@@ -872,7 +968,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -895,7 +994,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 114
+                end_line: 55
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 55
               }
               v: true
@@ -907,7 +1009,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 114
+                end_line: 55
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 55
               }
               v: true
@@ -923,7 +1028,10 @@ body {
         }
         location: "@test_stage/test.json"
         src {
+          end_column: 114
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -956,7 +1064,10 @@ body {
           }
         }
         src {
+          end_column: 16
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 59
         }
       }
@@ -979,7 +1090,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 130
+                end_line: 59
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 59
               }
               v: true
@@ -991,7 +1105,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 130
+                end_line: 59
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 59
               }
               v: true
@@ -1007,7 +1124,10 @@ body {
         }
         location: "@test_stage/test.parquet"
         src {
+          end_column: 130
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 59
         }
       }

--- a/tests/ast/data/Dataframe.cube.test
+++ b/tests/ast/data/Dataframe.cube.test
@@ -52,7 +52,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -84,7 +87,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -106,7 +112,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 29
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -122,7 +131,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -144,7 +156,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 31
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -159,7 +174,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -181,7 +199,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "num"
@@ -190,7 +211,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "str"
@@ -205,7 +229,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -240,14 +267,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 33
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 35
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 33
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
             }
@@ -262,7 +295,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -297,14 +333,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 34
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 37
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 34
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 37
               }
             }
@@ -318,7 +360,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -353,14 +398,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 33
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 39
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 33
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 39
               }
             }
@@ -368,7 +419,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 41
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               v: "str"
@@ -384,7 +438,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -419,14 +476,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 34
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 41
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 34
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 41
               }
             }
@@ -434,7 +497,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 43
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               v: "str"
@@ -449,7 +515,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Dataframe.distinct.test
+++ b/tests/ast/data/Dataframe.distinct.test
@@ -24,7 +24,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -53,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 27
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }

--- a/tests/ast/data/Dataframe.drop_duplicates.test
+++ b/tests/ast/data/Dataframe.drop_duplicates.test
@@ -40,7 +40,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -69,7 +72,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -96,7 +102,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -125,7 +134,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true
@@ -154,7 +166,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -180,7 +195,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }

--- a/tests/ast/data/Dataframe.filter.test
+++ b/tests/ast/data/Dataframe.filter.test
@@ -36,7 +36,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -77,14 +80,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 34
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 26
                           start_line: 27
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 34
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 27
                     }
                   }
@@ -92,14 +101,20 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 38
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 27
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 27
                 }
               }
@@ -122,14 +137,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 51
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 27
                         }
                         v: "B"
                       }
                     }
                     src {
+                      end_column: 51
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 27
                     }
                   }
@@ -137,20 +158,29 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 57
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 27
                     }
                     v: 100
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 27
             }
           }
@@ -163,7 +193,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -199,14 +232,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 29
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
               }
@@ -214,14 +253,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 37
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: 1
               }
             }
             src {
+              end_column: 37
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -234,7 +279,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -256,7 +304,10 @@ body {
           sp_column_sql_expr {
             sql: "a > 1 and b < 100"
             src {
+              end_column: 45
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
           }
@@ -269,7 +320,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -291,7 +345,10 @@ body {
           sp_column_sql_expr {
             sql: "a > 1"
             src {
+              end_column: 33
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
           }
@@ -304,7 +361,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,7 +63,10 @@ body {
               }
             }
             src {
+              end_column: 24
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 27
             }
           }
@@ -76,7 +82,10 @@ body {
               }
             }
             src {
+              end_column: 35
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 27
             }
           }
@@ -89,7 +98,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
         variadic: true
@@ -113,7 +125,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 46
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -154,14 +169,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 26
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 29
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 26
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -182,14 +203,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 26
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 29
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 26
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 29
             }
           }
@@ -202,7 +229,10 @@ body {
           }
         }
         src {
+          end_column: 26
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -225,7 +255,10 @@ body {
           bitfield1: 5
         }
         src {
+          end_column: 36
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }

--- a/tests/ast/data/Dataframe.group_by.test
+++ b/tests/ast/data/Dataframe.group_by.test
@@ -52,7 +52,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -84,7 +87,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -106,7 +112,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 33
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -122,7 +131,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -144,7 +156,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 35
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -159,7 +174,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -181,7 +199,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 42
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "num"
@@ -190,7 +211,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 42
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "str"
@@ -205,7 +229,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -240,14 +267,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 27
                     start_line: 35
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 37
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 27
                 start_line: 35
               }
             }
@@ -262,7 +295,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -297,14 +333,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 38
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 37
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 38
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 28
                 start_line: 37
               }
             }
@@ -318,7 +360,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -353,14 +398,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 27
                     start_line: 39
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 37
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 27
                 start_line: 39
               }
             }
@@ -368,7 +419,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 45
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               v: "str"
@@ -384,7 +438,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -419,14 +476,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 38
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 41
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 38
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 28
                 start_line: 41
               }
             }
@@ -434,7 +497,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 47
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               v: "str"
@@ -449,7 +515,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Dataframe.group_by_grouping_sets.test
+++ b/tests/ast/data/Dataframe.group_by_grouping_sets.test
@@ -62,7 +62,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -108,14 +111,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 62
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 29
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 29
                 }
               }
@@ -123,12 +132,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 63
+            end_line: 29
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 29
           }
         }
         src {
+          end_column: 64
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -172,26 +187,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 31
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 31
                 }
               }
             }
           }
           src {
+            end_column: 65
+            end_line: 31
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 31
           }
         }
         src {
+          end_column: 66
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true
@@ -222,7 +249,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 77
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 33
                 }
                 vs {
@@ -241,14 +271,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 63
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 55
                           start_line: 33
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 63
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 33
                     }
                   }
@@ -258,7 +294,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 77
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 33
                 }
                 vs {
@@ -277,14 +316,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 75
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 67
                           start_line: 33
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 33
                     }
                   }
@@ -294,12 +339,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 77
+            end_line: 33
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 33
           }
         }
         src {
+          end_column: 78
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
         variadic: true
@@ -330,7 +381,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 87
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 vs {
@@ -349,14 +403,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 63
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 55
                           start_line: 35
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 63
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 35
                     }
                   }
@@ -377,14 +437,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 73
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 65
                           start_line: 35
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 73
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 35
                     }
                   }
@@ -394,7 +460,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 87
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 vs {
@@ -413,14 +482,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 85
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 77
                           start_line: 35
                         }
                         v: "c"
                       }
                     }
                     src {
+                      end_column: 85
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 35
                     }
                   }
@@ -430,12 +505,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 87
+            end_line: 35
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 41
             start_line: 35
           }
         }
         src {
+          end_column: 88
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variadic: true
@@ -466,7 +547,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 49
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 37
                 }
                 vs {
@@ -485,14 +569,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 35
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 27
                           start_line: 37
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 35
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 27
                       start_line: 37
                     }
                   }
@@ -502,7 +592,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 49
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 37
                 }
                 vs {
@@ -521,14 +614,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 47
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 39
                           start_line: 37
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 47
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 37
                     }
                   }
@@ -538,12 +637,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 49
+            end_line: 37
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 37
           }
         }
         src {
+          end_column: 44
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
         variadic: true
@@ -574,7 +679,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
@@ -593,14 +701,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 35
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 27
                           start_line: 41
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 35
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 27
                       start_line: 41
                     }
                   }
@@ -621,14 +735,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 46
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 38
                           start_line: 41
                         }
                         v: "b"
                       }
                     }
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 41
                     }
                   }
@@ -638,7 +758,10 @@ body {
             args {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 41
                 }
                 vs {
@@ -657,14 +780,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 58
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 50
                           start_line: 41
                         }
                         v: "c"
                       }
                     }
                     src {
+                      end_column: 58
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 41
                     }
                   }
@@ -685,14 +814,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 68
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 60
                           start_line: 41
                         }
                         v: "d"
                       }
                     }
                     src {
+                      end_column: 68
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 41
                     }
                   }
@@ -702,12 +837,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 70
+            end_line: 41
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 41
           }
         }
         src {
+          end_column: 44
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
         variadic: true
@@ -751,14 +892,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 27
                       start_line: 45
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 27
                   start_line: 45
                 }
               }
@@ -779,26 +926,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 45
                     }
                     v: "b"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 45
                 }
               }
             }
           }
           src {
+            end_column: 47
+            end_line: 45
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 45
           }
         }
         src {
+          end_column: 44
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 47
         }
         variadic: true
@@ -842,14 +1001,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 49
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 49
                 }
               }
@@ -870,14 +1035,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 49
                     }
                     v: "b"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 49
                 }
               }
@@ -885,12 +1056,18 @@ body {
             variadic: true
           }
           src {
+            end_column: 45
+            end_line: 49
             file: "SRC_POSITION_TEST_MODE"
+            start_column: 13
             start_line: 49
           }
         }
         src {
+          end_column: 44
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
         variadic: true

--- a/tests/ast/data/Dataframe.join.asof.test
+++ b/tests/ast/data/Dataframe.join.asof.test
@@ -32,13 +32,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "A"
@@ -47,7 +53,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 1
@@ -56,7 +65,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 15
@@ -65,7 +77,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3.21
@@ -76,13 +91,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "A"
@@ -91,7 +112,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 2
@@ -100,7 +124,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 16
@@ -109,7 +136,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3.22
@@ -120,13 +150,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "B"
@@ -135,7 +171,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 1
@@ -144,7 +183,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 17
@@ -153,7 +195,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3.23
@@ -164,13 +209,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 70
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: "B"
@@ -179,7 +230,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 2
@@ -188,7 +242,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 18
@@ -197,7 +254,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 70
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 4.23
@@ -216,7 +276,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -239,13 +302,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 30
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: "A"
@@ -254,7 +323,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 1
@@ -263,7 +335,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 14
@@ -272,7 +347,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 3.19
@@ -283,13 +361,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 30
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: "B"
@@ -298,7 +382,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 2
@@ -307,7 +394,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 16
@@ -316,7 +406,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 71
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 30
                     }
                     v: 3.04
@@ -335,7 +428,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 30
         }
       }
@@ -368,7 +464,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 32
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 34
                     }
                   }
@@ -384,13 +483,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 42
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 34
                     }
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 34
                 }
               }
@@ -408,7 +513,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 53
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 34
                     }
                   }
@@ -424,19 +532,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 63
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 34
                     }
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 34
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 34
             }
           }
@@ -467,7 +584,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 35
                 }
               }
@@ -483,13 +603,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 34
               start_line: 35
             }
           }
@@ -505,7 +631,10 @@ body {
           value: "_R"
         }
         src {
+          end_column: 80
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 34
         }
       }
@@ -525,8 +654,11 @@ body {
         cols {
           string_val {
             src {
+              end_column: 42
+              end_line: 36
               file: "SRC_POSITION_TEST_MODE"
-              start_line: 34
+              start_column: 18
+              start_line: 36
             }
             v: "C1_L"
           }
@@ -534,8 +666,11 @@ body {
         cols {
           string_val {
             src {
+              end_column: 42
+              end_line: 36
               file: "SRC_POSITION_TEST_MODE"
-              start_line: 34
+              start_column: 18
+              start_line: 36
             }
             v: "C2_L"
           }
@@ -549,8 +684,11 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 34
+          start_column: 18
+          start_line: 36
         }
       }
     }
@@ -572,8 +710,11 @@ body {
           bitfield1: 4
         }
         src {
+          end_column: 52
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 34
+          start_column: 43
+          start_line: 36
         }
       }
     }

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -37,13 +37,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 140
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 1
@@ -52,7 +58,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 2
@@ -61,7 +70,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 3
@@ -70,7 +82,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 4
@@ -79,7 +94,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 5
@@ -88,7 +106,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 140
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 25
                     }
                     v: 6
@@ -109,7 +130,10 @@ body {
           }
         }
         src {
+          end_column: 140
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -132,13 +156,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 122
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 1
@@ -147,7 +177,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 2
@@ -156,7 +189,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 3
@@ -165,7 +201,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 4
@@ -174,7 +213,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 122
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     v: 5
@@ -194,7 +236,10 @@ body {
           }
         }
         src {
+          end_column: 122
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -230,14 +275,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 29
                     }
                     v: "\"A\""
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
               }
@@ -245,14 +296,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: 1
               }
             }
             src {
+              end_column: 42
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -265,7 +322,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -303,14 +363,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 73
+                          end_line: 29
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 61
                           start_line: 29
                         }
                         v: "\"A\""
                       }
                     }
                     src {
+                      end_column: 73
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 29
                     }
                   }
@@ -318,14 +384,20 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 77
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 29
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 29
                 }
               }
@@ -335,7 +407,10 @@ body {
             }
             name: "\"A\""
             src {
+              end_column: 91
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 29
             }
           }
@@ -356,14 +431,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 105
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 29
                 }
                 v: "\"B\""
               }
             }
             src {
+              end_column: 105
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 93
               start_line: 29
             }
           }
@@ -384,14 +465,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 119
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 29
                 }
                 v: "\"C\""
               }
             }
             src {
+              end_column: 119
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 107
               start_line: 29
             }
           }
@@ -412,14 +499,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 140
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 121
                   start_line: 29
                 }
                 v: "\"l_0001_C\""
               }
             }
             src {
+              end_column: 140
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 121
               start_line: 29
             }
           }
@@ -440,14 +533,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 161
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 142
                   start_line: 29
                 }
                 v: "\"l_0003_B\""
               }
             }
             src {
+              end_column: 161
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 142
               start_line: 29
             }
           }
@@ -460,7 +559,10 @@ body {
           }
         }
         src {
+          end_column: 162
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 49
           start_line: 29
         }
         variadic: true
@@ -497,7 +599,10 @@ body {
           }
         }
         src {
+          end_column: 163
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -518,7 +623,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0004_A\""
@@ -527,7 +635,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0004_B\""
@@ -536,7 +647,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0004_C\""
@@ -545,7 +659,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0000_A\""
@@ -554,7 +671,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0000_A\""
@@ -563,7 +683,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0002_A\""
@@ -572,7 +695,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0006_A\""
@@ -581,7 +707,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0006_B\""
@@ -590,7 +719,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"r_0006_C\""
@@ -599,7 +731,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0001_C\""
@@ -608,7 +743,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 35
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
             v: "\"l_0003_B\""
@@ -622,7 +760,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -646,7 +787,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 21
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }

--- a/tests/ast/data/Dataframe.rollup.test
+++ b/tests/ast/data/Dataframe.rollup.test
@@ -52,7 +52,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -84,7 +87,10 @@ body {
           }
         }
         src {
+          end_column: 26
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -106,7 +112,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 31
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 29
               }
               v: "num"
@@ -122,7 +131,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -144,7 +156,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 33
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 31
               }
               v: "num"
@@ -159,7 +174,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -181,7 +199,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 40
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "num"
@@ -190,7 +211,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 40
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 33
               }
               v: "str"
@@ -205,7 +229,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -240,14 +267,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 35
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 35
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 35
               }
             }
@@ -262,7 +295,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -297,14 +333,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 26
                     start_line: 37
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 36
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 26
                 start_line: 37
               }
             }
@@ -318,7 +360,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -353,14 +398,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 39
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 35
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 39
               }
             }
@@ -368,7 +419,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 43
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               v: "str"
@@ -384,7 +438,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -419,14 +476,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 26
                     start_line: 41
                   }
                   v: "num"
                 }
               }
               src {
+                end_column: 36
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 26
                 start_line: 41
               }
             }
@@ -434,7 +497,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 45
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               v: "str"
@@ -449,7 +515,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Dataframe.with_col_fns.test
+++ b/tests/ast/data/Dataframe.with_col_fns.test
@@ -56,7 +56,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -97,14 +100,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 48
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 38
                           start_line: 27
                         }
                         v: "num"
                       }
                     }
                     src {
+                      end_column: 48
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 27
                     }
                   }
@@ -125,20 +134,29 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 61
+                          end_line: 27
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 51
                           start_line: 27
                         }
                         v: "num"
                       }
                     }
                     src {
+                      end_column: 61
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 27
                     }
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 27
                 }
               }
@@ -146,14 +164,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 27
                 }
                 v: 2
               }
             }
             src {
+              end_column: 66
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 27
             }
           }
@@ -167,7 +191,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -194,7 +221,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         values {
@@ -215,14 +245,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 29
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 29
                 }
               }
@@ -243,20 +279,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 29
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 29
             }
           }
@@ -286,7 +331,10 @@ body {
           }
         }
         src {
+          end_column: 98
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         values {
@@ -307,14 +355,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 31
                 }
               }
@@ -335,20 +389,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 71
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 31
             }
           }
@@ -371,14 +434,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 73
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 73
                   start_line: 31
                 }
               }
@@ -399,20 +468,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 31
                     }
                     v: "num"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 73
               start_line: 31
             }
           }
@@ -448,14 +526,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 34
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 33
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 34
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
           }
@@ -471,7 +555,10 @@ body {
           value: "NEW"
         }
         src {
+          end_column: 42
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -508,14 +595,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 35
                       }
                       v: "STR"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 35
                   }
                 }
@@ -523,7 +616,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 44
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 35
                   }
                   v: "NEW"
@@ -531,7 +627,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
           }
@@ -544,7 +643,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -581,14 +683,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 37
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 37
                       }
                       v: "STR"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 37
                   }
                 }
@@ -596,7 +704,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 66
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 37
                   }
                   v: "NEW_STR"
@@ -607,7 +718,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 66
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 37
                   }
                   v: "NUM"
@@ -616,7 +730,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 66
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 37
                   }
                   v: "NEW_NUM"
@@ -624,7 +741,10 @@ body {
               }
             }
             src {
+              end_column: 66
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
           }
@@ -637,7 +757,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -658,7 +781,10 @@ body {
         col {
           string_val {
             src {
+              end_column: 50
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
             v: "STR"
@@ -673,7 +799,10 @@ body {
         }
         new_name: "NEW"
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -707,14 +836,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 41
                 }
                 v: "NUM"
               }
             }
             src {
+              end_column: 47
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 41
             }
           }
@@ -728,7 +863,10 @@ body {
         }
         new_name: "NEW_NUM"
         src {
+          end_column: 59
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }
@@ -762,14 +900,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 43
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 48
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 43
             }
           }
@@ -783,7 +927,10 @@ body {
         }
         new_name: "NEW_STR"
         src {
+          end_column: 60
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 43
         }
       }

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -72,7 +72,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -102,7 +105,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 28
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 27
         }
       }
@@ -129,7 +135,10 @@ body {
         }
         how: "all"
         src {
+          end_column: 37
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 29
         }
       }
@@ -156,7 +165,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 48
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 31
         }
         thresh {
@@ -186,7 +198,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 40
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 33
         }
         subset {
@@ -216,7 +231,10 @@ body {
         }
         how: "all"
         src {
+          end_column: 60
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 35
         }
         subset {
@@ -247,7 +265,10 @@ body {
         }
         how: "any"
         src {
+          end_column: 64
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 37
         }
         subset {
@@ -279,13 +300,19 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 39
         }
         value {
           int64_val {
             src {
+              end_column: 30
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 16
               start_line: 39
             }
             v: 42
@@ -314,7 +341,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 41
         }
         value_map {
@@ -323,7 +353,10 @@ body {
             _2 {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 41
                 }
                 v: 42
@@ -335,7 +368,10 @@ body {
             _2 {
               string_val {
                 src {
+                  end_column: 53
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 41
                 }
                 v: "abc"
@@ -366,7 +402,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 43
         }
         subset {
@@ -375,7 +414,10 @@ body {
         value {
           int64_val {
             src {
+              end_column: 44
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 16
               start_line: 43
             }
             v: 42
@@ -404,7 +446,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 45
         }
         subset {
@@ -413,7 +458,10 @@ body {
         value {
           string_val {
             src {
+              end_column: 49
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 16
               start_line: 45
             }
             v: "def"
@@ -446,7 +494,10 @@ body {
             _1 {
               int64_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: 1
@@ -455,7 +506,10 @@ body {
             _2 {
               int64_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: 10
@@ -466,7 +520,10 @@ body {
             _1 {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: "three"
@@ -475,7 +532,10 @@ body {
             _2 {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 47
                 }
                 v: "trzy"
@@ -484,13 +544,19 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 47
         }
         value {
           null_val {
             src {
+              end_column: 58
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 47
             }
           }
@@ -518,14 +584,20 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 49
         }
         to_replace_list {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 1
@@ -534,7 +606,10 @@ body {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 2
@@ -545,7 +620,10 @@ body {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 10
@@ -554,7 +632,10 @@ body {
           list {
             int64_val {
               src {
+                end_column: 50
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 49
               }
               v: 20
@@ -584,7 +665,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 51
         }
         subset {
@@ -593,7 +677,10 @@ body {
         to_replace_value {
           int64_val {
             src {
+              end_column: 55
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 51
             }
             v: 1
@@ -602,7 +689,10 @@ body {
         value {
           int64_val {
             src {
+              end_column: 55
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 51
             }
             v: 10

--- a/tests/ast/data/RelationalGroupedDataFrame.agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.agg.test
@@ -72,7 +72,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -97,7 +100,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 35
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 16
                 start_line: 27
               }
               v: "str"
@@ -113,7 +119,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 27
         }
       }
@@ -142,7 +151,10 @@ body {
           }
         }
         src {
+          end_column: 25
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -190,20 +202,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 34
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 24
                         start_line: 31
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 34
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 31
                   }
                 }
               }
               src {
+                end_column: 34
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 31
               }
             }
@@ -218,7 +239,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -266,20 +290,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 33
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 33
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 33
                   }
                 }
               }
               src {
+                end_column: 35
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 33
               }
             }
@@ -293,7 +326,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -341,20 +377,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 34
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 24
                         start_line: 35
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 34
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 34
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 24
                 start_line: 35
               }
             }
@@ -388,20 +433,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 46
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 35
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 46
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 36
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 46
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 36
                 start_line: 35
               }
             }
@@ -416,7 +470,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -464,20 +521,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 37
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 37
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 37
                   }
                 }
               }
               src {
+                end_column: 35
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 37
               }
             }
@@ -511,20 +577,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 47
+                        end_line: 37
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 37
                         start_line: 37
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 47
+                    end_line: 37
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 37
                     start_line: 37
                   }
                 }
               }
               src {
+                end_column: 47
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 37
                 start_line: 37
               }
             }
@@ -538,7 +613,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -560,13 +638,19 @@ body {
           args {
             list_val {
               src {
+                end_column: 37
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 39
               }
               vs {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: "num"
@@ -575,7 +659,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: "max"
@@ -593,7 +680,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -615,7 +705,10 @@ body {
           args {
             list_val {
               src {
+                end_column: 42
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 41
               }
               vs {
@@ -634,14 +727,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 34
+                        end_line: 41
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 24
                         start_line: 41
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 34
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 24
                     start_line: 41
                   }
                 }
@@ -649,7 +748,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 42
+                    end_line: 41
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 41
                   }
                   v: "max"
@@ -667,7 +769,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }
@@ -689,13 +794,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 63
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 43
               }
               vs {
                 string_val {
                   src {
+                    end_column: 63
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 43
                   }
                   v: "num"
@@ -704,7 +815,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 63
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 43
                   }
                   v: "max"
@@ -715,7 +829,10 @@ body {
           args {
             list_val {
               src {
+                end_column: 63
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 43
               }
               vs {
@@ -734,14 +851,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 53
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 43
                         start_line: 43
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 53
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 43
                     start_line: 43
                   }
                 }
@@ -749,7 +872,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 63
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 43
                   }
                   v: "sum"
@@ -766,7 +892,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 43
         }
       }
@@ -814,20 +943,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 35
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 25
                         start_line: 45
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 35
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 25
                     start_line: 45
                   }
                 }
               }
               src {
+                end_column: 35
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 45
               }
             }
@@ -835,13 +973,19 @@ body {
           args {
             tuple_val {
               src {
+                end_column: 85
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 45
               }
               vs {
                 string_val {
                   src {
+                    end_column: 85
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 45
                   }
                   v: "num"
@@ -850,7 +994,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 85
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 45
                   }
                   v: "max"
@@ -887,20 +1034,29 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 63
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 53
                         start_line: 45
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 63
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 53
                     start_line: 45
                   }
                 }
               }
               src {
+                end_column: 63
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 53
                 start_line: 45
               }
             }
@@ -908,7 +1064,10 @@ body {
           args {
             list_val {
               src {
+                end_column: 85
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 45
               }
               vs {
@@ -927,14 +1086,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 76
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 66
                         start_line: 45
                       }
                       v: "num"
                     }
                   }
                   src {
+                    end_column: 76
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 66
                     start_line: 45
                   }
                 }
@@ -942,7 +1107,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 85
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 45
                   }
                   v: "sum"
@@ -960,7 +1128,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 45
         }
       }
@@ -982,7 +1153,10 @@ body {
           args {
             seq_map_val {
               src {
+                end_column: 28
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 47
               }
             }
@@ -997,7 +1171,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 47
         }
       }
@@ -1022,7 +1199,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 49
                     }
                     v: "num"
@@ -1031,7 +1211,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 49
                     }
                     v: "max"
@@ -1039,7 +1222,10 @@ body {
                 }
               }
               src {
+                end_column: 40
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 49
               }
             }
@@ -1054,7 +1240,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 49
         }
       }
@@ -1079,7 +1268,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "num"
@@ -1088,7 +1280,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "max"
@@ -1099,7 +1294,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "str"
@@ -1108,7 +1306,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 15
                       start_line: 51
                     }
                     v: "sum"
@@ -1116,7 +1317,10 @@ body {
                 }
               }
               src {
+                end_column: 54
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 51
               }
             }
@@ -1131,7 +1335,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 51
         }
       }

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -1043,34 +1043,36 @@ body {
         }
         output_schema {
           fields {
-            column_identifier {
-              name: "location"
-            }
-            data_type {
-              sp_string_type {
-                length {
+            list {
+              column_identifier {
+                name: "location"
+              }
+              data_type {
+                sp_string_type {
+                  length {
+                  }
                 }
               }
+              nullable: true
             }
-            nullable: true
-          }
-          fields {
-            column_identifier {
-              name: "temp_c"
+            list {
+              column_identifier {
+                name: "temp_c"
+              }
+              data_type {
+                sp_float_type: true
+              }
+              nullable: true
             }
-            data_type {
-              sp_float_type: true
+            list {
+              column_identifier {
+                name: "temp_f"
+              }
+              data_type {
+                sp_float_type: true
+              }
+              nullable: true
             }
-            nullable: true
-          }
-          fields {
-            column_identifier {
-              name: "temp_f"
-            }
-            data_type {
-              sp_float_type: true
-            }
-            nullable: true
           }
         }
         src {

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -66,13 +66,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -81,59 +87,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 1
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 25
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 1
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 2
-                  }
-                }
-              }
-            }
-            vs {
-              tuple_val {
-                src {
-                  file: "SRC_POSITION_TEST_MODE"
-                  start_line: 25
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
-                      start_line: 25
-                    }
-                    v: 2
-                  }
-                }
-                vs {
-                  int64_val {
-                    src {
-                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -144,22 +101,31 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
-                    v: 2
+                    v: 1
                   }
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -170,13 +136,89 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 3
@@ -185,7 +227,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 1
@@ -196,13 +241,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 101
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 25
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 3
@@ -211,7 +262,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 25
                     }
                     v: 2
@@ -228,7 +282,10 @@ body {
           }
         }
         src {
+          end_column: 101
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -250,7 +307,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 24
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 27
               }
               v: "a"
@@ -266,7 +326,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -288,7 +351,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 36
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 27
               }
               v: "b"
@@ -304,7 +370,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -327,7 +396,10 @@ body {
           bitfield1: 3
         }
         src {
+          end_column: 46
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -356,7 +428,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 24
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 29
               }
               v: "a"
@@ -372,7 +447,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -394,7 +472,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 45
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 29
               }
               v: "b"
@@ -410,7 +491,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -433,7 +517,10 @@ body {
           bitfield1: 7
         }
         src {
+          end_column: 55
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -462,7 +549,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 24
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 31
               }
               v: "a"
@@ -478,7 +568,10 @@ body {
           }
         }
         src {
+          end_column: 24
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -504,7 +597,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -526,13 +622,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "SF"
@@ -541,7 +643,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 21.0
@@ -552,13 +657,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "SF"
@@ -567,7 +678,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 17.5
@@ -578,13 +692,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "SF"
@@ -593,7 +713,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 24.0
@@ -604,13 +727,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "NY"
@@ -619,7 +748,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 30.9
@@ -630,13 +762,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 46
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 40
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: "NY"
@@ -645,7 +783,10 @@ body {
                 vs {
                   float64_val {
                     src {
+                      end_column: 46
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 40
                     }
                     v: 33.6
@@ -662,7 +803,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 40
         }
       }
@@ -684,7 +828,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 31
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               v: "location"
@@ -700,7 +847,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -743,7 +893,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 75
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
             }
@@ -774,7 +927,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 75
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -807,7 +963,10 @@ body {
           _2 {
             list_val {
               src {
+                end_column: 75
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               vs {
@@ -819,7 +978,10 @@ body {
                     }
                   }
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                 }
@@ -830,7 +992,10 @@ body {
                     sp_float_type: true
                   }
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                 }
@@ -843,13 +1008,19 @@ body {
           _2 {
             list_val {
               src {
+                end_column: 75
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 43
               }
               vs {
                 string_val {
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                   v: "LOCATION"
@@ -858,7 +1029,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 75
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 43
                   }
                   v: "TEMP_C"
@@ -900,7 +1074,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }
@@ -920,8 +1097,11 @@ body {
         cols {
           string_val {
             src {
+              end_column: 94
+              end_line: 46
               file: "SRC_POSITION_TEST_MODE"
-              start_line: 43
+              start_column: 76
+              start_line: 46
             }
             v: "temp_c"
           }
@@ -935,8 +1115,11 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 43
+          start_column: 76
+          start_line: 46
         }
       }
     }
@@ -958,8 +1141,11 @@ body {
           bitfield1: 16
         }
         src {
+          end_column: 104
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 43
+          start_column: 95
+          start_line: 46
         }
       }
     }
@@ -988,13 +1174,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 153
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 49
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 1
@@ -1003,7 +1195,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "A"
@@ -1012,7 +1207,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 10000
@@ -1021,7 +1219,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "JAN"
@@ -1032,13 +1233,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 153
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 49
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 1
@@ -1047,7 +1254,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "B"
@@ -1056,7 +1266,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 400
@@ -1065,7 +1278,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "JAN"
@@ -1076,13 +1292,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 153
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 49
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 1
@@ -1091,7 +1313,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "B"
@@ -1100,7 +1325,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: 5000
@@ -1109,7 +1337,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 153
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 49
                     }
                     v: "FEB"
@@ -1128,7 +1359,10 @@ body {
           }
         }
         src {
+          end_column: 153
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
       }
@@ -1150,7 +1384,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 28
+                end_line: 54
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 54
               }
               v: "empid"
@@ -1166,7 +1403,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
       }
@@ -1193,14 +1433,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 59
+              end_line: 54
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 54
             }
             v: "month"
           }
         }
         src {
+          end_column: 59
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
         values {
@@ -1208,13 +1454,19 @@ body {
             v {
               list_val {
                 src {
+                  end_column: 59
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 54
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 54
                     }
                     v: "JAN"
@@ -1223,7 +1475,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 54
                     }
                     v: "FEB"
@@ -1252,7 +1507,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 73
+                end_line: 54
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 54
               }
               v: "amount"
@@ -1268,7 +1526,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
       }
@@ -1314,7 +1575,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 56
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 56
               }
               v: "empid"
@@ -1323,7 +1587,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 38
+                end_line: 56
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 56
               }
               v: "team"
@@ -1338,7 +1605,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1365,14 +1635,20 @@ body {
         pivot_col {
           string_val {
             src {
+              end_column: 53
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 56
             }
             v: "month"
           }
         }
         src {
+          end_column: 53
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1394,7 +1670,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 67
+                end_line: 56
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 56
               }
               v: "amount"
@@ -1410,7 +1689,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1430,7 +1712,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 89
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 56
             }
             v: "empid"
@@ -1439,7 +1724,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 89
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 56
             }
             v: "team"
@@ -1454,7 +1742,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -90,7 +90,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 124
+          end_line: 30
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 22
           start_line: 30
         }
       }
@@ -124,7 +127,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: 1
@@ -133,7 +139,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: "two"
@@ -145,7 +154,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param1"
@@ -154,7 +166,10 @@ body {
               vs {
                 int64_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: 10
@@ -165,7 +180,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param2"
@@ -174,7 +192,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "twenty"
@@ -182,7 +203,10 @@ body {
               }
             }
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
           }
@@ -190,14 +214,20 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: true
           }
         }
         src {
+          end_column: 89
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
       }
@@ -225,7 +255,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: 1
@@ -234,7 +267,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: "two"
@@ -246,7 +282,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param1"
@@ -255,7 +294,10 @@ body {
               vs {
                 int64_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: 10
@@ -266,7 +308,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "param2"
@@ -275,7 +320,10 @@ body {
               vs {
                 string_val {
                   src {
+                    end_column: 89
+                    end_line: 32
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 13
                     start_line: 32
                   }
                   v: "twenty"
@@ -283,7 +331,10 @@ body {
               }
             }
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
           }
@@ -291,14 +342,20 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 89
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 32
             }
             v: true
           }
         }
         src {
+          end_column: 89
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
       }
@@ -339,7 +396,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: 2
@@ -348,7 +408,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: "one"
@@ -357,7 +420,10 @@ body {
         pos_args {
           seq_map_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
@@ -365,13 +431,19 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
         }
         src {
+          end_column: 63
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 34
         }
       }
@@ -399,7 +471,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: 2
@@ -408,7 +483,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
             v: "one"
@@ -417,7 +495,10 @@ body {
         pos_args {
           seq_map_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
@@ -425,13 +506,19 @@ body {
         pos_args {
           bool_val {
             src {
+              end_column: 63
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 34
             }
           }
         }
         src {
+          end_column: 63
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 34
         }
       }

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -60,13 +60,19 @@ body {
                   list: "c"
                 }
                 src {
+                  end_column: 74
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 29
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 1
@@ -75,7 +81,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 2
@@ -84,7 +93,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 3
@@ -99,13 +111,19 @@ body {
                   list: "a"
                 }
                 src {
+                  end_column: 74
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 29
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 4
@@ -114,7 +132,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 29
                     }
                     v: 2
@@ -125,7 +146,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }
@@ -148,13 +172,19 @@ body {
             vs {
               sp_row {
                 src {
+                  end_column: 82
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 1
@@ -163,7 +193,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 3
@@ -172,7 +205,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 2
@@ -183,13 +219,19 @@ body {
             vs {
               sp_row {
                 src {
+                  end_column: 82
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 1
@@ -198,7 +240,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 2
@@ -207,7 +252,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 3
@@ -218,13 +266,19 @@ body {
             vs {
               sp_row {
                 src {
+                  end_column: 82
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 3
@@ -233,7 +287,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 2
@@ -242,7 +299,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 82
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 31
                     }
                     v: 1
@@ -253,7 +313,10 @@ body {
           }
         }
         src {
+          end_column: 82
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -276,13 +339,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 33
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 1
@@ -291,7 +360,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 2
@@ -302,13 +374,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 33
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 3
@@ -317,7 +395,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 33
                     }
                     v: 4
@@ -334,7 +415,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -357,13 +441,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: 1
@@ -372,7 +462,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: "snow"
@@ -383,13 +476,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: 3
@@ -398,7 +497,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: "flake"
@@ -436,7 +538,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -459,7 +564,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 1
@@ -468,7 +576,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 2
@@ -477,7 +588,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 3
@@ -486,7 +600,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
                 v: 4
@@ -500,7 +617,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -523,13 +643,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 83
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 1
@@ -538,7 +664,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 2
@@ -547,7 +676,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 3
@@ -556,7 +688,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 41
                     }
                     v: 4
@@ -575,7 +710,10 @@ body {
           }
         }
         src {
+          end_column: 83
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }
@@ -598,13 +736,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 43
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 1
@@ -613,7 +757,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 2
@@ -624,13 +771,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 75
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 43
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 3
@@ -639,7 +792,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                     v: 4
@@ -656,7 +812,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
       }
@@ -685,13 +844,19 @@ body {
                   list: "d"
                 }
                 src {
+                  end_column: 65
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 45
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 1
@@ -700,7 +865,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 2
@@ -709,7 +877,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 3
@@ -718,7 +889,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 65
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 45
                     }
                     v: 4
@@ -729,7 +903,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 45
         }
       }
@@ -755,7 +932,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: "a"
@@ -764,7 +944,10 @@ body {
                   vs {
                     int64_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: 1
@@ -772,7 +955,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 47
                 }
               }
@@ -783,7 +969,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: "b"
@@ -792,7 +981,10 @@ body {
                   vs {
                     int64_val {
                       src {
+                        end_column: 60
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 47
                       }
                       v: 2
@@ -800,7 +992,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 47
                 }
               }
@@ -808,7 +1003,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 47
         }
       }

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -514,25 +514,27 @@ body {
           sp_dataframe_schema__struct {
             v {
               fields {
-                column_identifier {
-                  name: "a"
+                list {
+                  column_identifier {
+                    name: "a"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
                 }
-                data_type {
-                  sp_integer_type: true
-                }
-                nullable: true
-              }
-              fields {
-                column_identifier {
-                  name: "b"
-                }
-                data_type {
-                  sp_string_type {
-                    length {
+                list {
+                  column_identifier {
+                    name: "b"
+                  }
+                  data_type {
+                    sp_string_type {
+                      length {
+                      }
                     }
                   }
+                  nullable: true
                 }
-                nullable: true
               }
             }
           }

--- a/tests/ast/data/Session.flatten.test
+++ b/tests/ast/data/Session.flatten.test
@@ -45,20 +45,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 25
                     }
                     v: "{\"a\": [1,2]}"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 25
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 25
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 25
             }
           }
@@ -70,7 +79,10 @@ body {
           value: "a"
         }
         src {
+          end_column: 89
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -104,14 +116,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 27
                 }
                 v: "NUM"
               }
             }
             src {
+              end_column: 40
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 27
             }
           }
@@ -121,7 +139,10 @@ body {
         }
         recursive: true
         src {
+          end_column: 71
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -69,14 +69,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 51
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 25
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 25
                 }
               }
@@ -97,26 +103,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 25
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 25
                     }
                     v: "two"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 25
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 25
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 25
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 25
             }
           }
         }
         src {
+          end_column: 64
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -165,14 +183,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 72
+                        end_line: 27
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 62
                         start_line: 27
                       }
                       v: "bar"
                     }
                   }
                   src {
+                    end_column: 72
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 62
                     start_line: 27
                   }
                 }
@@ -196,27 +220,39 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 56
+                        end_line: 27
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 50
                         start_line: 27
                       }
                       v: 3
                     }
                   }
                   src {
+                    end_column: 56
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 50
                     start_line: 27
                   }
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
           }
         }
         src {
+          end_column: 73
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -249,13 +285,19 @@ body {
               }
             }
             src {
+              end_column: 52
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
         }
         src {
+          end_column: 52
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -285,7 +327,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 37
           start_line: 32
         }
       }
@@ -312,13 +357,19 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 32
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 32
             }
           }
         }
         src {
+          end_column: 43
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 32
         }
       }
@@ -350,14 +401,20 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 47
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 35
             }
             v: "foo"
           }
         }
         src {
+          end_column: 47
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 37
           start_line: 35
         }
       }
@@ -384,13 +441,19 @@ body {
               }
             }
             src {
+              end_column: 48
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
           }
         }
         src {
+          end_column: 48
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -420,7 +483,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -447,13 +513,19 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 38
             }
           }
         }
         src {
+          end_column: 41
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 38
         }
       }
@@ -485,14 +557,20 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 50
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 40
             }
             v: "foo"
           }
         }
         src {
+          end_column: 50
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 40
         }
       }
@@ -519,13 +597,19 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 41
             }
           }
         }
         src {
+          end_column: 41
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
       }

--- a/tests/ast/data/Table.delete.test
+++ b/tests/ast/data/Table.delete.test
@@ -60,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -86,7 +89,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 19
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -119,7 +125,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variant {
@@ -144,7 +153,10 @@ body {
           bitfield1: 4
         }
         src {
+          end_column: 30
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -177,7 +189,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variant {
@@ -202,7 +217,10 @@ body {
           bitfield1: 7
         }
         src {
+          end_column: 79
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 35
         }
         statement_params {
@@ -239,7 +257,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variant {
@@ -274,7 +295,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 27
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 39
                 }
               }
@@ -282,14 +306,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 32
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 39
                 }
                 v: 1
               }
             }
             src {
+              end_column: 32
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 39
             }
           }
@@ -298,7 +328,10 @@ body {
           bitfield1: 10
         }
         src {
+          end_column: 33
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -331,7 +364,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variant {
@@ -357,7 +393,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 2
@@ -366,7 +405,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 3
@@ -375,7 +417,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 4
@@ -384,7 +429,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 43
                 }
                 v: 5
@@ -398,7 +446,10 @@ body {
           }
         }
         src {
+          end_column: 72
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 43
         }
       }
@@ -430,7 +481,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 45
                 }
               }
@@ -438,13 +492,19 @@ body {
             rhs {
               list_val {
                 src {
+                  end_column: 40
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 45
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 45
                     }
                     v: "num"
@@ -453,7 +513,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 45
             }
           }
@@ -469,7 +532,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 45
         }
       }

--- a/tests/ast/data/Table.drop_table.test
+++ b/tests/ast/data/Table.drop_table.test
@@ -24,7 +24,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -49,7 +52,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 23
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }

--- a/tests/ast/data/Table.init.test
+++ b/tests/ast/data/Table.init.test
@@ -24,7 +24,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -61,14 +64,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 39
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 27
             }
           }
@@ -89,14 +98,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 27
             }
           }
@@ -109,7 +124,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -192,25 +192,27 @@ body {
           sp_dataframe_schema__struct {
             v {
               fields {
-                column_identifier {
-                  name: "num"
+                list {
+                  column_identifier {
+                    name: "num"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
                 }
-                data_type {
-                  sp_integer_type: true
-                }
-                nullable: true
-              }
-              fields {
-                column_identifier {
-                  name: "str"
-                }
-                data_type {
-                  sp_string_type {
-                    length {
+                list {
+                  column_identifier {
+                    name: "str"
+                  }
+                  data_type {
+                    sp_string_type {
+                      length {
+                      }
                     }
                   }
+                  nullable: true
                 }
-                nullable: true
               }
             }
           }

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -84,13 +84,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 96
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 17
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: 1
@@ -99,7 +105,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: "one"
@@ -110,13 +119,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 96
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 17
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: 2
@@ -125,7 +140,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: "two"
@@ -136,13 +154,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 96
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 17
                   start_line: 27
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: 3
@@ -151,7 +175,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 17
                       start_line: 27
                     }
                     v: "three"
@@ -189,7 +216,10 @@ body {
           }
         }
         src {
+          end_column: 96
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 27
         }
       }
@@ -215,7 +245,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 32
         }
         variant {
@@ -244,7 +277,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 136
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 34
                     }
                     v: "str"
@@ -253,7 +289,10 @@ body {
                 _2 {
                   string_val {
                     src {
+                      end_column: 136
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 34
                     }
                     v: "value"
@@ -281,7 +320,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 43
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 34
                     }
                   }
@@ -297,13 +339,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 60
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 34
                     }
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 34
                 }
               }
@@ -321,7 +369,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 34
                     }
                   }
@@ -329,20 +380,29 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 34
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 34
                     }
                     v: "too_old"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 34
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 34
                 }
               }
             }
             src {
+              end_column: 92
+              end_line: 34
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 34
             }
           }
@@ -355,7 +415,10 @@ body {
           }
         }
         src {
+          end_column: 136
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 34
         }
       }
@@ -388,7 +451,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 37
         }
         variant {
@@ -425,7 +491,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 88
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 39
                     }
                   }
@@ -433,14 +502,20 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 39
                     }
                     v: "too_new"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 39
                 }
               }
@@ -450,7 +525,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: "str"
@@ -459,7 +537,10 @@ body {
                 _2 {
                   string_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: "value2"
@@ -476,7 +557,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: "num"
@@ -485,7 +569,10 @@ body {
                 _2 {
                   int64_val {
                     src {
+                      end_column: 167
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 39
                     }
                     v: 123
@@ -511,7 +598,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 39
                 }
               }
@@ -519,14 +609,20 @@ body {
             rhs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 39
                 }
                 v: "bar"
               }
             }
             src {
+              end_column: 51
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 39
             }
           }
@@ -539,7 +635,10 @@ body {
           }
         }
         src {
+          end_column: 167
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -572,7 +671,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 42
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 42
         }
         variant {
@@ -600,7 +702,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 140
+                    end_line: 44
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 44
                   }
                   v: "str"
@@ -611,7 +716,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 140
+                    end_line: 44
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 44
                   }
                   v: "value"
@@ -638,7 +746,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 43
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 44
                     }
                   }
@@ -654,13 +765,19 @@ body {
                       }
                     }
                     src {
+                      end_column: 60
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 44
                     }
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 44
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 44
                 }
               }
@@ -678,7 +795,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 44
                     }
                   }
@@ -686,20 +806,29 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 44
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 44
                     }
                     v: "too_old"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 44
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 44
                 }
               }
             }
             src {
+              end_column: 92
+              end_line: 44
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 44
             }
           }
@@ -712,7 +841,10 @@ body {
           }
         }
         src {
+          end_column: 140
+          end_line: 44
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 44
         }
       }
@@ -745,7 +877,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 46
         }
         variant {
@@ -782,7 +917,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 92
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 49
                     }
                   }
@@ -790,14 +928,20 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 49
                     }
                     v: "too_new"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 49
                 }
               }
@@ -806,7 +950,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 175
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 49
                   }
                   v: "str"
@@ -817,7 +964,10 @@ body {
               list {
                 string_val {
                   src {
+                    end_column: 175
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 8
                     start_line: 49
                   }
                   v: "value"
@@ -833,7 +983,10 @@ body {
                 _1 {
                   string_val {
                     src {
+                      end_column: 175
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 49
                     }
                     v: "str"
@@ -842,7 +995,10 @@ body {
                 _2 {
                   string_val {
                     src {
+                      end_column: 175
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 8
                       start_line: 49
                     }
                     v: "value3"
@@ -868,7 +1024,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 49
                 }
               }
@@ -876,14 +1035,20 @@ body {
             rhs {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 49
                 }
                 v: "foo"
               }
             }
             src {
+              end_column: 51
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 49
             }
           }
@@ -896,7 +1061,10 @@ body {
           }
         }
         src {
+          end_column: 175
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 49
         }
       }
@@ -929,7 +1097,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 52
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 52
         }
         variant {
@@ -971,7 +1142,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 54
                 }
               }
@@ -987,13 +1161,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 54
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 54
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 54
             }
           }
@@ -1006,7 +1186,10 @@ body {
           }
         }
         src {
+          end_column: 114
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
       }
@@ -1039,7 +1222,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 57
         }
         variant {
@@ -1075,7 +1261,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 113
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 59
                     }
                   }
@@ -1083,14 +1272,20 @@ body {
                 rhs {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 59
                     }
                     v: "too_new"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 100
                   start_line: 59
                 }
               }
@@ -1115,7 +1310,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 43
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 59
                     }
                   }
@@ -1123,14 +1321,20 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 59
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 59
                 }
               }
@@ -1148,7 +1352,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 66
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 59
                     }
                   }
@@ -1164,19 +1371,28 @@ body {
                       }
                     }
                     src {
+                      end_column: 83
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 59
                     }
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 29
               start_line: 59
             }
           }
@@ -1189,7 +1405,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 59
         }
       }
@@ -1222,7 +1441,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 62
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 17
           start_line: 62
         }
         variant {
@@ -1259,7 +1481,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 64
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 64
                 }
               }
@@ -1275,13 +1500,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 64
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 64
                 }
               }
             }
             src {
+              end_column: 70
+              end_line: 64
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 64
             }
           }
@@ -1294,7 +1525,10 @@ body {
           }
         }
         src {
+          end_column: 160
+          end_line: 64
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 64
         }
         statement_params {

--- a/tests/ast/data/Table.sample.test
+++ b/tests/ast/data/Table.sample.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -67,7 +70,10 @@ body {
           value: 100
         }
         src {
+          end_column: 38
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -102,7 +108,10 @@ body {
           value: 123
         }
         src {
+          end_column: 72
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -134,7 +143,10 @@ body {
           value: "SYSTEM"
         }
         src {
+          end_column: 59
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }

--- a/tests/ast/data/Table.update.test
+++ b/tests/ast/data/Table.update.test
@@ -52,7 +52,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -78,7 +81,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 21
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 27
         }
       }
@@ -108,7 +114,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 27
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 29
               }
             }
@@ -119,7 +128,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 27
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 29
         }
       }
@@ -149,7 +161,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 40
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 31
               }
               v: 1
@@ -169,7 +184,10 @@ body {
                 }
               }
               src {
+                end_column: 38
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 32
                 start_line: 31
               }
             }
@@ -180,7 +198,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 40
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 31
         }
       }
@@ -210,7 +231,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 43
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 33
               }
               v: 2
@@ -231,7 +255,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 33
                 }
               }
@@ -239,14 +266,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 33
                 }
                 v: 1
               }
             }
             src {
+              end_column: 42
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 33
             }
           }
@@ -255,7 +288,10 @@ body {
           bitfield1: 1
         }
         src {
+          end_column: 43
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }
@@ -285,7 +321,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 1
@@ -294,7 +333,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 2
@@ -303,7 +345,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 3
@@ -312,7 +357,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 20
                   start_line: 35
                 }
                 v: 4
@@ -326,7 +374,10 @@ body {
           }
         }
         src {
+          end_column: 72
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 35
         }
       }
@@ -349,7 +400,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 64
+                end_line: 37
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 37
               }
               v: 3
@@ -370,7 +424,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 37
                 }
               }
@@ -386,13 +443,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 37
             }
           }
@@ -408,7 +471,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 37
         }
       }
@@ -438,7 +504,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 80
+                end_line: 39
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 39
               }
               v: 4
@@ -458,7 +527,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 39
                 }
               }
@@ -474,13 +546,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 39
             }
           }
@@ -496,7 +574,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -526,7 +607,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 129
+                end_line: 41
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 8
                 start_line: 41
               }
               v: 5
@@ -546,7 +630,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 41
                 }
               }
@@ -562,13 +649,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 41
             }
           }
@@ -584,7 +677,10 @@ body {
           }
         }
         src {
+          end_column: 129
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 41
         }
         statement_params {

--- a/tests/ast/data/case_when.test
+++ b/tests/ast/data/case_when.test
@@ -64,7 +64,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -104,26 +107,38 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 43
+                        end_line: 27
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 27
                       }
                       v: "bool_col"
                     }
                   }
                   src {
+                    end_column: 43
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 27
                   }
                 }
               }
               src {
+                end_column: 52
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 27
               }
               value {
                 string_val {
                   src {
+                    end_column: 52
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 27
                   }
                   v: "true"
@@ -131,7 +146,10 @@ body {
               }
             }
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -144,7 +162,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -184,14 +205,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 29
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 29
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 29
                       }
                     }
@@ -199,26 +226,38 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 41
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 29
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 41
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 49
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 29
               }
               value {
                 string_val {
                   src {
+                    end_column: 49
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 29
                   }
                   v: "one"
@@ -244,14 +283,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 63
+                            end_line: 29
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 55
                             start_line: 29
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 63
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 55
                         start_line: 29
                       }
                     }
@@ -259,26 +304,38 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 68
+                        end_line: 29
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 55
                         start_line: 29
                       }
                       v: 2
                     }
                   }
                   src {
+                    end_column: 68
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 55
                     start_line: 29
                   }
                 }
               }
               src {
+                end_column: 76
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 29
               }
               value {
                 string_val {
                   src {
+                    end_column: 76
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 29
                   }
                   v: "two"
@@ -287,13 +344,19 @@ body {
             }
             cases {
               src {
+                end_column: 95
+                end_line: 29
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 29
               }
               value {
                 string_val {
                   src {
+                    end_column: 95
+                    end_line: 29
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 29
                   }
                   v: "other"
@@ -301,7 +364,10 @@ body {
               }
             }
             src {
+              end_column: 49
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -314,7 +380,10 @@ body {
           }
         }
         src {
+          end_column: 96
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -354,14 +423,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 31
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 31
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 31
                       }
                     }
@@ -369,20 +444,29 @@ body {
                   lower_bound {
                     int64_val {
                       src {
+                        end_column: 52
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 31
                       }
                       v: 37
                     }
                   }
                   src {
+                    end_column: 52
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 31
                   }
                   upper_bound {
                     int64_val {
                       src {
+                        end_column: 52
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 31
                       }
                       v: 42
@@ -391,7 +475,10 @@ body {
                 }
               }
               src {
+                end_column: 63
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 31
               }
               value {
@@ -410,14 +497,20 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 62
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 54
                         start_line: 31
                       }
                       v: "B"
                     }
                   }
                   src {
+                    end_column: 62
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 54
                     start_line: 31
                   }
                 }
@@ -425,7 +518,10 @@ body {
             }
             cases {
               src {
+                end_column: 83
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 31
               }
               value {
@@ -444,21 +540,30 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 82
+                        end_line: 31
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 74
                         start_line: 31
                       }
                       v: "C"
                     }
                   }
                   src {
+                    end_column: 82
+                    end_line: 31
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 74
                     start_line: 31
                   }
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -471,7 +576,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -511,32 +619,47 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 33
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 33
                           }
                           v: "A"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 33
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 33
                       }
                     }
                   }
                   src {
+                    end_column: 48
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 33
                   }
                 }
               }
               src {
+                end_column: 57
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 33
               }
               value {
                 string_val {
                   src {
+                    end_column: 57
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 33
                   }
                   v: "one"
@@ -545,13 +668,19 @@ body {
             }
             cases {
               src {
+                end_column: 76
+                end_line: 33
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 33
               }
               value {
                 string_val {
                   src {
+                    end_column: 76
+                    end_line: 33
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 33
                   }
                   v: "other"
@@ -559,7 +688,10 @@ body {
               }
             }
             src {
+              end_column: 57
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -572,7 +704,10 @@ body {
           }
         }
         src {
+          end_column: 77
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -612,26 +747,38 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 35
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 35
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 35
                       }
                     }
                   }
                   src {
+                    end_column: 46
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 55
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
               value {
@@ -650,14 +797,20 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 54
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 48
                         start_line: 35
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 54
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 48
                     start_line: 35
                   }
                 }
@@ -682,14 +835,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 69
+                            end_line: 35
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 61
                             start_line: 35
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 69
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 61
                         start_line: 35
                       }
                     }
@@ -697,20 +856,29 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 74
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 61
                         start_line: 35
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 74
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 61
                     start_line: 35
                   }
                 }
               }
               src {
+                end_column: 83
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
               value {
@@ -729,14 +897,20 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 82
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 76
                         start_line: 35
                       }
                       v: 2
                     }
                   }
                   src {
+                    end_column: 82
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 76
                     start_line: 35
                   }
                 }
@@ -744,7 +918,10 @@ body {
             }
             cases {
               src {
+                end_column: 101
+                end_line: 35
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 35
               }
               value {
@@ -763,21 +940,30 @@ body {
                   pos_args {
                     int64_val {
                       src {
+                        end_column: 100
+                        end_line: 35
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 94
                         start_line: 35
                       }
                       v: 3
                     }
                   }
                   src {
+                    end_column: 100
+                    end_line: 35
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 94
                     start_line: 35
                   }
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -790,7 +976,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -830,14 +1019,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 38
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 38
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 38
                       }
                     }
@@ -845,26 +1040,38 @@ body {
                   pattern {
                     string_val {
                       src {
+                        end_column: 52
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 38
                       }
                       v: "foo"
                     }
                   }
                   src {
+                    end_column: 52
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 38
                   }
                 }
               }
               src {
+                end_column: 60
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 38
               }
               value {
                 string_val {
                   src {
+                    end_column: 60
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 38
                   }
                   v: "foo"
@@ -873,13 +1080,19 @@ body {
             }
             cases {
               src {
+                end_column: 78
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 38
               }
               value {
                 string_val {
                   src {
+                    end_column: 78
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 38
                   }
                   v: "null"
@@ -905,14 +1118,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 92
+                            end_line: 38
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 84
                             start_line: 38
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 92
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 84
                         start_line: 38
                       }
                     }
@@ -920,26 +1139,38 @@ body {
                   pattern {
                     string_val {
                       src {
+                        end_column: 108
+                        end_line: 38
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 84
                         start_line: 38
                       }
                       v: "bar"
                     }
                   }
                   src {
+                    end_column: 108
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 84
                     start_line: 38
                   }
                 }
               }
               src {
+                end_column: 116
+                end_line: 38
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 38
               }
               value {
                 string_val {
                   src {
+                    end_column: 116
+                    end_line: 38
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 38
                   }
                   v: "bar"
@@ -947,7 +1178,10 @@ body {
               }
             }
             src {
+              end_column: 60
+              end_line: 38
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 38
             }
           }
@@ -960,7 +1194,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 38
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 38
         }
         variadic: true
@@ -1000,14 +1237,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 36
+                            end_line: 40
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 28
                             start_line: 40
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 36
+                        end_line: 40
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 28
                         start_line: 40
                       }
                     }
@@ -1028,32 +1271,47 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 47
+                            end_line: 40
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 39
                             start_line: 40
                           }
                           v: "b"
                         }
                       }
                       src {
+                        end_column: 47
+                        end_line: 40
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 39
                         start_line: 40
                       }
                     }
                   }
                   src {
+                    end_column: 47
+                    end_line: 40
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 28
                     start_line: 40
                   }
                 }
               }
               src {
+                end_column: 56
+                end_line: 40
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 40
               }
               value {
                 string_val {
                   src {
+                    end_column: 56
+                    end_line: 40
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 40
                   }
                   v: "both"
@@ -1062,13 +1320,19 @@ body {
             }
             cases {
               src {
+                end_column: 75
+                end_line: 40
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 40
               }
               value {
                 string_val {
                   src {
+                    end_column: 75
+                    end_line: 40
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 23
                     start_line: 40
                   }
                   v: "other"
@@ -1076,7 +1340,10 @@ body {
               }
             }
             src {
+              end_column: 56
+              end_line: 40
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 40
             }
           }
@@ -1089,7 +1356,10 @@ body {
           }
         }
         src {
+          end_column: 76
+          end_line: 40
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 40
         }
         variadic: true
@@ -1129,14 +1399,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 25
+                            end_line: 43
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 17
                             start_line: 43
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 25
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 17
                         start_line: 43
                       }
                     }
@@ -1144,26 +1420,38 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 30
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 17
                         start_line: 43
                       }
                       v: 1
                     }
                   }
                   src {
+                    end_column: 30
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 17
                     start_line: 43
                   }
                 }
               }
               src {
+                end_column: 38
+                end_line: 43
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 12
                 start_line: 43
               }
               value {
                 string_val {
                   src {
+                    end_column: 38
+                    end_line: 43
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 12
                     start_line: 43
                   }
                   v: "one"
@@ -1172,14 +1460,20 @@ body {
             }
             cases {
               src {
+                end_column: 35
+                end_line: 44
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 44
               }
               value {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 44
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 44
                   }
                   v: "other_one"
                 }
@@ -1204,14 +1498,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 45
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 45
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 45
                       }
                     }
@@ -1219,27 +1519,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 45
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 45
                       }
                       v: 2
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 45
                   }
                 }
               }
               src {
+                end_column: 39
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 45
               }
               value {
                 string_val {
                   src {
+                    end_column: 39
+                    end_line: 45
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 45
                   }
                   v: "two"
                 }
@@ -1247,14 +1559,20 @@ body {
             }
             cases {
               src {
+                end_column: 35
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 46
               }
               value {
                 string_val {
                   src {
+                    end_column: 35
+                    end_line: 46
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 46
                   }
                   v: "other_two"
                 }
@@ -1279,14 +1597,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 47
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 47
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 47
                       }
                     }
@@ -1294,27 +1618,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 47
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 47
                       }
                       v: 3
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 47
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 47
                   }
                 }
               }
               src {
+                end_column: 41
+                end_line: 47
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 47
               }
               value {
                 string_val {
                   src {
+                    end_column: 41
+                    end_line: 47
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 47
                   }
                   v: "three"
                 }
@@ -1322,14 +1658,20 @@ body {
             }
             cases {
               src {
+                end_column: 37
+                end_line: 48
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 48
               }
               value {
                 string_val {
                   src {
+                    end_column: 37
+                    end_line: 48
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 48
                   }
                   v: "other_three"
                 }
@@ -1354,14 +1696,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 49
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 49
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 49
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 49
                       }
                     }
@@ -1369,27 +1717,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 49
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 49
                       }
                       v: 4
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 49
                   }
                 }
               }
               src {
+                end_column: 40
+                end_line: 49
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 49
               }
               value {
                 string_val {
                   src {
+                    end_column: 40
+                    end_line: 49
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 49
                   }
                   v: "four"
                 }
@@ -1397,14 +1757,20 @@ body {
             }
             cases {
               src {
+                end_column: 36
+                end_line: 50
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 50
               }
               value {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 50
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 50
                   }
                   v: "other_four"
                 }
@@ -1429,14 +1795,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 26
+                            end_line: 51
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 18
                             start_line: 51
                           }
                           v: "a"
                         }
                       }
                       src {
+                        end_column: 26
+                        end_line: 51
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 51
                       }
                     }
@@ -1444,27 +1816,39 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 31
+                        end_line: 51
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 18
                         start_line: 51
                       }
                       v: 5
                     }
                   }
                   src {
+                    end_column: 31
+                    end_line: 51
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 18
                     start_line: 51
                   }
                 }
               }
               src {
+                end_column: 40
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 51
               }
               value {
                 string_val {
                   src {
+                    end_column: 40
+                    end_line: 51
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 51
                   }
                   v: "five"
                 }
@@ -1472,21 +1856,30 @@ body {
             }
             cases {
               src {
+                end_column: 36
+                end_line: 52
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 43
+                start_column: 13
+                start_line: 52
               }
               value {
                 string_val {
                   src {
+                    end_column: 36
+                    end_line: 52
                     file: "SRC_POSITION_TEST_MODE"
-                    start_line: 43
+                    start_column: 13
+                    start_line: 52
                   }
                   v: "other_five"
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 43
             }
           }
@@ -1499,7 +1892,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 42
         }
         variadic: true

--- a/tests/ast/data/col_alias.test
+++ b/tests/ast/data/col_alias.test
@@ -38,7 +38,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -77,14 +80,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 29
                 }
               }
@@ -94,7 +103,10 @@ body {
             }
             name: "test"
             src {
+              end_column: 44
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 29
             }
           }
@@ -107,7 +119,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -144,14 +159,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 31
                 }
               }
@@ -161,7 +182,10 @@ body {
             }
             name: "test"
             src {
+              end_column: 46
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 31
             }
           }
@@ -174,7 +198,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         variadic: true
@@ -211,14 +238,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 33
                 }
               }
@@ -228,7 +261,10 @@ body {
             }
             name: "test"
             src {
+              end_column: 45
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
           }
@@ -241,7 +277,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
         variadic: true
@@ -280,14 +319,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 33
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 35
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 33
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 35
                     }
                   }
@@ -295,14 +340,20 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 37
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 35
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 35
                 }
               }
@@ -312,7 +363,10 @@ body {
             }
             name: "test"
             src {
+              end_column: 51
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 35
             }
           }
@@ -325,7 +379,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variadic: true

--- a/tests/ast/data/col_asc.test
+++ b/tests/ast/data/col_asc.test
@@ -34,7 +34,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -73,14 +76,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -89,7 +98,10 @@ body {
               sp_null_order_default: true
             }
             src {
+              end_column: 37
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -102,7 +114,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -139,14 +154,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -155,7 +176,10 @@ body {
               sp_null_order_nulls_first: true
             }
             src {
+              end_column: 49
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -168,7 +192,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -205,14 +232,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
@@ -221,7 +254,10 @@ body {
               sp_null_order_nulls_last: true
             }
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -234,7 +270,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true

--- a/tests/ast/data/col_between.test
+++ b/tests/ast/data/col_between.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -64,14 +67,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -92,26 +101,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             upper_bound {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 42
@@ -127,7 +148,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/col_binops.test
+++ b/tests/ast/data/col_binops.test
@@ -77,7 +77,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -116,14 +119,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -144,20 +153,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -170,7 +188,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -207,14 +228,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -235,20 +262,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 29
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -261,7 +297,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -298,14 +337,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -326,20 +371,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 31
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -352,7 +406,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -389,14 +446,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
@@ -417,20 +480,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 33
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -443,7 +515,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -480,14 +555,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
@@ -508,20 +589,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 35
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -534,7 +624,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -571,14 +664,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
@@ -599,20 +698,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 37
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -625,7 +733,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -662,14 +773,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
@@ -690,20 +807,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 39
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -716,7 +842,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -753,14 +882,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
@@ -781,20 +916,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 41
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
           }
@@ -807,7 +951,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -844,14 +991,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
@@ -872,20 +1025,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 43
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
           }
@@ -898,7 +1060,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -935,14 +1100,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
@@ -963,20 +1134,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 45
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
           }
@@ -989,7 +1169,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -1026,14 +1209,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
@@ -1054,20 +1243,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 47
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
           }
@@ -1080,7 +1278,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -1117,14 +1318,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
@@ -1145,20 +1352,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 49
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
           }
@@ -1171,7 +1387,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -1208,14 +1427,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
@@ -1236,20 +1461,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 51
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
           }
@@ -1262,7 +1496,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1299,14 +1536,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
@@ -1327,20 +1570,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 53
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
           }
@@ -1353,7 +1605,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true

--- a/tests/ast/data/col_bitops.test
+++ b/tests/ast/data/col_bitops.test
@@ -33,7 +33,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -72,14 +75,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -100,20 +109,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -126,7 +144,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -163,14 +184,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -191,20 +218,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 29
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -217,7 +253,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -254,14 +293,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -282,20 +327,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 31
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -308,7 +362,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -129,7 +129,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -168,20 +171,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             to {
@@ -197,7 +209,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -234,20 +249,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
             to {
@@ -263,7 +287,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -300,20 +327,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             to {
@@ -329,7 +365,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -366,20 +405,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             to {
@@ -395,7 +443,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -432,20 +483,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
             to {
@@ -464,7 +524,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -501,20 +564,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
             to {
@@ -530,7 +602,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -567,20 +642,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
             to {
@@ -596,7 +680,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -633,20 +720,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
             to {
@@ -662,7 +758,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -699,20 +798,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
             to {
@@ -728,7 +836,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -765,20 +876,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
             to {
@@ -794,7 +914,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -831,20 +954,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
             to {
@@ -860,7 +992,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -897,20 +1032,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
             to {
@@ -930,7 +1074,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -967,20 +1114,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
             to {
@@ -996,7 +1152,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1033,20 +1192,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
             to {
@@ -1069,7 +1237,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -1106,20 +1277,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 55
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 55
             }
             to {
@@ -1148,7 +1328,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
         variadic: true
@@ -1185,20 +1368,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 59
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 57
             }
             to {
@@ -1219,7 +1411,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 57
         }
         variadic: true
@@ -1256,20 +1451,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 59
             }
             to {
@@ -1286,7 +1490,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 59
         }
         variadic: true
@@ -1323,20 +1530,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 61
             }
             to {
@@ -1352,7 +1568,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 61
         }
         variadic: true
@@ -1389,20 +1608,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 63
             }
             to {
@@ -1418,7 +1646,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 63
         }
         variadic: true
@@ -1455,20 +1686,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 65
             }
             to {
@@ -1484,7 +1724,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 65
         }
         variadic: true
@@ -1521,20 +1764,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 67
             }
             to {
@@ -1550,7 +1802,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 67
         }
         variadic: true
@@ -1587,20 +1842,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 69
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 69
             }
             to {
@@ -1616,7 +1880,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 69
         }
         variadic: true
@@ -1653,20 +1920,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 71
             }
             to {
@@ -1682,7 +1958,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 71
         }
         variadic: true
@@ -1719,20 +1998,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 73
             }
             to {
@@ -1748,7 +2036,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 73
         }
         variadic: true
@@ -1785,20 +2076,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 75
             }
             to {
@@ -1816,7 +2116,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 75
         }
         variadic: true
@@ -1853,20 +2156,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 77
             }
             to {
@@ -1884,7 +2196,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 77
         }
         variadic: true
@@ -1921,20 +2236,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 79
             }
             to {
@@ -1963,7 +2287,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 79
         }
         variadic: true

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -93,7 +93,7 @@ df = df.select(col("A").cast(MapType(StringType(), StringType(), structured=Fals
 
 df = df.select(col("A").cast(VectorType(FloatType(), 42)))
 
-df = df.select(col("A").cast(StructType([], structured=False)))
+df = df.select(col("A").cast(StructType(structured=False)))
 
 df = df.select(col("A").cast(VariantType()))
 

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -57,7 +57,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -96,20 +99,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             to {
@@ -129,7 +141,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -166,20 +181,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
             to {
@@ -199,7 +223,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -236,20 +263,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             to {
@@ -269,7 +305,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -306,20 +345,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             to {
@@ -339,7 +387,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -376,20 +427,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 80
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
             to {
@@ -410,7 +470,10 @@ body {
           }
         }
         src {
+          end_column: 81
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -447,20 +510,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
             to {
@@ -484,7 +556,10 @@ body {
           }
         }
         src {
+          end_column: 95
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -521,20 +596,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
             to {
@@ -555,7 +639,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -592,20 +679,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 28
+              end_line: 46
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
             to {
@@ -680,7 +776,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -707,61 +707,63 @@ body {
             to {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "test1"
-                  }
-                  data_type {
-                    sp_string_type {
-                      length {
-                      }
+                  list {
+                    column_identifier {
+                      name: "test1"
                     }
-                  }
-                }
-                fields {
-                  column_identifier {
-                    name: "test2"
-                  }
-                  data_type {
-                    sp_integer_type: true
-                  }
-                  nullable: true
-                }
-                fields {
-                  column_identifier {
-                    name: "test3"
-                  }
-                  data_type {
-                    sp_array_type {
-                      ty {
-                        sp_long_type: true
-                      }
-                    }
-                  }
-                  nullable: true
-                }
-                fields {
-                  column_identifier {
-                    name: "test4"
-                  }
-                  data_type {
-                    sp_map_type {
-                      key_ty {
-                        sp_decimal_type {
-                          precision: 42
-                          scale: 23
+                    data_type {
+                      sp_string_type {
+                        length {
                         }
                       }
-                      value_ty {
-                        sp_vector_type {
-                          dimension: 64
-                          ty {
-                            sp_float_type: true
+                    }
+                  }
+                  list {
+                    column_identifier {
+                      name: "test2"
+                    }
+                    data_type {
+                      sp_integer_type: true
+                    }
+                    nullable: true
+                  }
+                  list {
+                    column_identifier {
+                      name: "test3"
+                    }
+                    data_type {
+                      sp_array_type {
+                        ty {
+                          sp_long_type: true
+                        }
+                      }
+                    }
+                    nullable: true
+                  }
+                  list {
+                    column_identifier {
+                      name: "test4"
+                    }
+                    data_type {
+                      sp_map_type {
+                        key_ty {
+                          sp_decimal_type {
+                            precision: 42
+                            scale: 23
+                          }
+                        }
+                        value_ty {
+                          sp_vector_type {
+                            dimension: 64
+                            ty {
+                              sp_float_type: true
+                            }
                           }
                         }
                       }
                     }
+                    nullable: true
                   }
-                  nullable: true
                 }
                 structured: true
               }

--- a/tests/ast/data/col_desc.test
+++ b/tests/ast/data/col_desc.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -71,14 +74,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -87,7 +96,10 @@ body {
               sp_null_order_default: true
             }
             src {
+              end_column: 38
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -100,7 +112,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -137,14 +152,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -153,7 +174,10 @@ body {
               sp_null_order_nulls_first: true
             }
             src {
+              end_column: 50
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -166,7 +190,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -203,14 +230,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -219,7 +252,10 @@ body {
               sp_null_order_nulls_last: true
             }
             src {
+              end_column: 49
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -232,7 +268,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/col_getitem.test
+++ b/tests/ast/data/col_getitem.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -64,21 +67,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             idx: 2
             src {
+              end_column: 34
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -101,21 +113,30 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 27
                 }
               }
             }
             field: "test"
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 36
               start_line: 27
             }
           }
@@ -128,7 +149,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -71,14 +74,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -86,7 +95,10 @@ body {
             values {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 1
@@ -95,7 +107,10 @@ body {
             values {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 2
@@ -104,7 +119,10 @@ body {
             values {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 3
@@ -120,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -157,14 +178,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -186,7 +213,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -223,14 +253,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -238,13 +274,19 @@ body {
             values {
               list_val {
                 src {
+                  end_column: 48
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: 1
@@ -253,7 +295,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: 2
@@ -262,7 +307,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: 3
@@ -280,7 +328,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true

--- a/tests/ast/data/col_literal.test
+++ b/tests/ast/data/col_literal.test
@@ -165,7 +165,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variant {
@@ -204,14 +207,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -219,13 +228,19 @@ body {
             rhs {
               null_val {
                 src {
+                  end_column: 38
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -238,7 +253,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -275,14 +293,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
@@ -290,14 +314,20 @@ body {
             rhs {
               bool_val {
                 src {
+                  end_column: 38
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
                 v: true
               }
             }
             src {
+              end_column: 38
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -310,7 +340,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -347,14 +380,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
@@ -362,13 +401,19 @@ body {
             rhs {
               bool_val {
                 src {
+                  end_column: 39
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -381,7 +426,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -418,14 +466,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
@@ -433,14 +487,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
                 v: 42
               }
             }
             src {
+              end_column: 36
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -453,7 +513,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -490,14 +553,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
@@ -505,14 +574,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 39
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
                 v: 42.24
               }
             }
             src {
+              end_column: 39
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -525,7 +600,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -562,14 +640,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
@@ -577,14 +661,20 @@ body {
             rhs {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 40
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
           }
@@ -597,7 +687,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -634,14 +727,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
@@ -649,14 +748,20 @@ body {
             rhs {
               binary_val {
                 src {
+                  end_column: 60
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 60
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
           }
@@ -669,7 +774,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -706,14 +814,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
@@ -721,14 +835,20 @@ body {
             rhs {
               binary_val {
                 src {
+                  end_column: 56
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 56
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
           }
@@ -741,7 +861,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -778,14 +901,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
@@ -799,7 +928,10 @@ body {
                 month: 6
                 second: 33
                 src {
+                  end_column: 83
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
                 tz {
@@ -812,7 +944,10 @@ body {
               }
             }
             src {
+              end_column: 83
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
           }
@@ -825,7 +960,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -862,14 +1000,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
@@ -883,7 +1027,10 @@ body {
                 month: 6
                 second: 33
                 src {
+                  end_column: 156
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
                 tz {
@@ -896,7 +1043,10 @@ body {
               }
             }
             src {
+              end_column: 156
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
           }
@@ -909,7 +1059,10 @@ body {
           }
         }
         src {
+          end_column: 157
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -946,14 +1099,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
@@ -967,7 +1126,10 @@ body {
                 month: 6
                 second: 33
                 src {
+                  end_column: 145
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
                 tz {
@@ -980,7 +1142,10 @@ body {
               }
             }
             src {
+              end_column: 145
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
           }
@@ -993,7 +1158,10 @@ body {
           }
         }
         src {
+          end_column: 146
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1030,14 +1198,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
@@ -1047,14 +1221,20 @@ body {
                 day: 7
                 month: 6
                 src {
+                  end_column: 59
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
                 year: 2024
               }
             }
             src {
+              end_column: 59
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
           }
@@ -1067,7 +1247,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -1104,14 +1287,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 55
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
               }
@@ -1123,7 +1312,10 @@ body {
                 minute: 42
                 second: 23
                 src {
+                  end_column: 66
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
                 tz {
@@ -1135,7 +1327,10 @@ body {
               }
             }
             src {
+              end_column: 66
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 55
             }
           }
@@ -1148,7 +1343,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
         variadic: true
@@ -1185,14 +1383,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
               }
@@ -1204,7 +1408,10 @@ body {
                 minute: 42
                 second: 23
                 src {
+                  end_column: 139
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
                 tz {
@@ -1216,7 +1423,10 @@ body {
               }
             }
             src {
+              end_column: 139
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 57
             }
           }
@@ -1229,7 +1439,10 @@ body {
           }
         }
         src {
+          end_column: 140
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 57
         }
         variadic: true
@@ -1266,14 +1479,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
               }
@@ -1285,7 +1504,10 @@ body {
                 minute: 42
                 second: 23
                 src {
+                  end_column: 128
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
                 tz {
@@ -1297,7 +1519,10 @@ body {
               }
             }
             src {
+              end_column: 128
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 59
             }
           }
@@ -1310,7 +1535,10 @@ body {
           }
         }
         src {
+          end_column: 129
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 59
         }
         variadic: true
@@ -1347,14 +1575,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
               }
@@ -1362,14 +1596,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 42
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
                 v: inf
               }
             }
             src {
+              end_column: 42
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 61
             }
           }
@@ -1382,7 +1622,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 61
         }
         variadic: true
@@ -1419,14 +1662,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
               }
@@ -1434,14 +1683,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 42
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
                 v: inf
               }
             }
             src {
+              end_column: 42
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 63
             }
           }
@@ -1454,7 +1709,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 63
         }
         variadic: true
@@ -1491,14 +1749,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
               }
@@ -1506,14 +1770,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 42
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
                 v: nan
               }
             }
             src {
+              end_column: 42
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 65
             }
           }
@@ -1526,7 +1796,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 65
         }
         variadic: true
@@ -1563,14 +1836,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
               }
@@ -1578,14 +1857,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 46
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
                 v: inf
               }
             }
             src {
+              end_column: 46
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 67
             }
           }
@@ -1598,7 +1883,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 67
         }
         variadic: true
@@ -1635,14 +1923,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 69
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
               }
@@ -1650,14 +1944,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 47
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
                 v: -inf
               }
             }
             src {
+              end_column: 47
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 69
             }
           }
@@ -1670,7 +1970,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 69
         }
         variadic: true
@@ -1707,14 +2010,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
               }
@@ -1722,14 +2031,20 @@ body {
             rhs {
               float64_val {
                 src {
+                  end_column: 46
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
                 v: nan
               }
             }
             src {
+              end_column: 46
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 71
             }
           }
@@ -1742,7 +2057,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 71
         }
         variadic: true
@@ -1779,14 +2097,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
               }
@@ -1795,14 +2119,20 @@ body {
               big_decimal_val {
                 scale: -6
                 src {
+                  end_column: 66
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
                 unscaled_value: "]\361\271\260\255"
               }
             }
             src {
+              end_column: 66
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 73
             }
           }
@@ -1815,7 +2145,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 73
         }
         variadic: true
@@ -1852,14 +2185,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
               }
@@ -1868,14 +2207,20 @@ body {
               big_decimal_val {
                 scale: -6
                 src {
+                  end_column: 67
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
                 unscaled_value: "\242\016FOS"
               }
             }
             src {
+              end_column: 67
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 75
             }
           }
@@ -1888,7 +2233,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 75
         }
         variadic: true
@@ -1925,14 +2273,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
               }
@@ -1940,14 +2294,20 @@ body {
             rhs {
               big_decimal_val {
                 src {
+                  end_column: 57
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
                 unscaled_value: "\006(\037"
               }
             }
             src {
+              end_column: 57
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 77
             }
           }
@@ -1960,7 +2320,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 77
         }
         variadic: true
@@ -1997,14 +2360,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
               }
@@ -2012,14 +2381,20 @@ body {
             rhs {
               big_decimal_val {
                 src {
+                  end_column: 60
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
                 unscaled_value: "\030\014\271\030"
               }
             }
             src {
+              end_column: 60
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 79
             }
           }
@@ -2032,7 +2407,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 79
         }
         variadic: true
@@ -2069,14 +2447,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 81
                 }
               }
@@ -2084,14 +2468,20 @@ body {
             rhs {
               big_decimal_val {
                 src {
+                  end_column: 60
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 81
                 }
                 unscaled_value: "\030\014\271\030"
               }
             }
             src {
+              end_column: 60
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 81
             }
           }
@@ -2104,7 +2494,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 81
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 81
         }
         variadic: true
@@ -2141,14 +2534,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 83
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 83
                 }
               }
@@ -2159,13 +2558,19 @@ body {
                   value: "+F"
                 }
                 src {
+                  end_column: 61
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 83
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 83
             }
           }
@@ -2178,7 +2583,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 83
         }
         variadic: true
@@ -2215,14 +2623,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 85
                 }
               }
@@ -2233,13 +2647,19 @@ body {
                   value: "-F"
                 }
                 src {
+                  end_column: 62
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 85
             }
           }
@@ -2252,7 +2672,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 85
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 85
         }
         variadic: true
@@ -2289,14 +2712,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 87
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 87
                 }
               }
@@ -2307,13 +2736,19 @@ body {
                   value: "+n"
                 }
                 src {
+                  end_column: 56
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 87
             }
           }
@@ -2326,7 +2761,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 87
         }
         variadic: true
@@ -2363,14 +2801,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 89
                 }
               }
@@ -2381,13 +2825,19 @@ body {
                   value: "-n"
                 }
                 src {
+                  end_column: 57
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 89
             }
           }
@@ -2400,7 +2850,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 89
         }
         variadic: true
@@ -2437,14 +2890,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 91
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 91
                 }
               }
@@ -2455,13 +2914,19 @@ body {
                   value: "+N"
                 }
                 src {
+                  end_column: 57
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 91
             }
           }
@@ -2474,7 +2939,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 91
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 91
         }
         variadic: true
@@ -2511,14 +2979,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 93
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 93
                 }
               }
@@ -2529,13 +3003,19 @@ body {
                   value: "-N"
                 }
                 src {
+                  end_column: 58
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 93
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 93
             }
           }
@@ -2548,7 +3028,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 93
         }
         variadic: true
@@ -2585,14 +3068,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 95
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 95
                 }
               }
@@ -2603,7 +3092,10 @@ body {
                   vs {
                     int64_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                     }
@@ -2611,7 +3103,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: "test"
@@ -2622,7 +3117,10 @@ body {
                   vs {
                     float64_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: 42.24
@@ -2631,7 +3129,10 @@ body {
                   vs {
                     null_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                     }
@@ -2641,7 +3142,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: "hello"
@@ -2650,7 +3154,10 @@ body {
                   vs {
                     binary_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: "test"
@@ -2661,7 +3168,10 @@ body {
                   vs {
                     bool_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       v: true
@@ -2671,7 +3181,10 @@ body {
                     big_decimal_val {
                       scale: -6
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       unscaled_value: "\242\016FOS"
@@ -2682,7 +3195,10 @@ body {
                   vs {
                     null_val {
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                     }
@@ -2692,7 +3208,10 @@ body {
                       day: 7
                       month: 6
                       src {
+                        end_column: 165
+                        end_line: 95
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 23
                         start_line: 95
                       }
                       year: 2024
@@ -2700,13 +3219,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 165
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 95
                 }
               }
             }
             src {
+              end_column: 165
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 95
             }
           }
@@ -2719,7 +3244,10 @@ body {
           }
         }
         src {
+          end_column: 166
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 95
         }
         variadic: true
@@ -2756,14 +3284,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 97
                 }
               }
@@ -2771,19 +3305,28 @@ body {
             rhs {
               list_val {
                 src {
+                  end_column: 169
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 97
                 }
                 vs {
                   tuple_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     vs {
                       int64_val {
                         src {
+                          end_column: 169
+                          end_line: 97
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 97
                         }
                       }
@@ -2791,7 +3334,10 @@ body {
                     vs {
                       string_val {
                         src {
+                          end_column: 169
+                          end_line: 97
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 97
                         }
                         v: "test"
@@ -2800,7 +3346,10 @@ body {
                     vs {
                       float64_val {
                         src {
+                          end_column: 169
+                          end_line: 97
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 97
                         }
                         v: 42.24
@@ -2811,7 +3360,10 @@ body {
                 vs {
                   null_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                   }
@@ -2819,7 +3371,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     v: "hello"
@@ -2828,7 +3383,10 @@ body {
                 vs {
                   binary_val {
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                     v: "test"
@@ -2840,7 +3398,10 @@ body {
                       vs {
                         bool_val {
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                           v: true
@@ -2850,7 +3411,10 @@ body {
                         big_decimal_val {
                           scale: -6
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                           unscaled_value: "\242\016FOS"
@@ -2861,7 +3425,10 @@ body {
                       vs {
                         null_val {
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                         }
@@ -2871,7 +3438,10 @@ body {
                           day: 7
                           month: 6
                           src {
+                            end_column: 169
+                            end_line: 97
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 23
                             start_line: 97
                           }
                           year: 2024
@@ -2879,7 +3449,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 169
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 97
                     }
                   }
@@ -2887,7 +3460,10 @@ body {
               }
             }
             src {
+              end_column: 169
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 97
             }
           }
@@ -2900,7 +3476,10 @@ body {
           }
         }
         src {
+          end_column: 170
+          end_line: 97
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 97
         }
         variadic: true
@@ -2937,14 +3516,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 99
                 }
               }
@@ -2952,13 +3537,19 @@ body {
             rhs {
               tuple_val {
                 src {
+                  end_column: 175
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 99
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 175
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                   }
@@ -2966,13 +3557,19 @@ body {
                 vs {
                   tuple_val {
                     src {
+                      end_column: 175
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                     vs {
                       string_val {
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         v: "test"
@@ -2981,7 +3578,10 @@ body {
                     vs {
                       float64_val {
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         v: 42.24
@@ -2993,7 +3593,10 @@ body {
                           vs {
                             null_val {
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                             }
@@ -3001,13 +3604,19 @@ body {
                           vs {
                             tuple_val {
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                               vs {
                                 string_val {
                                   src {
+                                    end_column: 175
+                                    end_line: 99
                                     file: "SRC_POSITION_TEST_MODE"
+                                    start_column: 23
                                     start_line: 99
                                   }
                                   v: "hello"
@@ -3016,7 +3625,10 @@ body {
                               vs {
                                 binary_val {
                                   src {
+                                    end_column: 175
+                                    end_line: 99
                                     file: "SRC_POSITION_TEST_MODE"
+                                    start_column: 23
                                     start_line: 99
                                   }
                                   v: "test"
@@ -3026,7 +3638,10 @@ body {
                           }
                         }
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                       }
@@ -3036,13 +3651,19 @@ body {
                 vs {
                   list_val {
                     src {
+                      end_column: 175
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 99
                     }
                     vs {
                       bool_val {
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         v: true
@@ -3052,7 +3673,10 @@ body {
                       big_decimal_val {
                         scale: -6
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                         unscaled_value: "\242\016FOS"
@@ -3064,7 +3688,10 @@ body {
                           vs {
                             null_val {
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                             }
@@ -3074,7 +3701,10 @@ body {
                               day: 7
                               month: 6
                               src {
+                                end_column: 175
+                                end_line: 99
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 23
                                 start_line: 99
                               }
                               year: 2024
@@ -3082,7 +3712,10 @@ body {
                           }
                         }
                         src {
+                          end_column: 175
+                          end_line: 99
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 23
                           start_line: 99
                         }
                       }
@@ -3092,7 +3725,10 @@ body {
               }
             }
             src {
+              end_column: 175
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 99
             }
           }
@@ -3105,7 +3741,10 @@ body {
           }
         }
         src {
+          end_column: 176
+          end_line: 99
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 99
         }
         variadic: true

--- a/tests/ast/data/col_null_nan.test
+++ b/tests/ast/data/col_null_nan.test
@@ -37,7 +37,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -76,14 +79,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -104,20 +113,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -130,7 +148,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -167,20 +188,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -193,7 +223,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -230,20 +263,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -256,7 +298,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -293,20 +338,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -319,7 +373,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true

--- a/tests/ast/data/col_rbinops.test
+++ b/tests/ast/data/col_rbinops.test
@@ -53,7 +53,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -79,7 +82,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: 42
@@ -101,20 +107,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 27
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -127,7 +142,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -151,7 +169,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
                 v: 42
@@ -173,20 +194,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 29
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -199,7 +229,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -223,7 +256,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
                 v: 42
@@ -245,20 +281,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 31
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -271,7 +316,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -295,7 +343,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
                 v: 42
@@ -317,20 +368,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 33
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
           }
@@ -343,7 +403,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -367,7 +430,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
                 v: 42
@@ -389,20 +455,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 35
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -415,7 +490,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -439,7 +517,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 37
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
                 v: 42
@@ -461,20 +542,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 29
                       start_line: 37
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 29
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -487,7 +577,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -511,7 +604,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
                 v: 42
@@ -533,20 +629,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 39
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -559,7 +664,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -583,7 +691,10 @@ body {
             lhs {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
                 v: 42
@@ -605,20 +716,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 41
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
           }
@@ -631,7 +751,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true

--- a/tests/ast/data/col_star.test
+++ b/tests/ast/data/col_star.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -50,7 +53,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 31
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -63,7 +69,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/col_string.test
+++ b/tests/ast/data/col_string.test
@@ -49,7 +49,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -88,14 +91,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
@@ -103,14 +112,20 @@ body {
             pattern {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 44
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -123,7 +138,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -160,14 +178,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
@@ -175,14 +199,20 @@ body {
             pattern {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 46
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -195,7 +225,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -232,14 +265,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -247,14 +286,20 @@ body {
             prefix {
               string_val {
                 src {
+                  end_column: 50
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 50
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -267,7 +312,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -304,26 +352,38 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             suffix {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
                 v: "test"
@@ -339,7 +399,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -376,14 +439,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
@@ -404,14 +473,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 35
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 35
                 }
               }
@@ -432,20 +507,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 35
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
           }
@@ -458,7 +542,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -495,14 +582,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
@@ -510,14 +603,20 @@ body {
             collation_spec {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 47
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
           }
@@ -530,7 +629,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -567,14 +669,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
@@ -582,14 +690,20 @@ body {
             pattern {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 48
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
           }
@@ -602,7 +716,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -129,7 +129,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -168,20 +171,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
             to {
@@ -197,7 +209,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -234,20 +249,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
             to {
@@ -263,7 +287,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -300,20 +327,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
             to {
@@ -329,7 +365,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -366,20 +405,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 33
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 33
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 33
             }
             to {
@@ -395,7 +443,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
         variadic: true
@@ -432,20 +483,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 35
             }
             to {
@@ -464,7 +524,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
         variadic: true
@@ -501,20 +564,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 37
             }
             to {
@@ -530,7 +602,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
         variadic: true
@@ -567,20 +642,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 39
             }
             to {
@@ -596,7 +680,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 39
         }
         variadic: true
@@ -633,20 +720,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 41
             }
             to {
@@ -662,7 +758,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 41
         }
         variadic: true
@@ -699,20 +798,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 43
             }
             to {
@@ -728,7 +836,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 43
         }
         variadic: true
@@ -765,20 +876,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 45
             }
             to {
@@ -794,7 +914,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 45
         }
         variadic: true
@@ -831,20 +954,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 47
             }
             to {
@@ -860,7 +992,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 47
         }
         variadic: true
@@ -897,20 +1032,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 49
             }
             to {
@@ -930,7 +1074,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 49
         }
         variadic: true
@@ -967,20 +1114,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 51
             }
             to {
@@ -996,7 +1152,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 51
         }
         variadic: true
@@ -1033,20 +1192,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 53
             }
             to {
@@ -1069,7 +1237,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -1106,20 +1277,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 55
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 55
             }
             to {
@@ -1148,7 +1328,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
         variadic: true
@@ -1185,20 +1368,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 57
             }
             to {
@@ -1219,7 +1411,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 57
         }
         variadic: true
@@ -1256,20 +1451,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 59
             }
             to {
@@ -1286,7 +1490,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 59
         }
         variadic: true
@@ -1323,20 +1530,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 61
             }
             to {
@@ -1352,7 +1568,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 61
         }
         variadic: true
@@ -1389,20 +1608,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 63
             }
             to {
@@ -1418,7 +1646,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 63
         }
         variadic: true
@@ -1455,20 +1686,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 65
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 65
             }
             to {
@@ -1484,7 +1724,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 65
         }
         variadic: true
@@ -1521,20 +1764,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 67
             }
             to {
@@ -1550,7 +1802,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 67
         }
         variadic: true
@@ -1587,20 +1842,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 69
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 69
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 69
             }
             to {
@@ -1616,7 +1880,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 69
         }
         variadic: true
@@ -1653,20 +1920,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 71
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 71
             }
             to {
@@ -1682,7 +1958,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 71
         }
         variadic: true
@@ -1719,20 +1998,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 73
             }
             to {
@@ -1748,7 +2036,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 73
         }
         variadic: true
@@ -1785,20 +2076,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 75
             }
             to {
@@ -1816,7 +2116,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 75
         }
         variadic: true
@@ -1853,20 +2156,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 77
             }
             to {
@@ -1884,7 +2196,10 @@ body {
           }
         }
         src {
+          end_column: 52
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 77
         }
         variadic: true
@@ -1921,20 +2236,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 31
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 31
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 79
             }
             to {
@@ -1963,7 +2287,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 79
         }
         variadic: true

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -93,7 +93,7 @@ df = df.select(col("A").try_cast(MapType(StringType(), StringType(), structured=
 
 df = df.select(col("A").try_cast(VectorType(FloatType(), 42)))
 
-df = df.select(col("A").try_cast(StructType([], structured=False)))
+df = df.select(col("A").try_cast(StructType(structured=False)))
 
 df = df.select(col("A").try_cast(VariantType()))
 

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -76,7 +76,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 94
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 29
         }
       }
@@ -99,7 +102,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 v: 1
@@ -108,7 +114,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 v: 2
@@ -117,7 +126,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 31
                 }
                 v: 3
@@ -131,7 +143,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
       }
@@ -176,20 +191,29 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 34
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 26
                           start_line: 33
                         }
                         v: "a"
                       }
                     }
                     src {
+                      end_column: 34
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 33
                     }
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 33
                 }
               }
@@ -199,7 +223,10 @@ body {
             }
             name: "ans"
             src {
+              end_column: 46
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 33
             }
           }
@@ -212,7 +239,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
         variadic: true
@@ -236,7 +266,10 @@ body {
           bitfield1: 3
         }
         src {
+          end_column: 57
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 33
         }
       }
@@ -291,7 +324,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 124
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 37
         }
       }
@@ -327,7 +363,10 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 39
                     }
                     v: "add_two"
@@ -349,20 +388,29 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 46
+                          end_line: 39
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 38
                           start_line: 39
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 46
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 39
                     }
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 39
                 }
               }
@@ -372,7 +420,10 @@ body {
             }
             name: "a_Ans"
             src {
+              end_column: 60
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 39
             }
           }
@@ -385,7 +436,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         variadic: true
@@ -409,7 +463,10 @@ body {
           bitfield1: 7
         }
         src {
+          end_column: 71
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -471,7 +528,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 83
+                end_line: 45
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 41
               }
               v: true
@@ -504,7 +564,10 @@ body {
         }
         secure: true
         src {
+          end_column: 83
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 41
         }
         stage_location: "@"
@@ -562,7 +625,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 84
+                end_line: 52
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 48
               }
               v: true
@@ -594,7 +660,10 @@ body {
         }
         secure: true
         src {
+          end_column: 84
+          end_line: 52
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 48
         }
         stage_location: "@"
@@ -639,14 +708,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 28
                       start_line: 54
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 28
                   start_line: 54
                 }
               }
@@ -667,20 +742,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 54
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 54
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 54
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 54
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 54
             }
           }
@@ -693,7 +777,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 54
         }
         variadic: true

--- a/tests/ast/data/col_unary_ops.test
+++ b/tests/ast/data/col_unary_ops.test
@@ -29,7 +29,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -68,20 +71,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 27
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 27
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 27
                 }
               }
             }
             src {
+              end_column: 32
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -94,7 +106,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -131,20 +146,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 32
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 29
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 32
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 32
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -157,7 +181,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true

--- a/tests/ast/data/df_alias.test
+++ b/tests/ast/data/df_alias.test
@@ -24,7 +24,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -54,7 +57,10 @@ body {
         }
         name: "new_name"
         src {
+          end_column: 33
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }

--- a/tests/ast/data/df_analytics_functions.test
+++ b/tests/ast/data/df_analytics_functions.test
@@ -142,13 +142,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-01"
@@ -157,7 +163,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 101
@@ -166,7 +175,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 200
@@ -177,13 +189,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-02"
@@ -192,7 +210,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 101
@@ -201,7 +222,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 100
@@ -212,13 +236,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-03"
@@ -227,7 +257,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 101
@@ -236,7 +269,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 300
@@ -247,13 +283,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 43
+                  end_line: 32
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 32
                 }
                 vs {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: "2023-01-04"
@@ -262,7 +304,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 102
@@ -271,7 +316,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 43
+                      end_line: 32
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 32
                     }
                     v: 250
@@ -282,7 +330,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 32
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
       }
@@ -311,7 +362,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 34
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 32
         }
         variadic: true
@@ -343,7 +397,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 36
                 }
               }
@@ -351,14 +408,20 @@ body {
             rhs {
               int64_val {
                 src {
+                  end_column: 65
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 36
                 }
                 v: 2
               }
             }
             src {
+              end_column: 65
+              end_line: 36
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 36
             }
           }
@@ -372,7 +435,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 36
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 36
         }
       }
@@ -405,7 +471,10 @@ body {
         group_by: "PRODUCTKEY"
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 25
           start_line: 38
         }
         window_sizes: 2
@@ -447,7 +516,10 @@ body {
         group_by: "PRODUCTKEY"
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 26
           start_line: 48
         }
         window_sizes: 2
@@ -484,7 +556,10 @@ body {
         is_forward: true
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 29
           start_line: 56
         }
       }
@@ -522,7 +597,10 @@ body {
         is_forward: true
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 72
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 30
           start_line: 66
         }
       }
@@ -543,7 +621,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 74
             }
             v: "SALESAMOUNT"
@@ -561,7 +642,10 @@ body {
         lags: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 26
           start_line: 74
         }
       }
@@ -582,7 +666,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 27
               start_line: 81
             }
             v: "SALESAMOUNT"
@@ -602,7 +689,10 @@ body {
         lags: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 27
           start_line: 81
         }
       }
@@ -623,7 +713,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 94
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 27
               start_line: 89
             }
             v: "SALESAMOUNT"
@@ -641,7 +734,10 @@ body {
         leads: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 94
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 27
           start_line: 89
         }
       }
@@ -662,7 +758,10 @@ body {
         cols {
           string_val {
             src {
+              end_column: 9
+              end_line: 102
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 28
               start_line: 96
             }
             v: "SALESAMOUNT"
@@ -682,7 +781,10 @@ body {
         leads: 2
         order_by: "ORDERDATE"
         src {
+          end_column: 9
+          end_line: 102
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 28
           start_line: 96
         }
       }
@@ -724,13 +826,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 104
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 104
                 }
               }
             }
             src {
+              end_column: 70
+              end_line: 104
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 104
             }
           }
@@ -744,7 +852,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 104
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 104
         }
       }
@@ -777,7 +888,10 @@ body {
         group_by: "PRODUCTKEY"
         sliding_interval: "12H"
         src {
+          end_column: 9
+          end_line: 112
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 30
           start_line: 106
         }
         time_col: "ORDERDATE"
@@ -817,7 +931,10 @@ body {
         group_by: "PRODUCTKEY"
         sliding_interval: "12H"
         src {
+          end_column: 9
+          end_line: 124
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 117
         }
         time_col: "ORDERDATE"

--- a/tests/ast/data/df_col.test
+++ b/tests/ast/data/df_col.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
               }
             }
             src {
+              end_column: 36
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -73,7 +79,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 27
             }
           }
@@ -89,7 +98,10 @@ body {
               }
             }
             src {
+              end_column: 55
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 27
             }
           }
@@ -102,7 +114,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/df_drop.test
+++ b/tests/ast/data/df_drop.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -63,14 +66,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 29
+                    end_line: 27
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 21
                     start_line: 27
                   }
                   v: "A"
                 }
               }
               src {
+                end_column: 29
+                end_line: 27
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 27
               }
             }
@@ -85,7 +94,10 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }

--- a/tests/ast/data/df_except.test
+++ b/tests/ast/data/df_except.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -93,7 +99,10 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/df_first.test
+++ b/tests/ast/data/df_first.test
@@ -50,7 +50,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -81,7 +84,10 @@ body {
         }
         num: -5
         src {
+          end_column: 26
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -117,7 +123,10 @@ body {
         }
         num: 2
         src {
+          end_column: 37
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -153,7 +162,10 @@ body {
         }
         num: 1
         src {
+          end_column: 24
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -188,7 +200,10 @@ body {
         }
         num: 1
         src {
+          end_column: 35
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -222,7 +237,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         statement_params {

--- a/tests/ast/data/df_intersect.test
+++ b/tests/ast/data/df_intersect.test
@@ -29,7 +29,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -58,7 +61,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -94,7 +100,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/df_limit.test
+++ b/tests/ast/data/df_limit.test
@@ -32,7 +32,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -57,7 +60,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 31
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 27
             }
           }
@@ -70,7 +76,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true
@@ -98,7 +107,10 @@ body {
         }
         n: 3
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -120,7 +132,10 @@ body {
           sp_column_sql_expr {
             sql: "*"
             src {
+              end_column: 31
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 29
             }
           }
@@ -133,7 +148,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variadic: true
@@ -162,7 +180,10 @@ body {
         n: 1
         offset: 1
         src {
+          end_column: 53
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -64,7 +64,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -93,7 +96,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
         weights: 0.1
@@ -116,7 +122,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
           }
@@ -125,7 +134,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
       }
@@ -146,7 +158,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
             v: 1
@@ -156,7 +171,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
       }
@@ -177,7 +195,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 33
             }
             v: 2
@@ -187,7 +208,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 48
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 33
         }
       }
@@ -216,7 +240,10 @@ body {
           value: 24
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
         weights: 0.1
@@ -239,7 +266,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 57
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
           }
@@ -248,7 +278,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
       }
@@ -269,7 +302,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 57
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
             v: 1
@@ -279,7 +315,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
       }
@@ -300,7 +339,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 57
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
             v: 2
@@ -310,7 +352,10 @@ body {
           bitfield1: 6
         }
         src {
+          end_column: 57
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 37
         }
       }
@@ -346,14 +391,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 29
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 19
                       start_line: 39
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 29
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 19
                   start_line: 39
                 }
               }
@@ -374,20 +425,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 39
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 32
                       start_line: 39
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 19
               start_line: 39
             }
           }
@@ -400,7 +460,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
         variadic: true
@@ -424,7 +487,10 @@ body {
           bitfield1: 10
         }
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 39
         }
       }
@@ -460,7 +526,10 @@ body {
           value: 24
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
         weights: 0.1
@@ -484,7 +553,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 41
             }
           }
@@ -493,7 +565,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
       }
@@ -513,7 +588,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 41
             }
             v: 1
@@ -523,7 +601,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
       }
@@ -543,7 +624,10 @@ body {
         args {
           int64_val {
             src {
+              end_column: 48
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 41
             }
             v: 2
@@ -553,7 +637,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 48
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 41
         }
       }
@@ -576,7 +663,10 @@ body {
           bitfield1: 14
         }
         src {
+          end_column: 22
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 43
         }
       }

--- a/tests/ast/data/df_sample.test
+++ b/tests/ast/data/df_sample.test
@@ -28,7 +28,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,7 +63,10 @@ body {
           value: 3
         }
         src {
+          end_column: 27
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -89,7 +95,10 @@ body {
           value: 0.5
         }
         src {
+          end_column: 32
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }

--- a/tests/ast/data/df_sort.test
+++ b/tests/ast/data/df_sort.test
@@ -44,7 +44,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -86,14 +89,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 27
             }
           }
@@ -107,7 +116,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -145,14 +157,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 29
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 29
             }
           }
@@ -166,7 +184,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
       }
@@ -213,14 +234,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 31
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 31
             }
           }
@@ -241,14 +268,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 31
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 39
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 31
             }
           }
@@ -262,7 +295,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
       }
@@ -309,14 +345,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 33
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 33
             }
           }
@@ -337,14 +379,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 33
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 39
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 33
             }
           }
@@ -358,7 +406,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 33
         }
       }
@@ -410,14 +461,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 35
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 29
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 35
             }
           }
@@ -438,14 +495,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 35
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 39
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 35
             }
           }
@@ -466,14 +529,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 49
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 35
                 }
                 v: "C"
               }
             }
             src {
+              end_column: 49
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 35
             }
           }
@@ -487,7 +556,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 35
         }
       }
@@ -521,14 +593,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 21
                   start_line: 37
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 29
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 21
               start_line: 37
             }
           }
@@ -542,7 +620,10 @@ body {
           }
         }
         src {
+          end_column: 30
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 37
         }
       }

--- a/tests/ast/data/df_union.test
+++ b/tests/ast/data/df_union.test
@@ -48,7 +48,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -77,7 +80,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variant {
@@ -113,7 +119,10 @@ body {
           }
         }
         src {
+          end_column: 28
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -146,7 +155,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -172,7 +184,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
         variant {
@@ -201,7 +216,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variant {
@@ -237,7 +255,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -270,7 +291,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -610,7 +610,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -647,14 +650,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 33
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 29
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 33
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 29
             }
           }
@@ -667,7 +676,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 29
         }
         variadic: true
@@ -702,7 +714,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 31
                 }
                 v: "X"
@@ -711,14 +726,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 31
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 31
             }
           }
@@ -731,7 +752,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 31
         }
         variadic: true
@@ -766,14 +790,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 33
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 39
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 33
             }
           }
@@ -786,7 +816,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 33
         }
         variadic: true
@@ -821,14 +854,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 36
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 35
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 36
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 35
             }
           }
@@ -841,7 +880,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 35
         }
         variadic: true
@@ -876,7 +918,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 37
                 }
                 v: "X"
@@ -885,14 +930,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 37
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 41
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 37
             }
           }
@@ -905,7 +956,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 37
         }
         variadic: true
@@ -940,14 +994,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 39
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 42
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 39
             }
           }
@@ -960,7 +1020,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 39
         }
         variadic: true
@@ -995,14 +1058,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 31
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 41
                 }
                 v: 1
               }
             }
             src {
+              end_column: 31
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 41
             }
           }
@@ -1023,14 +1092,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 33
                   start_line: 41
                 }
                 v: "1"
               }
             }
             src {
+              end_column: 41
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 33
               start_line: 41
             }
           }
@@ -1051,14 +1126,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 51
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 41
                 }
                 v: 1.0
               }
             }
             src {
+              end_column: 51
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 41
             }
           }
@@ -1079,14 +1160,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 62
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 41
                 }
                 v: true
               }
             }
             src {
+              end_column: 62
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 41
             }
           }
@@ -1107,14 +1194,20 @@ body {
             pos_args {
               binary_val {
                 src {
+                  end_column: 76
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 41
                 }
                 v: "snow"
               }
             }
             src {
+              end_column: 76
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 41
             }
           }
@@ -1137,14 +1230,20 @@ body {
                 day: 2
                 month: 2
                 src {
+                  end_column: 108
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 41
                 }
                 year: 2023
               }
             }
             src {
+              end_column: 108
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 41
             }
           }
@@ -1165,13 +1264,19 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 121
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 110
                   start_line: 41
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 121
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 110
                       start_line: 41
                     }
                     v: 1
@@ -1180,7 +1285,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 121
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 110
                       start_line: 41
                     }
                     v: 2
@@ -1189,7 +1297,10 @@ body {
               }
             }
             src {
+              end_column: 121
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 110
               start_line: 41
             }
           }
@@ -1213,7 +1324,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 145
+                        end_line: 41
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 123
                         start_line: 41
                       }
                       v: "snow"
@@ -1222,7 +1336,10 @@ body {
                   vs {
                     string_val {
                       src {
+                        end_column: 145
+                        end_line: 41
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 123
                         start_line: 41
                       }
                       v: "flake"
@@ -1230,13 +1347,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 145
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 123
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 145
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 123
               start_line: 41
             }
           }
@@ -1249,7 +1372,10 @@ body {
           }
         }
         src {
+          end_column: 146
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 41
         }
         variadic: true
@@ -1285,13 +1411,19 @@ body {
               sp_column_sql_expr {
                 sql: "CURRENT_WAREHOUSE()"
                 src {
+                  end_column: 56
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 43
             }
           }
@@ -1304,7 +1436,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 43
         }
         variadic: true
@@ -1337,7 +1472,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 45
             }
           }
@@ -1350,7 +1488,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 45
         }
         variadic: true
@@ -1383,7 +1524,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 47
             }
           }
@@ -1396,7 +1540,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 47
         }
         variadic: true
@@ -1429,7 +1576,10 @@ body {
               }
             }
             src {
+              end_column: 39
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 49
             }
           }
@@ -1442,7 +1592,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 49
         }
         variadic: true
@@ -1475,7 +1628,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 51
             }
           }
@@ -1488,7 +1644,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 51
         }
         variadic: true
@@ -1521,7 +1680,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 53
             }
           }
@@ -1534,7 +1696,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 53
         }
         variadic: true
@@ -1567,7 +1732,10 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 55
             }
           }
@@ -1580,7 +1748,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 55
         }
         variadic: true
@@ -1613,7 +1784,10 @@ body {
               }
             }
             src {
+              end_column: 39
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 57
             }
           }
@@ -1626,7 +1800,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 57
         }
         variadic: true
@@ -1659,7 +1836,10 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 59
             }
           }
@@ -1672,7 +1852,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 59
         }
         variadic: true
@@ -1705,7 +1888,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 61
             }
           }
@@ -1718,7 +1904,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 61
         }
         variadic: true
@@ -1751,7 +1940,10 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 63
             }
           }
@@ -1764,7 +1956,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 63
         }
         variadic: true
@@ -1797,7 +1992,10 @@ body {
               }
             }
             src {
+              end_column: 42
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 65
             }
           }
@@ -1810,7 +2008,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 65
         }
         variadic: true
@@ -1843,7 +2044,10 @@ body {
               }
             }
             src {
+              end_column: 50
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 67
             }
           }
@@ -1856,7 +2060,10 @@ body {
           }
         }
         src {
+          end_column: 51
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 67
         }
         variadic: true
@@ -1904,14 +2111,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 69
                     }
                     v: "d"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 69
                 }
               }
@@ -1919,14 +2132,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 43
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 69
                 }
                 v: 4
               }
             }
             src {
+              end_column: 43
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 69
             }
           }
@@ -1939,7 +2158,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 69
         }
         variadic: true
@@ -1987,14 +2209,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 71
                 }
               }
@@ -2002,14 +2230,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 48
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 71
                 }
                 v: 4
               }
             }
             src {
+              end_column: 48
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 71
             }
           }
@@ -2022,7 +2256,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 71
         }
         variadic: true
@@ -2070,14 +2307,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 73
                 }
               }
@@ -2098,20 +2341,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 73
             }
           }
@@ -2124,7 +2376,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 73
         }
         variadic: true
@@ -2172,20 +2427,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 75
             }
           }
@@ -2219,20 +2483,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 75
             }
           }
@@ -2245,7 +2518,10 @@ body {
           }
         }
         src {
+          end_column: 61
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 75
         }
         variadic: true
@@ -2293,20 +2569,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 77
             }
           }
@@ -2340,20 +2625,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 77
             }
           }
@@ -2387,20 +2681,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 77
             }
           }
@@ -2413,7 +2716,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 77
         }
         variadic: true
@@ -2461,14 +2767,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 79
                 }
               }
@@ -2489,20 +2801,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 79
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 79
             }
           }
@@ -2536,14 +2857,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 79
                 }
               }
@@ -2551,14 +2878,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 76
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 79
                 }
                 v: -10
               }
             }
             src {
+              end_column: 76
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 79
             }
           }
@@ -2592,14 +2925,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 79
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 79
                 }
               }
@@ -2607,14 +2946,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 104
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 79
                 }
                 v: 42
               }
             }
             src {
+              end_column: 104
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 79
             }
           }
@@ -2627,7 +2972,10 @@ body {
           }
         }
         src {
+          end_column: 105
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 79
         }
         variadic: true
@@ -2675,14 +3023,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 81
                 }
               }
@@ -2703,20 +3057,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 81
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 81
             }
           }
@@ -2750,14 +3113,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 81
                 }
               }
@@ -2765,14 +3134,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 78
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 81
                 }
                 v: -10
               }
             }
             src {
+              end_column: 78
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 81
             }
           }
@@ -2806,14 +3181,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 81
                 }
               }
@@ -2821,14 +3202,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 107
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 81
                 }
                 v: 42
               }
             }
             src {
+              end_column: 107
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 80
               start_line: 81
             }
           }
@@ -2841,7 +3228,10 @@ body {
           }
         }
         src {
+          end_column: 108
+          end_line: 81
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 81
         }
         variadic: true
@@ -2876,7 +3266,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 83
                 }
                 v: "A"
@@ -2885,14 +3278,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 46
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 83
                 }
                 v: 10
               }
             }
             src {
+              end_column: 46
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 83
             }
           }
@@ -2913,7 +3312,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 62
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 83
                 }
                 v: "A"
@@ -2922,14 +3324,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 83
                 }
                 v: 2
               }
             }
             src {
+              end_column: 62
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 83
             }
           }
@@ -2963,14 +3371,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 79
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 71
                       start_line: 83
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 79
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 83
                 }
               }
@@ -2991,20 +3405,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 83
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 83
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 83
             }
           }
@@ -3017,7 +3440,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 83
         }
         variadic: true
@@ -3065,14 +3491,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 85
                 }
               }
@@ -3093,20 +3525,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 85
             }
           }
@@ -3140,14 +3581,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 85
                 }
               }
@@ -3168,20 +3615,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 89
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 58
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 89
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 85
             }
           }
@@ -3215,14 +3671,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 117
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 85
                 }
               }
@@ -3243,20 +3705,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 117
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 117
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 91
               start_line: 85
             }
           }
@@ -3290,14 +3761,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 144
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 136
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 144
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 136
                   start_line: 85
                 }
               }
@@ -3318,20 +3795,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 154
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 146
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 154
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 146
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 155
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 119
               start_line: 85
             }
           }
@@ -3365,14 +3851,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 187
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 157
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 187
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 157
                   start_line: 85
                 }
               }
@@ -3393,20 +3885,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 187
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 157
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 187
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 157
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 187
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 157
               start_line: 85
             }
           }
@@ -3440,14 +3941,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 220
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 189
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 220
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 189
                   start_line: 85
                 }
               }
@@ -3468,14 +3975,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 220
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 189
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 220
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 189
                   start_line: 85
                 }
               }
@@ -3496,20 +4009,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 220
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 189
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 220
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 189
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 220
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 189
               start_line: 85
             }
           }
@@ -3522,7 +4044,10 @@ body {
           }
         }
         src {
+          end_column: 221
+          end_line: 85
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 85
         }
         variadic: true
@@ -3570,14 +4095,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 87
                     }
                     v: "UTC"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 87
                 }
               }
@@ -3598,20 +4129,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 62
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 87
                     }
                     v: "a"
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 87
             }
           }
@@ -3645,14 +4185,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 124
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 87
                     }
                     v: "Asia/Shanghai"
                   }
                 }
                 src {
+                  end_column: 124
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 87
                 }
               }
@@ -3673,14 +4219,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 87
                     }
                     v: "UTC"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 87
                 }
               }
@@ -3701,20 +4253,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 87
                     }
                     v: "b"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 125
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 87
             }
           }
@@ -3727,7 +4288,10 @@ body {
           }
         }
         src {
+          end_column: 126
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 87
         }
         variadic: true
@@ -3775,20 +4339,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 89
             }
           }
@@ -3822,20 +4395,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 89
             }
           }
@@ -3848,7 +4430,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 89
         }
         variadic: true
@@ -3896,20 +4481,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 91
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 91
             }
           }
@@ -3943,20 +4537,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 39
                       start_line: 91
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 39
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 91
             }
           }
@@ -3969,7 +4572,10 @@ body {
           }
         }
         src {
+          end_column: 49
+          end_line: 91
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 91
         }
         variadic: true
@@ -4017,14 +4623,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 93
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 93
                 }
               }
@@ -4045,20 +4657,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 93
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 93
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 93
             }
           }
@@ -4071,7 +4692,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 93
         }
         variadic: true
@@ -4106,14 +4730,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 95
                 }
                 v: "*"
               }
             }
             src {
+              end_column: 35
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 95
             }
           }
@@ -4134,14 +4764,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 95
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 47
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 95
             }
           }
@@ -4175,20 +4811,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 95
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 95
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 95
             }
           }
@@ -4201,7 +4846,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 95
         }
         variadic: true
@@ -4234,7 +4882,10 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 97
             }
           }
@@ -4256,13 +4907,19 @@ body {
               sp_column_sql_expr {
                 sql: "*"
                 src {
+                  end_column: 66
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 97
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 97
             }
           }
@@ -4283,7 +4940,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "A"
@@ -4292,7 +4952,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "B"
@@ -4301,7 +4964,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "C"
@@ -4310,7 +4976,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 113
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 97
                 }
                 v: "D"
@@ -4332,20 +5001,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 112
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 97
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 112
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 97
                 }
               }
             }
             src {
+              end_column: 113
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 97
             }
           }
@@ -4358,7 +5036,10 @@ body {
           }
         }
         src {
+          end_column: 114
+          end_line: 97
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 97
         }
         variadic: true
@@ -4406,14 +5087,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 99
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 99
                 }
               }
@@ -4434,20 +5121,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 99
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 99
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 99
             }
           }
@@ -4460,7 +5156,10 @@ body {
           }
         }
         src {
+          end_column: 50
+          end_line: 99
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 99
         }
         variadic: true
@@ -4508,14 +5207,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 101
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 101
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 101
                 }
               }
@@ -4536,20 +5241,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 101
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 101
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 101
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 101
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 101
             }
           }
@@ -4562,7 +5276,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 101
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 101
         }
         variadic: true
@@ -4610,14 +5327,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 103
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 103
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 103
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 103
                 }
               }
@@ -4638,20 +5361,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 103
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 103
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 103
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 103
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 103
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 103
             }
           }
@@ -4664,7 +5396,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 103
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 103
         }
         variadic: true
@@ -4712,14 +5447,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
@@ -4740,14 +5481,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
@@ -4768,14 +5515,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
@@ -4796,20 +5549,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 105
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 105
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 105
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 105
             }
           }
@@ -4822,7 +5584,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 105
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 105
         }
         variadic: true
@@ -4870,14 +5635,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 107
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 107
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 107
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 107
                 }
               }
@@ -4898,20 +5669,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 107
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 107
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 107
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 107
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 107
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 107
             }
           }
@@ -4924,7 +5704,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 107
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 107
         }
         variadic: true
@@ -4972,14 +5755,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
@@ -5000,14 +5789,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
@@ -5028,14 +5823,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
@@ -5056,20 +5857,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 109
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 109
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 109
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 109
             }
           }
@@ -5082,7 +5892,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 109
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 109
         }
         variadic: true
@@ -5130,20 +5943,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 111
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 111
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 111
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 111
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 111
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 111
             }
           }
@@ -5156,7 +5978,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 111
         }
         variadic: true
@@ -5192,13 +6017,19 @@ body {
               sp_column_sql_expr {
                 sql: "*"
                 src {
+                  end_column: 33
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 113
             }
           }
@@ -5232,20 +6063,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 113
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 113
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 113
             }
           }
@@ -5279,20 +6119,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 113
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 113
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 113
             }
           }
@@ -5305,7 +6154,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 113
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 113
         }
         variadic: true
@@ -5353,20 +6205,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 115
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 115
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 115
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 115
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 115
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 115
             }
           }
@@ -5379,7 +6240,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 115
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 115
         }
         variadic: true
@@ -5427,20 +6291,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 117
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 117
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 117
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 117
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 117
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 117
             }
           }
@@ -5453,7 +6326,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 117
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 117
         }
         variadic: true
@@ -5501,20 +6377,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 119
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 119
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 119
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 119
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 119
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 119
             }
           }
@@ -5527,7 +6412,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 119
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 119
         }
         variadic: true
@@ -5575,20 +6463,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 121
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 121
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 121
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 121
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 121
             }
           }
@@ -5601,7 +6498,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 121
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 121
         }
         variadic: true
@@ -5649,20 +6549,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 123
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 123
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 123
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 123
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 123
             }
           }
@@ -5675,7 +6584,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 123
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 123
         }
         variadic: true
@@ -5723,20 +6635,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 125
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 125
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 125
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 125
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 125
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 125
             }
           }
@@ -5749,7 +6670,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 125
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 125
         }
         variadic: true
@@ -5797,20 +6721,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 127
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 127
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 127
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 127
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 127
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 127
             }
           }
@@ -5823,7 +6756,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 127
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 127
         }
         variadic: true
@@ -5871,20 +6807,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 129
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 129
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 129
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 129
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 129
             }
           }
@@ -5897,7 +6842,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 129
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 129
         }
         variadic: true
@@ -5945,20 +6893,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 131
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 131
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 131
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 131
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 131
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 131
             }
           }
@@ -5971,7 +6928,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 131
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 131
         }
         variadic: true
@@ -6019,20 +6979,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 133
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 133
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 133
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 133
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 133
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 133
             }
           }
@@ -6045,7 +7014,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 133
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 133
         }
         variadic: true
@@ -6093,20 +7065,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 135
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 135
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 135
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 135
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 135
             }
           }
@@ -6119,7 +7100,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 135
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 135
         }
         variadic: true
@@ -6167,20 +7151,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 137
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 137
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 137
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 137
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 137
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 137
             }
           }
@@ -6193,7 +7186,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 137
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 137
         }
         variadic: true
@@ -6241,20 +7237,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 139
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 139
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 139
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 139
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 139
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 139
             }
           }
@@ -6267,7 +7272,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 139
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 139
         }
         variadic: true
@@ -6315,14 +7323,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 141
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 141
                 }
               }
@@ -6330,14 +7344,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 52
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 141
                 }
                 v: 0.6
               }
             }
             src {
+              end_column: 52
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 141
             }
           }
@@ -6371,14 +7391,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 141
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 141
                 }
               }
@@ -6386,13 +7412,19 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 86
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 141
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 141
             }
           }
@@ -6405,7 +7437,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 141
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 141
         }
         variadic: true
@@ -6453,20 +7488,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 143
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 143
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 143
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 143
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 143
             }
           }
@@ -6479,7 +7523,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 143
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 143
         }
         variadic: true
@@ -6527,14 +7574,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 145
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 145
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 145
                 }
               }
@@ -6542,14 +7595,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 61
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 145
                 }
                 v: 0.3
               }
             }
             src {
+              end_column: 61
+              end_line: 145
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 145
             }
           }
@@ -6562,7 +7621,10 @@ body {
           }
         }
         src {
+          end_column: 62
+          end_line: 145
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 145
         }
         variadic: true
@@ -6610,20 +7672,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 147
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 147
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 147
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 147
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 147
             }
           }
@@ -6636,7 +7707,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 147
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 147
         }
         variadic: true
@@ -6684,20 +7758,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 149
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 149
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 149
             }
           }
@@ -6731,14 +7814,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 149
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 149
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 149
                 }
               }
@@ -6759,20 +7848,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 149
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 149
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 149
             }
           }
@@ -6785,7 +7883,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 149
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 149
         }
         variadic: true
@@ -6818,7 +7919,10 @@ body {
               }
             }
             src {
+              end_column: 35
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 151
             }
           }
@@ -6852,14 +7956,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 151
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 151
                 }
               }
@@ -6880,20 +7990,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 63
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 151
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 151
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 151
             }
           }
@@ -6906,7 +8025,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 151
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 151
         }
         variadic: true
@@ -6943,20 +8065,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 153
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 153
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 153
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 153
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 153
             }
           }
@@ -6969,7 +8100,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 153
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 153
         }
         variadic: true
@@ -7006,20 +8140,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 155
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 155
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 155
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 155
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 155
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 155
             }
           }
@@ -7032,7 +8175,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 155
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 155
         }
         variadic: true
@@ -7069,20 +8215,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 157
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 157
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 157
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 157
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 157
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 157
             }
           }
@@ -7095,7 +8250,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 157
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 157
         }
         variadic: true
@@ -7132,20 +8290,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 159
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 159
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 159
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 159
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 159
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 159
             }
           }
@@ -7158,7 +8325,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 159
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 159
         }
         variadic: true
@@ -7191,7 +8361,10 @@ body {
               }
             }
             src {
+              end_column: 33
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 161
             }
           }
@@ -7210,7 +8383,10 @@ body {
               }
             }
             src {
+              end_column: 47
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 161
             }
           }
@@ -7231,14 +8407,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 59
+                  end_line: 161
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 161
                 }
                 v: 10
               }
             }
             src {
+              end_column: 59
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 161
             }
           }
@@ -7251,7 +8433,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 161
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 161
         }
         variadic: true
@@ -7299,14 +8484,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 163
                 }
               }
@@ -7327,14 +8518,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 163
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 163
                 }
               }
@@ -7355,20 +8552,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 163
             }
           }
@@ -7402,14 +8608,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 75
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 163
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 163
                 }
               }
@@ -7432,20 +8644,29 @@ body {
                     pos_args {
                       float64_val {
                         src {
+                          end_column: 75
+                          end_line: 163
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 49
                           start_line: 163
                         }
                         v: 13.0
                       }
                     }
                     src {
+                      end_column: 75
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 163
                     }
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 163
                 }
                 to {
@@ -7469,20 +8690,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 163
             }
           }
@@ -7518,20 +8748,29 @@ body {
                     pos_args {
                       float64_val {
                         src {
+                          end_column: 97
+                          end_line: 163
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 77
                           start_line: 163
                         }
                         v: 0.2
                       }
                     }
                     src {
+                      end_column: 97
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 163
                     }
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 163
                 }
                 to {
@@ -7555,14 +8794,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 97
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 163
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 163
                 }
               }
@@ -7583,20 +8828,29 @@ body {
                 pos_args {
                   float64_val {
                     src {
+                      end_column: 97
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 163
                     }
                     v: 0.2
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 77
               start_line: 163
             }
           }
@@ -7609,7 +8863,10 @@ body {
           }
         }
         src {
+          end_column: 98
+          end_line: 163
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 163
         }
         variadic: true
@@ -7644,13 +8901,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 32
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 165
                 }
               }
             }
             src {
+              end_column: 32
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 165
             }
           }
@@ -7671,14 +8934,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 165
                 }
                 v: 10
               }
             }
             src {
+              end_column: 42
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 34
               start_line: 165
             }
           }
@@ -7699,14 +8968,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 165
                 }
                 v: -10
               }
             }
             src {
+              end_column: 53
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 165
             }
           }
@@ -7719,7 +8994,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 165
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 165
         }
         variadic: true
@@ -7754,14 +9032,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 32
+                  end_line: 167
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 167
                 }
                 v: 1
               }
             }
             src {
+              end_column: 32
+              end_line: 167
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 167
             }
           }
@@ -7774,7 +9058,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 167
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 167
         }
         variadic: true
@@ -7809,14 +9096,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 33
+                  end_line: 169
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 169
                 }
                 v: 12
               }
             }
             src {
+              end_column: 33
+              end_line: 169
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 169
             }
           }
@@ -7829,7 +9122,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 169
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 169
         }
         variadic: true
@@ -7864,14 +9160,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 34
+                  end_line: 171
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 171
                 }
                 v: 324
               }
             }
             src {
+              end_column: 34
+              end_line: 171
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 171
             }
           }
@@ -7884,7 +9186,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 171
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 171
         }
         variadic: true
@@ -7932,14 +9237,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 173
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 173
                 }
               }
@@ -7947,7 +9258,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 47
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 173
                 }
                 v: 10
@@ -7956,14 +9270,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 47
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 173
                 }
                 v: 3
               }
             }
             src {
+              end_column: 47
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 173
             }
           }
@@ -7997,14 +9317,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 68
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 173
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 173
                 }
               }
@@ -8012,7 +9338,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 76
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 173
                 }
                 v: 12
@@ -8021,14 +9350,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 76
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 173
                 }
                 v: 3
               }
             }
             src {
+              end_column: 76
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 173
             }
           }
@@ -8041,7 +9376,10 @@ body {
           }
         }
         src {
+          end_column: 77
+          end_line: 173
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 173
         }
         variadic: true
@@ -8089,14 +9427,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 175
                 }
               }
@@ -8104,13 +9448,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 44
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 175
             }
           }
@@ -8131,7 +9481,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 66
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 175
                 }
                 v: "A"
@@ -8140,13 +9493,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 66
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 66
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 175
             }
           }
@@ -8167,7 +9526,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 91
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 175
                 }
                 v: "A"
@@ -8176,14 +9538,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 91
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 175
                 }
                 v: "999.9"
               }
             }
             src {
+              end_column: 91
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 68
               start_line: 175
             }
           }
@@ -8217,14 +9585,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 111
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 103
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 111
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 175
                 }
               }
@@ -8245,20 +9619,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 121
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 113
                       start_line: 175
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 121
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 113
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 122
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 93
               start_line: 175
             }
           }
@@ -8271,7 +9654,10 @@ body {
           }
         }
         src {
+          end_column: 123
+          end_line: 175
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 175
         }
         variadic: true
@@ -8306,7 +9692,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 177
                 }
               }
@@ -8314,14 +9703,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 177
                 }
                 v: 1
               }
             }
             src {
+              end_column: 35
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 177
             }
           }
@@ -8342,7 +9737,10 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 51
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 177
                 }
                 v: 1.2
@@ -8351,14 +9749,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 51
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 177
                 }
                 v: 9.3
               }
             }
             src {
+              end_column: 51
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 177
             }
           }
@@ -8379,7 +9783,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 177
                 }
                 v: 10
@@ -8388,14 +9795,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 67
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 177
                 }
                 v: 89.2
               }
             }
             src {
+              end_column: 67
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 177
             }
           }
@@ -8416,7 +9829,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 81
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 177
                 }
                 v: "A"
@@ -8425,14 +9841,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 81
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 177
                 }
                 v: 1
               }
             }
             src {
+              end_column: 81
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 177
             }
           }
@@ -8453,7 +9875,10 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 97
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 177
                 }
                 v: 0.2
@@ -8462,14 +9887,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 97
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 177
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 97
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 177
             }
           }
@@ -8490,7 +9921,10 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 118
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 177
                 }
                 v: 0.3
@@ -8512,20 +9946,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 117
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 109
                       start_line: 177
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 117
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 109
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 118
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 99
               start_line: 177
             }
           }
@@ -8538,7 +9981,10 @@ body {
           }
         }
         src {
+          end_column: 119
+          end_line: 177
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 177
         }
         variadic: true
@@ -8586,20 +10032,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 179
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 179
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 179
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 179
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 179
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 179
             }
           }
@@ -8612,7 +10067,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 179
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 179
         }
         variadic: true
@@ -8660,20 +10118,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 181
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 181
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 181
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 181
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 181
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 181
             }
           }
@@ -8686,7 +10153,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 181
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 181
         }
         variadic: true
@@ -8734,20 +10204,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 183
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 183
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 183
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 183
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 183
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 183
             }
           }
@@ -8760,7 +10239,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 183
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 183
         }
         variadic: true
@@ -8808,20 +10290,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 185
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 185
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 185
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 185
             }
           }
@@ -8834,7 +10325,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 185
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 185
         }
         variadic: true
@@ -8882,20 +10376,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 187
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 187
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 187
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 187
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 187
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 187
             }
           }
@@ -8908,7 +10411,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 187
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 187
         }
         variadic: true
@@ -8956,14 +10462,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 189
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 189
                 }
               }
@@ -8984,20 +10496,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 189
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 189
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 189
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 189
             }
           }
@@ -9010,7 +10531,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 189
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 189
         }
         variadic: true
@@ -9058,20 +10582,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 191
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 191
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 191
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 191
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 191
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 191
             }
           }
@@ -9084,7 +10617,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 191
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 191
         }
         variadic: true
@@ -9132,20 +10668,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 193
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 193
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 193
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 193
             }
           }
@@ -9158,7 +10703,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 193
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 193
         }
         variadic: true
@@ -9206,20 +10754,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 195
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 195
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 195
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 195
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 195
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 195
             }
           }
@@ -9232,7 +10789,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 195
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 195
         }
         variadic: true
@@ -9280,20 +10840,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 197
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 197
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 197
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 197
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 197
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 197
             }
           }
@@ -9306,7 +10875,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 197
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 197
         }
         variadic: true
@@ -9354,20 +10926,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 199
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 199
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 199
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 199
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 199
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 199
             }
           }
@@ -9380,7 +10961,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 199
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 199
         }
         variadic: true
@@ -9428,20 +11012,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 201
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 201
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 201
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 201
             }
           }
@@ -9454,7 +11047,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 201
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 201
         }
         variadic: true
@@ -9502,14 +11098,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 203
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 203
                 }
               }
@@ -9530,20 +11132,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 203
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 203
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 203
             }
           }
@@ -9577,14 +11188,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 203
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 203
                 }
               }
@@ -9592,14 +11209,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 77
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 203
                 }
                 v: 10
               }
             }
             src {
+              end_column: 77
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 203
             }
           }
@@ -9612,7 +11235,10 @@ body {
           }
         }
         src {
+          end_column: 78
+          end_line: 203
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 203
         }
         variadic: true
@@ -9660,20 +11286,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 205
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 205
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 205
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 205
             }
           }
@@ -9686,7 +11321,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 205
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 205
         }
         variadic: true
@@ -9734,20 +11372,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 207
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 207
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 207
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 207
             }
           }
@@ -9760,7 +11407,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 207
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 207
         }
         variadic: true
@@ -9808,20 +11458,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 209
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 209
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 209
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 209
             }
           }
@@ -9834,7 +11493,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 209
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 209
         }
         variadic: true
@@ -9882,20 +11544,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 211
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 211
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 211
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 211
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 211
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 211
             }
           }
@@ -9908,7 +11579,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 211
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 211
         }
         variadic: true
@@ -9956,20 +11630,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 213
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 213
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 213
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 213
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 213
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 213
             }
           }
@@ -9982,7 +11665,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 213
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 213
         }
         variadic: true
@@ -10030,20 +11716,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 215
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 215
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 215
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 215
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 215
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 215
             }
           }
@@ -10056,7 +11751,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 215
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 215
         }
         variadic: true
@@ -10104,20 +11802,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 217
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 217
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 217
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 217
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 217
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 217
             }
           }
@@ -10130,7 +11837,10 @@ body {
           }
         }
         src {
+          end_column: 34
+          end_line: 217
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 217
         }
         variadic: true
@@ -10178,20 +11888,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 34
+                      end_line: 219
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 219
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 34
+                  end_line: 219
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 219
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 219
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 219
             }
           }
@@ -10204,7 +11923,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 219
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 219
         }
         variadic: true
@@ -10252,14 +11974,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 221
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 221
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 221
                 }
               }
@@ -10267,13 +11995,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 221
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 221
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 221
             }
           }
@@ -10307,14 +12041,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 221
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 221
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 221
                 }
               }
@@ -10322,14 +12062,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 58
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 221
                 }
                 v: 224
               }
             }
             src {
+              end_column: 58
+              end_line: 221
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 221
             }
           }
@@ -10342,7 +12088,10 @@ body {
           }
         }
         src {
+          end_column: 59
+          end_line: 221
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 221
         }
         variadic: true
@@ -10390,13 +12139,19 @@ body {
                 pos_args {
                   null_val {
                     src {
+                      end_column: 39
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 223
                     }
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 223
                 }
               }
@@ -10417,14 +12172,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 48
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 223
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 223
                 }
               }
@@ -10445,14 +12206,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 223
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 223
                 }
               }
@@ -10473,20 +12240,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 64
+                      end_line: 223
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 223
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 223
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 223
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 223
             }
           }
@@ -10499,7 +12275,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 223
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 223
         }
         variadic: true
@@ -10547,20 +12326,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 225
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 225
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 225
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 225
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 225
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 225
             }
           }
@@ -10573,7 +12361,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 225
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 225
         }
         variadic: true
@@ -10621,20 +12412,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 227
             }
           }
@@ -10668,20 +12468,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 227
             }
           }
@@ -10715,14 +12524,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 227
                 }
               }
@@ -10743,20 +12558,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 227
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 227
             }
           }
@@ -10790,14 +12614,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 227
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 227
                 }
               }
@@ -10818,20 +12648,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 107
+                      end_line: 227
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 227
                     }
                     v: "123"
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 227
                 }
               }
             }
             src {
+              end_column: 108
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 79
               start_line: 227
             }
           }
@@ -10844,7 +12683,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 227
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 227
         }
         variadic: true
@@ -10892,20 +12734,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 229
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 229
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 229
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 229
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 229
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 229
             }
           }
@@ -10918,7 +12769,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 229
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 229
         }
         variadic: true
@@ -10966,20 +12820,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 231
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 231
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 231
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 231
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 231
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 231
             }
           }
@@ -10992,7 +12855,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 231
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 231
         }
         variadic: true
@@ -11040,14 +12906,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 233
                 }
               }
@@ -11068,14 +12940,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 233
                 }
               }
@@ -11096,20 +12974,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 233
             }
           }
@@ -11143,14 +13030,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 233
                 }
               }
@@ -11158,7 +13051,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 71
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 233
                 }
                 v: 100
@@ -11180,20 +13076,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 71
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 233
             }
           }
@@ -11227,14 +13132,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 233
                 }
               }
@@ -11255,14 +13166,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 233
                 }
               }
@@ -11283,20 +13200,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 233
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 107
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 73
               start_line: 233
             }
           }
@@ -11309,7 +13235,10 @@ body {
           }
         }
         src {
+          end_column: 108
+          end_line: 233
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 233
         }
         variadic: true
@@ -11357,20 +13286,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 235
             }
           }
@@ -11404,20 +13342,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 235
             }
           }
@@ -11451,14 +13398,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 235
                 }
               }
@@ -11479,20 +13432,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 235
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 235
             }
           }
@@ -11526,14 +13488,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 235
                 }
               }
@@ -11554,20 +13522,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 235
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 103
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 235
             }
           }
@@ -11580,7 +13557,10 @@ body {
           }
         }
         src {
+          end_column: 104
+          end_line: 235
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 235
         }
         variadic: true
@@ -11628,14 +13608,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 237
                 }
               }
@@ -11656,14 +13642,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 237
                 }
               }
@@ -11684,20 +13676,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 237
             }
           }
@@ -11731,14 +13732,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 237
                 }
               }
@@ -11746,7 +13753,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 71
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 237
                 }
                 v: 100
@@ -11768,20 +13778,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 71
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 237
             }
           }
@@ -11815,14 +13834,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 237
                 }
               }
@@ -11843,14 +13868,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 237
                 }
               }
@@ -11871,20 +13902,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 237
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 107
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 73
               start_line: 237
             }
           }
@@ -11897,7 +13937,10 @@ body {
           }
         }
         src {
+          end_column: 108
+          end_line: 237
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 237
         }
         variadic: true
@@ -11945,20 +13988,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 239
             }
           }
@@ -11992,20 +14044,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 239
             }
           }
@@ -12039,14 +14100,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 239
                 }
               }
@@ -12067,20 +14134,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 239
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 239
             }
           }
@@ -12114,14 +14190,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 239
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 239
                 }
               }
@@ -12142,20 +14224,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 239
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 239
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 103
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 239
             }
           }
@@ -12168,7 +14259,10 @@ body {
           }
         }
         src {
+          end_column: 104
+          end_line: 239
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 239
         }
         variadic: true
@@ -12216,14 +14310,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 241
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 241
                 }
               }
@@ -12231,14 +14331,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 40
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 241
                 }
                 v: 1
               }
             }
             src {
+              end_column: 40
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 241
             }
           }
@@ -12272,14 +14378,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 241
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 241
                 }
               }
@@ -12287,14 +14399,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 62
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 241
                 }
                 v: 20
               }
             }
             src {
+              end_column: 62
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 241
             }
           }
@@ -12328,14 +14446,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 241
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 241
                 }
               }
@@ -12356,20 +14480,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 241
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 241
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 241
                 }
               }
             }
             src {
+              end_column: 85
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 241
             }
           }
@@ -12382,7 +14515,10 @@ body {
           }
         }
         src {
+          end_column: 86
+          end_line: 241
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 241
         }
         variadic: true
@@ -12430,20 +14566,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 243
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 243
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 243
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 243
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 243
             }
           }
@@ -12456,7 +14601,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 243
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 243
         }
         variadic: true
@@ -12504,20 +14652,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 245
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 245
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 245
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 245
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 245
             }
           }
@@ -12530,7 +14687,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 245
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 245
         }
         variadic: true
@@ -12578,20 +14738,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 247
             }
           }
@@ -12625,20 +14794,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 247
             }
           }
@@ -12672,14 +14850,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 247
                 }
               }
@@ -12700,20 +14884,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 247
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 247
             }
           }
@@ -12747,14 +14940,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 247
                 }
               }
@@ -12775,20 +14974,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 90
                       start_line: 247
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 90
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 99
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 75
               start_line: 247
             }
           }
@@ -12801,7 +15009,10 @@ body {
           }
         }
         src {
+          end_column: 100
+          end_line: 247
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 247
         }
         variadic: true
@@ -12849,20 +15060,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 249
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 31
                       start_line: 249
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 249
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 249
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 249
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 31
               start_line: 249
             }
           }
@@ -12875,7 +15095,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 249
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 249
         }
         variadic: true
@@ -12923,20 +15146,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 251
             }
           }
@@ -12970,20 +15202,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 251
             }
           }
@@ -13017,14 +15258,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 251
                 }
               }
@@ -13045,20 +15292,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 251
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 81
               start_line: 251
             }
           }
@@ -13092,14 +15348,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 143
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 118
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 143
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 118
                   start_line: 251
                 }
               }
@@ -13120,20 +15382,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 143
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 118
                       start_line: 251
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 143
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 118
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 143
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 118
               start_line: 251
             }
           }
@@ -13146,7 +15417,10 @@ body {
           }
         }
         src {
+          end_column: 144
+          end_line: 251
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 251
         }
         variadic: true
@@ -13181,7 +15455,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 57
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 253
                 }
                 v: "A"
@@ -13203,14 +15480,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 253
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 253
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 253
                 }
               }
@@ -13231,20 +15514,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 253
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 253
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 253
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 253
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 253
             }
           }
@@ -13257,7 +15549,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 253
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 253
         }
         variadic: true
@@ -13292,7 +15587,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 255
                 }
                 v: "A"
@@ -13301,14 +15599,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 38
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 255
                 }
                 v: 10
               }
             }
             src {
+              end_column: 38
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 255
             }
           }
@@ -13342,14 +15646,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 255
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 255
                 }
               }
@@ -13357,14 +15667,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 58
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 255
                 }
                 v: 4.3
               }
             }
             src {
+              end_column: 58
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 255
             }
           }
@@ -13385,7 +15701,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 73
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 255
                 }
                 v: "A"
@@ -13394,14 +15713,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 73
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 255
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 73
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 255
             }
           }
@@ -13414,7 +15739,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 255
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 255
         }
         variadic: true
@@ -13449,7 +15777,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 257
                 }
                 v: "A"
@@ -13458,14 +15789,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 38
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 257
                 }
                 v: 10
               }
             }
             src {
+              end_column: 38
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 257
             }
           }
@@ -13499,14 +15836,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 257
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 257
                 }
               }
@@ -13514,14 +15857,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 58
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 257
                 }
                 v: 4.3
               }
             }
             src {
+              end_column: 58
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 257
             }
           }
@@ -13542,7 +15891,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 73
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 257
                 }
                 v: "A"
@@ -13551,14 +15903,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 73
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 257
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 73
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 257
             }
           }
@@ -13571,7 +15929,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 257
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 257
         }
         variadic: true
@@ -13606,7 +15967,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 36
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 259
                 }
                 v: "A"
@@ -13615,13 +15979,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 36
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 259
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 259
             }
           }
@@ -13642,7 +16012,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 259
                 }
                 v: "A"
@@ -13651,13 +16024,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 259
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 259
             }
           }
@@ -13691,14 +16070,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 259
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 259
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 259
                 }
               }
@@ -13706,14 +16091,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 73
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 259
                 }
                 v: 4.7
               }
             }
             src {
+              end_column: 73
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 259
             }
           }
@@ -13726,7 +16117,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 259
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 259
         }
         variadic: true
@@ -13774,20 +16168,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 261
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 261
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 261
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 261
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 261
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 261
             }
           }
@@ -13800,7 +16203,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 261
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 261
         }
         variadic: true
@@ -13848,14 +16254,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 263
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 263
                 }
               }
@@ -13876,20 +16288,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 263
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 263
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 263
             }
           }
@@ -13923,14 +16344,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 263
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 263
                 }
               }
@@ -13951,20 +16378,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 263
                     }
                     v: "asfdg"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 263
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 263
             }
           }
@@ -13977,7 +16413,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 263
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 263
         }
         variadic: true
@@ -14025,14 +16464,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 265
                 }
               }
@@ -14053,14 +16498,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 265
                 }
               }
@@ -14081,20 +16532,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 265
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 265
             }
           }
@@ -14128,14 +16588,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 265
                 }
               }
@@ -14143,7 +16609,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 88
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 265
                 }
               }
@@ -14151,14 +16620,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 88
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 265
                 }
                 v: 10
               }
             }
             src {
+              end_column: 88
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 265
             }
           }
@@ -14192,14 +16667,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 108
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 108
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 100
                   start_line: 265
                 }
               }
@@ -14207,7 +16688,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 123
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 90
                   start_line: 265
                 }
                 v: 20
@@ -14229,20 +16713,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 122
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 114
                       start_line: 265
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 122
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 114
                   start_line: 265
                 }
               }
             }
             src {
+              end_column: 123
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 90
               start_line: 265
             }
           }
@@ -14255,7 +16748,10 @@ body {
           }
         }
         src {
+          end_column: 124
+          end_line: 265
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 265
         }
         variadic: true
@@ -14290,7 +16786,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
                 v: "A"
@@ -14299,7 +16798,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
                 v: "abc"
@@ -14308,14 +16810,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 56
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
                 v: 3
               }
             }
             src {
+              end_column: 56
+              end_line: 267
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 267
             }
           }
@@ -14349,14 +16857,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 267
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 267
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 267
                 }
               }
@@ -14377,14 +16891,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 267
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 267
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 267
                 }
               }
@@ -14392,14 +16912,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 96
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 267
                 }
                 v: 2
               }
             }
             src {
+              end_column: 96
+              end_line: 267
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 267
             }
           }
@@ -14412,7 +16938,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 267
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 267
         }
         variadic: true
@@ -14460,14 +16989,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 269
                 }
               }
@@ -14475,7 +17010,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 269
                 }
                 v: "B"
@@ -14497,20 +17035,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 269
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 269
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 269
             }
           }
@@ -14544,14 +17091,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 73
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 73
                   start_line: 269
                 }
               }
@@ -14572,14 +17125,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 269
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 269
                 }
               }
@@ -14600,14 +17159,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 269
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 269
                 }
               }
@@ -14615,7 +17180,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 116
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 269
                 }
                 v: 1
@@ -14624,7 +17192,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 116
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 269
                 }
                 v: 2
@@ -14633,14 +17204,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 116
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 269
                 }
                 v: "test"
               }
             }
             src {
+              end_column: 116
+              end_line: 269
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 269
             }
           }
@@ -14653,7 +17230,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 269
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 269
         }
         variadic: true
@@ -14688,7 +17268,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 53
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
                 v: "A"
@@ -14697,7 +17280,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 53
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
                 v: "B"
@@ -14706,14 +17292,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 53
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
                 v: 2
               }
             }
             src {
+              end_column: 53
+              end_line: 271
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 271
             }
           }
@@ -14726,7 +17318,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 271
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 271
         }
         variadic: true
@@ -14774,14 +17369,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
@@ -14789,7 +17390,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
                 v: "B"
@@ -14798,7 +17402,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
@@ -14806,7 +17413,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
                 v: 1
@@ -14815,13 +17425,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 60
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 273
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 273
             }
           }
@@ -14855,14 +17471,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 273
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 273
                 }
               }
@@ -14883,14 +17505,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 273
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 273
                 }
               }
@@ -14911,14 +17539,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 273
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 273
                 }
               }
@@ -14939,14 +17573,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 273
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 273
                 }
               }
@@ -14967,14 +17607,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 125
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 117
                       start_line: 273
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 125
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 117
                   start_line: 273
                 }
               }
@@ -14995,14 +17641,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 135
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 127
                       start_line: 273
                     }
                     v: "F"
                   }
                 }
                 src {
+                  end_column: 135
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 127
                   start_line: 273
                 }
               }
@@ -15010,7 +17662,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 152
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 273
                 }
                 v: 1
@@ -15019,7 +17674,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 152
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 273
                 }
                 v: "sgh"
@@ -15028,14 +17686,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 152
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 273
                 }
                 v: 99.9
               }
             }
             src {
+              end_column: 152
+              end_line: 273
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 273
             }
           }
@@ -15048,7 +17712,10 @@ body {
           }
         }
         src {
+          end_column: 153
+          end_line: 273
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 273
         }
         variadic: true
@@ -15096,14 +17763,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 275
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 275
                 }
               }
@@ -15111,7 +17784,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 275
                 }
               }
@@ -15119,13 +17795,19 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 275
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 275
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 275
             }
           }
@@ -15159,14 +17841,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 79
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 275
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 79
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 275
                 }
               }
@@ -15174,7 +17862,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 79
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 275
                 }
                 v: "B"
@@ -15183,14 +17874,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 79
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 275
                 }
                 v: "ahsgj"
               }
             }
             src {
+              end_column: 79
+              end_line: 275
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 275
             }
           }
@@ -15203,7 +17900,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 275
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 275
         }
         variadic: true
@@ -15251,14 +17951,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 107
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 277
                 }
               }
@@ -15279,14 +17985,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 107
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 277
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 107
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 277
                 }
               }
@@ -15294,14 +18006,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 107
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 277
                 }
                 v: 20
               }
             }
             src {
+              end_column: 107
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 277
             }
           }
@@ -15335,14 +18053,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 138
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 109
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 138
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 109
                   start_line: 277
                 }
               }
@@ -15363,14 +18087,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 138
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 109
                       start_line: 277
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 138
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 109
                   start_line: 277
                 }
               }
@@ -15391,20 +18121,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 137
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 129
                       start_line: 277
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 137
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 277
                 }
               }
             }
             src {
+              end_column: 138
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 109
               start_line: 277
             }
           }
@@ -15417,7 +18156,10 @@ body {
           }
         }
         src {
+          end_column: 139
+          end_line: 277
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 277
         }
         variadic: true
@@ -15465,14 +18207,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 34
                       start_line: 279
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 34
                   start_line: 279
                 }
               }
@@ -15480,14 +18228,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 55
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 279
                 }
                 v: "sp-upper"
               }
             }
             src {
+              end_column: 55
+              end_line: 279
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 279
             }
           }
@@ -15500,7 +18254,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 279
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 279
         }
         variadic: true
@@ -15548,20 +18305,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 281
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 281
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 281
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 281
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 281
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 281
             }
           }
@@ -15574,7 +18340,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 281
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 281
         }
         variadic: true
@@ -15622,14 +18391,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 283
                 }
               }
@@ -15650,14 +18425,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 283
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 283
                 }
               }
@@ -15678,20 +18459,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 283
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 283
             }
           }
@@ -15710,7 +18500,10 @@ body {
               }
             }
             src {
+              end_column: 62
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 283
             }
           }
@@ -15723,7 +18516,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 283
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 283
         }
         variadic: true
@@ -15771,14 +18567,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 285
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 285
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 285
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 285
                 }
               }
@@ -15799,14 +18601,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 285
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 285
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 285
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 285
                 }
               }
@@ -15827,20 +18635,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 285
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 285
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 285
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 285
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 285
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 285
             }
           }
@@ -15853,7 +18670,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 285
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 285
         }
         variadic: true
@@ -15901,14 +18721,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 287
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 287
                 }
               }
@@ -15929,14 +18755,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 287
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 287
                 }
               }
@@ -15957,20 +18789,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 287
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 287
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 287
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 287
             }
           }
@@ -16004,14 +18845,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 287
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 287
                 }
               }
@@ -16032,14 +18879,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 287
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 287
                 }
               }
@@ -16060,20 +18913,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 93
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 287
                     }
                     v: "ashg"
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 287
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 287
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 287
             }
           }
@@ -16086,7 +18948,10 @@ body {
           }
         }
         src {
+          end_column: 95
+          end_line: 287
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 287
         }
         variadic: true
@@ -16134,14 +18999,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 289
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 289
                 }
               }
@@ -16162,20 +19033,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 289
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 289
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 289
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 289
             }
           }
@@ -16188,7 +19068,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 289
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 289
         }
         variadic: true
@@ -16236,14 +19119,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 291
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 291
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 291
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 291
                 }
               }
@@ -16264,20 +19153,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 291
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 291
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 291
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 291
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 291
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 291
             }
           }
@@ -16290,7 +19188,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 291
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 291
         }
         variadic: true
@@ -16338,14 +19239,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 293
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 293
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 293
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 293
                 }
               }
@@ -16366,20 +19273,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 293
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 293
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 293
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 293
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 293
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 293
             }
           }
@@ -16392,7 +19308,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 293
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 293
         }
         variadic: true
@@ -16440,14 +19359,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 33
                       start_line: 295
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 33
                   start_line: 295
                 }
               }
@@ -16468,14 +19393,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 295
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 295
                 }
               }
@@ -16496,14 +19427,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 295
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 295
                 }
               }
@@ -16524,20 +19461,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 295
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 295
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 295
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 295
             }
           }
@@ -16571,14 +19517,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 295
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 295
                 }
               }
@@ -16586,7 +19538,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 98
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 295
                 }
                 v: 12
@@ -16595,7 +19550,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 98
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 295
                 }
                 v: 13
@@ -16617,20 +19575,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 97
+                      end_line: 295
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 89
                       start_line: 295
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 295
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 89
                   start_line: 295
                 }
               }
             }
             src {
+              end_column: 98
+              end_line: 295
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 295
             }
           }
@@ -16643,7 +19610,10 @@ body {
           }
         }
         src {
+          end_column: 99
+          end_line: 295
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 295
         }
         variadic: true
@@ -16691,14 +19661,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 297
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 297
                 }
               }
@@ -16719,20 +19695,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 36
                       start_line: 297
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 297
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 297
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 297
             }
           }
@@ -16766,14 +19751,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 297
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 297
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 297
                 }
               }
@@ -16781,14 +19772,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 65
+                  end_line: 297
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 297
                 }
                 v: 10
               }
             }
             src {
+              end_column: 65
+              end_line: 297
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 297
             }
           }
@@ -16801,7 +19798,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 297
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 297
         }
         variadic: true
@@ -16849,14 +19849,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 299
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 299
                 }
               }
@@ -16877,20 +19883,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 299
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 299
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 299
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 299
             }
           }
@@ -16924,14 +19939,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 62
+                      end_line: 299
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 299
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 62
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 299
                 }
               }
@@ -16939,14 +19960,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 299
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 299
                 }
                 v: 10
               }
             }
             src {
+              end_column: 67
+              end_line: 299
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 299
             }
           }
@@ -16959,7 +19986,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 299
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 299
         }
         variadic: true
@@ -17007,20 +20037,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 301
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 301
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 301
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 301
             }
           }
@@ -17033,7 +20072,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 301
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 301
         }
         variadic: true
@@ -17081,14 +20123,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 303
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 303
                 }
               }
@@ -17096,14 +20144,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 84
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 303
                 }
                 v: "bcd"
               }
             }
             src {
+              end_column: 84
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 303
             }
           }
@@ -17116,7 +20170,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 303
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 303
         }
         variadic: true
@@ -17164,14 +20221,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 305
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 305
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 305
                 }
               }
@@ -17192,20 +20255,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 305
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 305
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 305
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 305
             }
           }
@@ -17226,7 +20298,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 83
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 305
                 }
                 v: "A"
@@ -17235,14 +20310,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 83
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 305
                 }
                 v: "YYYY"
               }
             }
             src {
+              end_column: 83
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 305
             }
           }
@@ -17255,7 +20336,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 305
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 305
         }
         variadic: true
@@ -17303,20 +20387,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 307
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 307
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 307
             }
           }
@@ -17350,14 +20443,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 307
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 307
                 }
               }
@@ -17365,14 +20464,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 60
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 307
                 }
                 v: "YYYY"
               }
             }
             src {
+              end_column: 60
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 307
             }
           }
@@ -17406,14 +20511,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 307
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 307
                 }
               }
@@ -17434,20 +20545,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 307
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 307
                 }
               }
             }
             src {
+              end_column: 89
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 307
             }
           }
@@ -17460,7 +20580,10 @@ body {
           }
         }
         src {
+          end_column: 90
+          end_line: 307
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 307
         }
         variadic: true
@@ -17508,20 +20631,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 309
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 309
             }
           }
@@ -17555,20 +20687,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 68
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 309
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 309
             }
           }
@@ -17602,14 +20743,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 309
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 309
                 }
               }
@@ -17630,20 +20777,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 309
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 70
               start_line: 309
             }
           }
@@ -17656,7 +20812,10 @@ body {
           }
         }
         src {
+          end_column: 103
+          end_line: 309
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 309
         }
         variadic: true
@@ -17691,7 +20850,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 311
                 }
                 v: "A"
@@ -17700,13 +20862,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 47
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 311
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 311
             }
           }
@@ -17740,14 +20908,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 311
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 311
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 311
                 }
               }
@@ -17755,13 +20929,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 81
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 311
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 311
             }
           }
@@ -17782,7 +20962,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 311
                 }
                 v: "A"
@@ -17791,14 +20974,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 311
                 }
                 v: "auto"
               }
             }
             src {
+              end_column: 112
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 311
             }
           }
@@ -17832,14 +21021,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 139
+                      end_line: 311
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 131
                       start_line: 311
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 139
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 131
                   start_line: 311
                 }
               }
@@ -17860,20 +21055,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 149
+                      end_line: 311
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 141
                       start_line: 311
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 149
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 141
                   start_line: 311
                 }
               }
             }
             src {
+              end_column: 150
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 114
               start_line: 311
             }
           }
@@ -17886,7 +21090,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 311
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 311
         }
         variadic: true
@@ -17921,7 +21128,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 313
                 }
                 v: "A"
@@ -17930,13 +21140,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 47
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 313
             }
           }
@@ -17970,14 +21186,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 313
                 }
               }
@@ -17985,13 +21207,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 81
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 313
             }
           }
@@ -18012,7 +21240,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 313
                 }
                 v: "A"
@@ -18021,14 +21252,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 313
                 }
                 v: "auto"
               }
             }
             src {
+              end_column: 112
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 313
             }
           }
@@ -18062,14 +21299,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 139
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 131
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 139
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 131
                   start_line: 313
                 }
               }
@@ -18090,20 +21333,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 149
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 141
                       start_line: 313
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 149
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 141
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 150
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 114
               start_line: 313
             }
           }
@@ -18116,7 +21368,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 313
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 313
         }
         variadic: true
@@ -18151,7 +21406,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 315
                 }
                 v: "A"
@@ -18160,13 +21418,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 46
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 315
             }
           }
@@ -18200,14 +21464,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 315
                 }
               }
@@ -18215,13 +21485,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 79
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 315
             }
           }
@@ -18242,7 +21518,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 109
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 315
                 }
                 v: "A"
@@ -18251,14 +21530,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 109
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 315
                 }
                 v: "auto"
               }
             }
             src {
+              end_column: 109
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 81
               start_line: 315
             }
           }
@@ -18292,14 +21577,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 135
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 127
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 135
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 127
                   start_line: 315
                 }
               }
@@ -18320,20 +21611,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 145
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 137
                       start_line: 315
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 145
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 137
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 146
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 111
               start_line: 315
             }
           }
@@ -18346,7 +21646,10 @@ body {
           }
         }
         src {
+          end_column: 147
+          end_line: 315
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 315
         }
         variadic: true
@@ -18381,7 +21684,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 60
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 317
                 }
                 v: "A"
@@ -18403,20 +21709,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 59
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 317
                     }
                     v: 1234
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 60
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 317
             }
           }
@@ -18450,14 +21765,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 89
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 81
                       start_line: 317
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 317
                 }
               }
@@ -18478,20 +21799,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 317
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 100
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 317
             }
           }
@@ -18504,7 +21834,10 @@ body {
           }
         }
         src {
+          end_column: 101
+          end_line: 317
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 317
         }
         variadic: true
@@ -18539,7 +21872,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 58
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 319
                 }
                 v: "A"
@@ -18561,20 +21897,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 57
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 319
                     }
                     v: 1234
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 319
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 319
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 319
             }
           }
@@ -18608,14 +21953,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 319
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 319
                 }
               }
@@ -18636,20 +21987,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 95
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 87
                       start_line: 319
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 319
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 319
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 319
             }
           }
@@ -18662,7 +22022,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 319
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 319
         }
         variadic: true
@@ -18697,14 +22060,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 321
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 321
             }
           }
@@ -18725,7 +22094,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 62
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 321
                 }
                 v: "A"
@@ -18747,20 +22119,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 321
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 321
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 321
             }
           }
@@ -18794,20 +22175,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 321
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 321
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 87
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 321
             }
           }
@@ -18820,7 +22210,10 @@ body {
           }
         }
         src {
+          end_column: 88
+          end_line: 321
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 321
         }
         variadic: true

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -618,7 +618,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variant {
@@ -653,7 +656,10 @@ body {
               }
             }
             src {
+              end_column: 45
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 29
             }
           }
@@ -666,7 +672,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 29
         }
         variadic: true
@@ -699,7 +708,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 31
             }
           }
@@ -712,7 +724,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 31
         }
         variadic: true
@@ -745,7 +760,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 33
             }
           }
@@ -758,7 +776,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 33
         }
         variadic: true
@@ -806,20 +827,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 35
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 35
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 35
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 35
             }
           }
@@ -832,7 +862,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 35
         }
         variadic: true
@@ -880,20 +913,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 37
             }
           }
@@ -927,20 +969,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 37
             }
           }
@@ -974,14 +1025,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 37
                 }
               }
@@ -1002,20 +1059,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 37
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 95
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 67
               start_line: 37
             }
           }
@@ -1049,14 +1115,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 37
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 37
                 }
               }
@@ -1077,20 +1149,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 37
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 115
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 97
               start_line: 37
             }
           }
@@ -1103,7 +1184,10 @@ body {
           }
         }
         src {
+          end_column: 116
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 37
         }
         variadic: true
@@ -1151,20 +1235,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 39
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 39
             }
           }
@@ -1177,7 +1270,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 39
         }
         variadic: true
@@ -1225,14 +1321,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 41
                 }
               }
@@ -1240,14 +1342,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 41
                 }
                 v: "fr"
               }
             }
             src {
+              end_column: 45
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 41
             }
           }
@@ -1281,14 +1389,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 64
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 41
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 41
                 }
               }
@@ -1297,13 +1411,19 @@ body {
               sp_column_sql_expr {
                 sql: "\"B\""
                 src {
+                  end_column: 75
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 41
             }
           }
@@ -1316,7 +1436,10 @@ body {
           }
         }
         src {
+          end_column: 76
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 41
         }
         variadic: true
@@ -1364,14 +1487,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 43
                 }
               }
@@ -1379,14 +1508,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 49
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 43
                 }
                 v: "fr"
               }
             }
             src {
+              end_column: 49
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 43
             }
           }
@@ -1420,14 +1555,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 43
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 43
                 }
               }
@@ -1436,13 +1577,19 @@ body {
               sp_column_sql_expr {
                 sql: "\"B\""
                 src {
+                  end_column: 83
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 83
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 43
             }
           }
@@ -1455,7 +1602,10 @@ body {
           }
         }
         src {
+          end_column: 84
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 43
         }
         variadic: true
@@ -1503,20 +1653,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 45
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 45
             }
           }
@@ -1529,7 +1688,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 45
         }
         variadic: true
@@ -1577,20 +1739,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 36
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 47
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 36
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 47
             }
           }
@@ -1603,7 +1774,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 47
         }
         variadic: true
@@ -1651,20 +1825,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 49
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 49
             }
           }
@@ -1677,7 +1860,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 49
         }
         variadic: true
@@ -1725,20 +1911,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 51
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 51
             }
           }
@@ -1751,7 +1946,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 51
         }
         variadic: true
@@ -1799,20 +1997,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 35
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 53
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 35
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 53
             }
           }
@@ -1825,7 +2032,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 53
         }
         variadic: true
@@ -1858,7 +2068,10 @@ body {
               }
             }
             src {
+              end_column: 35
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 55
             }
           }
@@ -1871,7 +2084,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 55
         }
         variadic: true
@@ -1919,14 +2135,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 57
                 }
               }
@@ -1947,20 +2169,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 57
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 57
             }
           }
@@ -1994,14 +2225,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 57
                 }
               }
@@ -2022,20 +2259,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 52
                       start_line: 57
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 57
             }
           }
@@ -2069,14 +2315,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 57
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 57
                 }
               }
@@ -2097,20 +2349,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 108
                       start_line: 57
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 108
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 117
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 57
             }
           }
@@ -2123,7 +2384,10 @@ body {
           }
         }
         src {
+          end_column: 118
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 57
         }
         variadic: true
@@ -2171,20 +2435,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 43
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 59
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 43
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 59
             }
           }
@@ -2197,7 +2470,10 @@ body {
           }
         }
         src {
+          end_column: 44
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 59
         }
         variadic: true
@@ -2245,20 +2521,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 61
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 61
             }
           }
@@ -2271,7 +2556,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 61
         }
         variadic: true
@@ -2319,14 +2607,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 63
                 }
               }
@@ -2347,20 +2641,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 63
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 63
             }
           }
@@ -2394,14 +2697,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 63
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 63
                 }
               }
@@ -2422,20 +2731,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 63
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 63
             }
           }
@@ -2448,7 +2766,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 63
         }
         variadic: true
@@ -2496,20 +2817,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 65
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 65
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 65
             }
           }
@@ -2522,7 +2852,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 65
         }
         variadic: true
@@ -2570,14 +2903,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 67
                 }
               }
@@ -2598,20 +2937,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 67
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 67
             }
           }
@@ -2645,14 +2993,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 83
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 67
                 }
               }
@@ -2673,20 +3027,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 93
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 85
                       start_line: 67
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 67
             }
           }
@@ -2720,14 +3083,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 129
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 96
                       start_line: 67
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 129
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 96
                   start_line: 67
                 }
               }
@@ -2748,20 +3117,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 128
+                      end_line: 67
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 120
                       start_line: 67
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 128
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 120
                   start_line: 67
                 }
               }
             }
             src {
+              end_column: 129
+              end_line: 67
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 96
               start_line: 67
             }
           }
@@ -2774,7 +3152,10 @@ body {
           }
         }
         src {
+          end_column: 130
+          end_line: 67
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 67
         }
         variadic: true
@@ -2809,7 +3190,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 69
                 }
                 v: "A"
@@ -2818,7 +3202,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 69
                 }
                 v: "B"
@@ -2827,14 +3214,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 48
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 69
                 }
                 v: true
               }
             }
             src {
+              end_column: 48
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 69
             }
           }
@@ -2855,7 +3248,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 83
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 69
                 }
                 v: "A"
@@ -2877,14 +3273,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 69
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 69
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 69
                 }
               }
@@ -2892,14 +3294,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 83
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 69
                 }
                 v: true
               }
             }
             src {
+              end_column: 83
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 69
             }
           }
@@ -2920,7 +3328,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 114
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 69
                 }
                 v: "B"
@@ -2929,7 +3340,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 114
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 69
                 }
                 v: "A"
@@ -2938,13 +3352,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 114
+                  end_line: 69
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 69
                 }
               }
             }
             src {
+              end_column: 114
+              end_line: 69
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 85
               start_line: 69
             }
           }
@@ -2957,7 +3377,10 @@ body {
           }
         }
         src {
+          end_column: 115
+          end_line: 69
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 69
         }
         variadic: true
@@ -3005,20 +3428,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 71
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 71
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 71
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 71
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 71
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 71
             }
           }
@@ -3031,7 +3463,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 71
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 71
         }
         variadic: true
@@ -3079,20 +3514,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 73
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 73
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 73
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 73
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 73
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 73
             }
           }
@@ -3105,7 +3549,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 73
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 73
         }
         variadic: true
@@ -3153,20 +3600,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 75
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 75
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 75
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 75
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 75
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 75
             }
           }
@@ -3179,7 +3635,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 75
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 75
         }
         variadic: true
@@ -3227,14 +3686,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 77
                 }
               }
@@ -3242,7 +3707,10 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 41
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 77
                 }
                 v: true
@@ -3251,13 +3719,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 41
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 77
             }
           }
@@ -3291,14 +3765,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 64
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 64
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 77
                 }
               }
@@ -3306,7 +3786,10 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 64
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 77
                 }
                 v: true
@@ -3315,13 +3798,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 64
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 77
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 77
             }
           }
@@ -3355,14 +3844,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 77
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 77
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 77
                 }
               }
@@ -3370,7 +3865,10 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 99
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 77
                 }
               }
@@ -3378,14 +3876,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 99
+                  end_line: 77
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 77
                 }
                 v: true
               }
             }
             src {
+              end_column: 99
+              end_line: 77
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 66
               start_line: 77
             }
           }
@@ -3398,7 +3902,10 @@ body {
           }
         }
         src {
+          end_column: 100
+          end_line: 77
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 77
         }
         variadic: true
@@ -3446,14 +3953,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 79
                 }
               }
@@ -3474,20 +3987,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 79
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 79
             }
           }
@@ -3521,14 +4043,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 54
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 54
                   start_line: 79
                 }
               }
@@ -3549,20 +4077,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 79
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 79
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 79
                 }
               }
             }
             src {
+              end_column: 85
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 79
             }
           }
@@ -3575,7 +4112,10 @@ body {
           }
         }
         src {
+          end_column: 86
+          end_line: 79
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 79
         }
         variadic: true
@@ -3623,14 +4163,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 81
                 }
               }
@@ -3651,20 +4197,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 81
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 81
             }
           }
@@ -3698,14 +4253,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 58
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 81
                 }
               }
@@ -3726,20 +4287,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 81
                 }
               }
             }
             src {
+              end_column: 99
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 81
             }
           }
@@ -3773,14 +4343,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 130
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 122
                       start_line: 81
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 130
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 81
                 }
               }
@@ -3801,14 +4377,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 141
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 101
                       start_line: 81
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 141
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 101
                   start_line: 81
                 }
               }
@@ -3829,20 +4411,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 141
+                      end_line: 81
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 101
                       start_line: 81
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 141
+                  end_line: 81
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 101
                   start_line: 81
                 }
               }
             }
             src {
+              end_column: 141
+              end_line: 81
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 101
               start_line: 81
             }
           }
@@ -3855,7 +4446,10 @@ body {
           }
         }
         src {
+          end_column: 142
+          end_line: 81
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 81
         }
         variadic: true
@@ -3890,7 +4484,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 83
                 }
                 v: "A"
@@ -3899,7 +4496,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 83
                 }
                 v: "B"
@@ -3908,13 +4508,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 44
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 83
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 83
             }
           }
@@ -3935,7 +4541,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 75
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 83
                 }
                 v: "A"
@@ -3957,14 +4566,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 68
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 60
                       start_line: 83
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 60
                   start_line: 83
                 }
               }
@@ -3972,13 +4587,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 75
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 83
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 83
             }
           }
@@ -4012,14 +4633,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 83
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 83
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 83
                 }
               }
@@ -4027,7 +4654,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 105
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 83
                 }
                 v: "B"
@@ -4036,14 +4666,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 105
+                  end_line: 83
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 83
                 }
                 v: "C"
               }
             }
             src {
+              end_column: 105
+              end_line: 83
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 77
               start_line: 83
             }
           }
@@ -4056,7 +4692,10 @@ body {
           }
         }
         src {
+          end_column: 106
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 83
         }
         variadic: true
@@ -4091,7 +4730,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 85
                 }
                 v: "A"
@@ -4100,14 +4742,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 85
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 44
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 85
             }
           }
@@ -4128,7 +4776,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 63
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 85
                 }
                 v: "A"
@@ -4137,14 +4788,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 63
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 85
                 }
                 v: 10
               }
             }
             src {
+              end_column: 63
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 85
             }
           }
@@ -4178,14 +4835,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 85
                 }
               }
@@ -4193,13 +4856,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 86
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 85
             }
           }
@@ -4233,14 +4902,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 85
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 85
                 }
               }
@@ -4261,20 +4936,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 85
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 85
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 85
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 85
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 85
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 88
               start_line: 85
             }
           }
@@ -4287,7 +4971,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 85
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 85
         }
         variadic: true
@@ -4322,7 +5009,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 87
                 }
                 v: "A"
@@ -4331,14 +5021,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 44
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 87
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 44
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 87
             }
           }
@@ -4359,7 +5055,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 63
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 87
                 }
                 v: "A"
@@ -4368,14 +5067,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 63
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 87
                 }
                 v: 10
               }
             }
             src {
+              end_column: 63
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 87
             }
           }
@@ -4409,14 +5114,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 82
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 87
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 82
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 87
                 }
               }
@@ -4424,13 +5135,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 86
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 86
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 87
             }
           }
@@ -4464,14 +5181,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 97
                       start_line: 87
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 97
                   start_line: 87
                 }
               }
@@ -4492,20 +5215,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 115
+                      end_line: 87
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 87
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 115
+                  end_line: 87
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 87
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 87
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 88
               start_line: 87
             }
           }
@@ -4518,7 +5250,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 87
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 87
         }
         variadic: true
@@ -4553,7 +5288,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 57
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 89
                 }
                 v: "year"
@@ -4575,14 +5313,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 89
                 }
               }
@@ -4603,20 +5347,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 89
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 89
             }
           }
@@ -4637,7 +5390,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 91
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 89
                 }
                 v: "month"
@@ -4659,14 +5415,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 89
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 89
                 }
               }
@@ -4687,20 +5449,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 90
+                      end_line: 89
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 89
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 90
+                  end_line: 89
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 89
                 }
               }
             }
             src {
+              end_column: 91
+              end_line: 89
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 89
             }
           }
@@ -4713,7 +5484,10 @@ body {
           }
         }
         src {
+          end_column: 92
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 89
         }
         variadic: true
@@ -4748,7 +5522,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 91
                 }
                 v: "A"
@@ -4757,14 +5534,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 43
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 91
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 43
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 91
             }
           }
@@ -4798,14 +5581,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 91
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 91
                 }
               }
@@ -4826,20 +5615,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 91
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 63
                       start_line: 91
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 91
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 63
                   start_line: 91
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 91
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 91
             }
           }
@@ -4852,7 +5650,10 @@ body {
           }
         }
         src {
+          end_column: 73
+          end_line: 91
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 91
         }
         variadic: true
@@ -4887,7 +5688,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 93
                 }
                 v: "A"
@@ -4896,14 +5700,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 93
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 41
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 93
             }
           }
@@ -4937,14 +5747,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 93
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 93
                 }
               }
@@ -4965,20 +5781,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 93
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 93
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 93
             }
           }
@@ -4999,7 +5824,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 84
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 93
                 }
                 v: "A"
@@ -5008,14 +5836,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 84
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 93
                 }
                 v: 10
               }
             }
             src {
+              end_column: 84
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 70
               start_line: 93
             }
           }
@@ -5036,7 +5870,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 93
                 }
                 v: "B"
@@ -5045,14 +5882,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 101
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 93
                 }
                 v: 7.9
               }
             }
             src {
+              end_column: 101
+              end_line: 93
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 86
               start_line: 93
             }
           }
@@ -5065,7 +5908,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 93
         }
         variadic: true
@@ -5100,7 +5946,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 51
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 95
                 }
                 v: "year"
@@ -5122,14 +5971,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 95
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 95
                 }
               }
@@ -5150,20 +6005,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 95
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 95
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 95
             }
           }
@@ -5184,7 +6048,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 88
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 95
                 }
                 v: "year"
@@ -5206,14 +6073,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 95
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 95
                 }
               }
@@ -5234,20 +6107,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 87
+                      end_line: 95
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 95
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 87
+                  end_line: 95
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 95
                 }
               }
             }
             src {
+              end_column: 88
+              end_line: 95
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 95
             }
           }
@@ -5260,7 +6142,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 95
         }
         variadic: true
@@ -5295,7 +6180,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 48
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 97
                 }
                 v: "year"
@@ -5317,20 +6205,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 97
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 97
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 97
             }
           }
@@ -5351,7 +6248,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 77
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 97
                 }
                 v: "year"
@@ -5373,20 +6273,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 97
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 97
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 97
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 97
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 97
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 97
             }
           }
@@ -5399,7 +6308,10 @@ body {
           }
         }
         src {
+          end_column: 78
+          end_line: 97
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 97
         }
         variadic: true
@@ -5434,7 +6346,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 99
                 }
                 v: 10
@@ -5443,7 +6358,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 99
                 }
                 v: 2
@@ -5452,14 +6370,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 99
                 }
                 v: 1
               }
             }
             src {
+              end_column: 51
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 99
             }
           }
@@ -5480,7 +6404,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 80
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 99
                 }
                 v: 10
@@ -5489,7 +6416,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 80
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 99
                 }
                 v: "A"
@@ -5498,14 +6428,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 80
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 99
                 }
                 v: 1
               }
             }
             src {
+              end_column: 80
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 99
             }
           }
@@ -5526,7 +6462,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 99
                 }
                 v: "A"
@@ -5535,7 +6474,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 99
                 }
                 v: "B"
@@ -5544,14 +6486,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 112
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 99
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 112
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 82
               start_line: 99
             }
           }
@@ -5572,7 +6520,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 146
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 114
                   start_line: 99
                 }
                 v: 10
@@ -5594,14 +6545,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 142
+                      end_line: 99
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 134
                       start_line: 99
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 142
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 134
                   start_line: 99
                 }
               }
@@ -5609,14 +6566,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 146
+                  end_line: 99
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 114
                   start_line: 99
                 }
                 v: 1
               }
             }
             src {
+              end_column: 146
+              end_line: 99
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 114
               start_line: 99
             }
           }
@@ -5629,7 +6592,10 @@ body {
           }
         }
         src {
+          end_column: 147
+          end_line: 99
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 99
         }
         variadic: true
@@ -5664,7 +6630,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 49
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 101
                 }
                 v: "year"
@@ -5686,20 +6655,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 101
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 101
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 101
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 101
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 101
             }
           }
@@ -5720,7 +6698,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 79
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 101
                 }
                 v: "year"
@@ -5742,20 +6723,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 101
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 101
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 101
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 101
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 101
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 101
             }
           }
@@ -5768,7 +6758,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 101
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 101
         }
         variadic: true
@@ -5816,20 +6809,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 103
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 103
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 103
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 103
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 103
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 103
             }
           }
@@ -5842,7 +6844,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 103
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 103
         }
         variadic: true
@@ -5890,20 +6895,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 105
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 105
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 105
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 105
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 105
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 105
             }
           }
@@ -5916,7 +6930,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 105
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 105
         }
         variadic: true
@@ -5964,20 +6981,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 107
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 107
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 107
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 107
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 107
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 107
             }
           }
@@ -5990,7 +7016,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 107
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 107
         }
         variadic: true
@@ -6038,20 +7067,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 109
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 109
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 109
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 109
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 109
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 109
             }
           }
@@ -6064,7 +7102,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 109
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 109
         }
         variadic: true
@@ -6112,20 +7153,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 111
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 111
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 111
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 111
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 111
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 111
             }
           }
@@ -6138,7 +7188,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 111
         }
         variadic: true
@@ -6186,20 +7239,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 113
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 113
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 113
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 113
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 113
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 113
             }
           }
@@ -6212,7 +7274,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 113
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 113
         }
         variadic: true
@@ -6260,20 +7325,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 115
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 115
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 115
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 115
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 115
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 115
             }
           }
@@ -6286,7 +7360,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 115
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 115
         }
         variadic: true
@@ -6334,20 +7411,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 117
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 117
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 117
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 117
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 117
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 117
             }
           }
@@ -6360,7 +7446,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 117
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 117
         }
         variadic: true
@@ -6408,20 +7497,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 119
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 119
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 119
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 119
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 119
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 119
             }
           }
@@ -6434,7 +7532,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 119
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 119
         }
         variadic: true
@@ -6482,20 +7583,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 121
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 121
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 121
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 121
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 121
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 121
             }
           }
@@ -6508,7 +7618,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 121
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 121
         }
         variadic: true
@@ -6556,20 +7669,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 123
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 123
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 123
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 123
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 123
             }
           }
@@ -6582,7 +7704,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 123
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 123
         }
         variadic: true
@@ -6630,20 +7755,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 125
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 125
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 125
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 125
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 125
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 125
             }
           }
@@ -6656,7 +7790,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 125
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 125
         }
         variadic: true
@@ -6704,20 +7841,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 127
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 127
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 127
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 127
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 127
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 127
             }
           }
@@ -6730,7 +7876,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 127
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 127
         }
         variadic: true
@@ -6778,20 +7927,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 129
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 129
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 129
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 129
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 129
             }
           }
@@ -6804,7 +7962,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 129
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 129
         }
         variadic: true
@@ -6852,20 +8013,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 131
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 131
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 131
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 131
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 131
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 131
             }
           }
@@ -6878,7 +8048,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 131
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 131
         }
         variadic: true
@@ -6926,20 +8099,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 133
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 133
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 133
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 133
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 133
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 133
             }
           }
@@ -6952,7 +8134,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 133
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 133
         }
         variadic: true
@@ -7000,20 +8185,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 135
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 135
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 135
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 135
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 135
             }
           }
@@ -7026,7 +8220,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 135
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 135
         }
         variadic: true
@@ -7074,20 +8271,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 137
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 137
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 137
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 137
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 137
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 137
             }
           }
@@ -7100,7 +8306,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 137
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 137
         }
         variadic: true
@@ -7148,20 +8357,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 139
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 139
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 139
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 139
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 139
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 139
             }
           }
@@ -7174,7 +8392,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 139
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 139
         }
         variadic: true
@@ -7209,7 +8430,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 50
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 141
                 }
                 v: 1
@@ -7218,7 +8442,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 50
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 141
                 }
                 v: 2
@@ -7227,7 +8454,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 50
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 141
                 }
                 v: 3
@@ -7236,13 +8466,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 50
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 141
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 141
             }
           }
@@ -7263,7 +8499,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 141
                 }
                 v: "A"
@@ -7272,7 +8511,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 141
                 }
                 v: "B"
@@ -7281,7 +8523,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 141
                 }
                 v: "A"
@@ -7290,13 +8535,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 82
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 52
                   start_line: 141
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 141
             }
           }
@@ -7317,7 +8568,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 117
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 141
                 }
                 v: 1
@@ -7326,7 +8580,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 117
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 141
                 }
                 v: "A"
@@ -7348,14 +8605,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 141
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 108
                       start_line: 141
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 108
                   start_line: 141
                 }
               }
@@ -7363,13 +8626,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 117
+                  end_line: 141
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 141
                 }
               }
             }
             src {
+              end_column: 117
+              end_line: 141
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 141
             }
           }
@@ -7382,7 +8651,10 @@ body {
           }
         }
         src {
+          end_column: 118
+          end_line: 141
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 141
         }
         variadic: true
@@ -7417,7 +8689,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 143
                 }
                 v: "A"
@@ -7426,14 +8701,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 56
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 143
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 56
+              end_line: 143
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 143
             }
           }
@@ -7467,14 +8748,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 87
+                      end_line: 143
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 143
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 87
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 143
                 }
               }
@@ -7482,14 +8769,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 93
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 58
                   start_line: 143
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 93
+              end_line: 143
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 58
               start_line: 143
             }
           }
@@ -7523,14 +8816,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 124
+                      end_line: 143
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 116
                       start_line: 143
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 124
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 116
                   start_line: 143
                 }
               }
@@ -7551,20 +8850,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 134
+                      end_line: 143
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 126
                       start_line: 143
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 134
+                  end_line: 143
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 126
                   start_line: 143
                 }
               }
             }
             src {
+              end_column: 135
+              end_line: 143
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 95
               start_line: 143
             }
           }
@@ -7577,7 +8885,10 @@ body {
           }
         }
         src {
+          end_column: 136
+          end_line: 143
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 143
         }
         variadic: true
@@ -7612,7 +8923,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 145
                 }
                 v: 2000
@@ -7621,7 +8935,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 145
                 }
                 v: 12
@@ -7630,7 +8947,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 145
                 }
               }
@@ -7638,7 +8958,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 145
                 }
                 v: 12
@@ -7647,7 +8970,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 145
                 }
                 v: 3
@@ -7656,14 +8982,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 69
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 145
                 }
                 v: 1
               }
             }
             src {
+              end_column: 69
+              end_line: 145
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 145
             }
           }
@@ -7684,7 +9016,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
                 v: 2000
@@ -7693,7 +9028,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
                 v: 12
@@ -7702,7 +9040,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
               }
@@ -7710,7 +9051,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
                 v: 12
@@ -7719,7 +9063,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
                 v: 3
@@ -7728,7 +9075,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
                 v: 1
@@ -7737,13 +9087,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 120
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 145
                 }
               }
             }
             src {
+              end_column: 120
+              end_line: 145
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 71
               start_line: 145
             }
           }
@@ -7764,7 +9120,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
                 v: 2000
@@ -7773,7 +9132,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
                 v: 12
@@ -7782,7 +9144,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
               }
@@ -7790,7 +9155,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
                 v: 12
@@ -7799,7 +9167,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
                 v: 3
@@ -7808,7 +9179,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
                 v: 1
@@ -7817,7 +9191,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
               }
@@ -7825,13 +9202,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 177
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 122
                   start_line: 145
                 }
               }
             }
             src {
+              end_column: 177
+              end_line: 145
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 122
               start_line: 145
             }
           }
@@ -7852,7 +9235,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
                 v: 2000
@@ -7861,7 +9247,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
                 v: 12
@@ -7870,7 +9259,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
               }
@@ -7878,7 +9270,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
                 v: 12
@@ -7887,7 +9282,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
                 v: 3
@@ -7896,7 +9294,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
                 v: 1
@@ -7905,7 +9306,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
               }
@@ -7913,14 +9317,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 234
+                  end_line: 145
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 179
                   start_line: 145
                 }
                 v: "us"
               }
             }
             src {
+              end_column: 234
+              end_line: 145
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 179
               start_line: 145
             }
           }
@@ -7933,7 +9343,10 @@ body {
           }
         }
         src {
+          end_column: 235
+          end_line: 145
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 145
         }
         variadic: true
@@ -7968,7 +9381,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 147
                 }
                 v: "year"
@@ -7977,7 +9393,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 147
                 }
                 v: "month"
@@ -7986,7 +9405,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 147
                 }
                 v: "day"
@@ -7995,7 +9417,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 147
                 }
                 v: "hour"
@@ -8004,7 +9429,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 147
                 }
                 v: "minute"
@@ -8013,14 +9441,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 98
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 147
                 }
                 v: "second"
               }
             }
             src {
+              end_column: 98
+              end_line: 147
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 147
             }
           }
@@ -8054,14 +9488,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 136
+                      end_line: 147
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 121
                       start_line: 147
                     }
                     v: "date"
                   }
                 }
                 src {
+                  end_column: 136
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 121
                   start_line: 147
                 }
               }
@@ -8095,26 +9535,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 153
+                          end_line: 147
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 138
                           start_line: 147
                         }
                         v: "time"
                       }
                     }
                     src {
+                      end_column: 153
+                      end_line: 147
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 138
                       start_line: 147
                     }
                   }
                 }
                 src {
+                  end_column: 153
+                  end_line: 147
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 138
                   start_line: 147
                 }
               }
             }
             src {
+              end_column: 154
+              end_line: 147
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 100
               start_line: 147
             }
           }
@@ -8127,7 +9579,10 @@ body {
           }
         }
         src {
+          end_column: 155
+          end_line: 147
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 147
         }
         variadic: true
@@ -8162,7 +9617,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
                 v: 2000
@@ -8171,7 +9629,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
                 v: 12
@@ -8180,7 +9641,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
               }
@@ -8188,7 +9652,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
                 v: 12
@@ -8197,7 +9664,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
                 v: 3
@@ -8206,7 +9676,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
                 v: 1
@@ -8215,13 +9688,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 73
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 149
             }
           }
@@ -8242,7 +9721,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
                 v: 2000
@@ -8251,7 +9733,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
                 v: 12
@@ -8260,7 +9745,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
               }
@@ -8268,7 +9756,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
                 v: 12
@@ -8277,7 +9768,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
                 v: 3
@@ -8286,7 +9780,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
                 v: 1
@@ -8295,13 +9792,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 128
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 128
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 75
               start_line: 149
             }
           }
@@ -8322,7 +9825,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
                 v: 2000
@@ -8331,7 +9837,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
                 v: 12
@@ -8340,7 +9849,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
               }
@@ -8348,7 +9860,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
                 v: 12
@@ -8357,7 +9872,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
                 v: 3
@@ -8366,7 +9884,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
                 v: 1
@@ -8375,13 +9896,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 183
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 130
                   start_line: 149
                 }
               }
             }
             src {
+              end_column: 183
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 130
               start_line: 149
             }
           }
@@ -8402,7 +9929,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
                 v: 2000
@@ -8411,7 +9941,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
                 v: 12
@@ -8420,7 +9953,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
               }
@@ -8428,7 +9964,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
                 v: 12
@@ -8437,7 +9976,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
                 v: 3
@@ -8446,7 +9988,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
                 v: 1
@@ -8455,14 +10000,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 236
+                  end_line: 149
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 185
                   start_line: 149
                 }
                 v: 12
               }
             }
             src {
+              end_column: 236
+              end_line: 149
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 185
               start_line: 149
             }
           }
@@ -8475,7 +10026,10 @@ body {
           }
         }
         src {
+          end_column: 237
+          end_line: 149
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 149
         }
         variadic: true
@@ -8510,7 +10064,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 151
                 }
                 v: 2000
@@ -8519,7 +10076,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 151
                 }
                 v: 12
@@ -8528,7 +10088,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 151
                 }
               }
@@ -8536,7 +10099,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 151
                 }
                 v: 12
@@ -8545,7 +10111,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 151
                 }
                 v: 3
@@ -8554,14 +10123,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 73
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 151
                 }
                 v: 1
               }
             }
             src {
+              end_column: 73
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 151
             }
           }
@@ -8582,7 +10157,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
                 v: 2000
@@ -8591,7 +10169,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
                 v: 12
@@ -8600,7 +10181,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
               }
@@ -8608,7 +10192,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
                 v: 12
@@ -8617,7 +10204,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
                 v: 3
@@ -8626,7 +10216,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
                 v: 1
@@ -8648,20 +10241,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 127
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 75
                       start_line: 151
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 127
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 75
                   start_line: 151
                 }
               }
             }
             src {
+              end_column: 127
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 75
               start_line: 151
             }
           }
@@ -8682,7 +10284,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 151
                 }
                 v: 2000
@@ -8691,7 +10296,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 151
                 }
                 v: 12
@@ -8700,7 +10308,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 151
                 }
               }
@@ -8708,7 +10319,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 151
                 }
                 v: 12
@@ -8717,7 +10331,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 151
                 }
                 v: 3
@@ -8726,7 +10343,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 229
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 129
                   start_line: 151
                 }
                 v: 1
@@ -8748,7 +10368,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                     v: 2000
@@ -8757,7 +10380,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                     v: 12
@@ -8766,7 +10392,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                   }
@@ -8774,7 +10403,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                     v: 12
@@ -8783,7 +10415,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                     v: 3
@@ -8792,7 +10427,10 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                     v: 1
@@ -8801,20 +10439,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 228
+                      end_line: 151
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 177
                       start_line: 151
                     }
                     v: 12
                   }
                 }
                 src {
+                  end_column: 228
+                  end_line: 151
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 177
                   start_line: 151
                 }
               }
             }
             src {
+              end_column: 229
+              end_line: 151
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 129
               start_line: 151
             }
           }
@@ -8827,7 +10474,10 @@ body {
           }
         }
         src {
+          end_column: 230
+          end_line: 151
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 151
         }
         variadic: true
@@ -8862,7 +10512,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
                 v: 2000
@@ -8871,7 +10524,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
                 v: 12
@@ -8880,7 +10536,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
               }
@@ -8888,7 +10547,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
                 v: 12
@@ -8897,7 +10559,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
                 v: 3
@@ -8906,7 +10571,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
                 v: 1
@@ -8915,7 +10583,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
               }
@@ -8923,13 +10594,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 72
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 153
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 153
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 153
             }
           }
@@ -8950,7 +10627,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
                 v: 2000
@@ -8959,7 +10639,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
                 v: 12
@@ -8968,7 +10651,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
               }
@@ -8976,7 +10662,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
                 v: 12
@@ -8985,7 +10674,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
                 v: 3
@@ -8994,7 +10686,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
                 v: 1
@@ -9003,7 +10698,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
               }
@@ -9011,13 +10709,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 126
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 153
                 }
               }
             }
             src {
+              end_column: 126
+              end_line: 153
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 74
               start_line: 153
             }
           }
@@ -9038,7 +10742,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
                 v: 2000
@@ -9047,7 +10754,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
                 v: 12
@@ -9056,7 +10766,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
               }
@@ -9064,7 +10777,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
                 v: 12
@@ -9073,7 +10789,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
                 v: 3
@@ -9082,7 +10801,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
                 v: 1
@@ -9091,7 +10813,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
               }
@@ -9099,13 +10824,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 186
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 128
                   start_line: 153
                 }
               }
             }
             src {
+              end_column: 186
+              end_line: 153
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 128
               start_line: 153
             }
           }
@@ -9126,7 +10857,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
                 v: 2000
@@ -9135,7 +10869,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
                 v: 12
@@ -9144,7 +10881,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
               }
@@ -9152,7 +10892,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
                 v: 12
@@ -9161,7 +10904,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
                 v: 3
@@ -9170,7 +10916,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
                 v: 1
@@ -9179,7 +10928,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
               }
@@ -9187,14 +10939,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 246
+                  end_line: 153
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 188
                   start_line: 153
                 }
                 v: "us"
               }
             }
             src {
+              end_column: 246
+              end_line: 153
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 188
               start_line: 153
             }
           }
@@ -9207,7 +10965,10 @@ body {
           }
         }
         src {
+          end_column: 247
+          end_line: 153
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 153
         }
         variadic: true
@@ -9255,20 +11016,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 155
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 155
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 155
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 155
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 155
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 155
             }
           }
@@ -9281,7 +11051,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 155
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 155
         }
         variadic: true
@@ -9329,20 +11102,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 157
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 157
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 157
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 157
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 157
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 157
             }
           }
@@ -9355,7 +11137,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 157
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 157
         }
         variadic: true
@@ -9403,20 +11188,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 159
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 159
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 159
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 159
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 159
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 159
             }
           }
@@ -9429,7 +11223,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 159
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 159
         }
         variadic: true
@@ -9477,20 +11274,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 161
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 161
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 161
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 161
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 161
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 161
             }
           }
@@ -9503,7 +11309,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 161
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 161
         }
         variadic: true
@@ -9551,14 +11360,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 163
                 }
               }
@@ -9579,20 +11394,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 163
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 163
             }
           }
@@ -9626,14 +11450,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 163
                 }
               }
@@ -9654,20 +11484,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 163
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 60
               start_line: 163
             }
           }
@@ -9701,14 +11540,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 135
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 127
                       start_line: 163
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 135
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 127
                   start_line: 163
                 }
               }
@@ -9729,20 +11574,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 141
+                      end_line: 163
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 163
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 141
+                  end_line: 163
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 163
                 }
               }
             }
             src {
+              end_column: 141
+              end_line: 163
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 104
               start_line: 163
             }
           }
@@ -9755,7 +11609,10 @@ body {
           }
         }
         src {
+          end_column: 142
+          end_line: 163
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 163
         }
         variadic: true
@@ -9803,20 +11660,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 165
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 165
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 165
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 165
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 165
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 165
             }
           }
@@ -9829,7 +11695,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 165
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 165
         }
         variadic: true
@@ -9877,20 +11746,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 167
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 167
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 167
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 167
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 167
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 167
             }
           }
@@ -9903,7 +11781,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 167
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 167
         }
         variadic: true
@@ -9951,20 +11832,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 169
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 169
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 169
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 169
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 169
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 169
             }
           }
@@ -9977,7 +11867,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 169
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 169
         }
         variadic: true
@@ -10025,20 +11918,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 171
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 171
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 171
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 171
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 171
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 171
             }
           }
@@ -10072,20 +11974,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 171
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 59
                       start_line: 171
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 171
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 171
                 }
               }
             }
             src {
+              end_column: 74
+              end_line: 171
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 171
             }
           }
@@ -10098,7 +12009,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 171
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 171
         }
         variadic: true
@@ -10146,14 +12060,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 173
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 173
                 }
               }
@@ -10174,20 +12094,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 50
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 173
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 173
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 173
             }
           }
@@ -10221,14 +12150,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 173
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 173
                 }
               }
@@ -10249,20 +12184,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 173
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 173
                 }
               }
             }
             src {
+              end_column: 75
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 173
             }
           }
@@ -10296,14 +12240,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 90
                       start_line: 173
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 90
                   start_line: 173
                 }
               }
@@ -10324,20 +12274,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 108
+                      end_line: 173
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 100
                       start_line: 173
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 108
+                  end_line: 173
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 100
                   start_line: 173
                 }
               }
             }
             src {
+              end_column: 109
+              end_line: 173
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 77
               start_line: 173
             }
           }
@@ -10350,7 +12309,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 173
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 173
         }
         variadic: true
@@ -10398,14 +12360,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 175
                 }
               }
@@ -10426,20 +12394,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 47
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 175
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 48
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 175
             }
           }
@@ -10473,14 +12450,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 175
                 }
               }
@@ -10501,20 +12484,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 175
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 175
             }
           }
@@ -10548,14 +12540,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 89
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 81
                       start_line: 175
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 81
                   start_line: 175
                 }
               }
@@ -10576,20 +12574,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 99
+                      end_line: 175
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 91
                       start_line: 175
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 99
+                  end_line: 175
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 91
                   start_line: 175
                 }
               }
             }
             src {
+              end_column: 100
+              end_line: 175
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 71
               start_line: 175
             }
           }
@@ -10602,7 +12609,10 @@ body {
           }
         }
         src {
+          end_column: 101
+          end_line: 175
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 175
         }
         variadic: true
@@ -10650,20 +12660,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 177
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 177
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 177
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 177
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 177
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 177
             }
           }
@@ -10676,7 +12695,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 177
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 177
         }
         variadic: true
@@ -10709,7 +12731,10 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 179
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 179
             }
           }
@@ -10743,20 +12768,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 65
+                      end_line: 179
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 179
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 65
+                  end_line: 179
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 179
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 179
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 179
             }
           }
@@ -10790,14 +12824,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 89
+                      end_line: 179
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 179
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 89
+                  end_line: 179
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 179
                 }
               }
@@ -10818,14 +12858,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 105
+                      end_line: 179
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 179
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 105
+                  end_line: 179
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 179
                 }
               }
@@ -10846,20 +12892,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 179
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 96
                       start_line: 179
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 179
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 96
                   start_line: 179
                 }
               }
             }
             src {
+              end_column: 105
+              end_line: 179
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 67
               start_line: 179
             }
           }
@@ -10872,7 +12927,10 @@ body {
           }
         }
         src {
+          end_column: 106
+          end_line: 179
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 179
         }
         variadic: true
@@ -10905,7 +12963,10 @@ body {
               }
             }
             src {
+              end_column: 51
+              end_line: 181
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 181
             }
           }
@@ -10939,20 +13000,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 181
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 181
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 181
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 181
                 }
               }
             }
             src {
+              end_column: 81
+              end_line: 181
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 181
             }
           }
@@ -10986,14 +13056,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 113
+                      end_line: 181
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 107
                       start_line: 181
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 113
+                  end_line: 181
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 107
                   start_line: 181
                 }
               }
@@ -11014,14 +13090,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 129
+                      end_line: 181
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 181
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 129
+                  end_line: 181
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 181
                 }
               }
@@ -11042,20 +13124,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 128
+                      end_line: 181
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 120
                       start_line: 181
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 128
+                  end_line: 181
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 120
                   start_line: 181
                 }
               }
             }
             src {
+              end_column: 129
+              end_line: 181
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 83
               start_line: 181
             }
           }
@@ -11068,7 +13159,10 @@ body {
           }
         }
         src {
+          end_column: 130
+          end_line: 181
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 181
         }
         variadic: true
@@ -11116,14 +13210,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 183
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 183
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 183
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 183
                 }
               }
@@ -11144,20 +13244,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 183
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 183
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 183
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 183
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 183
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 183
             }
           }
@@ -11191,14 +13300,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 183
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 183
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 183
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 183
                 }
               }
@@ -11219,20 +13334,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 183
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 183
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 183
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 183
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 183
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 183
             }
           }
@@ -11245,7 +13369,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 183
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 183
         }
         variadic: true
@@ -11293,14 +13420,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 185
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 185
                 }
               }
@@ -11321,14 +13454,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 185
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 185
                 }
               }
@@ -11349,20 +13488,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 185
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 185
                 }
               }
             }
             src {
+              end_column: 53
+              end_line: 185
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 185
             }
           }
@@ -11396,14 +13544,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 68
                       start_line: 185
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 185
                 }
               }
@@ -11424,14 +13578,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 185
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 185
                 }
               }
@@ -11452,20 +13612,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 185
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 185
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 185
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 185
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 185
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 55
               start_line: 185
             }
           }
@@ -11478,7 +13647,10 @@ body {
           }
         }
         src {
+          end_column: 98
+          end_line: 185
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 185
         }
         variadic: true
@@ -11526,14 +13698,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 187
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 187
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 187
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 187
                 }
               }
@@ -11554,20 +13732,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 187
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 187
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 187
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 187
                 }
               }
             }
             src {
+              end_column: 50
+              end_line: 187
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 187
             }
           }
@@ -11601,14 +13788,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 187
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 187
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 187
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 187
                 }
               }
@@ -11629,19 +13822,28 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 83
+                      end_line: 187
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 187
                     }
                   }
                 }
                 src {
+                  end_column: 83
+                  end_line: 187
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 187
                 }
               }
             }
             src {
+              end_column: 84
+              end_line: 187
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 52
               start_line: 187
             }
           }
@@ -11654,7 +13856,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 187
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 187
         }
         variadic: true
@@ -11702,14 +13907,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 189
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 189
                 }
               }
@@ -11730,20 +13941,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 53
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 189
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 53
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 189
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 189
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 189
             }
           }
@@ -11777,14 +13997,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 189
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 189
                 }
               }
@@ -11805,20 +14031,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 189
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 189
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 189
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 189
                 }
               }
             }
             src {
+              end_column: 89
+              end_line: 189
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 189
             }
           }
@@ -11831,7 +14066,10 @@ body {
           }
         }
         src {
+          end_column: 90
+          end_line: 189
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 189
         }
         variadic: true
@@ -11879,20 +14117,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 191
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 191
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 191
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 191
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 191
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 191
             }
           }
@@ -11905,7 +14152,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 191
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 191
         }
         variadic: true
@@ -11953,14 +14203,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 193
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 193
                 }
               }
@@ -11981,14 +14237,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 193
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 193
                 }
               }
@@ -12009,20 +14271,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 52
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 193
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 52
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 193
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 193
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 193
             }
           }
@@ -12056,14 +14327,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 74
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 66
                       start_line: 193
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 74
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 193
                 }
               }
@@ -12084,14 +14361,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 84
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 76
                       start_line: 193
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 84
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 193
                 }
               }
@@ -12112,20 +14395,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 193
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 86
                       start_line: 193
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 193
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 86
                   start_line: 193
                 }
               }
             }
             src {
+              end_column: 95
+              end_line: 193
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 54
               start_line: 193
             }
           }
@@ -12138,7 +14430,10 @@ body {
           }
         }
         src {
+          end_column: 96
+          end_line: 193
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 193
         }
         variadic: true
@@ -12186,14 +14481,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 195
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 195
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 195
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 195
                 }
               }
@@ -12214,20 +14515,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 195
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 195
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 195
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 195
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 195
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 195
             }
           }
@@ -12261,14 +14571,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 77
+                      end_line: 195
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 195
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 77
+                  end_line: 195
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 195
                 }
               }
@@ -12289,20 +14605,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 87
+                      end_line: 195
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 79
                       start_line: 195
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 87
+                  end_line: 195
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 195
                 }
               }
             }
             src {
+              end_column: 88
+              end_line: 195
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 195
             }
           }
@@ -12315,7 +14640,10 @@ body {
           }
         }
         src {
+          end_column: 89
+          end_line: 195
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 195
         }
         variadic: true
@@ -12363,20 +14691,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 197
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 197
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 197
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 197
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 197
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 197
             }
           }
@@ -12389,7 +14726,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 197
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 197
         }
         variadic: true
@@ -12437,14 +14777,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 199
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 199
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 199
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 199
                 }
               }
@@ -12465,20 +14811,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 199
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 199
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 199
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 199
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 199
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 199
             }
           }
@@ -12512,14 +14867,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 199
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 199
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 199
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 199
                 }
               }
@@ -12540,20 +14901,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 199
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 64
                       start_line: 199
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 199
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 199
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 199
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 199
             }
           }
@@ -12566,7 +14936,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 199
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 199
         }
         variadic: true
@@ -12599,7 +14972,10 @@ body {
               }
             }
             src {
+              end_column: 44
+              end_line: 201
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 201
             }
           }
@@ -12633,14 +15009,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 71
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 63
                       start_line: 201
                     }
                     v: "k"
                   }
                 }
                 src {
+                  end_column: 71
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 63
                   start_line: 201
                 }
               }
@@ -12661,20 +15043,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 81
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 73
                       start_line: 201
                     }
                     v: "v"
                   }
                 }
                 src {
+                  end_column: 81
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 73
                   start_line: 201
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 201
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 201
             }
           }
@@ -12708,14 +15099,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 201
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 201
                 }
               }
@@ -12736,14 +15133,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 201
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 201
                 }
               }
@@ -12764,14 +15167,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 201
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 201
                 }
               }
@@ -12792,20 +15201,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 120
+                      end_line: 201
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 84
                       start_line: 201
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 120
+                  end_line: 201
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 201
                 }
               }
             }
             src {
+              end_column: 120
+              end_line: 201
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 201
             }
           }
@@ -12818,7 +15236,10 @@ body {
           }
         }
         src {
+          end_column: 121
+          end_line: 201
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 201
         }
         variadic: true
@@ -12851,7 +15272,10 @@ body {
               }
             }
             src {
+              end_column: 54
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 203
             }
           }
@@ -12885,14 +15309,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 91
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 83
                       start_line: 203
                     }
                     v: "k"
                   }
                 }
                 src {
+                  end_column: 91
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 83
                   start_line: 203
                 }
               }
@@ -12913,20 +15343,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 93
                       start_line: 203
                     }
                     v: "v"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 93
                   start_line: 203
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 203
             }
           }
@@ -12960,14 +15399,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 203
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 203
                 }
               }
@@ -12988,14 +15433,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 203
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 203
                 }
               }
@@ -13016,14 +15467,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 203
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 203
                 }
               }
@@ -13044,20 +15501,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 150
+                      end_line: 203
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 104
                       start_line: 203
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 150
+                  end_line: 203
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 104
                   start_line: 203
                 }
               }
             }
             src {
+              end_column: 150
+              end_line: 203
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 104
               start_line: 203
             }
           }
@@ -13070,7 +15536,10 @@ body {
           }
         }
         src {
+          end_column: 151
+          end_line: 203
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 203
         }
         variadic: true
@@ -13118,14 +15587,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 205
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 205
                 }
               }
@@ -13146,20 +15621,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 49
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 205
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 49
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 205
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 205
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 205
             }
           }
@@ -13193,14 +15677,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 73
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 65
                       start_line: 205
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 73
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 65
                   start_line: 205
                 }
               }
@@ -13221,14 +15711,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 205
                     }
                     v: "k1"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 205
                 }
               }
@@ -13249,14 +15745,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 205
                     }
                     v: "k2"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 205
                 }
               }
@@ -13277,14 +15779,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 205
                     }
                     v: "k3"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 205
                 }
               }
@@ -13305,20 +15813,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 98
+                      end_line: 205
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 51
                       start_line: 205
                     }
                     v: "k4"
                   }
                 }
                 src {
+                  end_column: 98
+                  end_line: 205
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 205
                 }
               }
             }
             src {
+              end_column: 98
+              end_line: 205
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 205
             }
           }
@@ -13331,7 +15848,10 @@ body {
           }
         }
         src {
+          end_column: 99
+          end_line: 205
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 205
         }
         variadic: true
@@ -13379,14 +15899,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 207
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 207
                 }
               }
@@ -13407,14 +15933,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 207
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 207
                 }
               }
@@ -13435,20 +15967,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 207
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 207
                 }
               }
             }
             src {
+              end_column: 54
+              end_line: 207
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 207
             }
           }
@@ -13482,14 +16023,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 78
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 70
                       start_line: 207
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 70
                   start_line: 207
                 }
               }
@@ -13510,14 +16057,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 86
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 207
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 207
                 }
               }
@@ -13538,14 +16091,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 95
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 207
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 95
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 207
                 }
               }
@@ -13566,20 +16125,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 101
+                      end_line: 207
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 56
                       start_line: 207
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 207
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 56
                   start_line: 207
                 }
               }
             }
             src {
+              end_column: 101
+              end_line: 207
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 56
               start_line: 207
             }
           }
@@ -13592,7 +16160,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 207
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 207
         }
         variadic: true
@@ -13640,14 +16211,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 209
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 209
                 }
               }
@@ -13668,20 +16245,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 209
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 209
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 209
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 209
             }
           }
@@ -13715,14 +16301,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 209
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 209
                 }
               }
@@ -13743,14 +16335,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 209
                     }
                     v: "k1"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 209
                 }
               }
@@ -13771,14 +16369,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 209
                     }
                     v: "k2"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 209
                 }
               }
@@ -13799,14 +16403,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 209
                     }
                     v: "k3"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 209
                 }
               }
@@ -13827,20 +16437,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 94
+                      end_line: 209
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 209
                     }
                     v: "k4"
                   }
                 }
                 src {
+                  end_column: 94
+                  end_line: 209
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 209
                 }
               }
             }
             src {
+              end_column: 94
+              end_line: 209
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 209
             }
           }
@@ -13853,7 +16472,10 @@ body {
           }
         }
         src {
+          end_column: 95
+          end_line: 209
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 209
         }
         variadic: true
@@ -13901,14 +16523,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 57
+                      end_line: 211
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 211
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 57
+                  end_line: 211
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 211
                 }
               }
@@ -13929,20 +16557,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 211
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 211
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 211
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 211
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 211
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 211
             }
           }
@@ -13955,7 +16592,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 211
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 211
         }
         variadic: true
@@ -14003,14 +16643,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 59
+                      end_line: 213
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 213
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 59
+                  end_line: 213
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 213
                 }
               }
@@ -14031,20 +16677,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 58
+                      end_line: 213
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 213
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 213
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 213
                 }
               }
             }
             src {
+              end_column: 59
+              end_line: 213
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 213
             }
           }
@@ -14057,7 +16712,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 213
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 213
         }
         variadic: true
@@ -14105,14 +16763,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 215
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 215
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 215
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 215
                 }
               }
@@ -14133,20 +16797,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 215
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 215
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 215
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 215
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 215
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 215
             }
           }
@@ -14159,7 +16832,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 215
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 215
         }
         variadic: true
@@ -14194,14 +16870,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 34
+                  end_line: 217
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 217
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 34
+              end_line: 217
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 217
             }
           }
@@ -14214,7 +16896,10 @@ body {
           }
         }
         src {
+          end_column: 35
+          end_line: 217
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 217
         }
         variadic: true
@@ -14249,14 +16934,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 219
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 219
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 46
+              end_line: 219
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 219
             }
           }
@@ -14269,7 +16960,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 219
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 219
         }
         variadic: true
@@ -14304,14 +16998,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 221
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 221
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 45
+              end_line: 221
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 221
             }
           }
@@ -14324,7 +17024,10 @@ body {
           }
         }
         src {
+          end_column: 46
+          end_line: 221
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 221
         }
         variadic: true
@@ -14359,14 +17062,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 223
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 223
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 35
+              end_line: 223
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 223
             }
           }
@@ -14379,7 +17088,10 @@ body {
           }
         }
         src {
+          end_column: 36
+          end_line: 223
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 223
         }
         variadic: true
@@ -14414,14 +17126,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 47
+                  end_line: 225
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 225
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 47
+              end_line: 225
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 225
             }
           }
@@ -14434,7 +17152,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 225
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 225
         }
         variadic: true
@@ -14469,14 +17190,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 227
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 227
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 46
+              end_line: 227
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 227
             }
           }
@@ -14489,7 +17216,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 227
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 227
         }
         variadic: true
@@ -14537,20 +17267,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 229
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 229
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 229
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 229
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 229
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 229
             }
           }
@@ -14563,7 +17302,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 229
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 229
         }
         variadic: true
@@ -14611,20 +17353,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 231
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 231
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 231
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 231
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 231
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 231
             }
           }
@@ -14637,7 +17388,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 231
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 231
         }
         variadic: true
@@ -14685,20 +17439,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 233
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 233
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 233
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 233
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 233
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 233
             }
           }
@@ -14711,7 +17474,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 233
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 233
         }
         variadic: true
@@ -14759,20 +17525,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 235
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 235
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 235
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 235
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 235
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 235
             }
           }
@@ -14785,7 +17560,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 235
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 235
         }
         variadic: true
@@ -14833,20 +17611,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 237
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 237
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 237
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 237
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 237
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 237
             }
           }
@@ -14859,7 +17646,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 237
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 237
         }
         variadic: true
@@ -14894,7 +17684,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 239
                 }
                 v: "A"
@@ -14903,14 +17696,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 239
                 }
                 v: "int"
               }
             }
             src {
+              end_column: 42
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 239
             }
           }
@@ -14931,7 +17730,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 65
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 239
                 }
                 v: "A"
@@ -14943,13 +17745,19 @@ body {
                   sp_long_type: true
                 }
                 src {
+                  end_column: 65
+                  end_line: 239
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 239
                 }
               }
             }
             src {
+              end_column: 65
+              end_line: 239
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 239
             }
           }
@@ -14962,7 +17770,10 @@ body {
           }
         }
         src {
+          end_column: 66
+          end_line: 239
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 239
         }
         variadic: true
@@ -14997,7 +17808,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 241
                 }
                 v: "A"
@@ -15006,14 +17820,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 46
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 241
                 }
                 v: "int"
               }
             }
             src {
+              end_column: 46
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 241
             }
           }
@@ -15034,7 +17854,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 73
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 241
                 }
                 v: "A"
@@ -15046,13 +17869,19 @@ body {
                   sp_long_type: true
                 }
                 src {
+                  end_column: 73
+                  end_line: 241
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 241
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 241
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 48
               start_line: 241
             }
           }
@@ -15065,7 +17894,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 241
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 241
         }
         variadic: true
@@ -15100,7 +17932,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 243
                 }
                 v: "A"
@@ -15109,7 +17944,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 41
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 243
                 }
               }
@@ -15117,13 +17955,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 41
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 243
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 243
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 243
             }
           }
@@ -15144,7 +17988,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 64
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 243
                 }
                 v: "A"
@@ -15153,7 +18000,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 64
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 243
                 }
               }
@@ -15161,13 +18011,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 64
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 243
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 243
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 243
             }
           }
@@ -15188,7 +18044,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 85
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 243
                 }
                 v: "A"
@@ -15197,7 +18056,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 85
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 243
                 }
                 v: 10
@@ -15206,13 +18068,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 85
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 243
                 }
               }
             }
             src {
+              end_column: 85
+              end_line: 243
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 66
               start_line: 243
             }
           }
@@ -15246,14 +18114,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 106
+                      end_line: 243
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 98
                       start_line: 243
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 106
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 98
                   start_line: 243
                 }
               }
@@ -15261,7 +18135,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 114
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 243
                 }
                 v: 10
@@ -15270,14 +18147,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 114
+                  end_line: 243
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 87
                   start_line: 243
                 }
                 v: 2
               }
             }
             src {
+              end_column: 114
+              end_line: 243
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 87
               start_line: 243
             }
           }
@@ -15290,7 +18173,10 @@ body {
           }
         }
         src {
+          end_column: 115
+          end_line: 243
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 243
         }
         variadic: true
@@ -15325,7 +18211,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 245
                 }
                 v: "A"
@@ -15334,7 +18223,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 40
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 245
                 }
               }
@@ -15342,13 +18234,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 40
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 245
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 245
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 245
             }
           }
@@ -15369,7 +18267,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 62
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 245
                 }
                 v: "A"
@@ -15378,7 +18279,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 62
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 245
                 }
               }
@@ -15386,13 +18290,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 62
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 245
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 245
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 245
             }
           }
@@ -15413,7 +18323,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 82
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 245
                 }
                 v: "A"
@@ -15422,7 +18335,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 82
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 245
                 }
                 v: 10
@@ -15431,13 +18347,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 82
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 64
                   start_line: 245
                 }
               }
             }
             src {
+              end_column: 82
+              end_line: 245
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 64
               start_line: 245
             }
           }
@@ -15471,14 +18393,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 245
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 245
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 245
                 }
               }
@@ -15486,7 +18414,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 110
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 245
                 }
                 v: 10
@@ -15495,14 +18426,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 110
+                  end_line: 245
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 84
                   start_line: 245
                 }
                 v: 2
               }
             }
             src {
+              end_column: 110
+              end_line: 245
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 84
               start_line: 245
             }
           }
@@ -15515,7 +18452,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 245
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 245
         }
         variadic: true
@@ -15563,20 +18503,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 247
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 247
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 247
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 247
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 247
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 247
             }
           }
@@ -15589,7 +18538,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 247
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 247
         }
         variadic: true
@@ -15637,20 +18589,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 249
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 249
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 249
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 249
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 249
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 249
             }
           }
@@ -15663,7 +18624,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 249
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 249
         }
         variadic: true
@@ -15711,20 +18675,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 251
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 251
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 251
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 251
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 251
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 251
             }
           }
@@ -15737,7 +18710,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 251
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 251
         }
         variadic: true
@@ -15785,20 +18761,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 253
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 253
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 253
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 253
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 253
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 253
             }
           }
@@ -15811,7 +18796,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 253
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 253
         }
         variadic: true
@@ -15859,20 +18847,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 255
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 255
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 255
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 255
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 255
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 255
             }
           }
@@ -15885,7 +18882,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 255
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 255
         }
         variadic: true
@@ -15933,20 +18933,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 257
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 257
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 257
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 257
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 257
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 257
             }
           }
@@ -15959,7 +18968,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 257
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 257
         }
         variadic: true
@@ -16007,20 +19019,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 259
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 259
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 259
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 259
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 259
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 259
             }
           }
@@ -16033,7 +19054,10 @@ body {
           }
         }
         src {
+          end_column: 48
+          end_line: 259
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 259
         }
         variadic: true
@@ -16081,20 +19105,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 46
+                      end_line: 261
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 261
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 46
+                  end_line: 261
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 261
                 }
               }
             }
             src {
+              end_column: 46
+              end_line: 261
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 261
             }
           }
@@ -16107,7 +19140,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 261
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 261
         }
         variadic: true
@@ -16155,20 +19191,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 263
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 263
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 263
             }
           }
@@ -16202,14 +19247,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 66
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 263
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 66
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 263
                 }
               }
@@ -16217,14 +19268,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 66
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 263
                 }
                 v: "BASE64"
               }
             }
             src {
+              end_column: 66
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 263
             }
           }
@@ -16258,14 +19315,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 86
+                      end_line: 263
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 263
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 86
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 263
                 }
               }
@@ -16273,14 +19336,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 96
+                  end_line: 263
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 263
                 }
                 v: "UTF-8"
               }
             }
             src {
+              end_column: 96
+              end_line: 263
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 68
               start_line: 263
             }
           }
@@ -16293,7 +19362,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 263
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 263
         }
         variadic: true
@@ -16341,20 +19413,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 39
+                      end_line: 265
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 265
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 265
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 265
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 265
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 265
             }
           }
@@ -16367,7 +19448,10 @@ body {
           }
         }
         src {
+          end_column: 40
+          end_line: 265
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 265
         }
         variadic: true
@@ -16415,20 +19499,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 38
+                      end_line: 267
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 267
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 38
+                  end_line: 267
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 267
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 267
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 267
             }
           }
@@ -16441,7 +19534,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 267
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 267
         }
         variadic: true
@@ -16489,20 +19585,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 40
+                      end_line: 269
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 269
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 40
+                  end_line: 269
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 269
                 }
               }
             }
             src {
+              end_column: 40
+              end_line: 269
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 269
             }
           }
@@ -16515,7 +19620,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 269
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 269
         }
         variadic: true
@@ -16563,20 +19671,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 41
+                      end_line: 271
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 271
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 41
+                  end_line: 271
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 271
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 271
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 271
             }
           }
@@ -16589,7 +19706,10 @@ body {
           }
         }
         src {
+          end_column: 42
+          end_line: 271
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 271
         }
         variadic: true
@@ -16637,20 +19757,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 37
+                      end_line: 273
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 273
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 273
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 273
                 }
               }
             }
             src {
+              end_column: 37
+              end_line: 273
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 273
             }
           }
@@ -16663,7 +19792,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 273
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 273
         }
         variadic: true
@@ -16711,14 +19843,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 275
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 275
                 }
               }
@@ -16739,20 +19877,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 275
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 275
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 275
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 275
                 }
               }
             }
             src {
+              end_column: 56
+              end_line: 275
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 275
             }
           }
@@ -16765,7 +19912,10 @@ body {
           }
         }
         src {
+          end_column: 57
+          end_line: 275
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 275
         }
         variadic: true
@@ -16813,20 +19963,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 277
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 277
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 277
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 277
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 277
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 277
             }
           }
@@ -16839,7 +19998,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 277
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 277
         }
         variadic: true
@@ -16887,14 +20049,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 279
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 279
                 }
               }
@@ -16915,14 +20083,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 279
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 279
                 }
               }
@@ -16930,13 +20104,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 42
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 279
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 279
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 279
             }
           }
@@ -16970,14 +20150,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 279
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 279
                 }
               }
@@ -16998,14 +20184,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 44
                       start_line: 279
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 279
                 }
               }
@@ -17013,13 +20205,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 63
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 279
                 }
               }
             }
             src {
+              end_column: 63
+              end_line: 279
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 279
             }
           }
@@ -17053,14 +20251,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 80
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 72
                       start_line: 279
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 80
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 72
                   start_line: 279
                 }
               }
@@ -17081,14 +20285,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 82
                       start_line: 279
                     }
                     v: "123"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 82
                   start_line: 279
                 }
               }
@@ -17109,20 +20319,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 102
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 94
                       start_line: 279
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 102
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 94
                   start_line: 279
                 }
               }
             }
             src {
+              end_column: 103
+              end_line: 279
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 65
               start_line: 279
             }
           }
@@ -17156,14 +20375,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 105
                       start_line: 279
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 105
                   start_line: 279
                 }
               }
@@ -17184,14 +20409,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 105
                       start_line: 279
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 105
                   start_line: 279
                 }
               }
@@ -17212,20 +20443,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 126
+                      end_line: 279
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 105
                       start_line: 279
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 126
+                  end_line: 279
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 105
                   start_line: 279
                 }
               }
             }
             src {
+              end_column: 126
+              end_line: 279
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 105
               start_line: 279
             }
           }
@@ -17238,7 +20478,10 @@ body {
           }
         }
         src {
+          end_column: 127
+          end_line: 279
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 279
         }
         variadic: true
@@ -17286,14 +20529,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 281
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 281
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 281
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 281
                 }
               }
@@ -17314,20 +20563,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 44
+                      end_line: 281
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 281
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 281
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 281
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 281
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 281
             }
           }
@@ -17340,7 +20598,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 281
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 281
         }
         variadic: true
@@ -17375,7 +20636,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 283
                 }
                 v: 1
@@ -17384,14 +20648,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 283
                 }
                 v: 2
               }
             }
             src {
+              end_column: 35
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 283
             }
           }
@@ -17425,14 +20695,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 283
                 }
               }
@@ -17440,14 +20716,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 48
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 283
                 }
                 v: 2
               }
             }
             src {
+              end_column: 48
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 283
             }
           }
@@ -17468,7 +20750,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 61
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 283
                 }
                 v: 3
@@ -17490,20 +20775,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 50
                       start_line: 283
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 50
                   start_line: 283
                 }
               }
             }
             src {
+              end_column: 61
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 50
               start_line: 283
             }
           }
@@ -17537,14 +20831,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 75
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 75
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 283
                 }
               }
@@ -17552,14 +20852,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 79
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 63
                   start_line: 283
                 }
                 v: 2
               }
             }
             src {
+              end_column: 79
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 63
               start_line: 283
             }
           }
@@ -17593,14 +20899,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 93
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 85
                       start_line: 283
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 85
                   start_line: 283
                 }
               }
@@ -17621,20 +20933,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 101
+                      end_line: 283
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 95
                       start_line: 283
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 101
+                  end_line: 283
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 95
                   start_line: 283
                 }
               }
             }
             src {
+              end_column: 102
+              end_line: 283
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 81
               start_line: 283
             }
           }
@@ -17647,7 +20968,10 @@ body {
           }
         }
         src {
+          end_column: 103
+          end_line: 283
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 283
         }
         variadic: true
@@ -17689,14 +21013,20 @@ body {
                           pos_args {
                             string_val {
                               src {
+                                end_column: 39
+                                end_line: 285
                                 file: "SRC_POSITION_TEST_MODE"
+                                start_column: 31
                                 start_line: 285
                               }
                               v: "a"
                             }
                           }
                           src {
+                            end_column: 39
+                            end_line: 285
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 31
                             start_line: 285
                           }
                         }
@@ -17704,14 +21034,20 @@ body {
                       rhs {
                         int64_val {
                           src {
+                            end_column: 43
+                            end_line: 285
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 31
                             start_line: 285
                           }
                           v: 2
                         }
                       }
                       src {
+                        end_column: 43
+                        end_line: 285
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 31
                         start_line: 285
                       }
                     }
@@ -17719,19 +21055,28 @@ body {
                   rhs {
                     int64_val {
                       src {
+                        end_column: 48
+                        end_line: 285
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 31
                         start_line: 285
                       }
                     }
                   }
                   src {
+                    end_column: 48
+                    end_line: 285
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 31
                     start_line: 285
                   }
                 }
               }
               src {
+                end_column: 62
+                end_line: 285
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 26
                 start_line: 285
               }
               value {
@@ -17750,21 +21095,30 @@ body {
                   pos_args {
                     string_val {
                       src {
+                        end_column: 61
+                        end_line: 285
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 50
                         start_line: 285
                       }
                       v: "even"
                     }
                   }
                   src {
+                    end_column: 61
+                    end_line: 285
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 50
                     start_line: 285
                   }
                 }
               }
             }
             src {
+              end_column: 62
+              end_line: 285
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 285
             }
           }
@@ -17777,7 +21131,10 @@ body {
           }
         }
         src {
+          end_column: 63
+          end_line: 285
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 285
         }
         variadic: true
@@ -17829,14 +21186,20 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 38
+                              end_line: 287
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 30
                               start_line: 287
                             }
                             v: "a"
                           }
                         }
                         src {
+                          end_column: 38
+                          end_line: 287
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 30
                           start_line: 287
                         }
                       }
@@ -17844,14 +21207,20 @@ body {
                     rhs {
                       int64_val {
                         src {
+                          end_column: 42
+                          end_line: 287
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 30
                           start_line: 287
                         }
                         v: 2
                       }
                     }
                     src {
+                      end_column: 42
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 287
                     }
                   }
@@ -17859,13 +21228,19 @@ body {
                 rhs {
                   int64_val {
                     src {
+                      end_column: 47
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 30
                       start_line: 287
                     }
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 287
                 }
               }
@@ -17886,14 +21261,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 49
                       start_line: 287
                     }
                     v: "even"
                   }
                 }
                 src {
+                  end_column: 60
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 49
                   start_line: 287
                 }
               }
@@ -17914,20 +21295,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 72
+                      end_line: 287
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 287
                     }
                     v: "odd"
                   }
                 }
                 src {
+                  end_column: 72
+                  end_line: 287
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 287
                 }
               }
             }
             src {
+              end_column: 73
+              end_line: 287
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 287
             }
           }
@@ -17940,7 +21330,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 287
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 287
         }
         variadic: true
@@ -17975,13 +21368,19 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 33
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 289
                 }
               }
             }
             src {
+              end_column: 33
+              end_line: 289
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 289
             }
           }
@@ -18002,7 +21401,10 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 60
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 289
                 }
                 vs {
@@ -18021,14 +21423,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 48
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 40
                           start_line: 289
                         }
                         v: "A"
                       }
                     }
                     src {
+                      end_column: 48
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 289
                     }
                   }
@@ -18036,7 +21444,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 289
                     }
                     v: "B"
@@ -18045,7 +21456,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 60
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 289
                     }
                     v: "A"
@@ -18054,7 +21468,10 @@ body {
               }
             }
             src {
+              end_column: 60
+              end_line: 289
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 289
             }
           }
@@ -18075,7 +21492,10 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 115
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 289
                 }
                 vs {
@@ -18094,14 +21514,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 78
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 67
                           start_line: 289
                         }
                         v: "col1"
                       }
                     }
                     src {
+                      end_column: 78
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 289
                     }
                   }
@@ -18122,14 +21548,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 91
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 80
                           start_line: 289
                         }
                         v: "col2"
                       }
                     }
                     src {
+                      end_column: 91
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 289
                     }
                   }
@@ -18139,19 +21571,28 @@ body {
             pos_args {
               list_val {
                 src {
+                  end_column: 115
+                  end_line: 289
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 289
                 }
                 vs {
                   list_val {
                     src {
+                      end_column: 115
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 289
                     }
                     vs {
                       int64_val {
                         src {
+                          end_column: 115
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 289
                         }
                         v: 1
@@ -18160,7 +21601,10 @@ body {
                     vs {
                       string_val {
                         src {
+                          end_column: 115
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 289
                         }
                         v: "a"
@@ -18171,13 +21615,19 @@ body {
                 vs {
                   list_val {
                     src {
+                      end_column: 115
+                      end_line: 289
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 289
                     }
                     vs {
                       int64_val {
                         src {
+                          end_column: 115
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 289
                         }
                         v: 2
@@ -18186,7 +21636,10 @@ body {
                     vs {
                       string_val {
                         src {
+                          end_column: 115
+                          end_line: 289
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 62
                           start_line: 289
                         }
                         v: "b"
@@ -18197,7 +21650,10 @@ body {
               }
             }
             src {
+              end_column: 115
+              end_line: 289
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 62
               start_line: 289
             }
           }
@@ -18210,7 +21666,10 @@ body {
           }
         }
         src {
+          end_column: 116
+          end_line: 289
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 289
         }
         variadic: true
@@ -18243,7 +21702,10 @@ body {
               }
             }
             src {
+              end_column: 37
+              end_line: 291
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 291
             }
           }
@@ -18256,7 +21718,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 291
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 291
         }
         variadic: true
@@ -18289,7 +21754,10 @@ body {
               }
             }
             src {
+              end_column: 32
+              end_line: 293
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 293
             }
           }
@@ -18302,7 +21770,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 293
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 293
         }
         variadic: true
@@ -18335,7 +21806,10 @@ body {
               }
             }
             src {
+              end_column: 40
+              end_line: 295
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 295
             }
           }
@@ -18348,7 +21822,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 295
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 295
         }
         variadic: true
@@ -18381,7 +21858,10 @@ body {
               }
             }
             src {
+              end_column: 38
+              end_line: 297
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 297
             }
           }
@@ -18394,7 +21874,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 297
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 297
         }
         variadic: true
@@ -18427,7 +21910,10 @@ body {
               }
             }
             src {
+              end_column: 38
+              end_line: 299
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 299
             }
           }
@@ -18440,7 +21926,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 299
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 299
         }
         variadic: true
@@ -18475,7 +21964,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 34
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 301
                 }
                 v: "A"
@@ -18484,7 +21976,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 34
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 301
                 }
                 v: 1
@@ -18493,7 +21988,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 34
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 301
                 }
               }
@@ -18501,13 +21999,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 34
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 301
                 }
               }
             }
             src {
+              end_column: 34
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 301
             }
           }
@@ -18541,14 +22045,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 48
+                      end_line: 301
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 40
                       start_line: 301
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 48
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 301
                 }
               }
@@ -18556,7 +22066,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 49
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 301
                 }
                 v: 1
@@ -18565,7 +22078,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 49
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 301
                 }
               }
@@ -18573,13 +22089,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 49
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 301
                 }
               }
             }
             src {
+              end_column: 49
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 36
               start_line: 301
             }
           }
@@ -18600,7 +22122,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 74
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 301
                 }
                 v: "A"
@@ -18609,7 +22134,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 74
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 301
                 }
                 v: 1
@@ -18618,7 +22146,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 74
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 301
                 }
               }
@@ -18626,14 +22157,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 74
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 51
                   start_line: 301
                 }
                 v: true
               }
             }
             src {
+              end_column: 74
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 51
               start_line: 301
             }
           }
@@ -18654,7 +22191,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 97
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 301
                 }
                 v: "A"
@@ -18663,7 +22203,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 97
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 301
                 }
                 v: 1
@@ -18685,14 +22228,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 301
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 88
                       start_line: 301
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 88
                   start_line: 301
                 }
               }
@@ -18700,13 +22249,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 97
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 76
                   start_line: 301
                 }
               }
             }
             src {
+              end_column: 97
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 76
               start_line: 301
             }
           }
@@ -18727,7 +22282,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 125
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 301
                 }
                 v: "A"
@@ -18736,7 +22294,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 125
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 301
                 }
                 v: 2
@@ -18758,14 +22319,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 118
+                      end_line: 301
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 111
                       start_line: 301
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 118
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 111
                   start_line: 301
                 }
               }
@@ -18773,14 +22340,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 125
+                  end_line: 301
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 301
                 }
                 v: true
               }
             }
             src {
+              end_column: 125
+              end_line: 301
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 99
               start_line: 301
             }
           }
@@ -18793,7 +22366,10 @@ body {
           }
         }
         src {
+          end_column: 126
+          end_line: 301
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 301
         }
         variadic: true
@@ -18828,7 +22404,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 35
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 303
                 }
                 v: "A"
@@ -18837,7 +22416,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 303
                 }
                 v: 1
@@ -18846,7 +22428,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 35
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 303
                 }
               }
@@ -18854,13 +22439,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 35
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 303
                 }
               }
             }
             src {
+              end_column: 35
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 303
             }
           }
@@ -18894,14 +22485,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 50
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 303
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 303
                 }
               }
@@ -18909,7 +22506,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 51
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 303
                 }
                 v: 1
@@ -18918,7 +22518,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 51
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 303
                 }
               }
@@ -18926,13 +22529,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 51
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 303
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 303
             }
           }
@@ -18953,7 +22562,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 77
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 303
                 }
                 v: "A"
@@ -18962,7 +22574,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 77
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 303
                 }
                 v: 1
@@ -18971,7 +22586,10 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 77
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 303
                 }
               }
@@ -18979,14 +22597,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 77
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 303
                 }
                 v: true
               }
             }
             src {
+              end_column: 77
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 303
             }
           }
@@ -19007,7 +22631,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 303
                 }
                 v: "A"
@@ -19016,7 +22643,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 101
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 303
                 }
                 v: 1
@@ -19038,14 +22668,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 100
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 92
                       start_line: 303
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 100
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 92
                   start_line: 303
                 }
               }
@@ -19053,13 +22689,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 101
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 79
                   start_line: 303
                 }
               }
             }
             src {
+              end_column: 101
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 79
               start_line: 303
             }
           }
@@ -19080,7 +22722,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 130
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 303
                 }
                 v: "A"
@@ -19089,7 +22734,10 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 130
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 303
                 }
                 v: 2
@@ -19111,14 +22759,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 123
+                      end_line: 303
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 116
                       start_line: 303
                     }
                     v: 20
                   }
                 }
                 src {
+                  end_column: 123
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 116
                   start_line: 303
                 }
               }
@@ -19126,14 +22780,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 130
+                  end_line: 303
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 103
                   start_line: 303
                 }
                 v: true
               }
             }
             src {
+              end_column: 130
+              end_line: 303
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 103
               start_line: 303
             }
           }
@@ -19146,7 +22806,10 @@ body {
           }
         }
         src {
+          end_column: 131
+          end_line: 303
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 303
         }
         variadic: true
@@ -19181,7 +22844,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 41
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 305
                 }
                 v: "A"
@@ -19190,13 +22856,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 41
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 305
                 }
               }
             }
             src {
+              end_column: 41
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 305
             }
           }
@@ -19217,7 +22889,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 64
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 305
                 }
                 v: "A"
@@ -19226,14 +22901,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 64
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 305
                 }
                 v: true
               }
             }
             src {
+              end_column: 64
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 43
               start_line: 305
             }
           }
@@ -19267,14 +22948,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 85
+                      end_line: 305
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 77
                       start_line: 305
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 85
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 77
                   start_line: 305
                 }
               }
@@ -19282,13 +22969,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 93
+                  end_line: 305
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 66
                   start_line: 305
                 }
               }
             }
             src {
+              end_column: 93
+              end_line: 305
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 66
               start_line: 305
             }
           }
@@ -19301,7 +22994,10 @@ body {
           }
         }
         src {
+          end_column: 94
+          end_line: 305
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 305
         }
         variadic: true
@@ -19336,7 +23032,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 307
                 }
                 v: "A"
@@ -19345,13 +23044,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 42
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 307
                 }
               }
             }
             src {
+              end_column: 42
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 307
             }
           }
@@ -19372,7 +23077,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 66
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 307
                 }
                 v: "A"
@@ -19381,14 +23089,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 66
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 307
                 }
                 v: true
               }
             }
             src {
+              end_column: 66
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 307
             }
           }
@@ -19422,14 +23136,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 88
+                      end_line: 307
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 80
                       start_line: 307
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 88
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 80
                   start_line: 307
                 }
               }
@@ -19437,13 +23157,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 96
+                  end_line: 307
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 68
                   start_line: 307
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 307
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 68
               start_line: 307
             }
           }
@@ -19456,7 +23182,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 307
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 307
         }
         variadic: true
@@ -19491,14 +23220,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 35
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 309
                 }
                 v: 10
               }
             }
             src {
+              end_column: 35
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 309
             }
           }
@@ -19532,20 +23267,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 47
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 37
                       start_line: 309
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 47
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 37
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 47
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 309
             }
           }
@@ -19579,20 +23323,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 63
+                      end_line: 309
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 55
                       start_line: 309
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 63
+                  end_line: 309
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 55
                   start_line: 309
                 }
               }
             }
             src {
+              end_column: 64
+              end_line: 309
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 49
               start_line: 309
             }
           }
@@ -19605,7 +23358,10 @@ body {
           }
         }
         src {
+          end_column: 65
+          end_line: 309
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 309
         }
         variadic: true
@@ -19640,14 +23396,20 @@ body {
             pos_args {
               float64_val {
                 src {
+                  end_column: 46
+                  end_line: 311
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 311
                 }
                 v: 0.4
               }
             }
             src {
+              end_column: 46
+              end_line: 311
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 311
             }
           }
@@ -19660,7 +23422,10 @@ body {
           }
         }
         src {
+          end_column: 47
+          end_line: 311
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 311
         }
         variadic: true
@@ -19693,7 +23458,10 @@ body {
               }
             }
             src {
+              end_column: 36
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 313
             }
           }
@@ -19727,20 +23495,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 51
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 38
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 38
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 51
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 38
               start_line: 313
             }
           }
@@ -19774,14 +23551,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 70
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 62
                       start_line: 313
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 70
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 62
                   start_line: 313
                 }
               }
@@ -19802,20 +23585,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 76
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 53
               start_line: 313
             }
           }
@@ -19849,14 +23641,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 313
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 313
                 }
               }
@@ -19877,14 +23675,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 313
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 313
                 }
               }
@@ -19905,14 +23709,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 313
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 313
                 }
               }
@@ -19933,14 +23743,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 313
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 313
                 }
               }
@@ -19961,14 +23777,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 313
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 313
                 }
               }
@@ -19989,20 +23811,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 116
+                      end_line: 313
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 78
                       start_line: 313
                     }
                     v: "F"
                   }
                 }
                 src {
+                  end_column: 116
+                  end_line: 313
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 313
                 }
               }
             }
             src {
+              end_column: 116
+              end_line: 313
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 313
             }
           }
@@ -20015,7 +23846,10 @@ body {
           }
         }
         src {
+          end_column: 117
+          end_line: 313
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 313
         }
         variadic: true
@@ -20048,7 +23882,10 @@ body {
               }
             }
             src {
+              end_column: 33
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 315
             }
           }
@@ -20082,20 +23919,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 45
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 35
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 35
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 35
               start_line: 315
             }
           }
@@ -20129,14 +23975,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 61
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 53
                       start_line: 315
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 61
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 53
                   start_line: 315
                 }
               }
@@ -20157,20 +24009,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 67
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 47
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 315
             }
           }
@@ -20204,14 +24065,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 315
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 315
                 }
               }
@@ -20232,14 +24099,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 315
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 315
                 }
               }
@@ -20260,14 +24133,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 315
                     }
                     v: "C"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 315
                 }
               }
@@ -20288,14 +24167,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 315
                     }
                     v: "D"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 315
                 }
               }
@@ -20316,14 +24201,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 315
                     }
                     v: "E"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 315
                 }
               }
@@ -20344,20 +24235,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 104
+                      end_line: 315
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 69
                       start_line: 315
                     }
                     v: "F"
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 315
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 69
                   start_line: 315
                 }
               }
             }
             src {
+              end_column: 104
+              end_line: 315
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 69
               start_line: 315
             }
           }
@@ -20370,7 +24270,10 @@ body {
           }
         }
         src {
+          end_column: 105
+          end_line: 315
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 315
         }
         variadic: true
@@ -20405,7 +24308,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 317
                 }
                 v: "A"
@@ -20414,7 +24320,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 317
                 }
               }
@@ -20422,13 +24331,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 38
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 38
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 317
             }
           }
@@ -20462,14 +24377,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 317
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 48
                       start_line: 317
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 48
                   start_line: 317
                 }
               }
@@ -20477,7 +24398,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 57
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 317
                 }
               }
@@ -20485,13 +24409,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 57
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 40
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 57
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 40
               start_line: 317
             }
           }
@@ -20512,7 +24442,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 76
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 317
                 }
                 v: "A"
@@ -20521,7 +24454,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 76
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 317
                 }
                 v: ","
@@ -20530,13 +24466,19 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 76
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 59
                   start_line: 317
                 }
               }
             }
             src {
+              end_column: 76
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 317
             }
           }
@@ -20557,7 +24499,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 317
                 }
                 v: "A"
@@ -20566,7 +24511,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 101
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 317
                 }
                 v: "|"
@@ -20575,14 +24523,20 @@ body {
             pos_args {
               bool_val {
                 src {
+                  end_column: 101
+                  end_line: 317
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 78
                   start_line: 317
                 }
                 v: true
               }
             }
             src {
+              end_column: 101
+              end_line: 317
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 78
               start_line: 317
             }
           }
@@ -20595,7 +24549,10 @@ body {
           }
         }
         src {
+          end_column: 102
+          end_line: 317
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 317
         }
         variadic: true
@@ -20630,14 +24587,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 42
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 319
                 }
                 v: "name"
               }
             }
             src {
+              end_column: 42
+              end_line: 319
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 319
             }
           }
@@ -20658,7 +24621,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 79
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 44
                   start_line: 319
                 }
                 v: "test"
@@ -20680,14 +24646,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 69
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 61
                       start_line: 319
                     }
                     v: "A"
                   }
                 }
                 src {
+                  end_column: 69
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 61
                   start_line: 319
                 }
               }
@@ -20708,20 +24680,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 78
+                      end_line: 319
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 71
                       start_line: 319
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 78
+                  end_line: 319
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 71
                   start_line: 319
                 }
               }
             }
             src {
+              end_column: 79
+              end_line: 319
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 44
               start_line: 319
             }
           }
@@ -20734,7 +24715,10 @@ body {
           }
         }
         src {
+          end_column: 80
+          end_line: 319
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 319
         }
         variadic: true
@@ -20769,7 +24753,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 321
                 }
                 v: "A"
@@ -20778,13 +24765,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 45
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 45
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 321
             }
           }
@@ -20805,7 +24798,10 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 72
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 321
                 }
                 v: "A"
@@ -20814,13 +24810,19 @@ body {
             pos_args {
               null_val {
                 src {
+                  end_column: 72
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 72
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 47
               start_line: 321
             }
           }
@@ -20854,14 +24856,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 97
+                      end_line: 321
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 89
                       start_line: 321
                     }
                     v: "B"
                   }
                 }
                 src {
+                  end_column: 97
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 89
                   start_line: 321
                 }
               }
@@ -20882,20 +24890,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 110
+                      end_line: 321
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 99
                       start_line: 321
                     }
                     v: "YYYY"
                   }
                 }
                 src {
+                  end_column: 110
+                  end_line: 321
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 99
                   start_line: 321
                 }
               }
             }
             src {
+              end_column: 111
+              end_line: 321
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 74
               start_line: 321
             }
           }
@@ -20908,7 +24925,10 @@ body {
           }
         }
         src {
+          end_column: 112
+          end_line: 321
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 321
         }
         variadic: true
@@ -20956,14 +24976,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 55
+                      end_line: 323
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 323
                     }
                     v: "needle"
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 323
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 323
                 }
               }
@@ -20984,14 +25010,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 54
+                      end_line: 323
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 323
                     }
                     v: "expr"
                   }
                 }
                 src {
+                  end_column: 54
+                  end_line: 323
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 323
                 }
               }
@@ -21012,20 +25044,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 55
+                      end_line: 323
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 26
                       start_line: 323
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 323
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 26
                   start_line: 323
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 323
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 323
             }
           }
@@ -21059,14 +25100,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 96
+                      end_line: 323
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 323
                     }
                     v: "needle"
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 323
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 323
                 }
               }
@@ -21087,14 +25134,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 92
+                      end_line: 323
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 74
                       start_line: 323
                     }
                     v: "test string"
                   }
                 }
                 src {
+                  end_column: 92
+                  end_line: 323
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 74
                   start_line: 323
                 }
               }
@@ -21115,20 +25168,29 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 96
+                      end_line: 323
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 57
                       start_line: 323
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 96
+                  end_line: 323
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 57
                   start_line: 323
                 }
               }
             }
             src {
+              end_column: 96
+              end_line: 323
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 57
               start_line: 323
             }
           }
@@ -21141,7 +25203,10 @@ body {
           }
         }
         src {
+          end_column: 97
+          end_line: 323
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 323
         }
         variadic: true
@@ -21189,20 +25254,29 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 42
+                      end_line: 325
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 31
                       start_line: 325
                     }
                     v: "expr"
                   }
                 }
                 src {
+                  end_column: 42
+                  end_line: 325
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 31
                   start_line: 325
                 }
               }
             }
             src {
+              end_column: 43
+              end_line: 325
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 26
               start_line: 325
             }
           }
@@ -21223,14 +25297,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 54
+                  end_line: 325
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 325
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 54
+              end_line: 325
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 45
               start_line: 325
             }
           }
@@ -21243,7 +25323,10 @@ body {
           }
         }
         src {
+          end_column: 55
+          end_line: 325
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 325
         }
         variadic: true

--- a/tests/ast/data/interval.test
+++ b/tests/ast/data/interval.test
@@ -85,7 +85,10 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 13
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 27
                 }
                 vs {
@@ -93,7 +96,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -110,7 +116,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -127,7 +136,10 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 13
+                  end_line: 33
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 27
                 }
                 vs {
@@ -135,7 +147,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -152,7 +167,10 @@ body {
                     day: 1
                     month: 1
                     src {
+                      end_column: 13
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 27
                     }
                     tz {
@@ -175,7 +193,10 @@ body {
           }
         }
         src {
+          end_column: 13
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -206,7 +227,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 20
+                  end_line: 36
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 12
                   start_line: 36
                 }
               }
@@ -229,7 +253,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 2
@@ -241,7 +268,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 2
@@ -253,7 +283,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 4
@@ -265,7 +298,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 3
@@ -277,7 +313,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 3
@@ -289,7 +328,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 1
@@ -301,7 +343,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 4
@@ -313,7 +358,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 1
@@ -325,7 +373,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 3
@@ -337,7 +388,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 48
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 37
                       }
                       v: 2
@@ -345,13 +399,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 13
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
               }
             }
             src {
+              end_column: 13
+              end_line: 48
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 36
             }
           }
@@ -364,7 +424,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
         variadic: true
@@ -396,7 +459,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 51
                 }
               }
@@ -419,7 +485,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 55
+                        end_line: 51
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 51
                       }
                       v: 1234
@@ -427,13 +496,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 55
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 51
             }
           }
@@ -446,7 +521,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 51
         }
         variadic: true
@@ -478,7 +556,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 20
+                  end_line: 54
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 12
                   start_line: 54
                 }
               }
@@ -501,7 +582,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 4
@@ -513,7 +597,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 5
@@ -525,7 +612,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 6
@@ -537,7 +627,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 2
@@ -549,7 +642,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 1
@@ -561,7 +657,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 7
@@ -573,7 +672,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 63
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 55
                       }
                       v: 3
@@ -581,13 +683,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 13
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 13
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 54
             }
           }
@@ -600,7 +708,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 64
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 53
         }
         variadic: true
@@ -632,7 +743,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 20
+                  end_line: 67
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 12
                   start_line: 67
                 }
               }
@@ -655,7 +769,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 4
@@ -667,7 +784,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 5
@@ -679,7 +799,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 9
@@ -691,7 +814,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 8
@@ -703,7 +829,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 6
@@ -715,7 +844,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 2
@@ -727,7 +859,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 10
@@ -739,7 +874,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 7
@@ -751,7 +889,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 3
@@ -763,7 +904,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 13
+                        end_line: 79
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 68
                       }
                       v: 1
@@ -771,13 +915,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 13
+                  end_line: 79
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 68
                 }
               }
             }
             src {
+              end_column: 13
+              end_line: 79
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 12
               start_line: 67
             }
           }
@@ -790,7 +940,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 80
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 66
         }
         variadic: true
@@ -822,7 +975,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 82
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 82
                 }
               }
@@ -845,7 +1001,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 67
+                        end_line: 82
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 82
                       }
                     }
@@ -856,7 +1015,10 @@ body {
                   _2 {
                     int64_val {
                       src {
+                        end_column: 67
+                        end_line: 82
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 36
                         start_line: 82
                       }
                       v: 21
@@ -864,13 +1026,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 82
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 36
                   start_line: 82
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 82
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 82
             }
           }
@@ -883,7 +1051,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 82
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 82
         }
         variadic: true

--- a/tests/ast/data/select.test
+++ b/tests/ast/data/select.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,14 +65,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 39
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 v: "STR"
               }
             }
             src {
+              end_column: 39
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 27
             }
           }
@@ -90,14 +99,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 38
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 30
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 38
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 30
               start_line: 27
             }
           }
@@ -110,7 +125,10 @@ body {
           }
         }
         src {
+          end_column: 39
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -50,13 +50,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 25
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 25
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
       }
@@ -78,13 +84,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
           }
         }
         src {
+          end_column: 59
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -106,13 +118,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 29
             }
           }
         }
         src {
+          end_column: 55
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }
@@ -134,13 +152,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 31
             }
           }
         }
         src {
+          end_column: 61
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
       }
@@ -162,13 +186,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }
@@ -190,13 +220,19 @@ body {
         reader {
           sp_dataframe_reader_init {
             src {
+              end_column: 26
+              end_line: 35
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 35
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 35
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 35
         }
       }
@@ -224,19 +260,28 @@ body {
                 reader {
                   sp_dataframe_reader_init {
                     src {
+                      end_column: 26
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                   }
                 }
                 src {
+                  end_column: 55
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 value {
                   bool_val {
                     src {
+                      end_column: 55
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 37
                     }
                     v: true
@@ -245,13 +290,19 @@ body {
               }
             }
             src {
+              end_column: 84
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 37
             }
             value {
               bool_val {
                 src {
+                  end_column: 84
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 37
                 }
                 v: true
@@ -260,7 +311,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
       }
@@ -286,7 +340,10 @@ body {
               _2 {
                 bool_val {
                   src {
+                    end_column: 80
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: true
@@ -298,7 +355,10 @@ body {
               _2 {
                 bool_val {
                   src {
+                    end_column: 80
+                    end_line: 39
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 14
                     start_line: 39
                   }
                   v: true
@@ -308,19 +368,28 @@ body {
             reader {
               sp_dataframe_reader_init {
                 src {
+                  end_column: 26
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 80
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 39
             }
           }
         }
         src {
+          end_column: 106
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
       }
@@ -360,14 +429,20 @@ body {
                       pos_args {
                         string_val {
                           src {
+                            end_column: 72
+                            end_line: 43
                             file: "SRC_POSITION_TEST_MODE"
+                            start_column: 41
                             start_line: 43
                           }
                           v: "METADATA$FILE_ROW_NUMBER"
                         }
                       }
                       src {
+                        end_column: 72
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 41
                         start_line: 43
                       }
                     }
@@ -375,7 +450,10 @@ body {
                   args {
                     string_val {
                       src {
+                        end_column: 104
+                        end_line: 43
                         file: "SRC_POSITION_TEST_MODE"
+                        start_column: 14
                         start_line: 43
                       }
                       v: "METADATA$FILE_LAST_MODIFIED"
@@ -386,13 +464,19 @@ body {
                 reader {
                   sp_dataframe_reader_init {
                     src {
+                      end_column: 26
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 14
                       start_line: 43
                     }
                   }
                 }
                 src {
+                  end_column: 104
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 14
                   start_line: 43
                 }
               }
@@ -430,13 +514,19 @@ body {
               }
             }
             src {
+              end_column: 124
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 43
             }
           }
         }
         src {
+          end_column: 150
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
       }

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -483,34 +483,36 @@ body {
             }
             schema {
               fields {
-                column_identifier {
-                  name: "a"
+                list {
+                  column_identifier {
+                    name: "a"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
                 }
-                data_type {
-                  sp_integer_type: true
-                }
-                nullable: true
-              }
-              fields {
-                column_identifier {
-                  name: "b"
-                }
-                data_type {
-                  sp_string_type {
-                    length {
+                list {
+                  column_identifier {
+                    name: "b"
+                  }
+                  data_type {
+                    sp_string_type {
+                      length {
+                      }
                     }
                   }
+                  nullable: true
                 }
-                nullable: true
-              }
-              fields {
-                column_identifier {
-                  name: "c"
+                list {
+                  column_identifier {
+                    name: "c"
+                  }
+                  data_type {
+                    sp_float_type: true
+                  }
+                  nullable: true
                 }
-                data_type {
-                  sp_float_type: true
-                }
-                nullable: true
               }
             }
             src {

--- a/tests/ast/data/session.sql.test
+++ b/tests/ast/data/session.sql.test
@@ -22,7 +22,10 @@ body {
       sp_sql {
         query: "select 42"
         src {
+          end_column: 37
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -43,7 +46,10 @@ body {
         params {
           int64_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: 1
@@ -52,7 +58,10 @@ body {
         params {
           string_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "a"
@@ -61,7 +70,10 @@ body {
         params {
           int64_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: 2
@@ -70,7 +82,10 @@ body {
         params {
           string_val {
             src {
+              end_column: 89
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 27
             }
             v: "b"
@@ -78,7 +93,10 @@ body {
         }
         query: "select * from values (?, ?), (?, ?)"
         src {
+          end_column: 89
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
       }
@@ -98,7 +116,10 @@ body {
       sp_sql {
         query: "select 42"
         src {
+          end_column: 42
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
       }

--- a/tests/ast/data/session_generator.test
+++ b/tests/ast/data/session_generator.test
@@ -38,14 +38,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 27
                 }
                 v: "A"
               }
             }
             src {
+              end_column: 40
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 27
             }
           }
@@ -66,20 +72,29 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 50
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 27
                 }
                 v: "B"
               }
             }
             src {
+              end_column: 50
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 27
             }
           }
         }
         src {
+          end_column: 51
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 27
         }
         variadic: true
@@ -114,14 +129,20 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 39
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 29
                 }
                 v: 1
               }
             }
             src {
+              end_column: 39
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 29
             }
           }
@@ -155,14 +176,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 29
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
@@ -183,14 +210,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 29
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
@@ -211,27 +244,39 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 29
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 29
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 29
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 29
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 29
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 29
             }
           }
         }
         row_count: 3
         src {
+          end_column: 71
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         variadic: true
@@ -266,13 +311,19 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 39
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 32
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 39
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 31
             }
           }
@@ -306,14 +357,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 31
                     }
                     v: 1
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 31
                 }
               }
@@ -334,14 +391,20 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 31
                     }
                     v: 10
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 31
                 }
               }
@@ -362,26 +425,38 @@ body {
                 pos_args {
                   int64_val {
                     src {
+                      end_column: 58
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 41
                       start_line: 31
                     }
                     v: 2
                   }
                 }
                 src {
+                  end_column: 58
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 31
                 }
               }
             }
             src {
+              end_column: 58
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 41
               start_line: 31
             }
           }
         }
         src {
+          end_column: 72
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 31
         }
         time_limit_seconds: 1

--- a/tests/ast/data/session_range.test
+++ b/tests/ast/data/session_range.test
@@ -29,7 +29,10 @@ body {
     expr {
       sp_range {
         src {
+          end_column: 29
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 25
         }
         start: 10
@@ -55,7 +58,10 @@ body {
           value: 10
         }
         src {
+          end_column: 32
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 27
         }
         start: 1
@@ -81,7 +87,10 @@ body {
           value: 10
         }
         src {
+          end_column: 35
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 29
         }
         start: 1
@@ -104,7 +113,10 @@ body {
     expr {
       sp_range {
         src {
+          end_column: 34
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 31
         }
         start: 1
@@ -127,7 +139,10 @@ body {
     expr {
       sp_range {
         src {
+          end_column: 37
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 33
         }
         start: 1

--- a/tests/ast/data/session_table_dq_abs_l.test
+++ b/tests/ast/data/session_table_dq_abs_l.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 88
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,14 +65,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -82,7 +91,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_abs_s.test
+++ b/tests/ast/data/session_table_dq_abs_s.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 85
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rs_l.test
+++ b/tests/ast/data/session_table_dq_rs_l.test
@@ -24,7 +24,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -61,14 +64,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -81,7 +90,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rs_s.test
+++ b/tests/ast/data/session_table_dq_rs_s.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rt_l.test
+++ b/tests/ast/data/session_table_dq_rt_l.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_dq_rt_s.test
+++ b/tests/ast/data/session_table_dq_rt_s.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 54
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -29,7 +29,10 @@ body {
           }
         }
         src {
+          end_column: 91
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 25
         }
         variant {
@@ -58,7 +61,10 @@ body {
           }
         }
         src {
+          end_column: 92
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 26
         }
         variant {
@@ -94,7 +100,10 @@ body {
           }
         }
         src {
+          end_column: 31
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
       }
@@ -128,14 +137,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 45
+                  end_line: 27
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 27
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 45
+              end_line: 27
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 27
             }
           }
@@ -148,7 +163,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 27
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 27
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_abs_l.test
+++ b/tests/ast/data/session_table_uq_abs_l.test
@@ -25,7 +25,10 @@ body {
           }
         }
         src {
+          end_column: 75
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -62,14 +65,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -82,7 +91,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_abs_s.test
+++ b/tests/ast/data/session_table_uq_abs_s.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 72
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rs_l.test
+++ b/tests/ast/data/session_table_uq_rs_l.test
@@ -24,7 +24,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -61,14 +64,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -81,7 +90,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rs_s.test
+++ b/tests/ast/data/session_table_uq_rs_s.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rt_l.test
+++ b/tests/ast/data/session_table_uq_rt_l.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_table_uq_rt_s.test
+++ b/tests/ast/data/session_table_uq_rt_s.test
@@ -23,7 +23,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -60,14 +63,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 29
+                  end_line: 26
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 26
                 }
                 v: "num"
               }
             }
             src {
+              end_column: 29
+              end_line: 26
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 13
               start_line: 26
             }
           }
@@ -80,7 +89,10 @@ body {
           }
         }
         src {
+          end_column: 29
+          end_line: 26
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 26
         }
         variadic: true

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -38,7 +38,10 @@ body {
         parallel: 4
         quote_identifiers: true
         src {
+          end_column: 53
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 29
         }
         table_name {
@@ -87,7 +90,10 @@ body {
           _2 {
             int64_val {
               src {
+                end_column: 260
+                end_line: 31
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 31
               }
               v: 90
@@ -98,7 +104,10 @@ body {
         overwrite: true
         parallel: 10
         src {
+          end_column: 260
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 31
         }
         table_name {

--- a/tests/ast/data/shadowed_local_name.test
+++ b/tests/ast/data/shadowed_local_name.test
@@ -34,7 +34,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
         variant {
@@ -72,14 +75,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 57
+                    end_line: 25
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 47
                     start_line: 25
                   }
                   v: "NUM"
                 }
               }
               src {
+                end_column: 57
+                end_line: 25
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 47
                 start_line: 25
               }
             }
@@ -94,7 +103,10 @@ body {
           }
         }
         src {
+          end_column: 58
+          end_line: 25
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 25
         }
       }
@@ -120,7 +132,10 @@ body {
           }
         }
         src {
+          end_column: 27
+          end_line: 28
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 28
         }
       }
@@ -148,7 +163,10 @@ body {
         input {
           string_val {
             src {
+              end_column: 52
+              end_line: 33
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 14
               start_line: 33
             }
             v: "STR"
@@ -162,7 +180,10 @@ body {
           value: "path"
         }
         src {
+          end_column: 52
+          end_line: 33
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 33
         }
       }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -175,11 +175,11 @@ res34 = sproc("select_sp", return_type=StructType([StructField("A", IntegerType(
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res38 = sproc("select_sp", return_type=StructType([], structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res38 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res42 = sproc("select_sp", return_type=StructType([], structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res42 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
@@ -1830,22 +1830,24 @@ body {
         return_type {
           sp_struct_type {
             fields {
-              column_identifier {
-                name: "A"
+              list {
+                column_identifier {
+                  name: "A"
+                }
+                data_type {
+                  sp_integer_type: true
+                }
+                nullable: true
               }
-              data_type {
-                sp_integer_type: true
+              list {
+                column_identifier {
+                  name: "B"
+                }
+                data_type {
+                  sp_integer_type: true
+                }
+                nullable: true
               }
-              nullable: true
-            }
-            fields {
-              column_identifier {
-                name: "B"
-              }
-              data_type {
-                sp_integer_type: true
-              }
-              nullable: true
             }
           }
         }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -237,7 +237,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 114
+          end_line: 42
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 42
         }
       }
@@ -257,7 +260,10 @@ body {
       sp_sql {
         query: "create or replace temp table test_from(test_str varchar) as select randstr(20, random()) from table (generator(rowCount => 100))"
         src {
+          end_column: 155
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 43
         }
       }
@@ -281,7 +287,10 @@ body {
           bitfield1: 2
         }
         src {
+          end_column: 165
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 43
         }
       }
@@ -311,7 +320,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 46
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 46
                 }
                 v: 1
@@ -320,7 +332,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 46
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 46
                 }
                 v: 2
@@ -329,7 +344,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 67
+                  end_line: 46
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 18
                   start_line: 46
                 }
                 v: 3
@@ -343,7 +361,10 @@ body {
           }
         }
         src {
+          end_column: 67
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 46
         }
       }
@@ -369,7 +390,10 @@ body {
           }
         }
         src {
+          end_column: 21
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
       }
@@ -395,7 +419,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 90
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 47
         }
         table_name {
@@ -433,7 +460,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 64
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 48
                 }
                 v: -1
@@ -442,7 +472,10 @@ body {
             vs {
               int64_val {
                 src {
+                  end_column: 64
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 16
                   start_line: 48
                 }
                 v: -2
@@ -456,7 +489,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 16
           start_line: 48
         }
       }
@@ -482,7 +518,10 @@ body {
           }
         }
         src {
+          end_column: 19
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 49
         }
       }
@@ -508,7 +547,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 86
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 49
         }
         table_name {
@@ -543,7 +585,10 @@ body {
       sp_sql {
         query: "call my_copy_sp(\'test_from\', \'test_to\', 10)"
         src {
+          end_column: 66
+          end_line: 50
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 50
         }
       }
@@ -566,7 +611,10 @@ body {
           bitfield1: 13
         }
         src {
+          end_column: 76
+          end_line: 50
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 50
         }
       }
@@ -599,7 +647,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
         variant {
@@ -624,7 +675,10 @@ body {
           bitfield1: 16
         }
         src {
+          end_column: 40
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 51
         }
       }
@@ -651,7 +705,10 @@ body {
       sp_sql {
         query: "drop table if exists test_to"
         src {
+          end_column: 55
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 54
         }
       }
@@ -675,7 +732,10 @@ body {
           bitfield1: 19
         }
         src {
+          end_column: 65
+          end_line: 54
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 54
         }
       }
@@ -716,7 +776,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_from"
@@ -725,7 +788,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_to"
@@ -734,14 +800,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: 10
           }
         }
         src {
+          end_column: 62
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -768,7 +840,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_from"
@@ -777,7 +852,10 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: "test_to"
@@ -786,14 +864,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 62
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 55
             }
             v: 10
           }
         }
         src {
+          end_column: 62
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -818,7 +902,10 @@ body {
           }
         }
         src {
+          end_column: 37
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
         variant {
@@ -847,7 +934,10 @@ body {
         }
         n: 10
         src {
+          end_column: 50
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
       }
@@ -872,7 +962,10 @@ body {
           }
         }
         src {
+          end_column: 56
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
       }
@@ -898,7 +991,10 @@ body {
           sp_save_mode_overwrite: true
         }
         src {
+          end_column: 122
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 39
         }
         table_name {
@@ -947,7 +1043,10 @@ body {
           }
         }
         src {
+          end_column: 32
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
         variant {
@@ -972,7 +1071,10 @@ body {
           bitfield1: 30
         }
         src {
+          end_column: 40
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -1020,7 +1122,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 59
         }
       }
@@ -1048,14 +1153,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 21
+              end_line: 66
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 66
             }
             v: 1
           }
         }
         src {
+          end_column: 21
+          end_line: 66
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 66
         }
       }
@@ -1074,7 +1185,10 @@ body {
       sp_sql {
         query: "select 1 + 1"
         src {
+          end_column: 63
+          end_line: 60
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 32
           start_line: 60
         }
       }
@@ -1097,7 +1211,10 @@ body {
           bitfield1: 35
         }
         src {
+          end_column: 73
+          end_line: 60
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 32
           start_line: 60
         }
       }
@@ -1132,7 +1249,10 @@ body {
       sp_sql {
         query: "select 1 + 2"
         src {
+          end_column: 52
+          end_line: 70
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 70
         }
       }
@@ -1155,7 +1275,10 @@ body {
           bitfield1: 39
         }
         src {
+          end_column: 62
+          end_line: 70
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 70
         }
       }
@@ -1182,7 +1305,10 @@ body {
       sp_sql {
         query: "create or replace temp stage mystage"
         src {
+          end_column: 63
+          end_line: 74
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 74
         }
       }
@@ -1206,7 +1332,10 @@ body {
           bitfield1: 42
         }
         src {
+          end_column: 73
+          end_line: 74
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 74
         }
       }
@@ -1266,7 +1395,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 83
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 75
         }
         stage_location: "@mystage"
@@ -1287,7 +1419,10 @@ body {
       sp_sql {
         query: "call mul_sp(5, 6)"
         src {
+          end_column: 40
+          end_line: 84
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 84
         }
       }
@@ -1310,7 +1445,10 @@ body {
           bitfield1: 46
         }
         src {
+          end_column: 50
+          end_line: 84
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 84
         }
       }
@@ -1370,7 +1508,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 95
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 87
         }
         stage_location: "@mystage"
@@ -1391,7 +1532,10 @@ body {
       sp_sql {
         query: "call mul_sp(5, 6)"
         src {
+          end_column: 40
+          end_line: 96
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 96
         }
       }
@@ -1414,7 +1558,10 @@ body {
           bitfield1: 50
         }
         src {
+          end_column: 50
+          end_line: 96
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 96
         }
       }
@@ -1483,7 +1630,10 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 9
+          end_line: 110
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 12
           start_line: 99
         }
         stage_location: "@mystage"
@@ -1505,7 +1655,10 @@ body {
       sp_sql {
         query: "call mul_sp(5, 6)"
         src {
+          end_column: 40
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 111
         }
       }
@@ -1528,7 +1681,10 @@ body {
           bitfield1: 54
         }
         src {
+          end_column: 50
+          end_line: 111
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 111
         }
       }
@@ -1578,8 +1734,11 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 112
+          end_line: 114
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 115
+          start_column: 9
+          start_line: 114
         }
         statement_params {
           _1: "SF_PARTNER"
@@ -1609,14 +1768,20 @@ body {
         pos_args {
           float64_val {
             src {
+              end_column: 29
+              end_line: 117
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 117
             }
             v: 1.5707963267948966
           }
         }
         src {
+          end_column: 29
+          end_line: 117
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 117
         }
       }
@@ -1686,8 +1851,11 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 150
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 121
+          start_column: 9
+          start_line: 120
         }
       }
     }
@@ -1713,7 +1881,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 123
             }
             v: 1
@@ -1722,14 +1893,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 123
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 123
             }
             v: 2
           }
         }
         src {
+          end_column: 23
+          end_line: 123
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 123
         }
       }
@@ -1748,7 +1925,10 @@ body {
       sp_sql {
         query: "SELECT 1 as A, 2 as B"
         src {
+          end_column: 61
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 122
         }
       }
@@ -1816,8 +1996,11 @@ body {
           }
         }
         src {
+          end_column: 123
+          end_line: 126
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 127
+          start_column: 9
+          start_line: 126
         }
       }
     }
@@ -1843,7 +2026,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 129
             }
             v: 1
@@ -1852,14 +2038,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 129
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 129
             }
             v: 2
           }
         }
         src {
+          end_column: 23
+          end_line: 129
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 129
         }
       }
@@ -1878,7 +2070,10 @@ body {
       sp_sql {
         query: "SELECT 1 as A, 2 as B"
         src {
+          end_column: 61
+          end_line: 128
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 128
         }
       }
@@ -1947,8 +2142,11 @@ body {
         }
         source_code_display: true
         src {
+          end_column: 14
+          end_line: 132
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 133
+          start_column: 9
+          start_line: 132
         }
       }
     }
@@ -1974,7 +2172,10 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 135
             }
             v: 1
@@ -1983,14 +2184,20 @@ body {
         pos_args {
           int64_val {
             src {
+              end_column: 23
+              end_line: 135
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 135
             }
             v: 2
           }
         }
         src {
+          end_column: 23
+          end_line: 135
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 135
         }
       }
@@ -2009,7 +2216,10 @@ body {
       sp_sql {
         query: "SELECT 1 as A, 2 as B"
         src {
+          end_column: 61
+          end_line: 134
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 134
         }
       }

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -127,7 +127,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 51
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 19
                 start_line: 45
               }
             }
@@ -146,7 +149,10 @@ body {
           sp_integer_type: true
         }
         src {
+          end_column: 9
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 19
           start_line: 45
         }
       }
@@ -169,13 +175,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 1
@@ -184,7 +196,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 3
@@ -195,13 +210,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 1
@@ -210,7 +231,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 4
@@ -221,13 +245,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 2
@@ -236,7 +266,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 5
@@ -247,13 +280,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 71
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 2
@@ -262,7 +301,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 71
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 53
                     }
                     v: 6
@@ -273,7 +315,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
       }
@@ -301,7 +346,10 @@ body {
           }
         }
         src {
+          end_column: 87
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 53
         }
         variadic: true
@@ -340,14 +388,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 28
+                    end_line: 55
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 55
                   }
                   v: "a"
                 }
               }
               src {
+                end_column: 28
+                end_line: 55
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 55
               }
             }
@@ -355,7 +409,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 29
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -378,7 +435,10 @@ body {
           bitfield1: 4
         }
         src {
+          end_column: 39
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 55
         }
       }
@@ -437,7 +497,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 90
+                end_line: 108
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 13
                 start_line: 105
               }
             }
@@ -448,7 +511,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 90
+                end_line: 108
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 13
                 start_line: 105
               }
               v: true
@@ -477,7 +543,10 @@ body {
           _2: "f"
         }
         src {
+          end_column: 90
+          end_line: 108
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 105
         }
         stage_location {
@@ -526,14 +595,20 @@ body {
               pos_args {
                 string_val {
                   src {
+                    end_column: 22
+                    end_line: 110
                     file: "SRC_POSITION_TEST_MODE"
+                    start_column: 15
                     start_line: 110
                   }
                   v: "a"
                 }
               }
               src {
+                end_column: 22
+                end_line: 110
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 15
                 start_line: 110
               }
             }
@@ -541,7 +616,10 @@ body {
           variadic: true
         }
         src {
+          end_column: 23
+          end_line: 110
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 110
         }
       }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -169,13 +169,15 @@ body {
             return_type {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "number"
+                  list {
+                    column_identifier {
+                      name: "number"
+                    }
+                    data_type {
+                      sp_integer_type: true
+                    }
+                    nullable: true
                   }
-                  data_type {
-                    sp_integer_type: true
-                  }
-                  nullable: true
                 }
               }
             }
@@ -377,13 +379,15 @@ body {
             return_type {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "number"
+                  list {
+                    column_identifier {
+                      name: "number"
+                    }
+                    data_type {
+                      sp_long_type: true
+                    }
+                    nullable: true
                   }
-                  data_type {
-                    sp_long_type: true
-                  }
-                  nullable: true
                 }
               }
             }
@@ -706,13 +710,15 @@ body {
             return_type {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "number"
+                  list {
+                    column_identifier {
+                      name: "number"
+                    }
+                    data_type {
+                      sp_integer_type: true
+                    }
+                    nullable: true
                   }
-                  data_type {
-                    sp_integer_type: true
-                  }
-                  nullable: true
                 }
               }
             }
@@ -957,22 +963,24 @@ body {
             return_type {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "a"
+                  list {
+                    column_identifier {
+                      name: "a"
+                    }
+                    data_type {
+                      sp_long_type: true
+                    }
+                    nullable: true
                   }
-                  data_type {
-                    sp_long_type: true
+                  list {
+                    column_identifier {
+                      name: "b"
+                    }
+                    data_type {
+                      sp_long_type: true
+                    }
+                    nullable: true
                   }
-                  nullable: true
-                }
-                fields {
-                  column_identifier {
-                    name: "b"
-                  }
-                  data_type {
-                    sp_long_type: true
-                  }
-                  nullable: true
                 }
               }
             }
@@ -1248,13 +1256,15 @@ body {
             return_type {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "two_x"
+                  list {
+                    column_identifier {
+                      name: "two_x"
+                    }
+                    data_type {
+                      sp_integer_type: true
+                    }
+                    nullable: true
                   }
-                  data_type {
-                    sp_integer_type: true
-                  }
-                  nullable: true
                 }
               }
             }
@@ -1439,22 +1449,24 @@ body {
             return_type {
               sp_struct_type {
                 fields {
-                  column_identifier {
-                    name: "two_x"
+                  list {
+                    column_identifier {
+                      name: "two_x"
+                    }
+                    data_type {
+                      sp_integer_type: true
+                    }
+                    nullable: true
                   }
-                  data_type {
-                    sp_integer_type: true
+                  list {
+                    column_identifier {
+                      name: "six_x"
+                    }
+                    data_type {
+                      sp_integer_type: true
+                    }
+                    nullable: true
                   }
-                  nullable: true
-                }
-                fields {
-                  column_identifier {
-                    name: "six_x"
-                  }
-                  data_type {
-                    sp_integer_type: true
-                  }
-                  nullable: true
                 }
               }
             }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -155,7 +155,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 132
+                end_line: 46
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 21
                 start_line: 46
               }
             }
@@ -180,7 +183,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 132
+          end_line: 46
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 21
           start_line: 46
         }
       }
@@ -221,20 +227,29 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 49
+                  end_line: 48
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 48
                 }
                 v: 20
               }
             }
             src {
+              end_column: 49
+              end_line: 48
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 42
               start_line: 48
             }
           }
         }
         src {
+          end_column: 50
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 48
         }
       }
@@ -261,13 +276,19 @@ body {
               }
             }
             src {
+              end_column: 51
+              end_line: 48
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 48
             }
           }
         }
         src {
+          end_column: 51
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 48
         }
       }
@@ -290,7 +311,10 @@ body {
           bitfield1: 3
         }
         src {
+          end_column: 61
+          end_line: 48
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 48
         }
       }
@@ -339,8 +363,11 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 39
+                end_line: 50
                 file: "SRC_POSITION_TEST_MODE"
-                start_line: 51
+                start_column: 9
+                start_line: 50
               }
             }
           }
@@ -364,8 +391,11 @@ body {
         }
         parallel: 4
         src {
+          end_column: 39
+          end_line: 50
           file: "SRC_POSITION_TEST_MODE"
-          start_line: 51
+          start_column: 9
+          start_line: 50
         }
       }
     }
@@ -386,13 +416,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 74
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 55
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 1
@@ -401,7 +437,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 2
@@ -412,13 +451,19 @@ body {
             vs {
               list_val {
                 src {
+                  end_column: 74
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 55
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 3
@@ -427,7 +472,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 74
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 55
                     }
                     v: 4
@@ -444,7 +492,10 @@ body {
           }
         }
         src {
+          end_column: 74
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 55
         }
       }
@@ -482,7 +533,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 45
+                  end_line: 56
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 41
                   start_line: 56
                 }
               }
@@ -498,13 +552,19 @@ body {
                   }
                 }
                 src {
+                  end_column: 51
+                  end_line: 56
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 47
                   start_line: 56
                 }
               }
             }
             src {
+              end_column: 52
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 32
               start_line: 56
             }
           }
@@ -518,7 +578,10 @@ body {
           }
         }
         src {
+          end_column: 53
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -546,7 +609,10 @@ body {
               }
             }
             src {
+              end_column: 63
+              end_line: 56
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 59
               start_line: 56
             }
           }
@@ -560,7 +626,10 @@ body {
           }
         }
         src {
+          end_column: 64
+          end_line: 56
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 56
         }
       }
@@ -623,7 +692,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 139
+                end_line: 63
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 25
                 start_line: 63
               }
             }
@@ -648,7 +720,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 139
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 25
           start_line: 63
         }
       }
@@ -689,20 +764,29 @@ body {
             pos_args {
               int64_val {
                 src {
+                  end_column: 52
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 65
                 }
                 v: 3
               }
             }
             src {
+              end_column: 52
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 65
             }
           }
         }
         src {
+          end_column: 53
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 31
           start_line: 65
         }
       }
@@ -729,13 +813,19 @@ body {
               }
             }
             src {
+              end_column: 54
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 65
             }
           }
         }
         src {
+          end_column: 54
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 65
         }
       }
@@ -758,7 +848,10 @@ body {
           bitfield1: 14
         }
         src {
+          end_column: 64
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 65
         }
       }
@@ -828,7 +921,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 40
+                end_line: 89
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 72
               }
             }
@@ -839,7 +935,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 40
+                end_line: 89
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 14
                 start_line: 72
               }
               v: true
@@ -888,7 +987,10 @@ body {
         }
         secure: true
         src {
+          end_column: 40
+          end_line: 89
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 72
         }
         stage_location: "@"
@@ -917,13 +1019,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 91
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 1
@@ -932,7 +1040,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: "one o one"
@@ -941,7 +1052,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 10
@@ -952,13 +1066,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 91
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 2
@@ -967,7 +1087,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: "twenty two"
@@ -976,7 +1099,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 20
@@ -987,13 +1113,19 @@ body {
             vs {
               tuple_val {
                 src {
+                  end_column: 9
+                  end_line: 93
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 13
                   start_line: 91
                 }
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 3
@@ -1002,7 +1134,10 @@ body {
                 vs {
                   string_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: "thirty three"
@@ -1011,7 +1146,10 @@ body {
                 vs {
                   int64_val {
                     src {
+                      end_column: 9
+                      end_line: 93
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 13
                       start_line: 91
                     }
                     v: 30
@@ -1022,7 +1160,10 @@ body {
           }
         }
         src {
+          end_column: 9
+          end_line: 93
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 91
         }
       }
@@ -1051,7 +1192,10 @@ body {
           }
         }
         src {
+          end_column: 38
+          end_line: 94
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 94
         }
       }
@@ -1090,7 +1234,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 104
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 20
                 start_line: 100
               }
             }
@@ -1115,7 +1262,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 9
+          end_line: 104
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 20
           start_line: 100
         }
       }
@@ -1143,14 +1293,20 @@ body {
         pos_args {
           string_val {
             src {
+              end_column: 32
+              end_line: 106
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 106
             }
             v: "a"
           }
         }
         src {
+          end_column: 32
+          end_line: 106
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 18
           start_line: 106
         }
       }
@@ -1177,7 +1333,10 @@ body {
               }
             }
             src {
+              end_column: 33
+              end_line: 106
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 106
             }
           }
@@ -1190,7 +1349,10 @@ body {
           }
         }
         src {
+          end_column: 33
+          end_line: 106
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 106
         }
         variadic: true
@@ -1214,7 +1376,10 @@ body {
           bitfield1: 22
         }
         src {
+          end_column: 43
+          end_line: 106
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 106
         }
       }
@@ -1260,7 +1425,10 @@ body {
           _2 {
             bool_val {
               src {
+                end_column: 9
+                end_line: 118
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 112
               }
             }
@@ -1294,7 +1462,10 @@ body {
         }
         parallel: 4
         src {
+          end_column: 9
+          end_line: 118
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 23
           start_line: 112
         }
       }
@@ -1330,13 +1501,19 @@ body {
               }
             }
             src {
+              end_column: 41
+              end_line: 120
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 37
               start_line: 120
             }
           }
         }
         src {
+          end_column: 42
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 24
           start_line: 120
         }
       }
@@ -1364,7 +1541,10 @@ body {
               }
             }
             src {
+              end_column: 22
+              end_line: 120
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 18
               start_line: 120
             }
           }
@@ -1379,7 +1559,10 @@ body {
               }
             }
             src {
+              end_column: 43
+              end_line: 120
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 120
             }
           }
@@ -1392,7 +1575,10 @@ body {
           }
         }
         src {
+          end_column: 43
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 120
         }
         variadic: true
@@ -1416,7 +1602,10 @@ body {
           bitfield1: 27
         }
         src {
+          end_column: 53
+          end_line: 120
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 120
         }
       }
@@ -1445,7 +1634,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 65
+                end_line: 122
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 122
               }
               v: "double"
@@ -1454,7 +1646,10 @@ body {
           args {
             string_val {
               src {
+                end_column: 65
+                end_line: 122
                 file: "SRC_POSITION_TEST_MODE"
+                start_column: 23
                 start_line: 122
               }
               v: "six_x"
@@ -1474,20 +1669,29 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 40
+                  end_line: 122
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 122
                 }
                 v: "a"
               }
             }
             src {
+              end_column: 40
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 122
             }
           }
         }
         src {
+          end_column: 65
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 23
           start_line: 122
         }
       }
@@ -1520,14 +1724,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 71
+                  end_line: 122
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 122
                 }
                 v: "a"
               }
             }
             src {
+              end_column: 71
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 122
             }
           }
@@ -1542,7 +1752,10 @@ body {
               }
             }
             src {
+              end_column: 71
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 122
             }
           }
@@ -1563,14 +1776,20 @@ body {
             pos_args {
               string_val {
                 src {
+                  end_column: 71
+                  end_line: 122
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 8
                   start_line: 122
                 }
                 v: "c"
               }
             }
             src {
+              end_column: 71
+              end_line: 122
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 8
               start_line: 122
             }
           }
@@ -1583,7 +1802,10 @@ body {
           }
         }
         src {
+          end_column: 71
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 122
         }
         variadic: true
@@ -1607,7 +1829,10 @@ body {
           bitfield1: 31
         }
         src {
+          end_column: 81
+          end_line: 122
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 8
           start_line: 122
         }
       }

--- a/tests/ast/data/windows.test
+++ b/tests/ast/data/windows.test
@@ -92,7 +92,10 @@ body {
           }
         }
         src {
+          end_column: 41
+          end_line: 29
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 29
         }
         variant {
@@ -131,14 +134,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 33
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 23
                       start_line: 31
                     }
                     v: "NUM"
                   }
                 }
                 src {
+                  end_column: 33
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 23
                   start_line: 31
                 }
               }
@@ -148,7 +157,10 @@ body {
             }
             name: "key"
             src {
+              end_column: 44
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 23
               start_line: 31
             }
           }
@@ -171,14 +183,20 @@ body {
                 pos_args {
                   string_val {
                     src {
+                      end_column: 56
+                      end_line: 31
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 46
                       start_line: 31
                     }
                     v: "STR"
                   }
                 }
                 src {
+                  end_column: 56
+                  end_line: 31
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 46
                   start_line: 31
                 }
               }
@@ -188,7 +206,10 @@ body {
             }
             name: "value"
             src {
+              end_column: 69
+              end_line: 31
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 46
               start_line: 31
             }
           }
@@ -201,7 +222,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 31
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 13
           start_line: 31
         }
         variadic: true
@@ -253,26 +277,38 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 36
+                              end_line: 37
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 24
                               start_line: 37
                             }
                             v: "value"
                           }
                         }
                         src {
+                          end_column: 36
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 37
                         }
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 37
                     }
                   }
                 }
                 src {
+                  end_column: 50
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 37
                 }
                 window_spec {
@@ -282,7 +318,10 @@ body {
                         n {
                           int64_val {
                             src {
+                              end_column: 98
+                              end_line: 33
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 33
                             }
                             v: 2
@@ -291,7 +330,10 @@ body {
                       }
                     }
                     src {
+                      end_column: 98
+                      end_line: 33
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 33
                     }
                     start {
@@ -315,20 +357,29 @@ body {
                             pos_args {
                               string_val {
                                 src {
+                                  end_column: 62
+                                  end_line: 33
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 18
                                   start_line: 33
                                 }
                                 v: "key"
                               }
                             }
                             src {
+                              end_column: 62
+                              end_line: 33
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 33
                             }
                           }
                         }
                         src {
+                          end_column: 62
+                          end_line: 33
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 18
                           start_line: 33
                         }
                         wnd {
@@ -349,26 +400,38 @@ body {
                                 pos_args {
                                   string_val {
                                     src {
+                                      end_column: 46
+                                      end_line: 33
                                       file: "SRC_POSITION_TEST_MODE"
+                                      start_column: 18
                                       start_line: 33
                                     }
                                     v: "value"
                                   }
                                 }
                                 src {
+                                  end_column: 46
+                                  end_line: 33
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 18
                                   start_line: 33
                                 }
                               }
                             }
                             src {
+                              end_column: 46
+                              end_line: 33
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 33
                             }
                             wnd {
                               sp_window_spec_empty {
                                 src {
+                                  end_column: 46
+                                  end_line: 33
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 18
                                   start_line: 33
                                 }
                               }
@@ -386,7 +449,10 @@ body {
             }
             name: "window1"
             src {
+              end_column: 65
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 37
             }
           }
@@ -424,26 +490,38 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 79
+                              end_line: 37
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 67
                               start_line: 37
                             }
                             v: "value"
                           }
                         }
                         src {
+                          end_column: 79
+                          end_line: 37
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 67
                           start_line: 37
                         }
                       }
                     }
                     src {
+                      end_column: 79
+                      end_line: 37
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 67
                       start_line: 37
                     }
                   }
                 }
                 src {
+                  end_column: 93
+                  end_line: 37
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 67
                   start_line: 37
                 }
                 window_spec {
@@ -452,7 +530,10 @@ body {
                       sp_window_relative_position__unbounded_following: true
                     }
                     src {
+                      end_column: 122
+                      end_line: 35
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 18
                       start_line: 35
                     }
                     start {
@@ -478,14 +559,20 @@ body {
                                 pos_args {
                                   string_val {
                                     src {
+                                      end_column: 44
+                                      end_line: 35
                                       file: "SRC_POSITION_TEST_MODE"
+                                      start_column: 34
                                       start_line: 35
                                     }
                                     v: "key"
                                   }
                                 }
                                 src {
+                                  end_column: 44
+                                  end_line: 35
                                   file: "SRC_POSITION_TEST_MODE"
+                                  start_column: 34
                                   start_line: 35
                                 }
                               }
@@ -494,19 +581,28 @@ body {
                               sp_null_order_default: true
                             }
                             src {
+                              end_column: 51
+                              end_line: 35
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 34
                               start_line: 35
                             }
                           }
                         }
                         src {
+                          end_column: 52
+                          end_line: 35
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 18
                           start_line: 35
                         }
                         wnd {
                           sp_window_spec_empty {
                             src {
+                              end_column: 52
+                              end_line: 35
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 18
                               start_line: 35
                             }
                           }
@@ -522,7 +618,10 @@ body {
             }
             name: "window2"
             src {
+              end_column: 108
+              end_line: 37
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 67
               start_line: 37
             }
           }
@@ -535,7 +634,10 @@ body {
           }
         }
         src {
+          end_column: 109
+          end_line: 37
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 37
         }
         variadic: true
@@ -585,26 +687,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 39
+                          end_line: 39
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 39
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 39
                     }
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 39
                 }
               }
             }
             src {
+              end_column: 67
+              end_line: 39
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 39
             }
             window_spec {
@@ -625,26 +739,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 66
+                          end_line: 39
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 45
                           start_line: 39
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 66
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 39
                     }
                   }
                 }
                 src {
+                  end_column: 66
+                  end_line: 39
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 39
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 66
+                      end_line: 39
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 39
                     }
                   }
@@ -661,7 +787,10 @@ body {
           }
         }
         src {
+          end_column: 68
+          end_line: 39
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 39
         }
         variadic: true
@@ -711,26 +840,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 39
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 41
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 39
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 41
                     }
                   }
                 }
                 src {
+                  end_column: 39
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 41
                 }
               }
             }
             src {
+              end_column: 77
+              end_line: 41
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 41
             }
             window_spec {
@@ -751,14 +892,20 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 76
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 45
                           start_line: 41
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 76
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 41
                     }
                   }
@@ -779,26 +926,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 76
+                          end_line: 41
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 45
                           start_line: 41
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 76
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 41
                     }
                   }
                 }
                 src {
+                  end_column: 76
+                  end_line: 41
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 45
                   start_line: 41
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 76
+                      end_line: 41
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 45
                       start_line: 41
                     }
                   }
@@ -815,7 +974,10 @@ body {
           }
         }
         src {
+          end_column: 78
+          end_line: 41
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 41
         }
         variadic: true
@@ -865,26 +1027,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 43
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 43
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 43
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 43
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 43
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 43
             }
             window_spec {
@@ -905,26 +1079,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 67
+                          end_line: 43
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 43
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 67
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 43
                     }
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 43
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 43
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 67
+                      end_line: 43
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 43
                     }
                   }
@@ -941,7 +1127,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 43
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 43
         }
         variadic: true
@@ -991,26 +1180,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 45
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 45
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 45
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 45
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 45
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 45
             }
             window_spec {
@@ -1031,26 +1232,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 68
+                          end_line: 45
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 45
                         }
                         v: "key"
                       }
                     }
                     src {
+                      end_column: 68
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 45
                     }
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 45
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 45
                 }
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 68
+                      end_line: 45
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 45
                     }
                   }
@@ -1067,7 +1280,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 45
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 45
         }
         variadic: true
@@ -1117,26 +1333,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 47
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 47
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 47
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 47
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 47
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 47
             }
             window_spec {
@@ -1146,7 +1374,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 47
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 47
                         }
                         v: 2
@@ -1155,7 +1386,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 47
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 47
                 }
                 start {
@@ -1163,7 +1397,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 47
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 47
                         }
                       }
@@ -1173,7 +1410,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 67
+                      end_line: 47
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 47
                     }
                   }
@@ -1190,7 +1430,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 47
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 47
         }
         variadic: true
@@ -1240,26 +1483,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 36
+                          end_line: 49
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 24
                           start_line: 49
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 36
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 24
                       start_line: 49
                     }
                   }
                 }
                 src {
+                  end_column: 36
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 24
                   start_line: 49
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 49
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 24
               start_line: 49
             }
             window_spec {
@@ -1269,7 +1524,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 49
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 49
                         }
                         v: 2
@@ -1278,7 +1536,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 49
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 42
                   start_line: 49
                 }
                 start {
@@ -1286,7 +1547,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 49
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 42
                           start_line: 49
                         }
                         v: 1
@@ -1297,7 +1561,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 68
+                      end_line: 49
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 42
                       start_line: 49
                     }
                   }
@@ -1314,7 +1581,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 49
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 14
           start_line: 49
         }
         variadic: true
@@ -1364,26 +1634,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 51
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 51
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 51
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 51
                 }
               }
             }
             src {
+              end_column: 68
+              end_line: 51
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 51
             }
             window_spec {
@@ -1393,7 +1675,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 51
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 51
                         }
                         v: 2
@@ -1402,7 +1687,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 67
+                  end_line: 51
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 51
                 }
                 start {
@@ -1410,7 +1698,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 67
+                          end_line: 51
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 51
                         }
                       }
@@ -1420,7 +1711,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 67
+                      end_line: 51
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 51
                     }
                   }
@@ -1437,7 +1731,10 @@ body {
           }
         }
         src {
+          end_column: 69
+          end_line: 51
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 51
         }
         variadic: true
@@ -1487,26 +1784,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 53
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 53
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 53
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 53
                 }
               }
             }
             src {
+              end_column: 69
+              end_line: 53
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 53
             }
             window_spec {
@@ -1516,7 +1825,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 53
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 53
                         }
                         v: 2
@@ -1525,7 +1837,10 @@ body {
                   }
                 }
                 src {
+                  end_column: 68
+                  end_line: 53
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 53
                 }
                 start {
@@ -1533,7 +1848,10 @@ body {
                     n {
                       int64_val {
                         src {
+                          end_column: 68
+                          end_line: 53
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 43
                           start_line: 53
                         }
                         v: 1
@@ -1544,7 +1862,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 68
+                      end_line: 53
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 53
                     }
                   }
@@ -1561,7 +1882,10 @@ body {
           }
         }
         src {
+          end_column: 70
+          end_line: 53
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 53
         }
         variadic: true
@@ -1611,26 +1935,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 55
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 55
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 55
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 55
                 }
               }
             }
             src {
+              end_column: 111
+              end_line: 55
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 55
             }
             window_spec {
@@ -1639,7 +1975,10 @@ body {
                   sp_window_relative_position__unbounded_following: true
                 }
                 src {
+                  end_column: 110
+                  end_line: 55
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 55
                 }
                 start {
@@ -1648,7 +1987,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 110
+                      end_line: 55
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 55
                     }
                   }
@@ -1665,7 +2007,10 @@ body {
           }
         }
         src {
+          end_column: 112
+          end_line: 55
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 55
         }
         variadic: true
@@ -1715,26 +2060,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 57
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 57
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 57
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 57
                 }
               }
             }
             src {
+              end_column: 110
+              end_line: 57
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 57
             }
             window_spec {
@@ -1743,7 +2100,10 @@ body {
                   sp_window_relative_position__unbounded_preceding: true
                 }
                 src {
+                  end_column: 109
+                  end_line: 57
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 57
                 }
                 start {
@@ -1752,7 +2112,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 109
+                      end_line: 57
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 57
                     }
                   }
@@ -1769,7 +2132,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 57
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 57
         }
         variadic: true
@@ -1819,26 +2185,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 59
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 59
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 59
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 59
                 }
               }
             }
             src {
+              end_column: 110
+              end_line: 59
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 59
             }
             window_spec {
@@ -1847,7 +2225,10 @@ body {
                   sp_window_relative_position__unbounded_following: true
                 }
                 src {
+                  end_column: 109
+                  end_line: 59
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 59
                 }
                 start {
@@ -1856,7 +2237,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 109
+                      end_line: 59
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 59
                     }
                   }
@@ -1873,7 +2257,10 @@ body {
           }
         }
         src {
+          end_column: 111
+          end_line: 59
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 59
         }
         variadic: true
@@ -1923,26 +2310,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 61
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 61
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 61
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 61
                 }
               }
             }
             src {
+              end_column: 109
+              end_line: 61
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 61
             }
             window_spec {
@@ -1951,7 +2350,10 @@ body {
                   sp_window_relative_position__unbounded_preceding: true
                 }
                 src {
+                  end_column: 108
+                  end_line: 61
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 43
                   start_line: 61
                 }
                 start {
@@ -1960,7 +2362,10 @@ body {
                 wnd {
                   sp_window_spec_empty {
                     src {
+                      end_column: 108
+                      end_line: 61
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 43
                       start_line: 61
                     }
                   }
@@ -1977,7 +2382,10 @@ body {
           }
         }
         src {
+          end_column: 110
+          end_line: 61
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 61
         }
         variadic: true
@@ -2027,26 +2435,38 @@ body {
                     pos_args {
                       string_val {
                         src {
+                          end_column: 37
+                          end_line: 63
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 63
                         }
                         v: "value"
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 63
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 63
                     }
                   }
                 }
                 src {
+                  end_column: 37
+                  end_line: 63
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 63
                 }
               }
             }
             src {
+              end_column: 44
+              end_line: 63
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 63
             }
           }
@@ -2059,7 +2479,10 @@ body {
           }
         }
         src {
+          end_column: 45
+          end_line: 63
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 63
         }
         variadic: true
@@ -2111,26 +2534,38 @@ body {
                         pos_args {
                           string_val {
                             src {
+                              end_column: 37
+                              end_line: 65
                               file: "SRC_POSITION_TEST_MODE"
+                              start_column: 25
                               start_line: 65
                             }
                             v: "value"
                           }
                         }
                         src {
+                          end_column: 37
+                          end_line: 65
                           file: "SRC_POSITION_TEST_MODE"
+                          start_column: 25
                           start_line: 65
                         }
                       }
                     }
                     src {
+                      end_column: 37
+                      end_line: 65
                       file: "SRC_POSITION_TEST_MODE"
+                      start_column: 25
                       start_line: 65
                     }
                   }
                 }
                 src {
+                  end_column: 44
+                  end_line: 65
                   file: "SRC_POSITION_TEST_MODE"
+                  start_column: 25
                   start_line: 65
                 }
               }
@@ -2140,7 +2575,10 @@ body {
             }
             name: "window1"
             src {
+              end_column: 59
+              end_line: 65
               file: "SRC_POSITION_TEST_MODE"
+              start_column: 25
               start_line: 65
             }
           }
@@ -2153,7 +2591,10 @@ body {
           }
         }
         src {
+          end_column: 60
+          end_line: 65
           file: "SRC_POSITION_TEST_MODE"
+          start_column: 15
           start_line: 65
         }
         variadic: true

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -474,8 +474,8 @@ def test_async_job_to_df(session, create_async_job_from_query_id):
 
 
 def test_async_job_result_wait_no_result(session):
-    async_job = session.sql("select system$wait(3)").collect_nowait()
     t0 = time()
+    async_job = session.sql("select system$wait(3)").collect_nowait()
     result = async_job.result("no_result")
     t1 = time()
     assert t1 - t0 >= 3.0

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -474,8 +474,8 @@ def test_async_job_to_df(session, create_async_job_from_query_id):
 
 
 def test_async_job_result_wait_no_result(session):
-    t0 = time()
     async_job = session.sql("select system$wait(3)").collect_nowait()
+    t0 = time()
     result = async_job.result("no_result")
     t1 = time()
     assert t1 - t0 >= 3.0

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -536,34 +536,13 @@ def test_structured_dtypes_negative(structured_type_session, structured_type_sup
     if not structured_type_support:
         pytest.skip("Test requires structured type support.")
 
-    # SNOW-1862700: Array Type and Map Type missing element or value fails to generate AST
-    with pytest.raises(
-        NotImplementedError, match="AST does not support empty element_type."
-    ):
-        x = ArrayType()
-        x._fill_ast(mock.Mock())
-
-    with pytest.raises(
-        NotImplementedError, match="AST does not support empty key or value type."
-    ):
-        x = MapType()
-        x._fill_ast(mock.Mock())
-
-    # Maptype requires both key and value type be set if either is set
-    with pytest.raises(
-        ValueError,
-        match="Must either set both key_type and value_type or leave both unset.",
-    ):
-        MapType(StringType())
+    x = StructType()
+    x._fill_ast(mock.Mock())
 
 
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
     reason="local testing does not fully support structured types yet.",
-)
-@pytest.mark.skipif(
-    "config.getoption('enable_ast', default=False)",
-    reason="SNOW-1862700: AST does not support new structured type semantics yet.",
 )
 def test_udaf_structured_map_downcast(
     structured_type_session, structured_type_support, caplog
@@ -975,10 +954,6 @@ def test_dtypes_vector(session):
     "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: SNOW-1372813 Cast to StructType not supported",
 )
-@pytest.mark.skipif(
-    "config.getoption('enable_ast', default=False)",
-    reason="SNOW-1862700: AST does not support new structured type semantics yet.",
-)
 def test_structured_dtypes_cast(structured_type_session, structured_type_support):
     if not structured_type_support:
         pytest.skip("Test requires structured type support.")
@@ -986,7 +961,7 @@ def test_structured_dtypes_cast(structured_type_session, structured_type_support
         [
             StructField("ARR", ArrayType(), nullable=True),
             StructField("MAP", MapType(), nullable=True),
-            StructField("OBJ", MapType(), nullable=True),
+            StructField("OBJ", StructType(), nullable=True),
         ]
     )
     expected_structured_schema = StructType(
@@ -1016,7 +991,7 @@ def test_structured_dtypes_cast(structured_type_session, structured_type_support
             [
                 StructField("arr", ArrayType()),
                 StructField("map", MapType()),
-                StructField("obj", MapType()),
+                StructField("obj", StructType()),
             ]
         ),
     )
@@ -1024,7 +999,7 @@ def test_structured_dtypes_cast(structured_type_session, structured_type_support
     assert df.collect() == [
         Row(
             "[\n  1,\n  2,\n  3\n]",
-            '{\n  "k1": 1,\n  "k2": 2\n}',
+            {"k1": "1", "k2": "2"},
             '{\n  "A": 1,\n  "B": "foobar"\n}',
         )
     ]

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -532,18 +532,6 @@ def test_structured_dtypes_iceberg(
     "config.getoption('local_testing_mode', default=False)",
     reason="local testing does not fully support structured types yet.",
 )
-def test_structured_dtypes_negative(structured_type_session, structured_type_support):
-    if not structured_type_support:
-        pytest.skip("Test requires structured type support.")
-
-    x = StructType()
-    x._fill_ast(mock.Mock())
-
-
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="local testing does not fully support structured types yet.",
-)
 def test_udaf_structured_map_downcast(
     structured_type_session, structured_type_support, caplog
 ):

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -574,7 +574,7 @@ def test_udaf_structured_map_downcast(
             "Snowflake does not support structured maps as return type for UDAFs. Downcasting to semi-structured object."
             in caplog.text
         )
-        assert MapCollector._return_type == MapType()
+        assert MapCollector._return_type == StructType()
 
 
 @pytest.mark.skipif(
@@ -960,7 +960,7 @@ def test_structured_dtypes_cast(structured_type_session, structured_type_support
     expected_semi_schema = StructType(
         [
             StructField("ARR", ArrayType(), nullable=True),
-            StructField("MAP", MapType(), nullable=True),
+            StructField("MAP", StructType(), nullable=True),
             StructField("OBJ", StructType(), nullable=True),
         ]
     )
@@ -990,7 +990,7 @@ def test_structured_dtypes_cast(structured_type_session, structured_type_support
         schema=StructType(
             [
                 StructField("arr", ArrayType()),
-                StructField("map", MapType()),
+                StructField("map", StructType()),
                 StructField("obj", StructType()),
             ]
         ),
@@ -999,7 +999,7 @@ def test_structured_dtypes_cast(structured_type_session, structured_type_support
     assert df.collect() == [
         Row(
             "[\n  1,\n  2,\n  3\n]",
-            {"k1": "1", "k2": "2"},
+            '{\n  "k1": 1,\n  "k2": 2\n}',
             '{\n  "A": 1,\n  "B": "foobar"\n}',
         )
     ]

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -331,7 +331,7 @@ def test_struct_type_add():
     field_c = StructField("c", LongType())
 
     expected = StructType([field_a, field_b, field_c])
-    struct_type = StructType().add(field_a).add(field_b).add("c", LongType())
+    struct_type = StructType([]).add(field_a).add(field_b).add("c", LongType())
     assert struct_type == expected
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1873529

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

  This change adds support for ArrayType and StructType having empty elements/fields in the AST. An ArrayType without an element_type represents a semi-structured Array. A StructType with fields set to None represents a semi-structured OBJECT. This semantics change is gated behind a client-side parameter in snowflake.snowpark.context.

With the new semantics enabled, OBJECTS are handled differently now. Previously semi-structred objects were represented with `MapType(StringType(), StringType())` while structured objects were represented with `StructType([...])`. After this change both are represented with StructType and MapType only represents MAP columns.