### PR TITLE
SNOW-1877354: Add pyproject.toml and tox dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "protoc-wheel-0==21.1", # Protocol buffer compiler for Snowpark IR
+    "mypy-protobuf", # used in generating typed Python code from protobuf for Snowpark IR
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ DEVELOPMENT_REQUIREMENTS = [
     "graphviz",  # used in plot tests
     "pytest-assume",  # sql counter check
     "decorator",  # sql counter check
-    "protoc-wheel-0==21.1",  # Protocol buffer compiler, for Snowpark IR
-    "mypy-protobuf",  # used in generating typed Python code from protobuf for Snowpark IR
     "lxml",  # used in read_xml tests
     "tox",  # used for setting up testing environments
 ]

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ DEVELOPMENT_REQUIREMENTS = [
     "protoc-wheel-0==21.1",  # Protocol buffer compiler, for Snowpark IR
     "mypy-protobuf",  # used in generating typed Python code from protobuf for Snowpark IR
     "lxml",  # used in read_xml tests
+    "tox",  # used for setting up testing environments
 ]
 
 # read the version


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1877354

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

As described in the linked JIRA, the `protoc-wheel-0` and `mypy-protobuf` dev dependencies must be installed _before_ `setup.py` is run, so a clean `pip install snowflake-snowpark-python[development]` will error if these packages were not installed beforehand. By adding `pyproject.toml` according to [these instructions](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#how-to-handle-additional-build-time-dependencies), we're able to specify these dependencies before `setup.py` is invoked, thereby removing the need to explicitly `pip install` those packages first. This can be verified by attempting to install the repository from a new conda environment, which fails on current main without first installing `protoc-wheel-0` and `mypy-protobuf`.

This PR also incidentally adds `tox` as a dev dependency, as we use it frequently for testing environments.