### PR TITLE
SNOW-1900040: Estimate an upper bound for row counts between operations in OrderedDataFrame

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -31,6 +31,10 @@ from snowflake.snowpark.functions import (
     sum as sum_,
 )
 from snowflake.snowpark.modin.plugin._typing import AlignTypeLit, JoinTypeLit
+from snowflake.snowpark.modin.plugin._internal.row_count_estimation import (
+    DataFrameOperation,
+    RowCountEstimator,
+)
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.table_function import TableFunctionCall
@@ -296,6 +300,8 @@ class OrderedDataFrame:
         self.row_count_snowflake_quoted_identifier = (
             row_count_snowflake_quoted_identifier
         )
+        self.row_count: Optional[int] = None
+        self.row_count_upper_bound: Optional[int] = None
 
     @property
     def ordering_columns(self) -> list[OrderingColumn]:
@@ -425,6 +431,17 @@ class OrderedDataFrame:
             *self.projected_column_snowflake_quoted_identifiers,
             count("*").over().as_(row_count_snowflake_quoted_identifier),
         )
+
+        # Get the row count from the underlying Snowpark dataframe.
+        materialized_row_count = (
+            ordered_dataframe._dataframe_ref.snowpark_dataframe.select(
+                row_count_snowflake_quoted_identifier
+            ).first()[row_count_snowflake_quoted_identifier.strip('"')]
+        )
+        # Set the row count and upper bound to the materialized row count.
+        ordered_dataframe.row_count = materialized_row_count
+        ordered_dataframe.row_count_upper_bound = materialized_row_count
+
         # inplace update so dataframe_ref can be shared. Note that we keep
         # the original ordering columns.
         ordered_dataframe.row_count_snowflake_quoted_identifier = (
@@ -626,7 +643,12 @@ class OrderedDataFrame:
                 snowpark_dataframe = self._dataframe_ref.snowpark_dataframe.select(
                     *cols
                 )
-                return OrderedDataFrame(DataFrameReference(snowpark_dataframe))
+                new_df = OrderedDataFrame(DataFrameReference(snowpark_dataframe))
+                # Update the row count upper bound
+                new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+                    self, DataFrameOperation.SELECT, args={}
+                )
+                return new_df
             elif isinstance(e, (Column, str)):
                 column_names = self._extract_quoted_identifiers_from_column_or_name(
                     e, active_columns
@@ -660,7 +682,7 @@ class OrderedDataFrame:
                 f"The Snowpark DataFrame in DataFrameReference with id={dataframe_ref._id} is updated"
             )
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             dataframe_ref,
             projected_column_snowflake_quoted_identifiers=new_projected_columns,
             # keep the original ordering columns and row position column
@@ -668,6 +690,12 @@ class OrderedDataFrame:
             row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
             row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
         )
+
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.SELECT, args={}
+        )
+        return new_df
 
     def dropna(
         self,
@@ -693,11 +721,16 @@ class OrderedDataFrame:
         result_column_quoted_identifiers = (
             projected_dataframe_ref.snowflake_quoted_identifiers
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(snowpark_dataframe, result_column_quoted_identifiers),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
             ordering_columns=self.ordering_columns,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.DROPNA, args={}
+        )
+        return new_df
 
     def union_all(self, other: "OrderedDataFrame") -> "OrderedDataFrame":
         """
@@ -720,10 +753,15 @@ class OrderedDataFrame:
         snowpark_dataframe = self_snowpark_dataframe_ref.snowpark_dataframe.union_all(
             other_snowpark_dataframe_ref.snowpark_dataframe
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(snowpark_dataframe, result_column_quoted_identifiers),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.UNION_ALL, args={"other": other}
+        )
+        return new_df
 
     def _extract_aggregation_result_column_quoted_identifiers(
         self,
@@ -775,7 +813,7 @@ class OrderedDataFrame:
             self._extract_aggregation_result_column_quoted_identifiers(*agg_exprs)
         )
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 self._dataframe_ref.snowpark_dataframe.group_by(cols).agg(*agg_exprs),
                 snowflake_quoted_identifiers=result_column_quoted_identifiers,
@@ -783,6 +821,11 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
             ordering_columns=[OrderingColumn(identifier) for identifier in cols],
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.GROUP_BY, args={}
+        )
+        return new_df
 
     def sort(
         self,
@@ -806,7 +849,7 @@ class OrderedDataFrame:
         if ordering_columns == self.ordering_columns:
             return self
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             self._to_projected_snowpark_dataframe_reference(
                 include_row_count_column=True, include_ordering_columns=True
             ),
@@ -817,6 +860,11 @@ class OrderedDataFrame:
             # No need to reset row count, since sorting should not add/drop rows.
             row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.SORT, args={}
+        )
+        return new_df
 
     def pivot(
         self,
@@ -834,7 +882,7 @@ class OrderedDataFrame:
         See detailed docstring in Snowpark DataFrame's pivot.
         """
         snowpark_dataframe = self.to_projected_snowpark_dataframe()
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             # the pivot result columns for dynamic pivot are data dependent, a schema call is required
             # to know all the quoted identifiers for the pivot result.
             DataFrameReference(
@@ -845,6 +893,11 @@ class OrderedDataFrame:
                 ).agg(*agg_exprs)
             )
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.PIVOT, args={}
+        )
+        return new_df
 
     def unpivot(
         self,
@@ -903,7 +956,7 @@ class OrderedDataFrame:
         ]
         # add the name column and value colum to the result
         result_column_quoted_identifiers += [name_column, value_column]
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 projected_dataframe_ref.snowpark_dataframe.unpivot(
                     value_column=value_column,
@@ -915,6 +968,11 @@ class OrderedDataFrame:
             ),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.UNPIVOT, args={"column_list": column_list}
+        )
+        return new_df
 
     def agg(
         self,
@@ -930,10 +988,15 @@ class OrderedDataFrame:
         result_column_quoted_identifiers = (
             self._extract_aggregation_result_column_quoted_identifiers(*exprs)
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(snowpark_dataframe, result_column_quoted_identifiers),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.AGG, args={}
+        )
+        return new_df
 
     def _deduplicate_active_column_snowflake_quoted_identifiers(
         self,
@@ -1189,13 +1252,26 @@ class OrderedDataFrame:
             # if no join needed, we simply return the deduplicated right frame with the projected columns
             # set to the left.projected_column_snowflake_quoted_identifiers and the deduplicated the right
             # projected_column_snowflake_quoted_identifiers.
-            return OrderedDataFrame(
+            new_df = OrderedDataFrame(
                 right._dataframe_ref,
                 projected_column_snowflake_quoted_identifiers=projected_column_snowflake_quoted_identifiers,
                 ordering_columns=self.ordering_columns,
                 row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
                 row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
             )
+            new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+                self,
+                DataFrameOperation.JOIN,
+                args={
+                    "left_on_cols": left_on_cols,
+                    "right_on_cols": right_on_cols,
+                    "how": how,
+                    "left_match_col": left_match_col,
+                    "right_match_col": right_match_col,
+                    "match_comparator": match_comparator,
+                },
+            )
+            return new_df
 
         # reproject the snowpark dataframe with only necessary columns
         left_snowpark_dataframe_ref = self._to_projected_snowpark_dataframe_reference(
@@ -1262,7 +1338,7 @@ class OrderedDataFrame:
         else:
             ordering_columns = self.ordering_columns + right.ordering_columns
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 snowpark_dataframe,
                 # the result of join retains column quoted identifier of both left + right
@@ -1272,6 +1348,19 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=projected_column_snowflake_quoted_identifiers,
             ordering_columns=ordering_columns,
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.JOIN,
+            args={
+                "left_on_cols": left_on_cols,
+                "right_on_cols": right_on_cols,
+                "how": how,
+                "left_match_col": left_match_col,
+                "right_match_col": right_match_col,
+                "match_comparator": match_comparator,
+            },
+        )
+        return new_df
 
     def _has_same_base_ordered_dataframe(self, other: "OrderedDataFrame") -> bool:
         """
@@ -1421,7 +1510,7 @@ class OrderedDataFrame:
                     include_row_count_column=False,
                 )
             )
-            return OrderedDataFrame(
+            new_df = OrderedDataFrame(
                 dataframe_ref=aligned_ordered_frame._dataframe_ref,
                 projected_column_snowflake_quoted_identifiers=self.projected_column_snowflake_quoted_identifiers
                 + aligned_ordered_frame.projected_column_snowflake_quoted_identifiers,
@@ -1429,6 +1518,12 @@ class OrderedDataFrame:
                 row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
                 row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
             )
+            new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+                self,
+                DataFrameOperation.ALIGN,
+                args={"right": right},
+            )
+            return new_df
 
         from snowflake.snowpark.modin.plugin._internal.join_utils import (
             JoinOrAlignOrderedDataframeResultHelper,
@@ -1731,7 +1826,13 @@ class OrderedDataFrame:
 
         # call select to make sure only the result_projected_column_snowflake_quoted_identifiers are projected
         # in the join result
-        return joined_ordered_frame.select(select_list)
+        new_df = joined_ordered_frame.select(select_list)
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.ALIGN,
+            args={"right": right},
+        )
+        return new_df
 
     def filter(self, expr: ColumnOrSqlExpr) -> "OrderedDataFrame":
         """
@@ -1744,7 +1845,7 @@ class OrderedDataFrame:
             include_ordering_columns=True
         )
         snowpark_dataframe = projected_dataframe_ref.snowpark_dataframe.filter(expr)
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 snowpark_dataframe,
                 # same columns are retained after filtering
@@ -1753,6 +1854,12 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=projected_dataframe_ref.snowflake_quoted_identifiers,
             ordering_columns=self.ordering_columns,
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.FILTER,
+            args={},
+        )
+        return new_df
 
     def limit(self, n: int, offset: int = 0, sort: bool = True) -> "OrderedDataFrame":
         """
@@ -1770,7 +1877,7 @@ class OrderedDataFrame:
         snowpark_dataframe = projected_dataframe_ref.snowpark_dataframe.limit(
             n=n, offset=offset
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 snowpark_dataframe,
                 # the same columns are retained for limit
@@ -1779,6 +1886,12 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=projected_dataframe_ref.snowflake_quoted_identifiers,
             ordering_columns=self.ordering_columns,
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.LIMIT,
+            args={"n": n},
+        )
+        return new_df
 
     @property
     def write(self) -> DataFrameWriter:
@@ -2009,7 +2122,7 @@ class OrderedDataFrame:
         # df_s = df.sample(frac=0.5)
         # assert df_s.index == df_s.index may fail because both the LHS and RHS will call the sample method during
         # evaluation and the results won't be deterministic.
-        return cache_result(
+        new_df = cache_result(
             OrderedDataFrame(
                 DataFrameReference(
                     snowpark_dataframe,
@@ -2020,3 +2133,9 @@ class OrderedDataFrame:
                 ordering_columns=self.ordering_columns,
             )
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.SAMPLE,
+            args={"n": n, "frac": frac},
+        )
+        return new_df

--- a/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+from enum import Enum
+from math import ceil
+
+if TYPE_CHECKING:
+    from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
+        OrderedDataFrame,
+    )
+
+
+class DataFrameOperation(Enum):
+    SELECT = "select"
+    DROPNA = "dropna"
+    UNION_ALL = "union_all"
+    GROUP_BY = "group_by"
+    SORT = "sort"
+    PIVOT = "pivot"
+    UNPIVOT = "unpivot"
+    AGG = "agg"
+    JOIN = "join"
+    ALIGN = "align"
+    FILTER = "filter"
+    LIMIT = "limit"
+    SAMPLE = "sample"
+
+
+class RowCountEstimator:
+    @staticmethod
+    def upper_bound(
+        df: OrderedDataFrame, operation: DataFrameOperation, args: dict[str, Any]
+    ) -> int | None:
+        """
+        Estimate the new upper bound for the row count after performing an operation
+        on the OrderedDataFrame.
+
+        Args:
+            df (OrderedDataFrame): The original dataframe on which the operation is executed
+            operation (DataFrameOperation): The transformation operation performed
+            args (dict): All arguments passed to the operation method
+
+        Returns:
+            int: The estimated upper bound on the number of rows in the resulting dataframe
+        """
+        # Get the current upper bound. If not set, return None
+        current = df.row_count_upper_bound
+        if current is None:
+            return None
+
+        # These operations preserve or reduce the row count, so we can use the current upper bound
+        if operation in {
+            DataFrameOperation.SELECT,
+            DataFrameOperation.DROPNA,
+            DataFrameOperation.GROUP_BY,
+            DataFrameOperation.SORT,
+            DataFrameOperation.PIVOT,
+            DataFrameOperation.FILTER,
+        }:
+            return current
+
+        # Union all combines the row counts of the two dataframes
+        elif operation == DataFrameOperation.UNION_ALL:
+            other: OrderedDataFrame = args["other"]
+            other_bound = other.row_count_upper_bound or other.row_count
+            if other_bound is None:
+                raise ValueError(
+                    "Cannot estimate row count: other DataFrame has no row count information."
+                )
+            return current + other_bound
+
+        # Unpivot creates a new row for each value in the column list
+        elif operation == DataFrameOperation.UNPIVOT:
+            column_list = args["column_list"]
+            return current * len(column_list)
+
+        # Agg aggregates the rows into a single row
+        elif operation == DataFrameOperation.AGG:
+            return 1
+
+        # TODO: Implement a better estimate by having cases for different join types
+        # Join can cause a Cartesian product with the row counts multiplying
+        elif operation == DataFrameOperation.JOIN:
+            right: OrderedDataFrame = args["right"]
+            right_bound = right.row_count_upper_bound or right.row_count
+            if right_bound is None:
+                raise ValueError(
+                    "Cannot estimate row count: right DataFrame has no row count information."
+                )
+            return current * right_bound
+
+        # TODO: Implement a better estimate by having cases for different align types
+        # Align can cause a Cartesian product with the row counts multiplying
+        elif operation == DataFrameOperation.ALIGN:
+            other_df: OrderedDataFrame = args["right"]
+            other_bound = other_df.row_count_upper_bound or other_df.row_count
+            if other_bound is None:
+                raise ValueError(
+                    "Cannot estimate row count: right DataFrame has no row count information."
+                )
+            return current * other_bound
+
+        # Limit sets the upper bound to n rows
+        elif operation == DataFrameOperation.LIMIT:
+            return args["n"]
+
+        # Sample can cause the row count to be set to n or reduced by a fraction
+        elif operation == DataFrameOperation.SAMPLE:
+            n, frac = args.get("n"), args.get("frac")
+            if n is not None:
+                return n
+            elif frac is not None:
+                return ceil(current * frac)
+            else:
+                raise ValueError(
+                    "Either 'n' or 'frac' must be provided for a sample operation"
+                )
+
+        else:
+            raise ValueError(f"Unsupported operation: {operation}")

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -456,6 +456,10 @@ def create_ordered_dataframe_with_readonly_temp_table(
         row_position_snowflake_quoted_identifier = (
             ordered_dataframe.row_position_snowflake_quoted_identifier
         )
+    # Set the materialized row count
+    materialized_row_count = ordered_dataframe._dataframe_ref.snowpark_dataframe.count()
+    ordered_dataframe.row_count = materialized_row_count
+    ordered_dataframe.row_count_upper_bound = materialized_row_count
     return ordered_dataframe, row_position_snowflake_quoted_identifier
 
 
@@ -1146,12 +1150,16 @@ def create_ordered_dataframe_from_pandas(
             ]
         ),
     )
-    return OrderedDataFrame(
+    ordered_df = OrderedDataFrame(
         DataFrameReference(snowpark_df, snowflake_quoted_identifiers),
         projected_column_snowflake_quoted_identifiers=snowflake_quoted_identifiers,
         ordering_columns=ordering_columns,
         row_position_snowflake_quoted_identifier=row_position_snowflake_quoted_identifier,
     )
+    # Set the materialized row count
+    ordered_df.row_count = df.shape[0]
+    ordered_df.row_count_upper_bound = df.shape[0]
+    return ordered_df
 
 
 def fill_none_in_index_labels(


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1900040

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This is a draft PR that implements a `RowCountEstimator` utility class to upper bound row the row count of a data frame after an operation.