### PR TITLE
SNOW-1882338 Fix AST `to_snowpark_pandas` test in nop testing mode

### DIFF
--- a/src/snowflake/snowpark/mock/_nop_plan.py
+++ b/src/snowflake/snowpark/mock/_nop_plan.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import Any, Dict, List, Optional
 
 import snowflake.snowpark
+from snowflake.snowpark.mock import TableEmulator
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark._internal.analyzer.binary_plan_node import Join
 from snowflake.snowpark._internal.analyzer.expression import (
@@ -116,6 +117,9 @@ def resolve_attributes(
         )
         pivot_attrs.extend(pivot_result_cols)
         attributes = pivot_attrs
+
+    elif isinstance(plan, TableEmulator):
+        attributes = [Attribute(name, _NumericType(), False) for name in plan.columns]
 
     elif isinstance(plan, TableUpdate):
         attributes = [

--- a/tests/ast/data/Dataframe.to_snowpark_pandas.test
+++ b/tests/ast/data/Dataframe.to_snowpark_pandas.test
@@ -30,8 +30,10 @@ body {
     expr {
       sp_table {
         name {
-          sp_table_name_flat {
-            name: "table1"
+          name {
+            sp_name_flat {
+              name: "table1"
+            }
           }
         }
         src {


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

  Fixes SNOW-1882338

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Add logic to the no-op AST testing code to create a temp read-only table for to_snowpark_pandas. This way `to_snowpark_pandas` works with both `nop` mode and `local_testing_mode`.