### PR TITLE
Turn off test_telemetry_func_call_count for github failure

### DIFF
--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -606,7 +606,7 @@ def test_telemetry_interchange_call_count():
 def test_telemetry_func_call_count(session):
     # TODO (SNOW-1893699): test failing on github with sql simplifier disabled.
     #   Turn this back on once fixed.
-    if session.sql_simpifier_enabbled is False:
+    if session.sql_simplifier_enabled is False:
         return
 
     with SqlCounter(query_count=4):


### PR DESCRIPTION
 Please describe how your code solves the related issue.

test_telemetry_func_call_count is failing with error 
```
2025-01-23T06:42:31.0419150Z [31mFAILED[0m tests/integ/modin/test_telemetry.py::[1mtest_telemetry_func_call_count[0m - IndexError: list index out of range
```
It seems the Dataframe.__repr__ is occurred once in the result telemetry data. Turn this test off for now.
