### PR TITLE
SNOW-1846317: Add support for reading/writing arrow data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 - Allow user input schema when reading JSON file on stage.
 - Added support for specifying a schema string (including implicit struct syntax) when calling `DataFrame.create_dataframe`.
   - `snowflake.core` is a dependency required for this feature.
+- Added support for converting Snowpark DataFrames to pyarrow Tables.
+- Added support for writing pyarrow Tables to Snowflake tables.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -4,9 +4,19 @@
 #
 
 import math
+import os
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union
+import tempfile
+from typing import Any, Dict, List, Optional, Tuple, Union, Literal, Sequence
 
+from snowflake.connector import ProgrammingError
+from snowflake.connector.cursor import SnowflakeCursor
+from snowflake.connector.options import pyarrow
+from snowflake.connector.pandas_tools import (
+    _create_temp_stage,
+    _create_temp_file_format,
+    build_location_helper,
+)
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,
     Except,
@@ -1656,3 +1666,244 @@ def cte_statement(queries: List[str], table_names: List[str]) -> str:
         for query, table_name in zip(queries, table_names)
     )
     return f"{WITH}{result}"
+
+
+def write_arrow(
+    cursor: SnowflakeCursor,
+    table: "pyarrow.Table",
+    table_name: str,
+    database: Optional[str] = None,
+    schema: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    compression: str = "gzip",
+    on_error: str = "abort_statement",
+    parallel: int = 4,
+    quote_identifiers: bool = True,
+    auto_create_table: bool = False,
+    overwrite: bool = False,
+    table_type: Literal["", "temp", "temporary", "transient"] = "",
+    use_logical_type: Optional[bool] = None,
+    use_scoped_temp_object: bool = False,
+    **kwargs: Any,
+) -> tuple[
+    bool,
+    int,
+    int,
+    Sequence[
+        tuple[
+            str,
+            str,
+            int,
+            int,
+            int,
+            int,
+            Optional[str],
+            Optional[int],
+            Optional[int],
+            Optional[str],
+        ]
+    ],
+]:
+    """Writes a pyarrow.Table to a Snowflake table.
+
+    The pyarrow Table is written out to temporary files, uploaded to a temporary stage, and then copied into the final location.
+
+    Returns whether all files were ingested correctly, number of chunks uploaded, and number of rows ingested
+    with all of the COPY INTO command's output for debugging purposes.
+
+    Args:
+        cursor: Snowflak connector cursor used to execute queries.
+        table: The pyarrow Table that is written.
+        table_name: Table name where we want to insert into.
+        database: Database schema and table is in, if not provided the default one will be used (Default value = None).
+        schema: Schema table is in, if not provided the default one will be used (Default value = None).
+        chunk_size: Number of elements to be inserted in each batch, if not provided all elements will be dumped
+            (Default value = None).
+        compression: The compression used on the Parquet files, can only be gzip, or snappy. Gzip gives a
+            better compression, while snappy is faster. Use whichever is more appropriate (Default value = 'gzip').
+        on_error: Action to take when COPY INTO statements fail, default follows documentation at:
+            https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
+            (Default value = 'abort_statement').
+        parallel: Number of threads to be used when uploading chunks, default follows documentation at:
+            https://docs.snowflake.com/en/sql-reference/sql/put.html#optional-parameters (Default value = 4).
+        quote_identifiers: By default, identifiers, specifically database, schema, table and column names
+            (from df.columns) will be quoted. If set to False, identifiers are passed on to Snowflake without quoting.
+            I.e. identifiers will be coerced to uppercase by Snowflake.  (Default value = True)
+        auto_create_table: When true, will automatically create a table with corresponding columns for each column in
+            the passed in DataFrame. The table will not be created if it already exists
+        table_type: The table type of to-be-created table. The supported table types include ``temp``/``temporary``
+            and ``transient``. Empty means permanent table as per SQL convention.
+        use_logical_type: Boolean that specifies whether to use Parquet logical types. With this file format option,
+            Snowflake can interpret Parquet logical types during data loading. To enable Parquet logical types,
+            set use_logical_type as True. Set to None to use Snowflakes default. For more information, see:
+            https://docs.snowflake.com/en/sql-reference/sql/create-file-format
+    """
+    # This function mostly copies the functionality of snowflake.connector.pandas_utils.write_pandas.
+    # It should be pushed down into the connector, but would require a minimum required version bump.
+    import pyarrow.parquet
+
+    if database is not None and schema is None:
+        raise ProgrammingError(
+            "Schema has to be provided to write_arrow when a database is provided"
+        )
+    compression_map = {"gzip": "auto", "snappy": "snappy"}
+    if compression not in compression_map.keys():
+        raise ProgrammingError(
+            f"Invalid compression '{compression}', only acceptable values are: {compression_map.keys()}"
+        )
+
+    if table_type and table_type.lower() not in ["temp", "temporary", "transient"]:
+        raise ValueError(
+            "Unsupported table type. Expected table types: temp/temporary, transient"
+        )
+
+    if chunk_size is None:
+        chunk_size = len(table)
+
+    if use_logical_type is None:
+        sql_use_logical_type = ""
+    elif use_logical_type:
+        sql_use_logical_type = " USE_LOGICAL_TYPE = TRUE"
+    else:
+        sql_use_logical_type = " USE_LOGICAL_TYPE = FALSE"
+
+    stage_location = _create_temp_stage(
+        cursor,
+        database,
+        schema,
+        quote_identifiers,
+        compression,
+        auto_create_table,
+        overwrite,
+        use_scoped_temp_object,
+    )
+    with tempfile.TemporaryDirectory() as tmp_folder:
+        for file_number, offset in enumerate(range(0, len(table), chunk_size)):
+            # write chunk to disk
+            chunk_path = os.path.join(tmp_folder, f"{table_name}_{file_number}.parquet")
+            pyarrow.parquet.write_table(
+                table.slice(offset=offset, length=chunk_size),
+                chunk_path,
+                **kwargs,
+            )
+            # upload chunk
+            upload_sql = (
+                "PUT /* Python:snowflake.snowpark._internal.analyzer.analyzer_utils.write_arrow() */ "
+                "'file://{path}' @{stage_location} PARALLEL={parallel}"
+            ).format(
+                path=chunk_path.replace("\\", "\\\\").replace("'", "\\'"),
+                stage_location=stage_location,
+                parallel=parallel,
+            )
+            cursor.execute(upload_sql, _is_internal=True)
+            # Remove chunk file
+            os.remove(chunk_path)
+
+    if quote_identifiers:
+        quote = '"'
+        snowflake_column_names = [str(c).replace('"', '""') for c in table.schema.names]
+    else:
+        quote = ""
+        snowflake_column_names = list(table.schema.names)
+    columns = quote + f"{quote},{quote}".join(snowflake_column_names) + quote
+
+    def drop_object(name: str, object_type: str) -> None:
+        drop_sql = f"DROP {object_type.upper()} IF EXISTS {name} /* Python:snowflake.snowpark._internal.analyzer.analyzer_utils.write_arrow() */"
+        cursor.execute(drop_sql, _is_internal=True)
+
+    if auto_create_table or overwrite:
+        file_format_location = _create_temp_file_format(
+            cursor,
+            database,
+            schema,
+            quote_identifiers,
+            compression_map[compression],
+            sql_use_logical_type,
+            use_scoped_temp_object,
+        )
+        infer_schema_sql = f"SELECT COLUMN_NAME, TYPE FROM table(infer_schema(location=>'@{stage_location}', file_format=>'{file_format_location}'))"
+        column_type_mapping = dict(
+            cursor.execute(infer_schema_sql, _is_internal=True).fetchall()
+        )
+        create_table_columns = ", ".join(
+            [
+                f"{quote}{snowflake_col}{quote} {column_type_mapping[col]}"
+                for snowflake_col, col in zip(
+                    snowflake_column_names, table.schema.names
+                )
+            ]
+        )
+
+        target_table_location = build_location_helper(
+            database,
+            schema,
+            random_name_for_temp_object(TempObjectType.TABLE)
+            if (overwrite and auto_create_table)
+            else table_name,
+            quote_identifiers,
+        )
+
+        create_table_sql = (
+            f"CREATE {table_type.upper()} TABLE IF NOT EXISTS {target_table_location} "
+            f"({create_table_columns})"
+            f" /* Python:snowflake.snowpark._internal.analyzer.analyzer_utils.write_arrow() */ "
+        )
+        cursor.execute(create_table_sql, _is_internal=True)
+        parquet_columns = "$1:" + ",$1:".join(
+            f"{quote}{snowflake_col}{quote}::{column_type_mapping[col]}"
+            for snowflake_col, col in zip(snowflake_column_names, table.schema.names)
+        )
+    else:
+        target_table_location = build_location_helper(
+            database=database,
+            schema=schema,
+            name=table_name,
+            quote_identifiers=quote_identifiers,
+        )
+        parquet_columns = "$1:" + ",$1:".join(
+            f"{quote}{snowflake_col}{quote}" for snowflake_col in snowflake_column_names
+        )
+
+    try:
+        if overwrite and (not auto_create_table):
+            truncate_sql = f"TRUNCATE TABLE {target_table_location} /* Python:snowflake.snowpark._internal.analyzer.analyzer_utils.write_arrow() */"
+            cursor.execute(truncate_sql, _is_internal=True)
+
+        copy_into_sql = (
+            f"COPY INTO {target_table_location} /* Python:snowflake.snowpark._internal.analyzer.analyzer_utils.write_arrow() */ "
+            f"({columns}) "
+            f"FROM (SELECT {parquet_columns} FROM @{stage_location}) "
+            f"FILE_FORMAT=("
+            f"TYPE=PARQUET "
+            f"COMPRESSION={compression_map[compression]}"
+            f"{' BINARY_AS_TEXT=FALSE' if auto_create_table or overwrite else ''}"
+            f"{sql_use_logical_type}"
+            f") "
+            f"PURGE=TRUE ON_ERROR={on_error}"
+        )
+        copy_results = cursor.execute(copy_into_sql, _is_internal=True).fetchall()
+
+        if overwrite and auto_create_table:
+            original_table_location = build_location_helper(
+                database=database,
+                schema=schema,
+                name=table_name,
+                quote_identifiers=quote_identifiers,
+            )
+            drop_object(original_table_location, "table")
+            rename_table_sql = f"ALTER TABLE {target_table_location} RENAME TO {original_table_location} /* Python:snowflake.snowpark._internal.analyzer.analyzer_utils.write_arrow() */"
+            cursor.execute(rename_table_sql, _is_internal=True)
+    except ProgrammingError:
+        if overwrite and auto_create_table:
+            # drop table only if we created a new one with a random name
+            drop_object(target_table_location, "table")
+        raise
+    finally:
+        cursor.close()
+
+    return (
+        all(e[1] == "LOADED" for e in copy_results),
+        len(copy_results),
+        sum(int(e[3]) for e in copy_results),
+        copy_results,
+    )

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1711,7 +1711,7 @@ def write_arrow(
     with all of the COPY INTO command's output for debugging purposes.
 
     Args:
-        cursor: Snowflak connector cursor used to execute queries.
+        cursor: Snowflake connector cursor used to execute queries.
         table: The pyarrow Table that is written.
         table_name: Table name where we want to insert into.
         database: Database schema and table is in, if not provided the default one will be used (Default value = None).

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1737,7 +1737,7 @@ def write_arrow(
             set use_logical_type as True. Set to None to use Snowflakes default. For more information, see:
             https://docs.snowflake.com/en/sql-reference/sql/create-file-format
     """
-    # This function mostly copies the functionality of snowflake.connector.pandas_utils.write_pandas.
+    # SNOW-1904593: This function mostly copies the functionality of snowflake.connector.pandas_utils.write_pandas.
     # It should be pushed down into the connector, but would require a minimum required version bump.
     import pyarrow.parquet  # type: ignore
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1752,7 +1752,7 @@ def write_arrow(
         )
 
     if table_type and table_type.lower() not in ["temp", "temporary", "transient"]:
-        raise ValueError(
+        raise ProgrammingError(
             "Unsupported table type. Expected table types: temp/temporary, transient"
         )
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1685,12 +1685,12 @@ def write_arrow(
     use_logical_type: Optional[bool] = None,
     use_scoped_temp_object: bool = False,
     **kwargs: Any,
-) -> tuple[
+) -> Tuple[
     bool,
     int,
     int,
     Sequence[
-        tuple[
+        Tuple[
             str,
             str,
             int,

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -739,10 +739,11 @@ class ServerConnection:
                             final_query = final_query.replace(holder, id_)
                         if i == len(main_queries) - 1 and dataframe_ast:
                             kwargs[DATAFRAME_AST_PARAMETER] = dataframe_ast
+                        is_final_query = i == len(main_queries) - 1
                         result = self.run_query(
                             final_query,
                             to_pandas,
-                            to_iter and (i == len(main_queries) - 1),
+                            to_iter and is_final_query,
                             is_ddl_on_temp_object=query.is_ddl_on_temp_object,
                             block=not is_last,
                             data_type=data_type,
@@ -752,7 +753,7 @@ class ServerConnection:
                             params=query.params,
                             ignore_results=ignore_results,
                             async_post_actions=post_actions,
-                            to_arrow=to_arrow,
+                            to_arrow=to_arrow and is_final_query,
                             **kwargs,
                         )
                         placeholders[query.query_id_place_holder] = (

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -489,6 +489,7 @@ class ServerConnection:
         num_statements: Optional[int] = None,
         ignore_results: bool = False,
         async_post_actions: Optional[List[Query]] = None,
+        to_arrow: bool = False,
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncJob]:
         try:
@@ -524,7 +525,10 @@ class ServerConnection:
             if ignore_results:
                 return {"data": None, "sfqid": results_cursor.sfqid}
             return self._to_data_or_iter(
-                results_cursor=results_cursor, to_pandas=to_pandas, to_iter=to_iter
+                results_cursor=results_cursor,
+                to_pandas=to_pandas,
+                to_iter=to_iter,
+                to_arrow=to_arrow,
             )
         else:
             return AsyncJob(
@@ -544,6 +548,7 @@ class ServerConnection:
         results_cursor: SnowflakeCursor,
         to_pandas: bool = False,
         to_iter: bool = False,
+        to_arrow: bool = False,
     ) -> Dict[str, Any]:
         qid = results_cursor.sfqid
         if to_iter:
@@ -576,6 +581,12 @@ class ServerConnection:
                 raise SnowparkClientExceptionMessages.SERVER_FAILED_FETCH_PANDAS(
                     str(ex)
                 )
+        elif to_arrow:
+            data_or_iter = (
+                results_cursor.fetch_arrow_batches()
+                if to_iter
+                else results_cursor.fetch_arrow_all(True)
+            )
         else:
             data_or_iter = (
                 iter(results_cursor) if to_iter else results_cursor.fetchall()
@@ -588,6 +599,7 @@ class ServerConnection:
         plan: SnowflakePlan,
         to_pandas: bool = False,
         to_iter: bool = False,
+        to_arrow: bool = False,
         block: bool = True,
         data_type: _AsyncResultType = _AsyncResultType.ROW,
         log_on_exception: bool = False,
@@ -615,10 +627,11 @@ class ServerConnection:
             data_type=data_type,
             log_on_exception=log_on_exception,
             case_sensitive=case_sensitive,
+            to_arrow=to_arrow,
         )
         if not block:
             return result_set
-        elif to_pandas:
+        elif to_pandas or to_arrow:
             return result_set["data"]
         else:
             if to_iter:
@@ -641,6 +654,7 @@ class ServerConnection:
         log_on_exception: bool = False,
         case_sensitive: bool = True,
         ignore_results: bool = False,
+        to_arrow: bool = False,
         **kwargs,
     ) -> Tuple[
         Dict[
@@ -698,6 +712,7 @@ class ServerConnection:
                     params=params,
                     ignore_results=ignore_results,
                     async_post_actions=post_actions,
+                    to_arrow=to_arrow,
                     **kwargs,
                 )
 
@@ -737,6 +752,7 @@ class ServerConnection:
                             params=query.params,
                             ignore_results=ignore_results,
                             async_post_actions=post_actions,
+                            to_arrow=to_arrow,
                             **kwargs,
                         )
                         placeholders[query.query_id_place_holder] = (

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1125,6 +1125,8 @@ class DataFrame:
 
         When the data is too large to fit into memory, you can use :meth:`to_arrow_batches`.
 
+        This function requires the optional dependenct snowflake-snowpark-python[pandas] be installed.
+
         Args:
             statement_params: Dictionary of statement level parameters to be set while executing this action.
             block: A bool value indicating whether this function will wait until the result is available.

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1110,6 +1110,79 @@ class DataFrame:
             **kwargs,
         )
 
+    @experimental(version="1.27.0")
+    def to_arrow(
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        block: bool = True,
+        _emit_ast: bool = True,
+        **kwargs: Dict[str, Any],
+    ):
+        """
+        Executes the query representing this DataFrame and returns the result as a
+        `pyarrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`.
+
+        When the data is too large to fit into memory, you can use :meth:`to_arrow_batches`.
+
+        Args:
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
+            block: A bool value indicating whether this function will wait until the result is available.
+                When it is ``False``, this function executes the underlying queries of the dataframe
+                asynchronously and returns an :class:`AsyncJob`.
+        """
+        return self._session._conn.execute(
+            self._plan,
+            to_pandas=False,
+            to_iter=False,
+            to_arrow=True,
+            block=block,
+            _statement_params=create_or_update_statement_params_with_query_tag(
+                statement_params or self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
+            ),
+            **kwargs,
+        )
+
+    @experimental(version="1.27.0")
+    def to_arrow_batches(
+        self,
+        *,
+        statement_params: Optional[Dict[str, str]] = None,
+        block: bool = True,
+        _emit_ast: bool = True,
+        **kwargs: Dict[str, Any],
+    ):
+        """
+        Executes the query representing this DataFrame and returns an iterator of
+        pyarrow Tables (containing a subset of rows) that you can use to
+        retrieve the results.
+
+        Unlike :meth:`to_arrow`, this method does not load all data into memory
+        at once.
+
+        Args:
+            statement_params: Dictionary of statement level parameters to be set while executing this action.
+            block: A bool value indicating whether this function will wait until the result is available.
+                When it is ``False``, this function executes the underlying queries of the dataframe
+                asynchronously and returns an :class:`AsyncJob`.
+        """
+        return self._session._conn.execute(
+            self._plan,
+            to_pandas=False,
+            to_iter=True,
+            to_arrow=True,
+            block=block,
+            data_type=_AsyncResultType.ITERATOR,
+            _statement_params=create_or_update_statement_params_with_query_tag(
+                statement_params or self._statement_params,
+                self._session.query_tag,
+                SKIP_LEVELS_TWO,
+            ),
+            **kwargs,
+        )
+
     @df_api_usage
     @publicapi
     def to_df(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2799,7 +2799,8 @@ class Session:
             overwrite=overwrite,
             table_type=table_type,
             use_logical_type=use_logical_type,
-            use_scoped_temp_object=self._use_scoped_temp_objects,
+            use_scoped_temp_object=self._use_scoped_temp_objects
+            and is_in_stored_procedure(),
         )
 
         if success:

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -38,11 +38,14 @@ import pkg_resources
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.context as context
 from snowflake.connector import ProgrammingError, SnowflakeConnection
-from snowflake.connector.options import installed_pandas, pandas
+from snowflake.connector.options import installed_pandas, pandas, pyarrow
 from snowflake.connector.pandas_tools import write_pandas
 from snowflake.snowpark._internal.analyzer import analyzer_utils
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
-from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
+from snowflake.snowpark._internal.analyzer.analyzer_utils import (
+    result_scan_statement,
+    write_arrow,
+)
 from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql
 from snowflake.snowpark._internal.analyzer.expression import Attribute
 from snowflake.snowpark._internal.analyzer.select_statement import (
@@ -2712,6 +2715,100 @@ class Session:
                 self._session_stage = full_qualified_stage_name
         return f"{STAGE_PREFIX}{self._session_stage}"
 
+    @experimental(version="1.27.0")
+    def write_arrow(
+        self,
+        table: "pyarrow.Table",
+        table_name: str,
+        *,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        chunk_size: Optional[int] = WRITE_PANDAS_CHUNK_SIZE,
+        compression: str = "gzip",
+        on_error: str = "abort_statement",
+        parallel: int = 4,
+        quote_identifiers: bool = True,
+        auto_create_table: bool = False,
+        overwrite: bool = False,
+        table_type: Literal["", "temp", "temporary", "transient"] = "",
+        use_logical_type: Optional[bool] = None,
+        _emit_ast: bool = True,
+        **kwargs: Dict[str, Any],
+    ) -> Table:
+        """Writes a pyarrow.Table to a Snowflake table.
+
+        The pyarrow Table is written out to temporary files, uploaded to a temporary stage, and then copied into the final location.
+
+        Returns a Snowpark Table that references the table referenced by table_name.
+
+        Args:
+            table: The pyarrow Table that is written.
+            table_name: Table name where we want to insert into.
+            database: Database schema and table is in, if not provided the default one will be used (Default value = None).
+            schema: Schema table is in, if not provided the default one will be used (Default value = None).
+            chunk_size: Number of elements to be inserted in each batch, if not provided all elements will be dumped
+                (Default value = None).
+            compression: The compression used on the Parquet files, can only be gzip, or snappy. Gzip gives a
+                better compression, while snappy is faster. Use whichever is more appropriate (Default value = 'gzip').
+            on_error: Action to take when COPY INTO statements fail, default follows documentation at:
+                https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
+                (Default value = 'abort_statement').
+            parallel: Number of threads to be used when uploading chunks, default follows documentation at:
+                https://docs.snowflake.com/en/sql-reference/sql/put.html#optional-parameters (Default value = 4).
+            quote_identifiers: By default, identifiers, specifically database, schema, table and column names
+                (from df.columns) will be quoted. If set to False, identifiers are passed on to Snowflake without quoting.
+                I.e. identifiers will be coerced to uppercase by Snowflake.  (Default value = True)
+            auto_create_table: When true, will automatically create a table with corresponding columns for each column in
+                the passed in DataFrame. The table will not be created if it already exists
+            table_type: The table type of to-be-created table. The supported table types include ``temp``/``temporary``
+                and ``transient``. Empty means permanent table as per SQL convention.
+            use_logical_type: Boolean that specifies whether to use Parquet logical types. With this file format option,
+                Snowflake can interpret Parquet logical types during data loading. To enable Parquet logical types,
+                set use_logical_type as True. Set to None to use Snowflakes default. For more information, see:
+                https://docs.snowflake.com/en/sql-reference/sql/create-file-format
+        """
+        cursor = self._conn._conn.cursor()
+
+        if quote_identifiers:
+            location = (
+                (('"' + database + '".') if database else "")
+                + (('"' + schema + '".') if schema else "")
+                + ('"' + table_name + '"')
+            )
+        else:
+            location = (
+                (database + "." if database else "")
+                + (schema + "." if schema else "")
+                + (table_name)
+            )
+
+        success, _, _, ci_output = write_arrow(
+            cursor=cursor,
+            table=table,
+            table_name=table_name,
+            database=database,
+            schema=schema,
+            chunk_size=chunk_size,
+            compression=compression,
+            on_error=on_error,
+            parallel=parallel,
+            quote_identifiers=quote_identifiers,
+            auto_create_table=auto_create_table,
+            overwrite=overwrite,
+            table_type=table_type,
+            use_logical_type=use_logical_type,
+            use_scoped_temp_object=self._use_scoped_temp_objects,
+        )
+
+        if success:
+            table = self.table(location, _emit_ast=False)
+            set_api_call_source(table, "Session.write_arrow")
+            return table
+        else:
+            raise SnowparkSessionException(
+                f"Failed to write arrow table to Snowflake. COPY INTO output {ci_output}"
+            )
+
     def _write_modin_pandas_helper(
         self,
         df: Union[
@@ -3051,7 +3148,7 @@ class Session:
     @publicapi
     def create_dataframe(
         self,
-        data: Union[List, Tuple, "pandas.DataFrame"],
+        data: Union[List, Tuple, "pandas.DataFrame", "pyarrow.Table"],
         schema: Optional[Union[StructType, Iterable[str], str]] = None,
         _emit_ast: bool = True,
     ) -> DataFrame:
@@ -3125,7 +3222,10 @@ class Session:
 
         if not isinstance(data, (list, tuple)) and (
             not installed_pandas
-            or (installed_pandas and not isinstance(data, pandas.DataFrame))
+            or (
+                installed_pandas
+                and not isinstance(data, (pandas.DataFrame, pyarrow.Table))
+            )
         ):
             raise TypeError(
                 "create_dataframe() function only accepts data as a list, tuple or a pandas DataFrame."
@@ -3135,7 +3235,7 @@ class Session:
         # Warn user to acknowledge this.
         if (
             installed_pandas
-            and isinstance(data, pandas.DataFrame)
+            and isinstance(data, (pandas.DataFrame, pyarrow.Table))
             and schema is not None
         ):
             warnings.warn(
@@ -3147,7 +3247,7 @@ class Session:
         # check to see if it is a pandas DataFrame and if so, write that to a temp
         # table and return as a DataFrame
         origin_data = data
-        if installed_pandas and isinstance(data, pandas.DataFrame):
+        if installed_pandas and isinstance(data, (pandas.DataFrame, pyarrow.Table)):
             temp_table_name = escape_quotes(
                 random_name_for_temp_object(TempObjectType.TABLE)
             )
@@ -3160,17 +3260,30 @@ class Session:
                 )
                 sf_schema = self._conn._get_current_parameter("schema", quoted=False)
 
-                table = self.write_pandas(
-                    data,
-                    temp_table_name,
-                    database=sf_database,
-                    schema=sf_schema,
-                    quote_identifiers=True,
-                    auto_create_table=True,
-                    table_type="temporary",
-                    use_logical_type=self._use_logical_type_for_create_df,
-                )
-                set_api_call_source(table, "Session.create_dataframe[pandas]")
+                if isinstance(data, pyarrow.Table):
+                    table = self.write_arrow(
+                        data,
+                        temp_table_name,
+                        database=sf_database,
+                        schema=sf_schema,
+                        quote_identifiers=True,
+                        auto_create_table=True,
+                        table_type="temporary",
+                        use_logical_type=self._use_logical_type_for_create_df,
+                    )
+                    set_api_call_source(table, "Session.create_dataframe[arrow]")
+                else:
+                    table = self.write_pandas(
+                        data,
+                        temp_table_name,
+                        database=sf_database,
+                        schema=sf_schema,
+                        quote_identifiers=True,
+                        auto_create_table=True,
+                        table_type="temporary",
+                        use_logical_type=self._use_logical_type_for_create_df,
+                    )
+                    set_api_call_source(table, "Session.create_dataframe[pandas]")
 
                 if _emit_ast:
                     stmt = self._ast_batch.assign()

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2739,6 +2739,8 @@ class Session:
 
         The pyarrow Table is written out to temporary files, uploaded to a temporary stage, and then copied into the final location.
 
+        This function requires the optional dependenct snowflake-snowpark-python[pandas] be installed.
+
         Returns a Snowpark Table that references the table referenced by table_name.
 
         Args:

--- a/tests/integ/test_df_to_arrow.py
+++ b/tests/integ/test_df_to_arrow.py
@@ -301,6 +301,10 @@ def test_misc_settings(
             assert any(re.match(query, call.args[0]) for call in execute.call_args_list)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 def test_write_arrow_negative(session, basic_arrow_table):
     with pytest.raises(
         ProgrammingError,

--- a/tests/integ/test_df_to_arrow.py
+++ b/tests/integ/test_df_to_arrow.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+import re
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Iterator
+from unittest import mock
+
+from snowflake.connector.errors import ProgrammingError
+
+from snowflake.snowpark._internal.analyzer.analyzer_utils import write_arrow
+from snowflake.snowpark.functions import col
+from snowflake.snowpark.row import Row
+from snowflake.snowpark.types import DecimalType
+
+from tests.utils import TestData, Utils
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pytest.skip("pyarrow is not available", allow_module_level=True)
+
+
+class ReMatch(str):
+    def __eq__(self, other):
+        return re.match(str(self), other) is not None
+
+
+@pytest.fixture(scope="module")
+def basic_arrow_table():
+    yield pa.Table.from_arrays([[1, 2, 3]], names=["a"])
+
+
+@pytest.fixture(scope="module")
+def arrow_table():
+    yield pa.Table.from_arrays(
+        [[1, 2, 3], ["a", "b", "c"], [1.0, 1.11, 0]], names=["A", "B", "C"]
+    )
+
+
+@pytest.mark.parametrize(
+    "example,expected",
+    [
+        (TestData.integer1, {"A": [1, 2, 3]}),
+        (
+            TestData.null_data1,
+            {"A": [None, Decimal("2"), Decimal("1"), Decimal("3"), None]},
+        ),
+        (
+            TestData.double1,
+            {"A": [Decimal("1.111"), Decimal("2.222"), Decimal("3.333")]},
+        ),
+        (TestData.string1, {"A": ["test1", "test2", "test3"], "B": ["a", "b", "c"]}),
+        pytest.param(
+            TestData.array1,
+            {
+                "ARR1": ["[\n  1,\n  2,\n  3\n]", "[\n  6,\n  7,\n  8\n]"],
+                "ARR2": ["[\n  3,\n  4,\n  5\n]", "[\n  9,\n  0,\n  1\n]"],
+            },
+            id="semi-structured array",
+        ),
+        pytest.param(
+            TestData.object2,
+            {
+                "OBJ": [
+                    '{\n  "age": 21,\n  "name": "Joe",\n  "zip": 21021\n}',
+                    '{\n  "age": 26,\n  "name": "Jay",\n  "zip": 94021\n}',
+                ],
+                "K": ["age", "key"],
+                "V": [Decimal("0"), Decimal("0")],
+                "FLAG": [True, False],
+            },
+            id="semi-structured object",
+        ),
+        (
+            TestData.datetime_primitives2,
+            {
+                "TIMESTAMP": [
+                    datetime(9999, 12, 31, 0, 0, 0, 123456),
+                    datetime(1583, 1, 1, 23, 59, 59, 567890),
+                ]
+            },
+        ),
+        (
+            TestData.date1,
+            {
+                "A": [date(2020, 8, 1), date(2010, 12, 1)],
+                "B": [Decimal("1"), Decimal("2")],
+            },
+        ),
+    ],
+)
+def test_to_arrow(session, example, expected):
+    df = example(session)
+    # Compare as python dict in order to avoid precision differences
+    assert df.to_arrow().to_pydict() == expected
+
+
+def test_to_arrow_decimal_precision(session):
+    data = [
+        [1111111111111111111, 222222222222222222],
+        [3333333333333333333, 444444444444444444],
+        [5555555555555555555, 666666666666666666],
+        [7777777777777777777, 888888888888888888],
+        [9223372036854775807, 111111111111111111],
+        [2222222222222222222, 333333333333333333],
+        [4444444444444444444, 555555555555555555],
+        [6666666666666666666, 777777777777777777],
+        [-9223372036854775808, 999999999999999999],
+    ]
+    df = session.create_dataframe(data, schema=["A", "B"],).select(
+        col("A").cast(DecimalType(38, 0)).alias("A"),
+        col("B").cast(DecimalType(18, 0)).alias("B"),
+    )
+
+    padf = df.to_arrow()
+    assert str(padf.schema[0].type) == "decimal128(38, 0)"
+    assert str(padf.schema[1].type) == "int64"
+    assert [[int(x) for x in y.values()] for y in padf.to_pylist()] == data
+
+
+def test_to_pandas_batches(session):
+    df = session.range(100000).cache_result()
+    iterator = df.to_arrow_batches()
+    assert isinstance(iterator, Iterator)
+
+    padf = df.to_arrow()
+    padf_list = list(iterator)
+    assert len(padf_list) > 1
+    assert pa.concat_tables(padf_list) == padf
+
+
+def test_create_dataframe_round_trip(session):
+    # Create a basic dataframe
+    df = session.create_dataframe([(1,), (2,), (3,)], schema=["A"])
+
+    # Convert to arrow Table
+    table = df.to_arrow()
+
+    # create df from arrow table
+    df2 = session.create_dataframe(table)
+
+    # Round trip should result in the same df
+    Utils.check_answer(df, df2)
+
+
+def test_write_arrow_overwrite_auto_create(session, basic_arrow_table):
+    table_name = Utils.random_table_name()
+    try:
+        # Initial auto_create should create the table and have three rows
+        session.write_arrow(basic_arrow_table, table_name, auto_create_table=True)
+        table1 = session.table(table_name)
+        Utils.check_answer(table1, [Row(1), Row(2), Row(3)])
+
+        # Second auto_create should just append to now existing table
+        session.write_arrow(basic_arrow_table, table_name, auto_create_table=True)
+        table2 = session.table(table_name)
+        Utils.check_answer(table2, [Row(1), Row(2), Row(3), Row(1), Row(2), Row(3)])
+
+        # Third auto_create should truncate existing table and replace rows
+        session.write_arrow(
+            basic_arrow_table, table_name, auto_create_table=True, overwrite=True
+        )
+        table3 = session.table(table_name)
+        Utils.check_answer(table3, [Row(1), Row(2), Row(3)])
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+@pytest.mark.parametrize("table_type", ["", "TEMPORARY", "TRANSIENT"])
+def test_write_arrow_table_type(session, arrow_table, table_type):
+    table_name = Utils.random_table_name()
+    try:
+        session.write_arrow(
+            arrow_table, table_name, auto_create_table=True, table_type=table_type
+        )
+        table_type = table_type or "replace TABLE"
+        ddl = session._run_query(f"select get_ddl('table', '{table_name}')")
+        assert table_type in ddl[0][0]
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+def test_write_arrow_chunk_size(session):
+    table_name = Utils.random_table_name()
+    try:
+        # create medium sized df that can be chunked
+        df = session.range(101)
+        table = df.to_arrow()
+        success, num_chunks, num_rows, _ = write_arrow(
+            session._conn._conn.cursor(),
+            table,
+            table_name,
+            auto_create_table=True,
+            chunk_size=25,
+        )
+        assert success
+        # 25 rows per chunk = 5 chunks
+        assert num_chunks == 5
+        # All rows should have been inserted
+        assert num_rows == 101
+    finally:
+        Utils.drop_table(session, table_name)
+
+
+@pytest.mark.parametrize("quote_identifiers", [True, False])
+def test_write_arrow_alternate_schema(session, basic_arrow_table, quote_identifiers):
+    db = session.get_current_database().strip('"')
+    table_name = Utils.random_table_name()
+    schema_name = (
+        "SNOWPARK_PYTHON_TEST_WRITE_ARROW_" + Utils.random_alphanumeric_str(4).upper()
+    )
+    try:
+        Utils.create_schema(session, schema_name)
+        table = session.write_arrow(
+            basic_arrow_table,
+            table_name,
+            database=db,
+            schema=schema_name,
+            auto_create_table=True,
+            quote_identifiers=quote_identifiers,
+        )
+        if quote_identifiers:
+            assert table.table_name == f'"{db}"."{schema_name}"."{table_name}"'
+            assert table.columns == ['"a"']
+        else:
+            assert table.table_name == f"{db}.{schema_name}.{table_name}"
+            assert table.columns == ["A"]
+    finally:
+        Utils.drop_table(session, table_name)
+        Utils.drop_schema(session, schema_name)
+
+
+@pytest.mark.parametrize(
+    "compression,parallel,use_logical_type,on_error",
+    [
+        ("gzip", 2, None, "SKIP_FILE"),
+        ("snappy", 3, True, "CONTINUE"),
+        ("gzip", 4, False, "ABORT_STATEMENT"),
+    ],
+)
+def test_misc_settings(
+    session, arrow_table, compression, parallel, use_logical_type, on_error
+):
+    copy_compression = {"gzip": "auto", "snappy": "snappy"}[compression]
+    sql_use_logical_type = (
+        "" if use_logical_type is None else f" USE_LOGICAL_TYPE = {use_logical_type}"
+    )
+    calls = [
+        f"^CREATE SCOPED TEMPORARY STAGE .* FILE_FORMAT=\\(TYPE=PARQUET COMPRESSION={compression}\\)",
+        f"PUT.*SNOWPARK_TEMP_STAGE_.*PARALLEL={parallel}",
+        f'COPY INTO "SNOWPARK_PYTHON_MOCKED_ARROW_TABLE" .* FILE_FORMAT=\\(TYPE=PARQUET COMPRESSION={copy_compression}{sql_use_logical_type.upper()}\\) PURGE=TRUE ON_ERROR={on_error}',
+    ]
+
+    with mock.patch("snowflake.connector.cursor.SnowflakeCursor.execute") as execute:
+        session.write_arrow(
+            arrow_table,
+            "SNOWPARK_PYTHON_MOCKED_ARROW_TABLE",
+            compression=compression,
+            parallel=parallel,
+            use_logical_type=use_logical_type,
+            on_error=on_error,
+        )
+        execute.assert_has_calls(
+            [mock.call(ReMatch(call), _is_internal=True) for call in calls],
+            any_order=True,
+        )
+
+
+def test_write_arrow_negative(session, basic_arrow_table):
+    with pytest.raises(
+        ProgrammingError,
+        match="Schema has to be provided to write_arrow when a database is provided",
+    ):
+        session.write_arrow(basic_arrow_table, "temp_table", database="foo")

--- a/tests/integ/test_df_to_arrow.py
+++ b/tests/integ/test_df_to_arrow.py
@@ -335,6 +335,14 @@ def test_write_arrow_negative(session, basic_arrow_table):
     ):
         session.write_arrow(basic_arrow_table, table_name)
 
+    # Truncate does not cause a table to be auto-generated
+    table_name = Utils.random_table_name()
+    with pytest.raises(
+        ProgrammingError,
+        match="^.*SQL compilation error:\nTable .* does not exist",
+    ):
+        session.write_arrow(basic_arrow_table, table_name, overwrite=True)
+
     with mock.patch(
         "snowflake.snowpark.session.write_arrow",
         return_value=(False, 0, 0, "<output here>"),

--- a/tests/integ/test_df_to_arrow.py
+++ b/tests/integ/test_df_to_arrow.py
@@ -43,6 +43,10 @@ def arrow_table():
     )
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 @pytest.mark.parametrize(
     "example,expected",
     [
@@ -101,6 +105,10 @@ def test_to_arrow(session, example, expected):
     assert df.to_arrow().to_pydict() == expected
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 def test_to_arrow_decimal_precision(session):
     data = [
         [1111111111111111111, 222222222222222222],
@@ -124,7 +132,11 @@ def test_to_arrow_decimal_precision(session):
     assert [[int(x) for x in y.values()] for y in padf.to_pylist()] == data
 
 
-def test_to_pandas_batches(session):
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
+def test_to_arrow_batches(session):
     df = session.range(100000).cache_result()
     iterator = df.to_arrow_batches()
     assert isinstance(iterator, Iterator)
@@ -149,6 +161,10 @@ def test_create_dataframe_round_trip(session):
     Utils.check_answer(df, df2)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 def test_write_arrow_overwrite_auto_create(session, basic_arrow_table):
     table_name = Utils.random_table_name()
     try:
@@ -172,6 +188,10 @@ def test_write_arrow_overwrite_auto_create(session, basic_arrow_table):
         Utils.drop_table(session, table_name)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 @pytest.mark.parametrize("table_type", ["", "TEMPORARY", "TRANSIENT"])
 def test_write_arrow_table_type(session, arrow_table, table_type):
     table_name = Utils.random_table_name()
@@ -186,6 +206,10 @@ def test_write_arrow_table_type(session, arrow_table, table_type):
         Utils.drop_table(session, table_name)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 def test_write_arrow_chunk_size(session):
     table_name = Utils.random_table_name()
     try:
@@ -208,6 +232,10 @@ def test_write_arrow_chunk_size(session):
         Utils.drop_table(session, table_name)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
 @pytest.mark.parametrize("quote_identifiers", [True, False])
 def test_write_arrow_alternate_schema(session, basic_arrow_table, quote_identifiers):
     db = session.get_current_database().strip('"')


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1846317

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR adds new methods `to_arrow` and `to_arrow_batches` to DataFrames. This methods converts the DataFrame to a local pyarrow Table. They work similarly to `to_pandas` and `to_pandas_batches` without having to pass through pandas.

  Additionally this PR adds support for `session.write_arrow` which allows writing a pyarrow Table to a snowflake table with similar configuration options to that given by `sesison.write_pandas`. The bulk of this functionality should probably be pushed down into the connector, but that will cause some dependency issues.