### PR TITLE
SNOW-1873566: Allow array type inputs to _concat_ws_ignore_nulls

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -165,7 +165,6 @@ from types import ModuleType
 from typing import Callable, Dict, List, Optional, Tuple, Union, overload
 
 import snowflake.snowpark
-from snowflake.snowpark import context
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.table_function
 from snowflake.snowpark._internal.analyzer.expression import (
@@ -3588,16 +3587,10 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
     # 4. Filter out nulls.
     # 5. Concatenate the non-null values into a single string.
 
-    not_null_lambda = (
-        "x -> x IS NOT NULL"
-        if context._use_structured_type_semantics
-        else "x -> NOT IS_NULL_VALUE(x)"
-    )
-
     def array_remove_nulls(col: Column) -> Column:
         """Expects an array and returns an array with nulls removed."""
         return builtin("filter", _emit_ast=False)(
-            col, sql_expr(not_null_lambda, _emit_ast=False)
+            col, sql_expr("x -> NOT IS_NULL_VALUE(x)", _emit_ast=False)
         )
 
     def concat_strings_with_sep(col: Column) -> Column:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3582,15 +3582,15 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
 
     # The implementation of this function is as follows with example input of
     # sep = "," and row = [a, NULL], b, NULL, c:
-    # 1. Convert all columns to array.
+    # 1. Cast all columns to array.
     #   [a, NULL], [b], NULL, [c]
-    # 2. Combine all arrays into a array of arrays after removing nulls.
+    # 2. Combine all arrays into a array of arrays after removing nulls (array_construct_compact).
     #   [[a, NULL], [b], [c]]
-    # 3. Flatten the array of arrays into a single array.
+    # 3. Flatten the array of arrays into a single array (array_flatten).
     #   [a, NULL, b, c]
-    # 4. Filter out nulls.
+    # 4. Filter out nulls (array_remove_nulls).
     #   [a, b, c]
-    # 5. Concatenate the non-null values into a single string.
+    # 5. Concatenate the non-null values into a single string (concat_strings_with_sep).
     #   "a,b,c"
 
     def array_remove_nulls(col: Column) -> Column:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3580,12 +3580,18 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
     columns = [_to_col_if_str(c, "_concat_ws_ignore_nulls") for c in cols]
     names = ",".join([c.get_name() for c in columns])
 
-    # The implementation of this function is as follows:
-    # 1. Convert all columns to arrays of strings.
+    # The implementation of this function is as follows with example input of
+    # sep = "," and row = [a, NULL], b, NULL, c:
+    # 1. Convert all columns to array.
+    #   [a, NULL], [b], NULL, [c]
     # 2. Combine all arrays into a array of arrays after removing nulls.
+    #   [[a, NULL], [b], [c]]
     # 3. Flatten the array of arrays into a single array.
+    #   [a, NULL, b, c]
     # 4. Filter out nulls.
+    #   [a, b, c]
     # 5. Concatenate the non-null values into a single string.
+    #   "a,b,c"
 
     def array_remove_nulls(col: Column) -> Column:
         """Expects an array and returns an array with nulls removed."""

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -174,10 +174,7 @@ def examples(structured_type_support):
 def structured_type_session(session, structured_type_support):
     if structured_type_support:
         with structured_types_enabled_session(session) as sess:
-            with mock.patch(
-                "snowflake.snowpark.context._use_structured_type_semantics", True
-            ):
-                yield sess
+            yield sess
     else:
         yield session
 

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -334,11 +334,10 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
         df = session.create_dataframe(data, schema=cols)
 
         # single character delimiter
-        Utils.check_answer(df.select(_concat_ws_ignore_nulls(",", *cols)),
-                           [Row("a,b,c,d,e"),
-                            Row("Hello,world,!,bye,world"),
-                            Row("R,H,TD"),
-                            Row("")])
+        Utils.check_answer(
+            df.select(_concat_ws_ignore_nulls(",", *cols)),
+            [Row("a,b,c,d,e"), Row("Hello,world,!,bye,world"), Row("R,H,TD"), Row("")],
+        )
 
     if structured_type_semantics:
         with structured_types_enabled_session(session) as session:

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -332,7 +332,13 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
 
     def check_concat_ws_ignore_nulls_output(session):
         df = session.create_dataframe(data, schema=cols)
-        df.select(_concat_ws_ignore_nulls(",", *cols))  # single character delimiter
+
+        # single character delimiter
+        Utils.check_answer(df.select(_concat_ws_ignore_nulls(",", *cols)),
+                           [Row("a,b,c,d,e"),
+                            Row("Hello,world,!,bye,world"),
+                            Row("R,H,TD"),
+                            Row("")])
 
     if structured_type_semantics:
         with structured_types_enabled_session(session) as session:

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -9,7 +9,6 @@ import json
 import math
 import re
 from itertools import chain
-from unittest import mock
 
 import pytest
 
@@ -366,10 +365,7 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
 
     if structured_type_semantics:
         with structured_types_enabled_session(session) as session:
-            with mock.patch(
-                "snowflake.snowpark.context._use_structured_type_semantics", True
-            ):
-                check_concat_ws_ignore_nulls_output(session)
+            check_concat_ws_ignore_nulls_output(session)
     else:
         check_concat_ws_ignore_nulls_output(session)
 

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -327,6 +327,7 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
         ),  # some nulls column
         ([None, None], ["R", "H"], None, "TD"),  # some nulls column
         (None, [None], None, None),  # all nulls column
+        (None, None, None, None),  # all nulls column
     ]
     cols = ["arr1", "arr2", "str1", "str2"]
 
@@ -336,7 +337,25 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
         # single character delimiter
         Utils.check_answer(
             df.select(_concat_ws_ignore_nulls(",", *cols)),
-            [Row("a,b,c,d,e"), Row("Hello,world,!,bye,world"), Row("R,H,TD"), Row("")],
+            [
+                Row("a,b,c,d,e"),
+                Row("Hello,world,!,bye,world"),
+                Row("R,H,TD"),
+                Row(""),
+                Row(""),
+            ],
+        )
+
+        # multi-character delimiter
+        Utils.check_answer(
+            df.select(_concat_ws_ignore_nulls(" : ", *cols)),
+            [
+                Row("a : b : c : d : e"),
+                Row("Hello : world : ! : bye : world"),
+                Row("R : H : TD"),
+                Row(""),
+                Row(""),
+            ],
         )
 
     if structured_type_semantics:

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -315,21 +315,27 @@ def test_concat_ws(session, col_a, col_b, col_c):
     assert res[0][0] == "1,2,3"
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="lambda function not supported",
+)
 @pytest.mark.parametrize("structured_type_semantics", [True, False])
 def test__concat_ws_ignore_nulls(session, structured_type_semantics):
     data = [
-        (["a", "b"], ["c"], "d", "e"),  # no nulls column
+        (["a", "b"], ["c"], "d", "e", 1, 2),  # no nulls column
         (
             ["Hello", None, "world"],
             [None, "!", None],
             "bye",
             "world",
+            3,
+            None,
         ),  # some nulls column
-        ([None, None], ["R", "H"], None, "TD"),  # some nulls column
-        (None, [None], None, None),  # all nulls column
-        (None, None, None, None),  # all nulls column
+        ([None, None], ["R", "H"], None, "TD", 4, 5),  # some nulls column
+        (None, [None], None, None, None, None),  # all nulls column
+        (None, None, None, None, None, None),  # all nulls column
     ]
-    cols = ["arr1", "arr2", "str1", "str2"]
+    cols = ["arr1", "arr2", "str1", "str2", "int1", "int2"]
 
     def check_concat_ws_ignore_nulls_output(session):
         df = session.create_dataframe(data, schema=cols)
@@ -338,9 +344,9 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
         Utils.check_answer(
             df.select(_concat_ws_ignore_nulls(",", *cols)),
             [
-                Row("a,b,c,d,e"),
-                Row("Hello,world,!,bye,world"),
-                Row("R,H,TD"),
+                Row("a,b,c,d,e,1,2"),
+                Row("Hello,world,!,bye,world,3"),
+                Row("R,H,TD,4,5"),
                 Row(""),
                 Row(""),
             ],
@@ -350,9 +356,9 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
         Utils.check_answer(
             df.select(_concat_ws_ignore_nulls(" : ", *cols)),
             [
-                Row("a : b : c : d : e"),
-                Row("Hello : world : ! : bye : world"),
-                Row("R : H : TD"),
+                Row("a : b : c : d : e : 1 : 2"),
+                Row("Hello : world : ! : bye : world : 3"),
+                Row("R : H : TD : 4 : 5"),
                 Row(""),
                 Row(""),
             ],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ import os
 import platform
 import random
 import string
+from unittest import mock
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -121,7 +122,8 @@ def iceberg_supported(session, local_testing_mode):
 def structured_types_enabled_session(session):
     for param in STRUCTURED_TYPE_PARAMETERS:
         session.sql(f"alter session set {param}=true").collect()
-    yield session
+    with mock.patch("snowflake.snowpark.context._use_structured_type_semantics", True):
+        yield session
     for param in STRUCTURED_TYPE_PARAMETERS:
         session.sql(f"alter session unset {param}").collect()
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1873566

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   With use of `filter` and `reduce` implement `_concat_ws_ignore_nulls` that accepts string columns and array of string columns as input and concatenates all the strings in given order by ignoring nulls.
