### PR TITLE
SNOW-1901507: Fix non-nullable struct type schema expressions

### DIFF
--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1568,6 +1568,10 @@ def test_cast_structtype_add(structured_type_session, structured_type_support):
         )
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="Structured types are not supported in Local Testing",
+)
 def test_non_nullable_schema(structured_type_session, structured_type_support):
     if not structured_type_support:
         pytest.skip("Test requires structured type support.")

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1566,3 +1566,32 @@ def test_cast_structtype_add(structured_type_session, structured_type_support):
             .as_("new_name"),
             col("dob"),
         )
+
+
+def test_non_nullable_schema(structured_type_session, structured_type_support):
+    if not structured_type_support:
+        pytest.skip("Test requires structured type support.")
+
+    schema = StructType(
+        [
+            StructField(
+                "struct",
+                StructType(
+                    [
+                        StructField("name", StringType(), True),
+                        StructField("age", IntegerType(), True),
+                    ]
+                ),
+                False,
+            )
+        ]
+    )
+    df = structured_type_session.createDataFrame(
+        [({"name": "Alice", "age": 2},), ({"name": "Bob", "age": 5},)], schema
+    )
+    assert df._format_schema() == (
+        "root\n"
+        ' |-- "STRUCT": StructType (nullable = True)\n'
+        ' |   |-- "name": StringType() (nullable = True)\n'
+        ' |   |-- "age": LongType() (nullable = True)'
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1901507

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR fixes an issue with `Session.create_dataframe` calls that would require a temp table creation. The issue caused incorrect schema_query generation when creating dataframes with non-nullable structured type columns. This was due to the temp table being created with a structured schema, but the schema query was expecting a string field instead.

  This PR fixes the problem by deferring temp table creation until after the schema attributes have been modified to account for data serialization. I've added a test that provides a scenario that would have thrown a sql exception previously.