### PR TITLE
SNOW-1734385: Do not create CTE when partitioning WithQueryBlocks

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/large_query_breakdown.py
+++ b/src/snowflake/snowpark/_internal/compiler/large_query_breakdown.py
@@ -367,7 +367,9 @@ class LargeQueryBreakdown:
         if isinstance(child, SelectSnowflakePlan):
             return self._extract_child_from_with_query_block(child.snowflake_plan)
 
-        raise ValueError(f"Invalid node type {type(child)} for partitioning.")
+        raise ValueError(
+            f"Invalid node type {type(child)} for partitioning."
+        )  # pragma: no cover
 
     def _get_partitioned_plan(self, child: TreeNode) -> SnowflakePlan:
         """This method takes cuts the child out from the root, creates a temp table plan for the

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import re
 import tempfile
 from unittest.mock import patch
 
@@ -220,7 +219,7 @@ def test_breakdown_at_with_query_node(session):
     assert len(queries["queries"]) == 2
     assert queries["queries"][0].startswith("CREATE  SCOPED TEMPORARY  TABLE")
     # SNOW-1734385: Remove it when the issue is fixed
-    assert "WITH SNOWPARK_TEMP_CTE_" in queries["queries"][0]
+    assert "WITH SNOWPARK_TEMP_CTE_" not in queries["queries"][0]
     assert len(queries["post_actions"]) == 1
 
 
@@ -773,12 +772,13 @@ def test_large_query_breakdown_with_nested_cte(session):
         queries = final_df.queries
         assert len(queries["queries"]) == 2
         assert len(queries["post_actions"]) == 1
-        match = re.search(r"SNOWPARK_TEMP_CTE_[\w]+", queries["queries"][0])
-        assert match is not None
-        cte_name_for_first_partition = match.group()
+
+        # assert that the first query contains the base temp table name
+        assert temp_table in queries["queries"][0]
+
         # assert that query for upper cte node is re-written and does not
-        # contain the cte name for the first partition
-        assert cte_name_for_first_partition not in queries["queries"][1]
+        # contain query for the base temp table
+        assert temp_table not in queries["queries"][1]
 
     check_result_with_and_without_breakdown(session, final_df)
 

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -218,7 +218,6 @@ def test_breakdown_at_with_query_node(session):
     queries = final_df.queries
     assert len(queries["queries"]) == 2
     assert queries["queries"][0].startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    # SNOW-1734385: Remove it when the issue is fixed
     assert "WITH SNOWPARK_TEMP_CTE_" not in queries["queries"][0]
     assert len(queries["post_actions"]) == 1
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1734385

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   When large query breakdown partitions node such that the child node being partitioned is a `WithQueryBlock`, do not create a cte. Instead, use the underlying sql to materialize it as a table.
