### PR TITLE
SNOW-1894152: Fix test_lineage_trace failure

### DIFF
--- a/tests/integ/test_lineage.py
+++ b/tests/integ/test_lineage.py
@@ -161,6 +161,7 @@ def test_lineage_trace(session):
     session.sql(f"GRANT select on VIEW {db}.{schema}.V5 TO ROLE {test_role}").collect()
     session.sql(f"GRANT CREATE VIEW ON schema {schema} TO ROLE {test_role}").collect()
     session.sql(f"USE ROLE {test_role}").collect()
+    session.sql("USE SECONDARY ROLES NONE").collect()
     session.sql(
         f"CREATE OR REPLACE VIEW {db}.{schema}.V6 AS SELECT * FROM {db}.{schema}.V5"
     ).collect()

--- a/tests/integ/test_lineage.py
+++ b/tests/integ/test_lineage.py
@@ -60,7 +60,6 @@ def remove_created_on_field(df):
     return df
 
 
-@pytest.mark.skip("SNOW-1894152: Skipping to unblock precommits.")
 @pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 def test_lineage_trace(session):
     """


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1894152

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   The test example started failing due to a recent BCR that enabled secondary roles by default. The added statement should ensure that the test role is unable to see the data that is supposed to be masked in this test. For more information see here:
   https://community.snowflake.com/s/article/default-secondary-roles-all-overview-and-additional-explanations