### PR TITLE
NOSNOW - Add `n` to the recorded Dataframe.show AST, add Dataframe.show test

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -209,7 +209,7 @@ message SpPandasDataFrameType {
   repeated SpDataType col_types = 2;
 }
 
-// dataframe.ir:62
+// dataframe.ir:63
 message SpDataframeData {
   oneof sealed_value {
     SpDataframeData_List sp_dataframe_data__list = 1;
@@ -218,17 +218,17 @@ message SpDataframeData {
   }
 }
 
-// dataframe.ir:63
+// dataframe.ir:64
 message SpDataframeData_List {
   repeated Expr vs = 1;
 }
 
-// dataframe.ir:64
+// dataframe.ir:65
 message SpDataframeData_Tuple {
   repeated Expr vs = 1;
 }
 
-// dataframe.ir:65
+// dataframe.ir:66
 message SpDataframeData_Pandas {
   StagedPandasDataframe v = 1;
 }
@@ -251,7 +251,7 @@ message SpDataframeSchema_Struct {
   SpStructType v = 1;
 }
 
-// dataframe.ir:80
+// dataframe.ir:81
 message SpFlattenMode {
   oneof variant {
     bool sp_flatten_mode_array = 1;
@@ -260,7 +260,7 @@ message SpFlattenMode {
   }
 }
 
-// dataframe.ir:234
+// dataframe.ir:235
 message SpJoinType {
   oneof variant {
     bool sp_join_type__asof = 1;
@@ -330,7 +330,7 @@ message SpSaveMode {
   }
 }
 
-// dataframe.ir:99
+// dataframe.ir:100
 message SpTableVariant {
   oneof variant {
     bool sp_session_table = 1;
@@ -372,7 +372,7 @@ message SrcPosition {
   int64 start_line = 5;
 }
 
-// dataframe.ir:68
+// dataframe.ir:69
 message StagedPandasDataframe {
   SpNameRef temp_table = 1;
 }
@@ -1407,28 +1407,28 @@ message SpColumnWithinGroup {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:42
+// dataframe.ir:43
 message SpCreateDataframe {
   SpDataframeData data = 1;
   SpDataframeSchema schema = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:167
+// dataframe.ir:168
 message SpDataframeAgg {
   SpDataframeExpr df = 1;
   ExprArgList exprs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:172
+// dataframe.ir:173
 message SpDataframeAlias {
   SpDataframeExpr df = 1;
   string name = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:391
+// dataframe.ir:392
 message SpDataframeAnalyticsComputeLag {
   repeated Expr cols = 1;
   SpDataframeExpr df = 2;
@@ -1439,7 +1439,7 @@ message SpDataframeAnalyticsComputeLag {
   SrcPosition src = 7;
 }
 
-// dataframe.ir:400
+// dataframe.ir:401
 message SpDataframeAnalyticsComputeLead {
   repeated Expr cols = 1;
   SpDataframeExpr df = 2;
@@ -1450,7 +1450,7 @@ message SpDataframeAnalyticsComputeLead {
   SrcPosition src = 7;
 }
 
-// dataframe.ir:382
+// dataframe.ir:383
 message SpDataframeAnalyticsCumulativeAgg {
   repeated Tuple_String_List_String aggs = 1;
   SpDataframeExpr df = 2;
@@ -1461,7 +1461,7 @@ message SpDataframeAnalyticsCumulativeAgg {
   SrcPosition src = 7;
 }
 
-// dataframe.ir:373
+// dataframe.ir:374
 message SpDataframeAnalyticsMovingAgg {
   repeated Tuple_String_List_String aggs = 1;
   SpDataframeExpr df = 2;
@@ -1472,7 +1472,7 @@ message SpDataframeAnalyticsMovingAgg {
   repeated int64 window_sizes = 7;
 }
 
-// dataframe.ir:409
+// dataframe.ir:410
 message SpDataframeAnalyticsTimeSeriesAgg {
   repeated Tuple_String_List_String aggs = 1;
   SpDataframeExpr df = 2;
@@ -1498,7 +1498,7 @@ message SpDataframeCol {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:22
+// dataframe.ir:23
 message SpDataframeCollect {
   bool block = 1;
   bool case_sensitive = 2;
@@ -1525,7 +1525,7 @@ message SpDataframeCopyIntoTable {
   google.protobuf.StringValue validation_mode = 12;
 }
 
-// dataframe.ir:16
+// dataframe.ir:17
 message SpDataframeCount {
   bool block = 1;
   VarId id = 2;
@@ -1561,7 +1561,7 @@ message SpDataframeCreateOrReplaceView {
   repeated Tuple_String_String statement_params = 6;
 }
 
-// dataframe.ir:177
+// dataframe.ir:178
 message SpDataframeCrossJoin {
   SpDataframeExpr lhs = 1;
   google.protobuf.StringValue lsuffix = 2;
@@ -1577,34 +1577,34 @@ message SpDataframeCube {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:184
+// dataframe.ir:185
 message SpDataframeDescribe {
   ExprArgList cols = 1;
   SpDataframeExpr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:189
+// dataframe.ir:190
 message SpDataframeDistinct {
   SpDataframeExpr df = 1;
   SrcPosition src = 2;
 }
 
-// dataframe.ir:193
+// dataframe.ir:194
 message SpDataframeDrop {
   ExprArgList cols = 1;
   SpDataframeExpr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:198
+// dataframe.ir:199
 message SpDataframeDropDuplicates {
   ExprArgList cols = 1;
   SpDataframeExpr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:203
+// dataframe.ir:204
 message SpDataframeExcept {
   SpDataframeExpr df = 1;
   SpDataframeExpr other = 2;
@@ -1693,14 +1693,14 @@ message SpDataframeExpr {
   }
 }
 
-// dataframe.ir:208
+// dataframe.ir:209
 message SpDataframeFilter {
   Expr condition = 1;
   SpDataframeExpr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:222
+// dataframe.ir:223
 message SpDataframeFirst {
   bool block = 1;
   SpDataframeExpr df = 2;
@@ -1709,7 +1709,7 @@ message SpDataframeFirst {
   repeated Tuple_String_String statement_params = 5;
 }
 
-// dataframe.ir:213
+// dataframe.ir:214
 message SpDataframeFlatten {
   SpDataframeExpr df = 1;
   Expr input = 2;
@@ -1734,14 +1734,14 @@ message SpDataframeGroupByGroupingSets {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:229
+// dataframe.ir:230
 message SpDataframeIntersect {
   SpDataframeExpr df = 1;
   SpDataframeExpr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:245
+// dataframe.ir:246
 message SpDataframeJoin {
   Expr join_expr = 1;
   SpJoinType join_type = 2;
@@ -1753,14 +1753,14 @@ message SpDataframeJoin {
   SrcPosition src = 8;
 }
 
-// dataframe.ir:255
+// dataframe.ir:256
 message SpDataframeJoinTableFunction {
   Expr fn = 1;
   SpDataframeExpr lhs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:260
+// dataframe.ir:261
 message SpDataframeLimit {
   SpDataframeExpr df = 1;
   int64 n = 2;
@@ -1768,7 +1768,7 @@ message SpDataframeLimit {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:139
+// dataframe.ir:140
 message SpDataframeNaDrop_Python {
   SpDataframeExpr df = 1;
   string how = 2;
@@ -1777,7 +1777,7 @@ message SpDataframeNaDrop_Python {
   google.protobuf.Int64Value thresh = 5;
 }
 
-// dataframe.ir:133
+// dataframe.ir:134
 message SpDataframeNaDrop_Scala {
   repeated string cols = 1;
   SpDataframeExpr df = 2;
@@ -1785,7 +1785,7 @@ message SpDataframeNaDrop_Scala {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:146
+// dataframe.ir:147
 message SpDataframeNaFill {
   SpDataframeExpr df = 1;
   SrcPosition src = 2;
@@ -1794,7 +1794,7 @@ message SpDataframeNaFill {
   Map_String_Expr value_map = 5;
 }
 
-// dataframe.ir:153
+// dataframe.ir:154
 message SpDataframeNaReplace {
   SpDataframeExpr df = 1;
   Map_Expr_Expr replacement_map = 2;
@@ -1806,7 +1806,7 @@ message SpDataframeNaReplace {
   List_Expr values = 8;
 }
 
-// dataframe.ir:266
+// dataframe.ir:267
 message SpDataframeNaturalJoin {
   SpJoinType join_type = 1;
   SpDataframeExpr lhs = 2;
@@ -1823,7 +1823,7 @@ message SpDataframePivot {
   SpPivotValue values = 5;
 }
 
-// dataframe.ir:280
+// dataframe.ir:281
 message SpDataframeRandomSplit {
   SpDataframeExpr df = 1;
   google.protobuf.Int64Value seed = 2;
@@ -1882,7 +1882,7 @@ message SpDataframeRef {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:287
+// dataframe.ir:288
 message SpDataframeRename {
   Expr col_or_mapper = 1;
   SpDataframeExpr df = 2;
@@ -1897,7 +1897,7 @@ message SpDataframeRollup {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:293
+// dataframe.ir:294
 message SpDataframeSample {
   SpDataframeExpr df = 1;
   google.protobuf.Int64Value num = 2;
@@ -1905,14 +1905,14 @@ message SpDataframeSample {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:300
+// dataframe.ir:301
 message SpDataframeSelect_Columns {
   ExprArgList cols = 1;
   SpDataframeExpr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:305
+// dataframe.ir:306
 message SpDataframeSelect_Exprs {
   SpDataframeExpr df = 1;
   ExprArgList exprs = 2;
@@ -1922,10 +1922,11 @@ message SpDataframeSelect_Exprs {
 // dataframe.ir:12
 message SpDataframeShow {
   VarId id = 1;
-  SrcPosition src = 2;
+  int64 n = 2;
+  SrcPosition src = 3;
 }
 
-// dataframe.ir:310
+// dataframe.ir:311
 message SpDataframeSort {
   Expr ascending = 1;
   ExprArgList cols = 2;
@@ -1977,14 +1978,14 @@ message SpDataframeStatSampleBy {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:123
+// dataframe.ir:124
 message SpDataframeToDf {
   ExprArgList col_names = 1;
   SpDataframeExpr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:31
+// dataframe.ir:32
 message SpDataframeToLocalIterator {
   bool block = 1;
   bool case_sensitive = 2;
@@ -1993,7 +1994,7 @@ message SpDataframeToLocalIterator {
   repeated Tuple_String_String statement_params = 5;
 }
 
-// dataframe.ir:111
+// dataframe.ir:112
 message SpDataframeToPandas {
   bool block = 1;
   VarId id = 2;
@@ -2001,7 +2002,7 @@ message SpDataframeToPandas {
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe.ir:117
+// dataframe.ir:118
 message SpDataframeToPandasBatches {
   bool block = 1;
   VarId id = 2;
@@ -2009,35 +2010,35 @@ message SpDataframeToPandasBatches {
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe.ir:317
+// dataframe.ir:318
 message SpDataframeUnion {
   SpDataframeExpr df = 1;
   SpDataframeExpr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:322
+// dataframe.ir:323
 message SpDataframeUnionAll {
   SpDataframeExpr df = 1;
   SpDataframeExpr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:327
+// dataframe.ir:328
 message SpDataframeUnionAllByName {
   SpDataframeExpr df = 1;
   SpDataframeExpr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:332
+// dataframe.ir:333
 message SpDataframeUnionByName {
   SpDataframeExpr df = 1;
   SpDataframeExpr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:272
+// dataframe.ir:273
 message SpDataframeUnpivot {
   repeated Expr column_list = 1;
   SpDataframeExpr df = 2;
@@ -2047,7 +2048,7 @@ message SpDataframeUnpivot {
   string value_column = 6;
 }
 
-// dataframe.ir:337
+// dataframe.ir:338
 message SpDataframeWithColumn {
   Expr col = 1;
   string col_name = 2;
@@ -2055,7 +2056,7 @@ message SpDataframeWithColumn {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:343
+// dataframe.ir:344
 message SpDataframeWithColumnRenamed {
   Expr col = 1;
   SpDataframeExpr df = 2;
@@ -2063,7 +2064,7 @@ message SpDataframeWithColumnRenamed {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:349
+// dataframe.ir:350
 message SpDataframeWithColumns {
   repeated string col_names = 1;
   SpDataframeExpr df = 2;
@@ -2097,7 +2098,7 @@ message SpDatatypeVal {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:72
+// dataframe.ir:73
 message SpFlatten {
   Expr input = 1;
   SpFlattenMode mode = 2;
@@ -2113,7 +2114,7 @@ message SpFnRef {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:82
+// dataframe.ir:83
 message SpGenerator {
   ExprArgList columns = 1;
   int64 row_count = 2;
@@ -2121,7 +2122,7 @@ message SpGenerator {
   int64 time_limit_seconds = 4;
 }
 
-// dataframe.ir:355
+// dataframe.ir:356
 message SpGroupingSets {
   ExprArgList sets = 1;
   SrcPosition src = 2;
@@ -2135,13 +2136,13 @@ message SpMatchedClause {
   }
 }
 
-// dataframe.ir:426
+// dataframe.ir:427
 message SpMergeDeleteWhenMatchedClause {
   Expr condition = 1;
   SrcPosition src = 2;
 }
 
-// dataframe.ir:430
+// dataframe.ir:431
 message SpMergeInsertWhenNotMatchedClause {
   Expr condition = 1;
   List_Expr insert_keys = 2;
@@ -2149,7 +2150,7 @@ message SpMergeInsertWhenNotMatchedClause {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:421
+// dataframe.ir:422
 message SpMergeUpdateWhenMatchedClause {
   Expr condition = 1;
   SrcPosition src = 2;
@@ -2162,7 +2163,7 @@ message SpNameRef {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:88
+// dataframe.ir:89
 message SpRange {
   google.protobuf.Int64Value end = 1;
   SrcPosition src = 2;
@@ -2276,20 +2277,20 @@ message SpRow {
   repeated Expr vs = 3;
 }
 
-// dataframe.ir:107
+// dataframe.ir:108
 message SpSessionTableFunction {
   Expr fn = 1;
   SrcPosition src = 2;
 }
 
-// dataframe.ir:94
+// dataframe.ir:95
 message SpSql {
   repeated Expr params = 1;
   string query = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:101
+// dataframe.ir:102
 message SpTable {
   bool is_temp_table_for_cleanup = 1;
   SpNameRef name = 2;
@@ -2297,7 +2298,7 @@ message SpTable {
   SpTableVariant variant = 4;
 }
 
-// dataframe.ir:436
+// dataframe.ir:437
 message SpTableDelete {
   bool block = 1;
   Expr condition = 2;
@@ -2307,7 +2308,7 @@ message SpTableDelete {
   repeated Tuple_String_String statement_params = 6;
 }
 
-// dataframe.ir:444
+// dataframe.ir:445
 message SpTableDropTable {
   VarId id = 1;
   SrcPosition src = 2;
@@ -2328,7 +2329,7 @@ message SpTableFnCallOver {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:448
+// dataframe.ir:449
 message SpTableMerge {
   bool block = 1;
   repeated SpMatchedClause clauses = 2;
@@ -2339,7 +2340,7 @@ message SpTableMerge {
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe.ir:457
+// dataframe.ir:458
 message SpTableSample {
   SpDataframeExpr df = 1;
   google.protobuf.Int64Value num = 2;
@@ -2349,7 +2350,7 @@ message SpTableSample {
   SrcPosition src = 6;
 }
 
-// dataframe.ir:465
+// dataframe.ir:466
 message SpTableUpdate {
   repeated Tuple_String_Expr assignments = 1;
   bool block = 2;
@@ -2360,7 +2361,7 @@ message SpTableUpdate {
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe.ir:359
+// dataframe.ir:360
 message SpToSnowparkPandas {
   List_String columns = 1;
   SpDataframeExpr df = 2;
@@ -2464,7 +2465,7 @@ message SpWriteJson {
   repeated Tuple_String_String statement_params = 9;
 }
 
-// dataframe.ir:47
+// dataframe.ir:48
 message SpWritePandas {
   bool auto_create_table = 1;
   google.protobuf.Int64Value chunk_size = 2;

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4497,6 +4497,7 @@ class DataFrame:
             debug_check_missing_ast(self._ast_id, self)
             if self._ast_id is not None:
                 repr.expr.sp_dataframe_show.id.bitfield1 = self._ast_id
+            repr.expr.sp_dataframe_show.n = n
             self._session._ast_batch.eval(repr)
 
             _, kwargs[DATAFRAME_AST_PARAMETER] = self._session._ast_batch.flush()

--- a/tests/ast/data/Dataframe.show.test
+++ b/tests/ast/data/Dataframe.show.test
@@ -1,0 +1,396 @@
+## TEST CASE
+
+df = session.create_dataframe([(1, 1),(1, 2),(2, 1),(2, 2),(3, 1),(3, 2)], schema=["a", "b"])
+
+df1 = df.show()
+
+df1 = df.show(1)
+
+df1 = df.show(10)
+
+df1 = df.show(-2)
+
+## EXPECTED UNPARSER OUTPUT
+
+df = session.create_dataframe([(1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2)], schema=["a", "b"])
+
+df.show(n=10)
+
+df.show(n=1)
+
+df.show(n=10)
+
+df.show(n=-2)
+
+## EXPECTED ENCODED AST
+
+interned_value_table {
+  string_values {
+    key: -1
+  }
+  string_values {
+    key: 2
+    value: "SRC_POSITION_TEST_MODE"
+  }
+}
+body {
+  assign {
+    expr {
+      sp_create_dataframe {
+        data {
+          sp_dataframe_data__list {
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: 2
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: 2
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: 2
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: 2
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: 2
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 3
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 1
+                  }
+                }
+              }
+            }
+            vs {
+              tuple_val {
+                src {
+                  end_column: 101
+                  end_line: 25
+                  file: 2
+                  start_column: 13
+                  start_line: 25
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 3
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 101
+                      end_line: 25
+                      file: 2
+                      start_column: 13
+                      start_line: 25
+                    }
+                    v: 2
+                  }
+                }
+              }
+            }
+          }
+        }
+        schema {
+          sp_dataframe_schema__list {
+            vs: "a"
+            vs: "b"
+          }
+        }
+        src {
+          end_column: 101
+          end_line: 25
+          file: 2
+          start_column: 13
+          start_line: 25
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 1
+    var_id {
+      bitfield1: 1
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_show {
+        id {
+          bitfield1: 1
+        }
+        n: 10
+      }
+    }
+    symbol {
+    }
+    uid: 2
+    var_id {
+      bitfield1: 2
+    }
+  }
+}
+body {
+  eval {
+    uid: 3
+    var_id {
+      bitfield1: 2
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_show {
+        id {
+          bitfield1: 1
+        }
+        n: 1
+      }
+    }
+    symbol {
+    }
+    uid: 4
+    var_id {
+      bitfield1: 4
+    }
+  }
+}
+body {
+  eval {
+    uid: 5
+    var_id {
+      bitfield1: 4
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_show {
+        id {
+          bitfield1: 1
+        }
+        n: 10
+      }
+    }
+    symbol {
+    }
+    uid: 6
+    var_id {
+      bitfield1: 6
+    }
+  }
+}
+body {
+  eval {
+    uid: 7
+    var_id {
+      bitfield1: 6
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      sp_dataframe_show {
+        id {
+          bitfield1: 1
+        }
+        n: -2
+      }
+    }
+    symbol {
+    }
+    uid: 8
+    var_id {
+      bitfield1: 8
+    }
+  }
+}
+body {
+  eval {
+    uid: 9
+    var_id {
+      bitfield1: 8
+    }
+  }
+}
+client_ast_version: 1
+client_language {
+  python_language {
+    version {
+      label: "final"
+      major: 3
+      minor: 9
+      patch: 1
+    }
+  }
+}
+client_version {
+  major: 1
+  minor: 27
+}

--- a/tests/ast/data/Dataframe.show.test
+++ b/tests/ast/data/Dataframe.show.test
@@ -14,13 +14,13 @@ df1 = df.show(-2)
 
 df = session.create_dataframe([(1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2)], schema=["a", "b"])
 
-df.show(n=10)
+df.show()
 
-df.show(n=1)
+df.show(1)
 
-df.show(n=10)
+df.show()
 
-df.show(n=-2)
+df.show(-2)
 
 ## EXPECTED ENCODED AST
 


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.


   Fixes NOSNOW

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Dataframe.show was incorrectly recorded in the AST -- there was no logic transmitting the value of `n`/number of rows to retrieve for show. I added `n` to the corresponding AST and added a Dataframe.show test for it.
