### PR TITLE
NO-SNOW: Limit Python 3.12 and local testing suites

### DIFF
--- a/.github/workflows/daily_precommit.yml
+++ b/.github/workflows/daily_precommit.yml
@@ -373,9 +373,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - image_name: macos-latest
-            download_name: macos  # it includes doctest
+        os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         cloud-provider: [aws]
     steps:

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -245,7 +245,7 @@ jobs:
         exclude:
           # only run each version on one os
           # daily-precommit does full matrix
-          # macos rusn 3.8 and 3.9
+          # macos runs 3.8 and 3.9
           - os: macos-latest
             python-version: "3.12"
           - os: macos-latest

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -134,6 +134,25 @@ jobs:
           - os: windows-latest-64-cores
             python-version: "3.11"
             cloud-provider: azure
+          # limit python 3.12 to one os per csp
+          - os: macos-latest
+            python-version: "3.12"
+            cloud-provider: aws
+          - os: macos-latest
+            python-version: "3.12"
+            cloud-provider: gcp
+          - os: ubuntu-latest-64-cores
+            python-version: "3.12"
+            cloud-provider: azure
+          - os: ubuntu-latest-64-cores
+            python-version: "3.12"
+            cloud-provider: gcp
+          - os: windows-latest-64-cores
+            python-version: "3.12"
+            cloud-provider: azure
+          - os: windows-latest-64-cores
+            python-version: "3.12"
+            cloud-provider: aws
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -223,6 +242,32 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         cloud-provider: [aws]
+        exclude:
+          # only run each version on one os
+          # daily-precommit does full matrix
+          # macos rusn 3.8 and 3.9
+          - os: macos-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.9"
+          # windows runs 3.9 and 3.11
+          - os: windows-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.8"
+          # ubuntu runs 3.12
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.8"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR reduces the matrix for python 3.12 support in branch precommits in order to reduce strain on the testing warehouse. Additionally, it reduces the matrix for local testing to reduce strain on github runners.