### PR TITLE
SNOW-1936459: Add modin as optional dependency to meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,9 @@ requirements:
     - protobuf >=3.20,<6
     - python-dateutil
     - tzlocal
+  run_constrained:
+    # Snowpark pandas
+    - modin==0.30.1
 
 test:
   imports:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1936459

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Previously, when upgrading the version of the `modin` package required by Snowpark pandas, users in Snowflake environments (and our server-side test cases) ran into issues where the conda installation would pick a newer version of modin before Snowpark pandas released with support for it. This creates an annoying situation where we would need to attempt to synchronize the addition of a newer version of `modin` into the Snowflake Anaconda channel with the corresponding release of Snowpark Python that supports it.

As it turns out, conda recipes can define a [`run_constrained`](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#run-constrained) field to restrict optional dependencies like this. This will allow us to pull newer versions of `modin` into the Anaconda channel before updating Snowpark pandas to support it. (see [slack discussion](https://snowflake.slack.com/archives/C07BQJV0RLJ/p1738868920967189) for details)