### PR TITLE
SNOW-1877144: Use only small values in dummy input for type inference

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -842,15 +842,13 @@ def convert_numpy_int_result_to_int(value: Any) -> Any:
 
 
 DUMMY_BOOL_INPUT = native_pd.Series([False, True])
-DUMMY_INT_INPUT = native_pd.Series(
-    [-37, -9, -2, -1, 0, 2, 3, 5, 7, 9, 13, 16, 20]
-    + np.power(10, np.arange(19)).tolist()
-    + np.multiply(-1, np.power(10, np.arange(19))).tolist()
-)
+# Note: we use only small dummy values here to avoid the risk of certain callables
+# taking a long time to execute (where execution time is a function of the input value).
+# As a downside this reduces diversity in input data so will reduce the effectiveness
+# type inference framework in some rare cases.
+DUMMY_INT_INPUT = native_pd.Series([-37, -9, -2, -1, 0, 2, 3, 5, 7, 9, 13, 16, 20, 101])
 DUMMY_FLOAT_INPUT = native_pd.Series(
-    [-9.9, -2.2, -1.0, 0.0, 0.5, 0.33, None, 0.99, 2.0, 3.0, 5.0, 7.7, 9.898989]
-    + np.power(10.1, np.arange(19)).tolist()
-    + np.multiply(-1.0, np.power(10.1, np.arange(19))).tolist()
+    [-9.9, -2.2, -1.0, 0.0, 0.5, 0.33, None, 0.99, 2.0, 3.0, 5.0, 7.7, 9.898989, 100.1]
 )
 DUMMY_STRING_INPUT = native_pd.Series(
     ["", "a", "A", "0", "1", "01", "123", "-1", "-12", "true", "True", "false", "False"]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1877144

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Use only small dummy values here to avoid the risk of certain callables
taking a long time to execute (where execution time is a function of the input value).
As a downside this reduces diversity in input data so will reduce the effectiveness
type inference framework in some rare cases.
