### PR TITLE
Revert "SNOW-1936459: Add modin as optional dependency to meta.yaml"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,9 +47,6 @@ requirements:
     - protobuf >=3.20,<6
     - python-dateutil
     - tzlocal
-  run_constrained:
-    # Snowpark pandas
-    - modin==0.30.1
 
 test:
   imports:


### PR DESCRIPTION
Reverts snowflakedb/snowpark-python#3025 due to failing daily test run: https://github.com/snowflakedb/snowpark-python/actions/runs/13393686608/job/37407491773

This seems to cause hard conflicts with snowflake-ml-python's pandas dependency requirements.