### PR TITLE
SNOW-192360: [Local Testing] Fix Join On column order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 - Added support for applying Snowflake Cortex functions `Summarize` and `Sentiment`.
 
+### Snowpark Local Testing Updates
+
+#### Bug Fixes
+
+- Fixed a bug in Dataframe.join that caused columns to have incorrect typing.
+
 ## 1.27.0 (2025-02-03)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -1362,6 +1362,8 @@ def execute_mock_plan(
                     col for col in result_df.columns.tolist() if col not in on
                 ]
                 result_df = result_df[reordered_cols]
+                sf_types = {col: result_df.sf_types[col] for col in reordered_cols}
+                result_df.sf_types = sf_types
 
         common_columns = set(L_expr_to_alias.keys()).intersection(
             R_expr_to_alias.keys()

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1283,6 +1283,25 @@ def test_join_left_outer(session):
     assert sorted(res, key=lambda r: r[0]) == expected
 
 
+def test_join_on_order(session):
+    """
+    Test that an 'on' clause in a different order from the data frame re-orders the columns correctly.
+    """
+    df1 = session.create_dataframe([(1, "A", 3)], schema=["A", "B", "C"])
+    df2 = session.create_dataframe([(1, "A", 4)], schema=["A", "B", "D"])
+
+    df3 = df1.join(df2, on=["B", "A"])
+    assert df3.schema == StructType(
+        [
+            StructField("B", StringType(), nullable=False),
+            StructField("A", LongType(), nullable=False),
+            StructField("C", LongType(), nullable=False),
+            StructField("D", LongType(), nullable=False),
+        ]
+    )
+    Utils.check_answer(df3, [Row(B="A", A=1, C=3, D=4)])
+
+
 @pytest.mark.xfail(
     "config.getoption('local_testing_mode', default=False)",
     reason="schema_query is not supported in Local Testing",


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-192360

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Local testing had a bug where the type information for columns would be in correct if multiple columns were specified in the `on` parameter. The names of the columns were correctly reordered, but not the types. This change updates the types as well in order to avoid this issue.