### PR TITLE
SNOW-1830529 Add decoder logic for `to_local_iterator`, `to_pandas`, `to_snowpark_pandas`, and `to_pandas_batch`

### DIFF
--- a/src/snowflake/snowpark/mock/_nop_plan.py
+++ b/src/snowflake/snowpark/mock/_nop_plan.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import Any, Dict, List, Optional
 
 import snowflake.snowpark
+from snowflake.snowpark.mock import TableEmulator
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark._internal.analyzer.binary_plan_node import Join
 from snowflake.snowpark._internal.analyzer.expression import (
@@ -116,6 +117,9 @@ def resolve_attributes(
         )
         pivot_attrs.extend(pivot_result_cols)
         attributes = pivot_attrs
+
+    elif isinstance(plan, TableEmulator):
+        attributes = [Attribute(name, _NumericType(), False) for name in plan.columns]
 
     elif isinstance(plan, TableUpdate):
         attributes = [

--- a/tests/ast/data/Dataframe.to_snowpark_pandas.test
+++ b/tests/ast/data/Dataframe.to_snowpark_pandas.test
@@ -30,8 +30,10 @@ body {
     expr {
       sp_table {
         name {
-          sp_table_name_flat {
-            name: "table1"
+          name {
+            sp_name_flat {
+              name: "table1"
+            }
           }
         }
         src {

--- a/tests/ast/decoder.py
+++ b/tests/ast/decoder.py
@@ -1437,6 +1437,41 @@ class Decoder:
                 else:
                     return df.to_df(col_names)
 
+            case "sp_dataframe_to_local_iterator":
+                df = self.symbol_table[
+                    expr.sp_dataframe_to_local_iterator.id.bitfield1
+                ][1]
+                statement_params = self.get_statement_params(
+                    MessageToDict(expr.sp_dataframe_to_local_iterator)
+                )
+                block = expr.sp_dataframe_to_local_iterator.block
+                case_sensitive = expr.sp_dataframe_to_local_iterator.case_sensitive
+                return df.to_local_iterator(
+                    statement_params=statement_params,
+                    block=block,
+                    case_sensitive=case_sensitive,
+                )
+
+            case "sp_dataframe_to_pandas":
+                df = self.symbol_table[expr.sp_dataframe_to_pandas.id.bitfield1][1]
+                statement_params = self.get_statement_params(
+                    MessageToDict(expr.sp_dataframe_to_pandas)
+                )
+                block = expr.sp_dataframe_to_pandas.block
+                return df.to_pandas(statement_params=statement_params, block=block)
+
+            case "sp_dataframe_to_pandas_batches":
+                df = self.symbol_table[
+                    expr.sp_dataframe_to_pandas_batches.id.bitfield1
+                ][1]
+                statement_params = self.get_statement_params(
+                    MessageToDict(expr.sp_dataframe_to_pandas_batches)
+                )
+                block = expr.sp_dataframe_to_pandas_batches.block
+                return df.to_pandas_batches(
+                    statement_params=statement_params, block=block
+                )
+
             case "sp_dataframe_unpivot":
                 df = self.decode_expr(expr.sp_dataframe_unpivot.df)
                 column_list = [


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1830529

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Added decoder logic for `to_local_iterator`, `to_pandas`, `to_snowpark_pandas`, and `to_pandas_batch`.
