### PR TITLE
SNOW-1926346: Implement groupby transform without pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 
 - Fixed a bug in `apply` where kwargs were not being correctly passed into the applied function.
 
+#### Improvements
+- Improved performance of `DataFrame.groupby.transform` and `Series.groupby.transform` by avoiding expensive pivot step.
+
+
 ### Snowpark Local Testing Updates
 
 #### New Features

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -444,7 +444,9 @@ def apply_groupby_func_to_df(
     args: tuple,
     kwargs: dict,
     force_list_like_to_series: bool = False,
-) -> Tuple[native_pd.Series, native_pd.DataFrame, native_pd.DataFrame]:
+) -> Tuple[
+    native_pd.Series, native_pd.DataFrame, native_pd.DataFrame
+]:  # pragma: no cover
     """
     Restore input dataframe received in udtf to original schema.
     Args:

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -434,7 +434,7 @@ def create_groupby_transform_func(
     )
 
 
-def create_udtf_for_groupby_apply(
+def create_udtf_for_groupby_transform(
     func: Callable,
     args: tuple,
     kwargs: dict,
@@ -445,8 +445,215 @@ def create_udtf_for_groupby_apply(
     session: Session,
     series_groupby: bool,
     by_types: list[DataType],
+    by_labels: list[Hashable],
     existing_identifiers: list[str],
     force_list_like_to_series: bool = False,
+) -> UserDefinedTableFunction:
+    """
+    Creates snowpark python UDTF for groupby.transform.
+
+    The UDTF takes as input the following columns in the listed order:
+    1. The original row position within the dataframe (not just within the group)
+    2. All the by columns (these are constant across the group, but in the case
+    #  of SeriesGroupBy, we need these so we can name each input series by the
+    #  group label)
+    3. All the index columns
+    4. All the data columns
+
+    The UDF returns as output the following columns in the listed order.
+    1. row position column.
+    2. All the index columns.
+    3. All the data columns with transformed values (except by columns).
+
+    Args
+    ----
+    func: The function we need to apply to each group
+    args: Function's positional arguments
+    kwargs: Function's keyword arguments
+    data_column_index: Column labels for the input dataframe
+    index_column_names: Names of the input dataframe's index
+    input_data_column_types: Types of the input dataframe's data columns
+    input_index_column_types: Types of the input dataframe's index columns
+    session: the current session
+    series_groupby: Whether we are performing a SeriesGroupBy.apply() instead of DataFrameGroupBy.apply()
+    by_labels: The pandas lables of the by columns.
+    by_types: The snowflake types of the by columns.
+    existing_identifiers: List of existing column identifiers; these are omitted when creating new column identifiers.
+    force_list_like_to_series: Force the function result to series if it is list-like
+
+    Returns
+    -------
+    A UDTF that will apply the provided function to a group and return a
+    dataframe representing all the data and metadata of the result.
+    """
+
+    # Get the length of this list outside the vUDTF function because the vUDTF
+    # doesn't have access to the Snowpark module, which defines these types.
+    num_by = len(by_types)
+    from snowflake.snowpark.modin.plugin.extensions.utils import (
+        try_convert_index_to_native,
+    )
+
+    data_column_index = try_convert_index_to_native(data_column_index)
+
+    class ApplyFunc:
+        def end_partition(self, df: native_pd.DataFrame):  # type: ignore[no-untyped-def] # pragma: no cover: adding type hint causes an error when creating udtf. also, skip coverage for this function because coverage tools can't tell that we're executing this function because we execute it in a UDTF.
+            """
+            Apply the user-provided function to the group represented by this partition.
+
+            Args
+            ----
+            df: The dataframe representing one group
+
+            Returns
+            -------
+            A dataframe representing the result of applying the user-provided
+            function to this group.
+            """
+            # The first column is row position. Save it for later.
+            row_position_column_number = 0
+            row_positions = df.iloc[:, row_position_column_number]
+            current_column_position = row_position_column_number + 1
+
+            # The next columns are the by columns. Since we are only looking at
+            # one group, every row in the by columns is the same, so get the
+            # group label from the first row.
+            group_label = tuple(
+                df.iloc[0, current_column_position : current_column_position + num_by]
+            )
+            current_column_position = current_column_position + num_by
+            if len(group_label) == 1:
+                group_label = group_label[0]
+
+            df = df.iloc[:, current_column_position:]
+            # Snowflake names the original columns "ARG1", "ARG2", ... "ARGN".
+            # the columns after the by columns are the index columns.
+            df.set_index(
+                [
+                    f"ARG{i}"
+                    for i in range(
+                        1 + current_column_position,
+                        1 + current_column_position + len(index_column_names),
+                    )
+                ],
+                inplace=True,
+            )
+            df.index.names = index_column_names
+            if series_groupby:
+                # For SeriesGroupBy, there should be only one data column.
+                num_columns = len(df.columns)
+                assert (
+                    num_columns == 1
+                ), f"Internal error: SeriesGroupBy func should apply to series, but input data had {num_columns} columns."
+                input_object = df.iloc[:, 0].rename(group_label)
+            else:
+                input_object = df.set_axis(data_column_index, axis="columns")
+            # Use infer_objects() because integer columns come as floats
+            # TODO: file snowpark bug about that. Asked about this here:
+            # https://github.com/snowflakedb/snowpandas/pull/823/files#r1507286892
+            input_object = input_object.infer_objects()
+            func_result = func(input_object, *args, **kwargs)
+            if (
+                force_list_like_to_series
+                and not isinstance(func_result, native_pd.Series)
+                and native_pd.api.types.is_list_like(func_result)
+            ):
+                if len(func_result) == 1:
+                    func_result = func_result[0]
+                else:
+                    func_result = native_pd.Series(func_result)
+                    if len(func_result) == len(df.index):
+                        func_result.index = df.index
+            if isinstance(func_result, native_pd.Series):
+                if series_groupby:
+                    func_result_as_frame = func_result.to_frame()
+                    func_result_as_frame.columns = [MODIN_UNNAMED_SERIES_LABEL]
+                else:
+                    # If function returns series, we have to transpose the series
+                    # and change its metadata a little bit, but after that we can
+                    # continue largely as if the function has returned a dataframe.
+                    #
+                    # If the series has a 1-dimensional index, the series name
+                    # becomes the name of the column index. For example, if
+                    # `func` returned the series native_pd.Series([1], name='a'):
+                    #
+                    # 0    1
+                    # Name: a, dtype: int64
+                    #
+                    # The result needs to use the dataframe
+                    # pd.DataFrame([1], columns=pd.Index([0], name='a'):
+                    #
+                    # a  0
+                    # 0  1
+                    #
+                    name = func_result.name
+                    func_result.name = None
+                    func_result_as_frame = func_result.to_frame().T
+                    if func_result_as_frame.columns.nlevels == 1:
+                        func_result_as_frame.columns.name = name
+                func_result = func_result_as_frame
+            func_result = func_result.applymap(
+                lambda x: handle_missing_value_in_variant(
+                    convert_numpy_int_result_to_int(x)
+                )
+            ).astype("object")
+            func_result.reset_index(inplace=True, drop=False)
+            func_result.insert(0, "__row_position__", row_positions)
+            return func_result
+
+    input_types = [
+        # first input column is the integer row number. the row number integer
+        # becomes a float inside the UDTF due to SNOW-1184587
+        LongType(),
+        # the next columns are the by columns...
+        *by_types,
+        # then the index columns for the input dataframe or series...
+        *input_index_column_types,
+        # ...then the data columns for the input dataframe or series.
+        *input_data_column_types,
+    ]
+
+    output_col_labels = ["__row_position__", *index_column_names] + [
+        col for col in data_column_index if col not in by_labels
+    ]
+
+    output_col_types = [LongType(), *input_index_column_types] + [VariantType()] * (
+        len(data_column_index) - len(by_types)
+    )
+
+    # Generate new column identifiers for all required UDTF columns with the helper
+    # below to prevent collisions in column identifiers.
+    output_col_ids = generate_snowflake_quoted_identifiers_helper(
+        pandas_labels=output_col_labels,
+        excluded=existing_identifiers,
+        wrap_double_underscore=False,
+    )
+    return sp_func.udtf(
+        ApplyFunc,
+        output_schema=PandasDataFrameType(output_col_types, output_col_ids),
+        input_types=[PandasDataFrameType(col_types=input_types)],
+        # We have to specify the local pandas package so that the UDF's pandas
+        # behavior is consistent with client-side pandas behavior.
+        packages=[native_pd] + list(session.get_packages().values()),
+        session=session,
+    )
+
+
+def create_udtf_for_groupby_apply(
+    func: Callable,
+    args: tuple,
+    kwargs: dict,
+    data_column_index: native_pd.Index,
+    index_column_names: list,
+    input_data_column_types: list[DataType],
+    input_index_column_types: list[DataType],
+    session: Session,
+    series_groupby: bool,
+    by_labels: list[Hashable],
+    by_types: list[DataType],
+    existing_identifiers: list[str],
+    force_list_like_to_series: bool = False,
+    is_transform: bool = False,
 ) -> UserDefinedTableFunction:
     """
     Create a UDTF from the Python function for groupby.apply.
@@ -535,15 +742,34 @@ def create_udtf_for_groupby_apply(
     input_index_column_types: Types of the input dataframe's index columns
     session: the current session
     series_groupby: Whether we are performing a SeriesGroupBy.apply() instead of DataFrameGroupBy.apply()
+    by_labels: The pandas lables of the by columns.
     by_types: The snowflake types of the by columns.
     existing_identifiers: List of existing column identifiers; these are omitted when creating new column identifiers.
     force_list_like_to_series: Force the function result to series if it is list-like
+    is_transform: Whether the function is a transform or not.
 
     Returns
     -------
     A UDTF that will apply the provided function to a group and return a
     dataframe representing all the data and metadata of the result.
     """
+
+    if is_transform:
+        return create_udtf_for_groupby_transform(
+            func,
+            args,
+            kwargs,
+            data_column_index,
+            index_column_names,
+            input_data_column_types,
+            input_index_column_types,
+            session,
+            series_groupby,
+            by_types,
+            by_labels,
+            existing_identifiers,
+            force_list_like_to_series,
+        )
 
     # Get the length of this list outside the vUDTF function because the vUDTF
     # doesn't have access to the Snowpark module, which defines these types.
@@ -568,8 +794,6 @@ def create_udtf_for_groupby_apply(
             A dataframe representing the result of applying the user-provided
             function to this group.
             """
-            current_column_position = 0
-
             # The first column is row position. Save it for later.
             row_position_column_number = 0
             row_positions = df.iloc[:, row_position_column_number]

--- a/src/snowflake/snowpark/modin/plugin/extensions/groupby_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/groupby_overrides.py
@@ -130,6 +130,9 @@ class DataFrameGroupBy(metaclass=TelemetryMeta):
             "group_keys": group_keys,
         }
         self._kwargs.update(kwargs)
+        if "apply_op" not in self._kwargs:
+            # Can be "apply", "transform", "filter" or "aggregate"
+            self._kwargs.update({"apply_op": "apply"})
 
     def _override(self, **kwargs):
         """
@@ -381,6 +384,7 @@ class DataFrameGroupBy(metaclass=TelemetryMeta):
             dropna=False,
             sort=self._sort,
         )
+        groupby_obj._kwargs["apply_op"] = "transform"
 
         # Apply the transform function to each group.
         res = groupby_obj.apply(

--- a/tests/integ/modin/groupby/test_groupby_transform.py
+++ b/tests/integ/modin/groupby/test_groupby_transform.py
@@ -49,7 +49,7 @@ def test_dataframe_groupby_transform(
     #   temporary function's resultant table.
     # - A second join is performed only when the groupby object specifies dropna=True.
     #   This is because a loc set operation is being performed to correctly set NA values.
-    with SqlCounter(query_count=6, join_count=1 + (1 if dropna else 0), udtf_count=1):
+    with SqlCounter(query_count=4, join_count=1 + (1 if dropna else 0), udtf_count=1):
         eval_snowpark_pandas_result(
             *df_with_multiple_columns,
             lambda df: df.groupby(
@@ -99,7 +99,7 @@ def test_dataframe_groupby_transform_with_func_args_and_kwargs(
     #   temporary function's resultant table.
     # - A second join is performed only when the groupby object specifies dropna=True.
     #   This is because a loc set operation is being performed to correctly set NA values.
-    with SqlCounter(query_count=6, join_count=1 + (1 if dropna else 0), udtf_count=1):
+    with SqlCounter(query_count=4, join_count=1 + (1 if dropna else 0), udtf_count=1):
         eval_snowpark_pandas_result(
             *df_with_multiple_columns,
             lambda df: df.groupby(
@@ -112,6 +112,9 @@ def test_dataframe_groupby_transform_with_func_args_and_kwargs(
         )
 
 
+@pytest.mark.skip(
+    reason="SNOW-1933703: Raise NotImplementedError for groupby transform"
+)
 @sql_count_checker(
     query_count=9,
     join_count=4,
@@ -141,9 +144,9 @@ def test_dataframe_groupby_transform_conflicting_labels_negative():
 
 
 @sql_count_checker(
-    query_count=11,
-    join_count=8,
-    udtf_count=2,
+    query_count=7,
+    join_count=12,
+    udtf_count=1,
     high_count_expected=True,
     high_count_reason="performing two groupby transform operations that use UDTFs and compare with pandas",
 )
@@ -167,9 +170,9 @@ def test_dataframe_groupby_transform_conflicting_labels():
 
 
 @sql_count_checker(
-    query_count=11,
-    join_count=5,
-    udtf_count=2,
+    query_count=7,
+    join_count=4,
+    udtf_count=1,
     high_count_expected=True,
     high_count_reason="performing two groupby transform operations that use UDTFs and compare with pandas",
 )

--- a/tests/integ/modin/groupby/test_groupby_transform.py
+++ b/tests/integ/modin/groupby/test_groupby_transform.py
@@ -145,6 +145,9 @@ def test_dataframe_groupby_transform_conflicting_labels_negative():
 
 @sql_count_checker(
     query_count=7,
+    # Pivot step performs force materialization of the dataframe. So joins in subquery
+    # are not carried over but after removing the pivot step subquery is present
+    # multiple times resulting to increase in join count.
     join_count=12,
     udtf_count=1,
     high_count_expected=True,

--- a/tests/integ/utils/sql_counter.py
+++ b/tests/integ/utils/sql_counter.py
@@ -35,6 +35,7 @@ WITH = "WITH "
 CREATE_TEMP_TABLE = "CREATE  TEMPORARY  TABLE"
 UNION = " UNION "
 WINDOW = " OVER "
+WITH_SNOWPARK_TEMP_CTE = "WITH SNOWPARK_TEMP_CTE_"
 
 NO_CHECK = "no_check"
 
@@ -350,7 +351,8 @@ class SqlCounter(QueryListener):
 
     def actual_udtf_count(self):
         return self._count_by_query_substr(
-            [SELECT, INSERT, CREATE_TEMP_TABLE], [TEMP_TABLE_FUNCTION]
+            [SELECT, INSERT, CREATE_TEMP_TABLE, WITH_SNOWPARK_TEMP_CTE],
+            [TEMP_TABLE_FUNCTION],
         )
 
     def actual_udf_count(self):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1926346

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR reimplements groupby.transform which does not use pivot. Output of transform maintains same row index as existing dataframe and column index omits by columns. We use this property of transform to correctly create output schema of UDTF and avoid expensive pivot step.
   Note: We still generate VARIANT columns (same as existing implementation). In follow up PR use type inference framework to return correct types in output.
   Note: It's possible that lambda passed in transform does not adhere to expected output schema. It should be rare but will improve this as well when we add type inference in groupby.transform.
