### PR TITLE
SNOW-1934027: Skip cortex tests on python 3.12.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,9 @@ setup(
             "scikit-learn",  # Snowpark pandas 3rd party library testing
             # plotly version restricted due to foreseen change in query counts in version 6.0.0+
             "plotly<6.0.0",  # Snowpark pandas 3rd party library testing
-            "snowflake-ml-python",
+            # TODO(SNOW-1938831): Test snowflake-ml-python on python 3.12 once
+            # snowflake-ml-python is available on python 3.12.
+            "snowflake-ml-python; python_version<'3.12'",
         ],
         "localtest": [
             "pandas",

--- a/tests/integ/modin/test_apply_snowflake_cortex_functions.py
+++ b/tests/integ/modin/test_apply_snowflake_cortex_functions.py
@@ -9,7 +9,13 @@ from pytest import param
 
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import running_on_jenkins
-from snowflake.cortex import Sentiment, Summarize, Translate
+
+# snowflake-ml-python, which provides snowflake.cortex, may not be available in
+# the test environment. If it's not available, skip all tests in this module.
+cortex = pytest.importorskip("snowflake.cortex")
+Sentiment = cortex.Sentiment
+Summarize = cortex.Summarize
+Translate = cortex.Translate
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
snowflake-ml-python, which provides snowflake.cortex, is not available on python 3.12. Skip the cortex Snowpark pandas tests on python versions >= 3.12.

Fixes SNOW-1934027

- daily tests run with python 3.9 and 3.10 using this branch: https://github.com/snowflakedb/snowpark-python/actions/runs/13405095565
- daily tests run with python 3.11 and 3.12 using this branch: https://github.com/snowflakedb/snowpark-python/actions/runs/13405093963
