### PR TITLE
[SNOW-1894051]Turn off time consuming test from github actions

### DIFF
--- a/tests/integ/modin/frame/test_apply.py
+++ b/tests/integ/modin/frame/test_apply.py
@@ -31,7 +31,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from conftest import RUNNING_ON_GH
+from tests.utils import RUNNING_ON_GH
 
 # TODO SNOW-891796: replace native_pd with pd after allowing using snowpandas module/function in UDF
 

--- a/tests/integ/modin/frame/test_apply.py
+++ b/tests/integ/modin/frame/test_apply.py
@@ -31,6 +31,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from conftest import RUNNING_ON_GH
 
 # TODO SNOW-891796: replace native_pd with pd after allowing using snowpandas module/function in UDF
 
@@ -329,6 +330,7 @@ def test_axis_1_return_not_json_serializable_label():
         snow_df.apply(lambda x: native_pd.DataFrame([1, 2]), axis=1).to_pandas()
 
 
+@pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
 def test_axis_1_apply_args_kwargs():
     def f(x, y, z=1) -> int:
         return x.sum() + y + z

--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -24,6 +24,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from conftest import RUNNING_ON_GH
 
 # test data which has a python type as return type that is not a pandas Series/pandas DataFrame/tuple/list
 BASIC_DATA_FUNC_PYTHON_RETURN_TYPE_MAP = [
@@ -352,6 +353,7 @@ def test_axis_0_return_list():
     )
 
 
+@pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
 @pytest.mark.parametrize(
     "apply_func",
     [
@@ -655,6 +657,7 @@ def test_apply_nested_series_negative():
 import scipy.stats  # noqa: E402
 
 
+@pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
 @pytest.mark.parametrize(
     "packages,expected_query_count",
     [

--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -24,7 +24,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from conftest import RUNNING_ON_GH
+from tests.utils import RUNNING_ON_GH
 
 # test data which has a python type as return type that is not a pandas Series/pandas DataFrame/tuple/list
 BASIC_DATA_FUNC_PYTHON_RETURN_TYPE_MAP = [

--- a/tests/integ/modin/frame/test_cache_result.py
+++ b/tests/integ/modin/frame/test_cache_result.py
@@ -14,7 +14,7 @@ from tests.integ.modin.utils import (
     create_test_dfs,
 )
 from tests.integ.utils.sql_counter import SqlCounter
-from conftest import RUNNING_ON_GH
+from tests.utils import RUNNING_ON_GH
 
 
 def assert_empty_snowpark_pandas_equals_to_pandas(snow_df, native_df):

--- a/tests/integ/modin/frame/test_cache_result.py
+++ b/tests/integ/modin/frame/test_cache_result.py
@@ -14,6 +14,7 @@ from tests.integ.modin.utils import (
     create_test_dfs,
 )
 from tests.integ.utils.sql_counter import SqlCounter
+from conftest import RUNNING_ON_GH
 
 
 def assert_empty_snowpark_pandas_equals_to_pandas(snow_df, native_df):
@@ -175,6 +176,7 @@ class TestCacheResultReducesQueryCount:
                 cached_snow_df, native_df
             )
 
+    @pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
     def test_cache_result_post_apply(self, inplace, simple_test_data):
         # In this test, the caching doesn't aid in the query counts since
         # the implementation of apply(axis=1) itself contains intermediate

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -299,7 +299,7 @@ class TestFuncReturnsDataFrame:
         join_count=JOIN_COUNT,
     )
     def test_group_by_level(
-            self, grouping_dfs_with_multiindexes, level, include_groups
+        self, grouping_dfs_with_multiindexes, level, include_groups
     ):
         eval_snowpark_pandas_result(
             *grouping_dfs_with_multiindexes,

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -26,7 +26,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result as _eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from conftest import RUNNING_ON_GH
+from tests.utils import RUNNING_ON_GH
 
 # Use the workaround shown below for applying functions that are attributes
 # of this module.

--- a/tests/integ/modin/series/test_apply_and_map.py
+++ b/tests/integ/modin/series/test_apply_and_map.py
@@ -32,7 +32,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from conftest import RUNNING_ON_GH
+from tests.utils import RUNNING_ON_GH
 
 BASIC_DATA_FUNC_RETURN_TYPE_MAP = [
     ([1, 2, 3, None], lambda x: x + 1, "int"),

--- a/tests/integ/modin/series/test_apply_and_map.py
+++ b/tests/integ/modin/series/test_apply_and_map.py
@@ -32,6 +32,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from conftest import RUNNING_ON_GH
 
 BASIC_DATA_FUNC_RETURN_TYPE_MAP = [
     ([1, 2, 3, None], lambda x: x + 1, "int"),
@@ -467,6 +468,7 @@ class TestApplyOrMapCallable:
     # This import is related to the test below. Do not remove.
     import scipy  # noqa: E402
 
+    @pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
     @pytest.mark.parametrize(
         "package,expected_query_count",
         [

--- a/tests/integ/modin/series/test_items.py
+++ b/tests/integ/modin/series/test_items.py
@@ -16,6 +16,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from conftest import RUNNING_ON_GH
 
 # To generate seeded random data.
 rng = np.random.default_rng(12345)
@@ -62,6 +63,7 @@ def test_items(series):
     )
 
 
+@pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
 def test_items_large_series():
     size = PARTITION_SIZE * 2 + 1
     data = rng.integers(low=-1500, high=1500, size=size)

--- a/tests/integ/modin/series/test_items.py
+++ b/tests/integ/modin/series/test_items.py
@@ -16,7 +16,7 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from conftest import RUNNING_ON_GH
+from tests.utils import RUNNING_ON_GH
 
 # To generate seeded random data.
 rng = np.random.default_rng(12345)

--- a/tests/integ/modin/window/test_rolling.py
+++ b/tests/integ/modin/window/test_rolling.py
@@ -567,7 +567,7 @@ class TestTimedelta:
         ],
     )
     @pytest.mark.parametrize("agg_func", agg_func_supported_for_timedelta)
-    @window
+    @pytest.mark.parametrize("window", [1, 2, 6])
     @min_periods
     @center
     def test_rolling_aggregation_supported(


### PR DESCRIPTION
Please describe how your code solves the related issue.

Turn off couple of time consuming tests of snowpark pandas. The test turned off in the github took over miniutes to finish


verified with jenkins run https://snowpark-python-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/SnowparkPythonSnowPandasDailyRegressRunner/197458/
