### PR TITLE
SNOW-1916378: Remove Snowpark python functions snowflake_cortex_summarize and snowflake_cortex_sentiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Snowpark Python API Updates
 
-#### Deprecations:
+#### Removed Features:
 
-- Deprecated Snowpark Python function `snowflake_cortex_summarize`. Users can install snowflake-ml-python and use the snowflake.cortex.summarize function instead.
-- Deprecated Snowpark Python function `snowflake_cortex_sentiment`. Users can install snowflake-ml-python and use the snowflake.cortex.sentiment function instead.
+- Removed Snowpark Python function `snowflake_cortex_summarize`. Users can install snowflake-ml-python and use the snowflake.cortex.summarize function instead.
+- Removed Snowpark Python function `snowflake_cortex_sentiment`. Users can install snowflake-ml-python and use the snowflake.cortex.sentiment function instead.
 
 #### New Features
 

--- a/docs/source/snowpark/functions.rst
+++ b/docs/source/snowpark/functions.rst
@@ -310,8 +310,6 @@ Functions
     sinh
     size
     skew
-    snowflake_cortex_sentiment
-    snowflake_cortex_summarize
     sort_array
     soundex
     split

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -212,7 +212,6 @@ from snowflake.snowpark._internal.utils import (
     publicapi,
     validate_object_name,
     check_create_map_parameter,
-    deprecated,
 )
 from snowflake.snowpark.column import (
     CaseExpr,
@@ -10778,43 +10777,6 @@ def make_interval(
 
     res._ast = ast
     return res
-
-
-@deprecated(
-    version="1.28.0",
-    extra_warning_text="Please consider installing snowflake-ml-python and using `snowflake.cortex.summarize` instead.",
-    extra_doc_string="Use :meth:`snowflake.cortex.summarize` instead.",
-)
-def snowflake_cortex_summarize(text: ColumnOrLiteralStr):
-    """
-    Summarizes the given English-language input text.
-    Args:
-        text: A string containing the English text from which a summary should be generated.
-    Returns:
-        A string containing a summary of the original text.
-    """
-    sql_func_name = "snowflake.cortex.summarize"
-    text_col = _to_col_if_lit(text, sql_func_name)
-    return builtin(sql_func_name)(text_col)
-
-
-@deprecated(
-    version="1.28.0",
-    extra_warning_text="Please consider installing snowflake-ml-python and using `snowflake.cortex.sentiment` instead.",
-    extra_doc_string="Use :meth:`snowflake.cortex.sentiment` instead.",
-)
-def snowflake_cortex_sentiment(text: ColumnOrLiteralStr):
-    """
-    A string containing the text for which a sentiment score should be calculated.
-    Args:
-        text: A string containing the English text from which a summary should be generated.
-    Returns:
-        A floating-point number from -1 to 1 (inclusive) indicating the level of negative or positive sentiment in the
-        text. Values around 0 indicate neutral sentiment.
-    """
-    sql_func_name = "snowflake.cortex.sentiment"
-    text_col = _to_col_if_lit(text, sql_func_name)
-    return builtin(sql_func_name)(text_col)
 
 
 @publicapi


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1916378

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

  BCR: Remove Snowpark python functions snowflake_cortex_summarize and snowflake_cortex_sentiment since users can use functions from Cortex directly.
