### PR TITLE
SNOW-1914374 Capture the AST unparser STDERR on failure

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -4,6 +4,7 @@
 syntax = "proto3";
 
 option java_package = "com.snowflake.snowpark.proto";
+option java_outer_classname = "JavaProto";
 
 package ast;
 

--- a/tests/ast/ast_test_utils.py
+++ b/tests/ast/ast_test_utils.py
@@ -29,6 +29,13 @@ SUPPRESS_AST_LISTENER_REENTRY = False
 VALIDATION_QUERY_RECORD = None
 
 
+class UnparserInvocationError(Exception):
+    def __init__(self, error_output: str) -> None:
+        super().__init__(
+            f"The unparser invocation failed. STDERR contents: \n{error_output}"
+        )
+
+
 def render(ast_base64: Union[str, List[str]], unparser_jar: Optional[str]) -> str:
     """Uses the unparser to render the AST."""
     assert (
@@ -38,22 +45,27 @@ def render(ast_base64: Union[str, List[str]], unparser_jar: Optional[str]) -> st
     if isinstance(ast_base64, str):
         ast_base64 = [ast_base64]
 
-    res = subprocess.run(
-        [
-            "java",
-            "-cp",
-            unparser_jar,
-            "com.snowflake.snowpark.unparser.UnparserCli",
-            ",".join(
-                ast_base64
-            ),  # base64 strings will not contain , so pass multiple batches comma-separated.
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-    return res.stdout
+    try:
+        res = subprocess.run(
+            [
+                "java",
+                "-cp",
+                unparser_jar,
+                "com.snowflake.snowpark.unparser.UnparserCli",
+                ",".join(
+                    ast_base64
+                ),  # base64 strings will not contain , so pass multiple batches comma-separated.
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return res.stdout
+    except subprocess.CalledProcessError as e:
+        if e.stderr is not None:
+            raise UnparserInvocationError(e.stderr) from e
+        raise
+    return ""
 
 
 def generate_error_trace_info(python_text, exception=None):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1914374

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This is a test-only change.
When the AST unparser fails, it's frequently unclear why.
Capture the STDERR of the unparser on failure and add a new exception to the exception chain. Preserve the original `CallProcessError`, as well.
