### PR TITLE
SNOW-1938767: Fix Series.rename_axis AttributeError bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 - Fixed a bug in Dataframe.join that caused columns to have incorrect typing.
 - Fixed a bug in when statements that caused incorrect results in the otherwise clause.
-
+- Fixed a bug in `Series.rename_axis` where an `AttributeError` was being raised.
 
 
 

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2594,6 +2594,23 @@ class Series(BasePandasDataset):
         -------
         Series or None
             Series, or None if ``inplace=True``.
+
+        Examples
+        --------
+        Series
+
+        >>> s = pd.Series(["dog", "cat", "monkey"])
+        s
+        0       dog
+        1       cat
+        2    monkey
+        dtype: object
+        >>> s.rename_axis("animal")
+        animal
+        0    dog
+        1    cat
+        2    monkey
+        dtype: object
         """
 
     def rename():

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2607,8 +2607,8 @@ class Series(BasePandasDataset):
         dtype: object
         >>> s.rename_axis("animal")
         animal
-        0    dog
-        1    cat
+        0       dog
+        1       cat
         2    monkey
         dtype: object
         """

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -2600,7 +2600,7 @@ class Series(BasePandasDataset):
         Series
 
         >>> s = pd.Series(["dog", "cat", "monkey"])
-        s
+        >>> s
         0       dog
         1       cat
         2    monkey

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -43,6 +43,7 @@ def _set_axis_name(
     -------
     DataFrame or None
     """
+    assert axis == 0, f"Expected 'axis=0', got 'axis={axis}'"
     renamed = self if inplace else self.copy()
     renamed.index = renamed.index.set_names(name)
     if not inplace:

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -13,13 +13,40 @@ from typing import Any, Literal, Optional, Union
 import modin.pandas as pd
 import pandas
 from modin.pandas.api.extensions import register_series_accessor
-from pandas._typing import IndexLabel
+from pandas._typing import Axis, IndexLabel
 
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
 from snowflake.snowpark.modin.plugin.extensions.utils import add_cache_result_docstring
 from snowflake.snowpark.modin.plugin.utils.warning_message import (
     materialization_warning,
 )
+
+
+@register_series_accessor("_set_axis_name")
+def _set_axis_name(
+    self, name: Union[str, Iterable[str]], axis: Axis = 0, inplace: bool = False
+) -> Union[pd.Series, None]:
+    """
+    Alter the name or names of the axis.
+
+    Parameters
+    ----------
+    name : str or list of str
+        Name for the Index, or list of names for the MultiIndex.
+    axis : str or int, default: 0
+        The axis to set the label.
+        0 or 'index' for the index, 1 or 'columns' for the columns.
+    inplace : bool, default: False
+        Whether to modify `self` directly or return a copy.
+
+    Returns
+    -------
+    DataFrame or None
+    """
+    renamed = self if inplace else self.copy()
+    renamed.index = renamed.index.set_names(name)
+    if not inplace:
+        return renamed
 
 
 @register_series_accessor("to_snowflake")

--- a/tests/integ/modin/series/test_rename_axis.py
+++ b/tests/integ/modin/series/test_rename_axis.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import modin.pandas as pd
+import pandas as native_pd
+import pytest
+
+import snowflake.snowpark.modin.plugin  # noqa: F401
+from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.integ.utils.sql_counter import sql_count_checker
+
+
+@pytest.mark.parametrize("mapper", [None, "A", ["A"]])
+@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.parametrize("inplace", [True, False])
+@sql_count_checker(query_count=1)
+def test_rename_axis(mapper, copy, inplace):
+    data = [10, 1, 1.6]
+
+    native_ser = native_pd.Series(data)
+    snow_ser = pd.Series(native_ser)
+
+    eval_snowpark_pandas_result(
+        snow_ser,
+        native_ser,
+        lambda ser: ser.rename_axis(
+            mapper=mapper,
+            copy=copy,
+            inplace=inplace,
+        ),
+        inplace=inplace,
+        test_attrs=False if inplace else True,
+        check_names=False if inplace else True,
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1938767

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Fix a `Series.rename_axis` bug, where the method `_set_axis_name` was only defined for `DataFrame` but not for `Series`. And hence an `AttributeError` was being raised whenever `Series.rename_axis` (which calls `_set_axis_name` internally) is called.
