### PR TITLE
SNOW-1937038: Fix test_hist for the sproc environment

### DIFF
--- a/tests/integ/modin/series/test_hist.py
+++ b/tests/integ/modin/series/test_hist.py
@@ -9,11 +9,17 @@ import pytest
 
 from matplotlib.testing.decorators import check_figures_equal
 from tests.integ.utils.sql_counter import sql_count_checker
+from tests.utils import IS_IN_STORED_PROC
 
 fig_test = plt.figure()
 fig_ref = plt.figure()
 
 
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Creating a subdirectory for 'check_figures_equal' in the current (root) "
+    "directory is not supported in stored proc environment.",
+)
 @check_figures_equal()
 @sql_count_checker(query_count=2)
 @pytest.mark.parametrize("grid", [True, False])


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1937038

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Fix test_hist for the sproc environment. The tests in test_hist.py attempt to create a subdirectory directory in the current directory to output the image files corresponding to the charts generated by snowpack pandas and native pandas, and then compare them. For sprocs, creating a subdirectory in the current (root) directory is not allowed.
  
  This PR skips those tests whenever the sproc environment is detected.
