### PR TITLE
SNOW-1934822: Fix query count mismatch in pandas tests

### DIFF
--- a/tests/integ/modin/frame/test_iloc.py
+++ b/tests/integ/modin/frame/test_iloc.py
@@ -802,19 +802,8 @@ def test_df_iloc_get_key_bool_series_with_1k_shape(key, native_df_1k_1k):
             else df.iloc[: len(key)].iloc[key[: len(df)]]
         )
 
-    query_count = 6
-    high_count_reason = None
-    if len(key) >= 300:
-        query_count = 11
-        high_count_reason = """
-            6 queries includes 5 queries to prepare the temp table for df, including create, insert, drop the temp table (3)
-            and alter session to set and unset query_tag (2) and one select query.
-            11 queries add extra 5 queries to prepare the temp table for key
-        """
-
-    _test_df_iloc_with_1k_shape(
-        native_df_1k_1k, iloc_helper, query_count, 1, high_count_reason
-    )
+    query_count = 7 if len(key) >= 300 else 4
+    _test_df_iloc_with_1k_shape(native_df_1k_1k, iloc_helper, query_count, 1)
 
 
 def _test_df_iloc_with_1k_shape(
@@ -1053,17 +1042,8 @@ def test_df_iloc_get_key_int_series_with_1k_shape(key, native_df_1k_1k):
             else df.iloc[[k for k in key if -1001 < k < 1000]]
         )
 
-    high_count_reason = """
-        6 queries includes queries to create, insert, and drop the temp table (3), alter session
-        to set and unset query_tag (2) and one select query.
-        Another 5 query to prepare the temp table for df again due to the fact it is used in another
-        join even though it is in the same query.
-        11 queries add extra 5 queries to prepare the temp table for key
-    """
-    query_count = 6 if len(key) < 300 else 11
-    _test_df_iloc_with_1k_shape(
-        native_df_1k_1k, iloc_helper, query_count, 2, high_count_reason
-    )
+    query_count = 4 if len(key) < 300 else 7
+    _test_df_iloc_with_1k_shape(native_df_1k_1k, iloc_helper, query_count, 2)
 
 
 ILOC_GET_INT_SCALAR_KEYS = [0, -3, 4, -7, 6, -6, -8, 7, 52879115, -9028751]

--- a/tests/integ/modin/frame/test_iloc.py
+++ b/tests/integ/modin/frame/test_iloc.py
@@ -802,6 +802,9 @@ def test_df_iloc_get_key_bool_series_with_1k_shape(key, native_df_1k_1k):
             else df.iloc[: len(key)].iloc[key[: len(df)]]
         )
 
+    # 4 queries includes 3 queries to prepare the temp table for df, including create,
+    # insert, drop the temp table (3) and one select query.
+    # 7 queries add extra 3 queries to prepare the temp table for key.
     query_count = 7 if len(key) >= 300 else 4
     _test_df_iloc_with_1k_shape(native_df_1k_1k, iloc_helper, query_count, 1)
 
@@ -1042,6 +1045,9 @@ def test_df_iloc_get_key_int_series_with_1k_shape(key, native_df_1k_1k):
             else df.iloc[[k for k in key if -1001 < k < 1000]]
         )
 
+    # 4 queries includes 3 queries to prepare the temp table for df, including create,
+    # insert, drop the temp table (3) and one select query.
+    # 7 queries add extra 3 queries to prepare the temp table for key.
     query_count = 4 if len(key) < 300 else 7
     _test_df_iloc_with_1k_shape(native_df_1k_1k, iloc_helper, query_count, 2)
 

--- a/tests/integ/modin/frame/test_itertuples.py
+++ b/tests/integ/modin/frame/test_itertuples.py
@@ -163,7 +163,7 @@ def test_df_itertuples_large_df(size):
         query_count=query_count,
         join_count=0,
         high_count_expected=True,
-        high_count_reason="DataFrame spans multiple iteration partitions, each of which requires 6 queries",
+        high_count_reason="DataFrame spans multiple iteration partitions, each of which requires 4 queries",
     ):
         eval_snowpark_pandas_result(
             snowpark_df,

--- a/tests/integ/modin/frame/test_itertuples.py
+++ b/tests/integ/modin/frame/test_itertuples.py
@@ -158,7 +158,7 @@ def test_df_itertuples_large_df(size):
     data = rng.integers(low=-1500, high=1500, size=size)
     native_df = native_pd.DataFrame(data)
     snowpark_df = pd.DataFrame(native_df)
-    query_count = (np.floor(size / PARTITION_SIZE) + 1) * 6
+    query_count = (np.floor(size / PARTITION_SIZE) + 1) * 4
     with SqlCounter(
         query_count=query_count,
         join_count=0,

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -1835,19 +1835,8 @@ def test_df_loc_get_key_bool_series_with_1k_shape(key, native_df_1k_1k):
             else df.iloc[: len(key)].loc[native_pd.Series(key, dtype="bool")]
         )
 
-    query_count = 6
-    high_count_reason = None
-    if len(key) >= 300:
-        query_count = 11
-        high_count_reason = """
-            6 queries includes 5 queries to prepare the temp table for df, including create, insert, drop the temp table (3)
-            and alter session to set and unset query_tag (2) and one select query
-            11 queries add extra 5 queries to prepare the temp table for key
-        """
-
-    _test_df_loc_with_1k_shape(
-        native_df_1k_1k, loc_helper, query_count, high_count_reason
-    )
+    query_count = 7 if len(key) >= 300 else 4
+    _test_df_loc_with_1k_shape(native_df_1k_1k, loc_helper, query_count)
 
 
 def _test_df_loc_with_1k_shape(
@@ -2057,19 +2046,8 @@ def test_df_loc_get_key_non_boolean_series_with_1k_shape(key, native_df_1k_1k):
             else df.loc[[k for k in key if k in range(1000)]]
         )
 
-    query_count = 6
-    high_count_reason = None
-    if len(key) >= 300:
-        query_count = 11
-        high_count_reason = """
-            6 queries includes 5 queries to prepare the temp table for df, including create, insert, drop the temp table (3)
-            and alter session to set and unset query_tag (2) and one select query
-            11 queries add extra 5 queries to prepare the temp table for key
-        """
-
-    _test_df_loc_with_1k_shape(
-        native_df_1k_1k, loc_helper, query_count, high_count_reason
-    )
+    query_count = 7 if len(key) >= 300 else 4
+    _test_df_loc_with_1k_shape(native_df_1k_1k, loc_helper, query_count)
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/modin/frame/test_loc.py
+++ b/tests/integ/modin/frame/test_loc.py
@@ -1835,6 +1835,9 @@ def test_df_loc_get_key_bool_series_with_1k_shape(key, native_df_1k_1k):
             else df.iloc[: len(key)].loc[native_pd.Series(key, dtype="bool")]
         )
 
+    # 4 queries includes 3 queries to prepare the temp table for df, including create,
+    # insert, drop the temp table (3) and one select query.
+    # 7 queries add extra 3 queries to prepare the temp table for key.
     query_count = 7 if len(key) >= 300 else 4
     _test_df_loc_with_1k_shape(native_df_1k_1k, loc_helper, query_count)
 
@@ -2046,6 +2049,9 @@ def test_df_loc_get_key_non_boolean_series_with_1k_shape(key, native_df_1k_1k):
             else df.loc[[k for k in key if k in range(1000)]]
         )
 
+    # 4 queries includes 3 queries to prepare the temp table for df, including create,
+    # insert, drop the temp table (3) and one select query.
+    # 7 queries add extra 3 queries to prepare the temp table for key.
     query_count = 7 if len(key) >= 300 else 4
     _test_df_loc_with_1k_shape(native_df_1k_1k, loc_helper, query_count)
 

--- a/tests/integ/modin/series/test_items.py
+++ b/tests/integ/modin/series/test_items.py
@@ -74,7 +74,7 @@ def test_items_large_series():
         query_count=query_count,
         join_count=0,
         high_count_expected=True,
-        high_count_reason="Series spans multiple iteration partitions, each of which requires 6 queries",
+        high_count_reason="Series spans multiple iteration partitions, each of which requires 4 queries",
     ):
         eval_snowpark_pandas_result(
             snow_series,

--- a/tests/integ/modin/series/test_items.py
+++ b/tests/integ/modin/series/test_items.py
@@ -69,7 +69,7 @@ def test_items_large_series():
     data = rng.integers(low=-1500, high=1500, size=size)
     native_series = native_pd.Series(data)
     snow_series = pd.Series(native_series)
-    query_count = (np.floor(size / PARTITION_SIZE) + 1) * 6
+    query_count = (np.floor(size / PARTITION_SIZE) + 1) * 4
     with SqlCounter(
         query_count=query_count,
         join_count=0,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1934822

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   We removed set/unset query tag queries in a recent change
   SNOW-1909920: Remove stacktrace from query-tag (#2981)
   This reduced query count by 2 for all tests that materialize data as intermediate step. This PR fixes query count for some tests which we don't run in precommit but only in daily regress runner. 
Success Run with this PR: https://snowpark-python-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/SnowparkPythonSnowPandasDailyRegressRunner/197533