### PR TITLE
SNOW-1830544, SNOW-1830604 Decoder logic for Session.create_dataframe, Window/WindowSpec, and Session.range 

### DIFF
--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -337,7 +337,7 @@ def build_proto_from_struct_type(
 
     expr.structured = schema.structured
     for field in schema.fields:
-        ast_field = expr.fields.add()
+        ast_field = expr.fields.list.add()
         field.column_identifier._fill_ast(ast_field.column_identifier)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "ColumnIdentifier" has no attribute "_fill_ast"
         field.datatype._fill_ast(ast_field.data_type)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
         ast_field.nullable = field.nullable

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -412,25 +412,27 @@ body {
           sp_dataframe_schema__struct {
             v {
               fields {
-                column_identifier {
-                  name: "a"
+                list {
+                  column_identifier {
+                    name: "a"
+                  }
+                  data_type {
+                    sp_integer_type: true
+                  }
+                  nullable: true
                 }
-                data_type {
-                  sp_integer_type: true
-                }
-                nullable: true
-              }
-              fields {
-                column_identifier {
-                  name: "b"
-                }
-                data_type {
-                  sp_string_type {
-                    length {
+                list {
+                  column_identifier {
+                    name: "b"
+                  }
+                  data_type {
+                    sp_string_type {
+                      length {
+                      }
                     }
                   }
+                  nullable: true
                 }
-                nullable: true
               }
             }
           }

--- a/tests/ast/decoder.py
+++ b/tests/ast/decoder.py
@@ -8,6 +8,8 @@ from typing import Any, Optional, Iterable, List, Union, Dict, Tuple, Callable
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 
+from snowflake.snowpark.window import WindowSpec, Window, WindowRelativePosition
+
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 
 from google.protobuf.json_format import MessageToDict
@@ -527,6 +529,100 @@ class Decoder:
         offset_seconds = tz_expr.offset_seconds
         return timezone(offset=timedelta(seconds=offset_seconds), name=tz_name)
 
+    def decode_window_spec_expr(self, window_spec_expr: proto.SpWindowSpecExpr) -> Any:
+        """
+        Decode a window specification expression.
+
+        Parameters
+        ----------
+        window_spec_expr : proto.SpWindowSpecExpr
+            The expression to decode.
+
+        Returns
+        -------
+        Any
+            The decoded window specification.
+        """
+        match window_spec_expr.WhichOneof("variant"):
+            case "sp_window_spec_empty":
+                return Window._spec()
+            case "sp_window_spec_order_by":
+                window_spec = self.decode_window_spec_expr(
+                    window_spec_expr.sp_window_spec_order_by.wnd
+                )
+                cols = self.decode_col_exprs(
+                    window_spec_expr.sp_window_spec_order_by.cols
+                )
+                return window_spec.order_by(*cols)
+            case "sp_window_spec_partition_by":
+                window_spec = self.decode_window_spec_expr(
+                    window_spec_expr.sp_window_spec_partition_by.wnd
+                )
+                cols = self.decode_col_exprs(
+                    window_spec_expr.sp_window_spec_partition_by.cols
+                )
+                return window_spec.partition_by(*cols)
+            case "sp_window_spec_range_between":
+                start = self.decode_window_relative_position(
+                    window_spec_expr.sp_window_spec_range_between.start
+                )
+                end = self.decode_window_relative_position(
+                    window_spec_expr.sp_window_spec_range_between.end
+                )
+                window_spec = self.decode_window_spec_expr(
+                    window_spec_expr.sp_window_spec_range_between.wnd
+                )
+                return window_spec.range_between(start, end)
+            case "sp_window_spec_rows_between":
+                start = self.decode_window_relative_position(
+                    window_spec_expr.sp_window_spec_rows_between.start
+                )
+                end = self.decode_window_relative_position(
+                    window_spec_expr.sp_window_spec_rows_between.end
+                )
+                window_spec = self.decode_window_spec_expr(
+                    window_spec_expr.sp_window_spec_rows_between.wnd
+                )
+                return window_spec.rows_between(start, end)
+            case None:
+                # This is for the case col.over() where the window spec is None.
+                return None
+            case _:
+                raise ValueError(
+                    "Unknown window specification type: %s"
+                    % window_spec_expr.WhichOneof("variant")
+                )
+
+    def decode_window_relative_position(
+        self, wnd_relative_position: proto.SpWindowRelativePosition
+    ):
+        """
+        Helper function for AST decoding to fill relative positions for window spec range-between, and rows-between.
+        If the value passed in for start/end is of type WindowRelativePosition encoding will preserve the syntax.
+        (For example, Window.CURRENT_ROW)
+
+        Parameters
+        ----------
+        wnd_relative_position : proto.SpWindowRelativePosition
+            The expression to decode.
+        """
+        match wnd_relative_position.WhichOneof("variant"):
+            case "sp_window_relative_position__current_row":
+                return WindowRelativePosition.CURRENT_ROW
+            case "sp_window_relative_position__position":
+                return self.decode_expr(
+                    wnd_relative_position.sp_window_relative_position__position.n
+                )
+            case "sp_window_relative_position__unbounded_following":
+                return WindowRelativePosition.UNBOUNDED_FOLLOWING
+            case "sp_window_relative_position__unbounded_preceding":
+                return WindowRelativePosition.UNBOUNDED_PRECEDING
+            case _:
+                raise ValueError(
+                    "Unknown window relative position type: %s"
+                    % wnd_relative_position.WhichOneof("variant")
+                )
+
     def binop(self, ast, fn):
         return fn(self.decode_expr(ast.lhs), self.decode_expr(ast.rhs))
 
@@ -841,6 +937,12 @@ class Decoder:
             case "sp_column_is_null":
                 col = self.decode_expr(expr.sp_column_is_null.col)
                 return col.is_null()
+
+            case "sp_column_over":
+                col = self.decode_expr(expr.sp_column_over.col)
+                return col.over(
+                    window=self.decode_window_spec_expr(expr.sp_column_over.window_spec)
+                )
 
             case "sp_column_sql_expr":
                 sql_expr = expr.sp_column_sql_expr.sql
@@ -1588,6 +1690,12 @@ class Decoder:
                     return grouped_df.agg(*exprs)
                 else:
                     return grouped_df.agg(exprs)
+
+            case "sp_range":
+                start = expr.sp_range.start
+                end = expr.sp_range.end.value if expr.sp_range.HasField("end") else None
+                step = expr.sp_range.step.value if expr.sp_range.HasField("step") else 1
+                return self.session.range(start, end, step)
 
             case "sp_relational_grouped_dataframe_apply_in_pandas":
                 # TODO: SNOW-1830603 Flesh out this logic when implementing UDTFs. Need to create a dict to maintain


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1830544, SNOW-1830604

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Added decoder logic for Session.create_dataframe, Window/WindowSpec, and Session.range. Did not add logic for Session.create_dataframe_from_pandas since the test is disabled.
