### PR TITLE
SNOW-1229442: Remove skipped large `df.quantile` test

### DIFF
--- a/tests/integ/modin/frame/test_quantile.py
+++ b/tests/integ/modin/frame/test_quantile.py
@@ -137,15 +137,11 @@ def test_quantile_datetime_negative():
         snow_df.quantile(numeric_only=False)
 
 
-@pytest.mark.skip(
-    reason="Bug in quantile emitting large amount of queries except for small data. TODO: SNOW-1229442",
-)
-@sql_count_checker(query_count=0)
+@sql_count_checker(query_count=6, union_count=15)
 def test_quantile_large():
-    snow_series = pd.DataFrame({"a": range(1000), "b": range(1000)})
+    native_df = native_pd.DataFrame({"a": range(1000), "b": range(1000)})
+    snow_df = pd.DataFrame(native_df)
     q = np.linspace(0, 1, 16)
-
-    # actual query count for this 81. This seems like a bug.
-    ans = snow_series.quantile(q, interpolation="linear").to_pandas()
-
-    assert len(ans) == len(q)
+    eval_snowpark_pandas_result(
+        snow_df, native_df, lambda df: df.quantile(q, interpolation="linear")
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1229442

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

A single `df.quantile` call with large data + many quantiles previously emitted 81 queries, many of which were duplicate temp table operations. After #2090, this number was reduced to 6, so we can remove the `pytest.skip` on the offending test.