### PR TITLE
SNOW-1904798: Update schema query when attributes are available

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -246,6 +246,9 @@ class Attribute(Expression, NamedExpression):
     def __str__(self):
         return self.name
 
+    def __repr__(self):
+        return f"Attribute({self.name}, {self.datatype}, {self.nullable})"
+
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return {self.name}
 

--- a/src/snowflake/snowpark/_internal/analyzer/expression.py
+++ b/src/snowflake/snowpark/_internal/analyzer/expression.py
@@ -246,9 +246,6 @@ class Attribute(Expression, NamedExpression):
     def __str__(self):
         return self.name
 
-    def __repr__(self):
-        return f"Attribute({self.name}, {self.datatype}, {self.nullable})"
-
     def dependent_column_names(self) -> Optional[AbstractSet[str]]:
         return {self.name}
 

--- a/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/metadata_utils.py
@@ -147,8 +147,8 @@ def infer_metadata(
         # If source_plan is a SelectStatement, SQL simplifier is enabled
         elif isinstance(source_plan, SelectStatement):
             # When attributes is cached on source_plan, just use it
-            if source_plan._attributes is not None:
-                attributes = source_plan._attributes
+            if source_plan.attributes is not None:
+                attributes = source_plan.attributes
             # When _column_states.projection is available, we can just use it,
             # which is either (only one happen):
             # 1) cached on self._snowflake_plan._quoted_identifiers
@@ -199,7 +199,7 @@ def cache_metadata_if_select_statement(
         isinstance(source_plan, SelectStatement)
         and source_plan._session.reduce_describe_query_enabled
     ):
-        source_plan._attributes = metadata.attributes
+        source_plan.attributes = metadata.attributes
         # When source_plan doesn't have a projection, it's a simple `SELECT * from ...`,
         # which means source_plan has the same metadata as its child plan,
         # we should cache it on the child plan too.

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -865,6 +865,16 @@ class SelectStatement(Selectable):
         return self.from_.query_params
 
     @property
+    def attributes(self) -> Optional[List[Attribute]]:
+        return self._attributes
+
+    @attributes.setter
+    def attributes(self, value: Optional[List[Attribute]]):
+        self._attributes = value
+        if self._session.reduce_describe_query_enabled and value is not None:
+            self._schema_query = analyzer_utils.schema_value_statement(value)
+
+    @property
     def schema_query(self) -> str:
         if self._schema_query:
             return self._schema_query
@@ -1190,7 +1200,7 @@ class SelectStatement(Selectable):
                 from_=self.to_subqueryable(), where=col, analyzer=self.analyzer
             )
         if self._session.reduce_describe_query_enabled:
-            new._attributes = self._attributes
+            new.attributes = self.attributes
 
         return new
 
@@ -1225,7 +1235,7 @@ class SelectStatement(Selectable):
                 analyzer=self.analyzer,
             )
         if self._session.reduce_describe_query_enabled:
-            new._attributes = self._attributes
+            new.attributes = self.attributes
 
         return new
 
@@ -1309,7 +1319,7 @@ class SelectStatement(Selectable):
             new.post_actions = new.from_.post_actions
             new._merge_projection_complexity_with_subquery = False
         if self._session.reduce_describe_query_enabled:
-            new._attributes = self._attributes
+            new.attributes = self.attributes
 
         return new
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -358,12 +358,10 @@ class SnowflakePlan(LogicalPlan):
         # We need to cache attributes on SelectStatement too because df._plan is not
         # carried over to next SelectStatement (e.g., check the implementation of df.filter()).
         cache_metadata_if_select_statement(self.source_plan, self._metadata)
-        # No simplifier case relies on this schema_query change to update SHOW TABLES to a nested sql friendly query.
-        if (
-            not self.schema_query
-            or not self.session.sql_simplifier_enabled
-            or self.session.reduce_describe_query_enabled
-        ):
+        # When the reduce_describe_query_enabled is enabled, we cache the attributes in
+        # self._metadata using original schema query. Thus we can update the schema query
+        # to simplify plans built on top of this plan.
+        if self.session.reduce_describe_query_enabled:
             self.schema_query = schema_value_statement(attributes)
         return attributes
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -361,7 +361,13 @@ class SnowflakePlan(LogicalPlan):
         # When the reduce_describe_query_enabled is enabled, we cache the attributes in
         # self._metadata using original schema query. Thus we can update the schema query
         # to simplify plans built on top of this plan.
-        if self.session.reduce_describe_query_enabled:
+        # When sql simplifier is disabled, we cannot build nested schema query for example
+        #  SELECT  *  FROM (show schemas) LIMIT 1, therefore we need to built the schema
+        # query based on the attributes.
+        if (
+            self.session.reduce_describe_query_enabled
+            or not self.session.sql_simplifier_enabled
+        ):
             self.schema_query = schema_value_statement(attributes)
         return attributes
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -359,7 +359,11 @@ class SnowflakePlan(LogicalPlan):
         # carried over to next SelectStatement (e.g., check the implementation of df.filter()).
         cache_metadata_if_select_statement(self.source_plan, self._metadata)
         # No simplifier case relies on this schema_query change to update SHOW TABLES to a nested sql friendly query.
-        if not self.schema_query or not self.session.sql_simplifier_enabled:
+        if (
+            not self.schema_query
+            or not self.session.sql_simplifier_enabled
+            or self.session.reduce_describe_query_enabled
+        ):
             self.schema_query = schema_value_statement(attributes)
         return attributes
 

--- a/tests/integ/test_reduce_describe_query.py
+++ b/tests/integ/test_reduce_describe_query.py
@@ -406,3 +406,37 @@ def test_reduce_describe_query_enabled_on_session(db_parameters):
         }
         with Session.builder.configs(parameters).create() as new_session2:
             assert new_session2.reduce_describe_query_enabled is not default_value
+
+
+def test_update_schema_query_when_attributes_available(session):
+    df = session.create_dataframe(data=[(1, 2), (3, 4)], schema=["a", "b"])
+    df = df.withColumn("c", df.a + df.b)
+    df = df.withColumn("d", df.a + df.b + df.c)
+
+    original_schema_query = df._plan.schema_query
+    simplified_schema_query1 = ' SELECT 0 :: BIGINT AS "A", 0 :: BIGINT AS "B", 0 :: BIGINT AS "C", 0 :: BIGINT AS "D"'
+    simplified_schema_query2 = ' SELECT 0 :: BIGINT AS "A", 0 :: BIGINT AS "B", 0 :: BIGINT AS "C", 0 :: BIGINT AS "D", 0 :: BIGINT AS "E"'
+
+    assert df._plan._metadata.attributes is None
+    df.columns  # trigger describe query
+
+    assert df._plan._metadata.attributes is not None
+    if session.reduce_describe_query_enabled:
+        assert df._plan.schema_query == simplified_schema_query1
+    else:
+        assert df._plan.schema_query == original_schema_query
+
+    # Check that dataframe built on top of the previous one with
+    # attributes updated will build a simplified schema query
+    df = df.withColumn("e", df.a + df.b + df.c + df.d)
+
+    assert df._plan._metadata.attributes is None
+    if session.reduce_describe_query_enabled:
+        assert simplified_schema_query1 in df._plan.schema_query
+    else:
+        assert original_schema_query in df._plan.schema_query
+
+    df.columns  # trigger describe query
+    assert df._plan._metadata.attributes is not None
+    if session.reduce_describe_query_enabled:
+        assert df._plan.schema_query == simplified_schema_query2


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1904798

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   When reduce describe query change is enabled, the snowpark client will update the underlying schema query for `SnowflakePlan` and `SelectStatement` so that future plans that are built on top of current will use a simpler schema query.

