### PR TITLE
SNOW-1878372: Fix analyzer access across threads

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -4,7 +4,7 @@
 #
 import uuid
 from collections import Counter, defaultdict
-from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, DefaultDict, Dict, List, Union
 
 from snowflake.connector import IntegrityError
 
@@ -168,7 +168,7 @@ class Analyzer:
         self.plan_builder = SnowflakePlanBuilder(self.session)
         self.generated_alias_maps = {}
         self.subquery_plans = []
-        self.alias_maps_to_use: Optional[Dict[uuid.UUID, str]] = None
+        self.alias_maps_to_use: Dict[uuid.UUID, str] = {}
 
     def analyze(
         self,
@@ -368,7 +368,6 @@ class Analyzer:
             return expr.sql
 
         if isinstance(expr, Attribute):
-            assert self.alias_maps_to_use is not None
             name = self.alias_maps_to_use.get(expr.expr_id, expr.name)
             return quote_name(name)
 

--- a/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
@@ -197,7 +197,7 @@ def cache_metadata_if_select_statement(
 
     if (
         isinstance(source_plan, SelectStatement)
-        and source_plan.analyzer.session.reduce_describe_query_enabled
+        and source_plan._session.reduce_describe_query_enabled
     ):
         source_plan._attributes = metadata.attributes
         # When source_plan doesn't have a projection, it's a simple `SELECT * from ...`,

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -229,8 +229,10 @@ class Selectable(LogicalPlan, ABC):
         ] = None,  # Use Any because it's recursive.
     ) -> None:
         super().__init__()
-        # Due to multi-threading changes, we need to use the session object to
-        # access the analyzer created for current thread.
+        # With multi-threading support, each thread has its own analyzer which can be
+        # accessed through session object. Therefore, we need to store the session in
+        # the Selectable object and use the session to access the appropriate analyzer
+        # for current thread.
         self._session = analyzer.session
         self.pre_actions: Optional[List["Query"]] = None
         self.post_actions: Optional[List["Query"]] = None

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -253,7 +253,7 @@ class Selectable(LogicalPlan, ABC):
     @property
     def analyzer(self) -> "Analyzer":
         """Get the analyzer for used for the current thread"""
-        if self._analyzer is None:
+        return self._analyzer or self._session._analyzer
             return self._session._analyzer
         return self._analyzer
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -254,8 +254,6 @@ class Selectable(LogicalPlan, ABC):
     def analyzer(self) -> "Analyzer":
         """Get the analyzer for used for the current thread"""
         return self._analyzer or self._session._analyzer
-            return self._session._analyzer
-        return self._analyzer
 
     @analyzer.setter
     def analyzer(self, value: "Analyzer") -> None:

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -383,7 +383,6 @@ def warn_session_config_update_in_multithreaded_mode(config: str) -> None:
             "You might have more than one threads sharing the Session object trying to update "
             f"{config}. Updating this while other tasks are running can potentially cause "
             "unexpected behavior. Please update the session configuration before starting the threads."
-            f"active threads: {threading.active_count()}"
         )
 
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -383,6 +383,7 @@ def warn_session_config_update_in_multithreaded_mode(config: str) -> None:
             "You might have more than one threads sharing the Session object trying to update "
             f"{config}. Updating this while other tasks are running can potentially cause "
             "unexpected behavior. Please update the session configuration before starting the threads."
+            f"active threads: {threading.active_count()}"
         )
 
 

--- a/src/snowflake/snowpark/mock/_nop_analyzer.py
+++ b/src/snowflake/snowpark/mock/_nop_analyzer.py
@@ -102,7 +102,7 @@ class NopSelectExecutionPlan(MockSelectExecutionPlan):
 class NopSelectableEntity(MockSelectableEntity):
     @property
     def attributes(self):
-        return resolve_attributes(self.entity_plan, session=self.analyzer.session)
+        return resolve_attributes(self.entity_plan, session=self._session)
 
 
 class NopAnalyzer(MockAnalyzer):

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -986,7 +986,7 @@ def execute_mock_plan(
         res_df = execute_mock_plan(
             MockExecutionPlan(
                 first_operand.selectable,
-                source_plan.analyzer.session,
+                source_plan._session,
             ),
             expr_to_alias,
         )
@@ -994,7 +994,7 @@ def execute_mock_plan(
             operand = source_plan.set_operands[i]
             operator = operand.operator
             cur_df = execute_mock_plan(
-                MockExecutionPlan(operand.selectable, source_plan.analyzer.session),
+                MockExecutionPlan(operand.selectable, source_plan._session),
                 expr_to_alias,
             )
             if len(res_df.columns) != len(cur_df.columns):

--- a/src/snowflake/snowpark/mock/_select_statement.py
+++ b/src/snowflake/snowpark/mock/_select_statement.py
@@ -64,7 +64,7 @@ class MockSelectable(LogicalPlan, ABC):
         analyzer: "Analyzer",
     ) -> None:
         super().__init__()
-        self.analyzer = analyzer
+        self._session = analyzer.session
         self.pre_actions = None
         self.post_actions = None
         self.flatten_disabled: bool = False
@@ -75,6 +75,10 @@ class MockSelectable(LogicalPlan, ABC):
         self.df_aliased_col_name_to_real_col_name: DefaultDict[
             str, Dict[str, str]
         ] = defaultdict(dict)
+
+    @property
+    def analyzer(self) -> "Analyzer":
+        return self._session._analyzer
 
     @property
     def sql_query(self) -> str:
@@ -97,7 +101,7 @@ class MockSelectable(LogicalPlan, ABC):
         from snowflake.snowpark.mock._plan import MockExecutionPlan
 
         if self._execution_plan is None:
-            self._execution_plan = MockExecutionPlan(self, self.analyzer.session)
+            self._execution_plan = MockExecutionPlan(self, self._session)
         return self._execution_plan
 
     @property

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -70,6 +70,7 @@ def reset_node(node: LogicalPlan, query_generator: QueryGenerator) -> None:
     def reset_selectable(selectable_node: Selectable) -> None:
         # reset the analyzer to use the current query generator instance to
         # ensure the new query generator is used during the resolve process
+        selectable_node._is_valid_for_replacement = True
         selectable_node.analyzer = query_generator
         if not isinstance(selectable_node, (SelectSnowflakePlan, SelectSQL)):
             selectable_node._snowflake_plan = None

--- a/tests/integ/test_multithreading.py
+++ b/tests/integ/test_multithreading.py
@@ -987,6 +987,11 @@ def select_aliased_col(df2):
     Utils.check_answer(df2, [Row(A1=1), Row(A1=3)])
 
 
+@pytest.mark.xfail(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="SNOW-1373887: Support basic diamond shaped joins in Local Testing",
+    run=False,
+)
 @pytest.mark.parametrize(
     "f1,f2", [(create_and_join, join_again), (create_aliased_df, select_aliased_col)]
 )
@@ -999,10 +1004,7 @@ def test_SNOW_1878372(threadsafe_session, f1, f2):
 
         def run(self):
             if self._target is not None:
-                try:
-                    self.result = self._target(*self._args, **self._kwargs)
-                except Exception as e:
-                    print(f"Error: {e}")
+                self.result = self._target(*self._args, **self._kwargs)
 
     t1 = ReturnableThread(target=f1, args=(threadsafe_session,))
     t1.start()

--- a/tests/integ/test_multithreading.py
+++ b/tests/integ/test_multithreading.py
@@ -667,7 +667,6 @@ def test_concurrent_update_on_sensitive_configs(
             not in caplog.text
         )
 
-    caplog.clear()
     with caplog.at_level(logging.WARNING):
         with ThreadPoolExecutor(max_workers=5) as executor:
             for _ in range(5):

--- a/tests/unit/compiler/test_large_query_breakdown.py
+++ b/tests/unit/compiler/test_large_query_breakdown.py
@@ -39,10 +39,14 @@ from snowflake.snowpark._internal.analyzer.unary_plan_node import (
 from snowflake.snowpark._internal.compiler.large_query_breakdown import (
     LargeQueryBreakdown,
 )
+from snowflake.snowpark.session import Session
 
+dummy_session = mock.create_autospec(Session)
+dummy_analyzer = mock.create_autospec(Analyzer)
+dummy_analyzer.session = dummy_session
 empty_logical_plan = LogicalPlan()
 empty_expression = Expression()
-empty_selectable = SelectSQL("dummy_query", analyzer=mock.create_autospec(Analyzer))
+empty_selectable = SelectSQL("dummy_query", analyzer=dummy_analyzer)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/compiler/test_replace_child_and_update_node.py
+++ b/tests/unit/compiler/test_replace_child_and_update_node.py
@@ -455,7 +455,8 @@ def test_select_statement(
     new_replaced_plan = plan.children_plan_nodes[0]
     assert isinstance(new_replaced_plan, SelectSnowflakePlan)
     assert new_replaced_plan._snowflake_plan.source_plan == new_plan
-    assert new_replaced_plan.analyzer == mock_query_generator
+    # new_replaced_plan is created with QueryGenerator.to_selectable
+    assert new_replaced_plan.analyzer == mock_analyzer
 
     post_actions = [Query("drop table if exists table_name")]
     new_replaced_plan.post_actions = post_actions

--- a/tests/unit/test_cte.py
+++ b/tests/unit/test_cte.py
@@ -84,7 +84,7 @@ def test_find_duplicate_subtrees(test_case):
     assert repeated_node_complexity == expected_repeated_node_complexity
 
 
-def test_encode_node_id_with_query_select_sql(mock_analyzer):
+def test_encode_node_id_with_query_select_sql(mock_session, mock_analyzer):
     sql_text = "select 1 as a, 2 as b"
     select_sql_node = SelectSQL(
         sql=sql_text,

--- a/tests/unit/test_deepcopy.py
+++ b/tests/unit/test_deepcopy.py
@@ -6,7 +6,6 @@ import uuid
 from unittest import mock
 
 from snowflake.snowpark import Session, functions as F, types as T
-from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.analyzer_utils import UNION
 from snowflake.snowpark._internal.analyzer.select_statement import (
     ColumnStateDict,
@@ -114,11 +113,9 @@ def verify_copied_selectable(
     assert copy.deepcopy(original_selectable, memo) is copied_selectable
 
 
-def test_selectable_entity():
-    analyzer = mock.create_autospec(Analyzer)
-    session = mock.create_autospec(Session)
+def test_selectable_entity(mock_session, mock_analyzer):
     selectable_entity = SelectableEntity(
-        SnowflakeTable("TEST_TABLE", session=session), analyzer=analyzer
+        SnowflakeTable("TEST_TABLE", session=mock_session), analyzer=mock_analyzer
     )
     init_selectable_fields(selectable_entity, init_plan=False)
     copied_selectable = copy.deepcopy(selectable_entity)
@@ -126,12 +123,11 @@ def test_selectable_entity():
     assert copied_selectable.entity.name == selectable_entity.entity.name
 
 
-def test_select_sql():
-    analyzer = mock.create_autospec(Analyzer)
+def test_select_sql(mock_session, mock_analyzer):
     # none-select sql
     sql = "show tables limit 10"
     select_sql = SelectSQL(
-        sql, convert_to_select=False, analyzer=analyzer, params=[1, "a", 2, "b"]
+        sql, convert_to_select=False, analyzer=mock_analyzer, params=[1, "a", 2, "b"]
     )
 
     init_selectable_fields(select_sql, init_plan=True)
@@ -148,13 +144,11 @@ def test_select_sql():
     assert copied_selectable.original_sql == select_sql.original_sql
 
 
-def test_select_snowflake_plan():
-    analyzer = mock.create_autospec(Analyzer)
-    session = mock.create_autospec(Session)
-    snowflake_plan = init_snowflake_plan(session)
+def test_select_snowflake_plan(mock_session, mock_analyzer):
+    snowflake_plan = init_snowflake_plan(mock_session)
     select_snowflake_plan = SelectSnowflakePlan(
         snowflake_plan=snowflake_plan,
-        analyzer=analyzer,
+        analyzer=mock_analyzer,
     )
     init_selectable_fields(select_snowflake_plan, init_plan=False)
     copied_selectable = copy.deepcopy(select_snowflake_plan)
@@ -164,9 +158,7 @@ def test_select_snowflake_plan():
     assert copied_selectable._query_params == copied_selectable._query_params
 
 
-def test_select_statement():
-    analyzer = mock.create_autospec(Analyzer)
-    session = mock.create_autospec(Session)
+def test_select_statement(mock_session, mock_analyzer):
     projection = [
         F.cast(F.col("B"), T.IntegerType())._expression,
         (F.col("A") + F.col("B")).alias("A")._expression,
@@ -176,7 +168,7 @@ def test_select_statement():
     limit_ = 5
     offset = 2
     from_ = SelectableEntity(
-        SnowflakeTable("TEST_TABLE", session=session), analyzer=analyzer
+        SnowflakeTable("TEST_TABLE", session=mock_session), analyzer=mock_analyzer
     )
     select_snowflake_plan = SelectStatement(
         projection=projection,
@@ -185,7 +177,7 @@ def test_select_statement():
         order_by=order_by,
         limit_=limit_,
         offset=offset,
-        analyzer=analyzer,
+        analyzer=mock_analyzer,
     )
     init_selectable_fields(select_snowflake_plan, init_plan=False)
     copied_selectable = copy.deepcopy(select_snowflake_plan)
@@ -198,13 +190,11 @@ def test_select_statement():
     assert copied_selectable._query_params == select_snowflake_plan._query_params
 
 
-def test_select_table_function():
-    analyzer = mock.create_autospec(Analyzer)
-    session = mock.create_autospec(Session)
+def test_select_table_function(mock_session, mock_analyzer):
     select_table_function_plan = SelectTableFunction(
         func_expr=TableFunctionExpression(func_name="test_table_function"),
-        snowflake_plan=init_snowflake_plan(session),
-        analyzer=analyzer,
+        snowflake_plan=init_snowflake_plan(mock_session),
+        analyzer=mock_analyzer,
     )
     init_selectable_fields(select_table_function_plan, init_plan=False)
     copied_selectable = copy.deepcopy(select_table_function_plan)
@@ -217,21 +207,19 @@ def test_select_table_function():
     )
 
 
-def test_set_statement():
-    analyzer = mock.create_autospec(Analyzer)
-    session = mock.create_autospec(Session)
+def test_set_statement(mock_session, mock_analyzer):
     # construct the SetOperands
     select_entity1 = SelectableEntity(
-        SnowflakeTable("TEST_TABLE", session=session), analyzer=analyzer
+        SnowflakeTable("TEST_TABLE", session=mock_session), analyzer=mock_analyzer
     )
     select_entity2 = SelectableEntity(
-        SnowflakeTable("TEST_TABLE2", session=session), analyzer=analyzer
+        SnowflakeTable("TEST_TABLE2", session=mock_session), analyzer=mock_analyzer
     )
     operand1 = SetOperand(selectable=select_entity1, operator=UNION)
     operand2 = SetOperand(selectable=select_entity2, operator=UNION)
 
     # construct the set statement
-    set_statement = SetStatement(*[operand1, operand2], analyzer=analyzer)
+    set_statement = SetStatement(*[operand1, operand2], analyzer=mock_analyzer)
     init_selectable_fields(set_statement, init_plan=False)
     copied_selectable = copy.deepcopy(set_statement)
     verify_copied_selectable(copied_selectable, set_statement, expect_plan_copied=False)

--- a/tests/unit/test_query_plan_analysis.py
+++ b/tests/unit/test_query_plan_analysis.py
@@ -198,7 +198,9 @@ def test_select_table_function_individual_node_complexity(
 
 
 @pytest.mark.parametrize("set_operator", [UNION, UNION_ALL, INTERSECT, EXCEPT])
-def test_set_statement_individual_node_complexity(mock_session, mock_analyzer, set_operator):
+def test_set_statement_individual_node_complexity(
+    mock_session, mock_analyzer, set_operator
+):
     mock_selectable = mock.create_autospec(Selectable)
     mock_selectable.pre_actions = None
     mock_selectable.post_actions = None
@@ -389,7 +391,9 @@ def test_subtract_complexities(complexity1, complexity2, expected_result):
     assert subtract_complexities(complexity1, complexity2) == expected_result
 
 
-def test_select_statement_get_complexity_map_no_column_state(mock_session, mock_analyzer):
+def test_select_statement_get_complexity_map_no_column_state(
+    mock_session, mock_analyzer
+):
     mock_from = mock.create_autospec(Selectable)
     mock_from.pre_actions = None
     mock_from.post_actions = None
@@ -407,7 +411,9 @@ def test_select_statement_get_complexity_map_no_column_state(mock_session, mock_
     assert select_statement.get_projection_name_complexity_map() is None
 
 
-def test_select_statement_get_complexity_map_mismatch_projection_length(mock_session, mock_analyzer):
+def test_select_statement_get_complexity_map_mismatch_projection_length(
+    mock_session, mock_analyzer
+):
     mock_from = mock.create_autospec(Selectable)
     mock_from.pre_actions = None
     mock_from.post_actions = None

--- a/tests/unit/test_query_plan_analysis.py
+++ b/tests/unit/test_query_plan_analysis.py
@@ -121,7 +121,7 @@ def test_selectable_entity_individual_node_complexity(mock_session, mock_analyze
     assert plan_node.individual_node_complexity == {PlanNodeCategory.COLUMN: 1}
 
 
-def test_select_sql_individual_node_complexity(mock_analyzer):
+def test_select_sql_individual_node_complexity(mock_session, mock_analyzer):
     plan_node = SelectSQL("non-select statement", analyzer=mock_analyzer)
     assert plan_node.individual_node_complexity == {PlanNodeCategory.COLUMN: 1}
 
@@ -198,7 +198,7 @@ def test_select_table_function_individual_node_complexity(
 
 
 @pytest.mark.parametrize("set_operator", [UNION, UNION_ALL, INTERSECT, EXCEPT])
-def test_set_statement_individual_node_complexity(mock_analyzer, set_operator):
+def test_set_statement_individual_node_complexity(mock_session, mock_analyzer, set_operator):
     mock_selectable = mock.create_autospec(Selectable)
     mock_selectable.pre_actions = None
     mock_selectable.post_actions = None
@@ -389,7 +389,7 @@ def test_subtract_complexities(complexity1, complexity2, expected_result):
     assert subtract_complexities(complexity1, complexity2) == expected_result
 
 
-def test_select_statement_get_complexity_map_no_column_state(mock_analyzer):
+def test_select_statement_get_complexity_map_no_column_state(mock_session, mock_analyzer):
     mock_from = mock.create_autospec(Selectable)
     mock_from.pre_actions = None
     mock_from.post_actions = None
@@ -407,7 +407,7 @@ def test_select_statement_get_complexity_map_no_column_state(mock_analyzer):
     assert select_statement.get_projection_name_complexity_map() is None
 
 
-def test_select_statement_get_complexity_map_mismatch_projection_length(mock_analyzer):
+def test_select_statement_get_complexity_map_mismatch_projection_length(mock_session, mock_analyzer):
     mock_from = mock.create_autospec(Selectable)
     mock_from.pre_actions = None
     mock_from.post_actions = None


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1878372

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   In this change, we make the following changes to `Selectable`:
   - the analyzer object is accessed via a thread so that each selectable uses the analyzer created for the dedicated thread.
   - the analyzer can be set to a different analyzer only during optimization stage when `_is_valid_for_replacement=True`.

  We also update `Analyzer` to initialize `alias_maps_to_use` with an empty dict `{}` instead of `None`. In single threaded-case, `resolve` would initialize alias_maps_to_use to `{}` and then use it for `analyze` but in multithreaded-case, it is possible for one thread to call `resolve` and a different thread to call `analyze`.
