### PR TITLE
SNOW-890686: Remove test_groupby_sort_false_multiindex_series

### DIFF
--- a/tests/integ/modin/groupby/conftest.py
+++ b/tests/integ/modin/groupby/conftest.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import pandas as native_pd
 import modin.pandas as pd
 import numpy as np
 import pytest
@@ -154,13 +155,13 @@ def df_multi():
 
 
 @pytest.fixture(scope="function")
-def series_multi_numeric():
-    index = pd.MultiIndex(
+def native_series_multi_numeric():
+    index = native_pd.MultiIndex(
         levels=[[1, 2], [1, 2]],
         codes=[[0, 0, 0, 0, 1, 1], [1, 1, 0, 0, 0, 0]],
         names=["a", "b"],
     )
-    return pd.Series([0, 1.0, 2.0, 3.0, 4.0, 5.0], index=index)
+    return native_pd.Series([0, 1.0, 2.0, 3.0, 4.0, 5.0], index=index)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integ/modin/groupby/test_groupby_default2pandas.py
+++ b/tests/integ/modin/groupby/test_groupby_default2pandas.py
@@ -125,11 +125,11 @@ def test_groupby_with_numpy_array(basic_snowpark_pandas_df) -> None:
     [[2, 1, 1, 2, 3, 3], [[2, 1, 1, 2, 3, 3], "a"]],
 )
 @sql_count_checker(query_count=1)
-def test_groupby_series_with_numpy_array(series_multi_numeric, by_list) -> None:
+def test_groupby_series_with_numpy_array(native_series_multi_numeric, by_list) -> None:
     with pytest.raises(
         NotImplementedError, match=AGGREGATE_UNSUPPORTED_GROUPING_ERROR_PATTERN
     ):
-        series_multi_numeric.groupby(by=by_list).max()
+        pd.Series(native_series_multi_numeric).groupby(by=by_list).max()
 
 
 def test_groupby_with_external_series(basic_snowpark_pandas_df) -> None:

--- a/tests/integ/modin/groupby/test_groupby_ngroups.py
+++ b/tests/integ/modin/groupby/test_groupby_ngroups.py
@@ -17,11 +17,11 @@ def assert_ngroups_equal(snow_res, pd_res):
 
 
 @pytest.mark.parametrize("by", ["a", "b", ["a", "b"]])
-@sql_count_checker(query_count=2)
-def test_groupby_sort_multiindex_series(series_multi_numeric, by):
+@sql_count_checker(query_count=1)
+def test_groupby_sort_multiindex_series(native_series_multi_numeric, by):
 
-    snow_ser = series_multi_numeric
-    native_ser = series_multi_numeric.to_pandas()
+    snow_ser = pd.Series(native_series_multi_numeric)
+    native_ser = native_series_multi_numeric
     eval_snowpark_pandas_result(
         snow_ser,
         native_ser,

--- a/tests/integ/modin/groupby/test_groupby_series.py
+++ b/tests/integ/modin/groupby/test_groupby_series.py
@@ -12,40 +12,20 @@ from pandas.errors import SpecificationError
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import (
-    assert_snowpark_pandas_equal_to_pandas,
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import sql_count_checker
 
 
 @pytest.mark.parametrize("by", ["a", ["b"], ["a", "b"]])
-@sql_count_checker(query_count=2)
-def test_groupby_sort_multiindex_series(series_multi_numeric, agg_method, by):
-    native_mseries_group = series_multi_numeric.to_pandas().groupby(by=by, sort=True)
-    mseries_group = series_multi_numeric.groupby(by=by, sort=True)
+@pytest.mark.parametrize("sort", [True, False])
+@sql_count_checker(query_count=1)
+def test_groupby_sort_multiindex_series(
+    native_series_multi_numeric, agg_method, by, sort
+):
+    native_mseries_group = native_series_multi_numeric.groupby(by=by, sort=sort)
+    mseries_group = pd.Series(native_series_multi_numeric).groupby(by=by, sort=sort)
     eval_snowpark_pandas_result(mseries_group, native_mseries_group, agg_method)
-
-
-@sql_count_checker(query_count=3)
-def test_groupby_sort_false_multiindex_series(series_multi_numeric):
-    # it is known that groupby sort=False is buggy with multiIndex, it is always
-    # sorting when only part of the level is used.
-    # https://github.com/pandas-dev/pandas/issues/17537
-    # The bug is fixed in 2.0.0, our behavior aligns with the fixed behavior.
-    # Once updated to 2.0.0.
-    # test_groupby_sort_false_multiindex_series is added to test the correct sort=False
-    # behavior, once updated to 2.0.0, we can merge this with test_groupby_sort_multiindex_series
-    # TODO (SNOW-890686): merge test_groupby_sort_false_multiindex_series and test_groupby_sort_multiindex_series
-    #       once Snowpark pandas is updated to align with pandas 2.0.x
-    result = series_multi_numeric.groupby("b", sort=False).max()
-    expected = native_pd.Series([1, 5], index=native_pd.Index([2, 1], name="b"))
-    assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
-
-    eval_snowpark_pandas_result(
-        series_multi_numeric,
-        series_multi_numeric.to_pandas(),
-        lambda df: df.groupby(["a", "b"]).max(),
-    )
 
 
 @sql_count_checker(query_count=2)
@@ -172,12 +152,12 @@ def test_groupby_series_numeric_only(series_str, numeric_only):
 
 
 @pytest.mark.parametrize("level", [0, 1, [1, 0], "b", [1, 1], [0, "b"], [-1]])
-@sql_count_checker(query_count=2)
-def test_groupby_sort_multiindex_series_level(series_multi_numeric, level):
-    native_series = series_multi_numeric.to_pandas()
-
+@sql_count_checker(query_count=1)
+def test_groupby_sort_multiindex_series_level(native_series_multi_numeric, level):
     eval_snowpark_pandas_result(
-        series_multi_numeric, native_series, lambda ser: ser.groupby(level=level).sum()
+        pd.Series(native_series_multi_numeric),
+        native_series_multi_numeric,
+        lambda ser: ser.groupby(level=level).sum(),
     )
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-890686

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

The test named in the PR was separated from the more general test because of a pandas bug with `groupby(sort=False)` that was fixed in 2.0.X. This PR removes this test and adds parametrization on the `sort` parameter to `test_groupby_sort_multiindex_series`.

This PR incidentally reduces some query counts by changing a test fixture from a Snowpark pandas Series to a native one to avoid some materializations.