### PR TITLE
SNOW-1708509: Add support for artifact_repository to udxf

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1281,6 +1281,12 @@ def create_python_udf_or_sp(
     )
     imports_in_sql = f"IMPORTS=({all_imports})" if all_imports else ""
     packages_in_sql = f"PACKAGES=({all_packages})" if all_packages else ""
+
+    if artifact_repository_packages and not artifact_repository:
+        raise ValueError(
+            "artifact_repository must be specified when artifact_repository_packages has been specified"
+        )
+
     artifact_repository_in_sql = (
         f"ARTIFACT_REPOSITORY={artifact_repository}" if artifact_repository else ""
     )

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -986,6 +986,10 @@ class StoredProcedureRegistration:
                     native_app_params=native_app_params,
                     copy_grants=copy_grants,
                     runtime_version=runtime_version_from_requirement,
+                    artifact_repository=kwargs.get("artifact_repository"),
+                    artifact_repository_packages=kwargs.get(
+                        "artifact_repository_packages"
+                    ),
                 )
             # an exception might happen during registering a stored procedure
             # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -811,6 +811,8 @@ class UDAFRegistration:
                 native_app_params=native_app_params,
                 copy_grants=copy_grants,
                 runtime_version=runtime_version_from_requirement,
+                artifact_repository=kwargs.get("artifact_repository"),
+                artifact_repository_packages=kwargs.get("artifact_repository_packages"),
             )
         # an exception might happen during registering a udaf
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -1004,6 +1004,8 @@ class UDFRegistration:
                 native_app_params=native_app_params,
                 copy_grants=copy_grants,
                 runtime_version=runtime_version_from_requirement,
+                artifact_repository=kwargs.get("artifact_repository"),
+                artifact_repository_packages=kwargs.get("artifact_repository_packages"),
             )
         # an exception might happen during registering a udf
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -1071,6 +1071,8 @@ class UDTFRegistration:
                 native_app_params=native_app_params,
                 copy_grants=copy_grants,
                 runtime_version=runtime_version_from_requirement,
+                artifact_repository=kwargs.get("artifact_repository"),
+                artifact_repository_packages=kwargs.get("artifact_repository_packages"),
             )
         # an exception might happen during registering a udtf
         # (e.g., a dependency might not be found on the stage),

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -10,6 +10,7 @@ import pytest
 import snowflake.connector
 from snowflake.snowpark import Session
 from snowflake.snowpark._internal.utils import set_ast_state, AstFlagSource
+from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.mock._connection import MockServerConnection
 from tests.ast.ast_test_utils import (
     close_full_ast_validation_mode,
@@ -60,80 +61,74 @@ CONNECTION_PARAMETERS = {
 def set_up_external_access_integration_resources(
     session, rule1, rule2, key1, key2, integration1, integration2
 ):
-    session.sql(
-        "CREATE API INTEGRATION IF NOT EXISTS "
-        "SNOWPARK_PYTHON_TEST_INTEGRATION API_PROVIDER = pypi "
-        "ENABLED = TRUE"
-    ).collect()
-
-    session.sql(
-        "CREATE ARTIFACT REPOSITORY IF NOT EXISTS "
-        f'{CONNECTION_PARAMETERS["database"]}.{CONNECTION_PARAMETERS["schema"]}.SNOWPARK_PYTHON_TEST_REPOSITORY '
-        "TYPE = pip API_INTEGRATION = SNOWPARK_PYTHON_TEST_INTEGRATION"
-    ).collect()
-
-    # IMPORTANT SETUP NOTES: the test role needs to be granted the creation privilege
-    # log into the admin account and run the following sql to grant the privilege
-    # GRANT CREATE INTEGRATION ON ACCOUNT TO ROLE <test_role>;
-    # prepare external access resource
-    session.sql(
-        f"""
-CREATE NETWORK RULE  IF NOT EXISTS {rule1}
-  MODE = EGRESS
-  TYPE = HOST_PORT
-  VALUE_LIST = ('www.google.com')
-"""
-    ).collect()
-    session.sql(
-        f"""
-CREATE NETWORK RULE IF NOT EXISTS {rule2}
-  MODE = EGRESS
-  TYPE = HOST_PORT
-  VALUE_LIST = ('www.microsoft.com')
-"""
-    ).collect()
-    session.sql(
-        f"""
-CREATE SECRET IF NOT EXISTS {key1}
-  TYPE = GENERIC_STRING
-  SECRET_STRING = 'replace-with-your-api-key'
-"""
-    ).collect()
-    session.sql(
-        f"""
-CREATE SECRET IF NOT EXISTS {key2}
-  TYPE = GENERIC_STRING
-  SECRET_STRING = 'replace-with-your-api-key_2'
-"""
-    ).collect()
-    session.sql(
-        f"""
-CREATE EXTERNAL ACCESS INTEGRATION IF NOT EXISTS {integration1}
-  ALLOWED_NETWORK_RULES = ({rule1})
-  ALLOWED_AUTHENTICATION_SECRETS = ({key1})
-  ENABLED = true
-"""
-    ).collect()
-    session.sql(
-        f"""
-CREATE EXTERNAL ACCESS INTEGRATION IF NOT EXISTS {integration2}
-  ALLOWED_NETWORK_RULES = ({rule2})
-  ALLOWED_AUTHENTICATION_SECRETS = ({key2})
-  ENABLED = true
-"""
-    ).collect()
-    CONNECTION_PARAMETERS["external_access_rule1"] = rule1
-    CONNECTION_PARAMETERS["external_access_rule2"] = rule2
-    CONNECTION_PARAMETERS["external_access_key1"] = key1
-    CONNECTION_PARAMETERS["external_access_key2"] = key2
-    CONNECTION_PARAMETERS["external_access_integration1"] = integration1
-    CONNECTION_PARAMETERS["external_access_integration2"] = integration2
+    try:
+        # IMPORTANT SETUP NOTES: the test role needs to be granted the creation privilege
+        # log into the admin account and run the following sql to grant the privilege
+        # GRANT CREATE INTEGRATION ON ACCOUNT TO ROLE <test_role>;
+        # prepare external access resource
+        session.sql(
+            f"""
+    CREATE IF NOT EXISTS NETWORK RULE {rule1}
+      MODE = EGRESS
+      TYPE = HOST_PORT
+      VALUE_LIST = ('www.google.com');
+    """
+        ).collect()
+        session.sql(
+            f"""
+    CREATE IF NOT EXISTS NETWORK RULE {rule2}
+      MODE = EGRESS
+      TYPE = HOST_PORT
+      VALUE_LIST = ('www.microsoft.com');
+    """
+        ).collect()
+        session.sql(
+            f"""
+    CREATE IF NOT EXISTS SECRET {key1}
+      TYPE = GENERIC_STRING
+      SECRET_STRING = 'replace-with-your-api-key';
+    """
+        ).collect()
+        session.sql(
+            f"""
+    CREATE IF NOT EXISTS SECRET {key2}
+      TYPE = GENERIC_STRING
+      SECRET_STRING = 'replace-with-your-api-key_2';
+    """
+        ).collect()
+        session.sql(
+            f"""
+    CREATE IF NOT EXISTS EXTERNAL ACCESS INTEGRATION {integration1}
+      ALLOWED_NETWORK_RULES = ({rule1})
+      ALLOWED_AUTHENTICATION_SECRETS = ({key1})
+      ENABLED = true;
+    """
+        ).collect()
+        session.sql(
+            f"""
+    CREATE IF NOT EXISTS EXTERNAL ACCESS INTEGRATION {integration2}
+      ALLOWED_NETWORK_RULES = ({rule2})
+      ALLOWED_AUTHENTICATION_SECRETS = ({key2})
+      ENABLED = true;
+    """
+        ).collect()
+        CONNECTION_PARAMETERS["external_access_rule1"] = rule1
+        CONNECTION_PARAMETERS["external_access_rule2"] = rule2
+        CONNECTION_PARAMETERS["external_access_key1"] = key1
+        CONNECTION_PARAMETERS["external_access_key2"] = key2
+        CONNECTION_PARAMETERS["external_access_integration1"] = integration1
+        CONNECTION_PARAMETERS["external_access_integration2"] = integration2
+    except SnowparkSQLException:
+        # GCP currently does not support external access integration
+        # we can remove the exception once the integration is available on GCP
+        pass
 
     session.sql(
         "CREATE API INTEGRATION IF NOT EXISTS "
         "SNOWPARK_PYTHON_TEST_INTEGRATION API_PROVIDER = pypi "
         "ENABLED = TRUE"
     ).collect()
+
     session.sql(
         "CREATE ARTIFACT REPOSITORY IF NOT EXISTS "
         f'{CONNECTION_PARAMETERS["database"]}.{CONNECTION_PARAMETERS["schema"]}.SNOWPARK_PYTHON_TEST_REPOSITORY '

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -68,49 +68,55 @@ def set_up_external_access_integration_resources(
         # prepare external access resource
         session.sql(
             f"""
-    CREATE IF NOT EXISTS NETWORK RULE {rule1}
+    CREATE NETWORK RULE  IF NOT EXISTS {rule1}
       MODE = EGRESS
       TYPE = HOST_PORT
-      VALUE_LIST = ('www.google.com');
+      VALUE_LIST = ('www.google.com')
     """
         ).collect()
         session.sql(
             f"""
-    CREATE IF NOT EXISTS NETWORK RULE {rule2}
+    CREATE NETWORK RULE IF NOT EXISTS {rule2}
       MODE = EGRESS
       TYPE = HOST_PORT
-      VALUE_LIST = ('www.microsoft.com');
+      VALUE_LIST = ('www.microsoft.com')
     """
         ).collect()
         session.sql(
             f"""
-    CREATE IF NOT EXISTS SECRET {key1}
+    CREATE SECRET IF NOT EXISTS {key1}
       TYPE = GENERIC_STRING
-      SECRET_STRING = 'replace-with-your-api-key';
+      SECRET_STRING = 'replace-with-your-api-key'
     """
         ).collect()
         session.sql(
             f"""
-    CREATE IF NOT EXISTS SECRET {key2}
+    CREATE SECRET IF NOT EXISTS {key2}
       TYPE = GENERIC_STRING
-      SECRET_STRING = 'replace-with-your-api-key_2';
+      SECRET_STRING = 'replace-with-your-api-key_2'
     """
         ).collect()
         session.sql(
             f"""
-    CREATE IF NOT EXISTS EXTERNAL ACCESS INTEGRATION {integration1}
+    CREATE EXTERNAL ACCESS INTEGRATION IF NOT EXISTS {integration1}
       ALLOWED_NETWORK_RULES = ({rule1})
       ALLOWED_AUTHENTICATION_SECRETS = ({key1})
-      ENABLED = true;
+      ENABLED = true
     """
         ).collect()
         session.sql(
             f"""
-    CREATE IF NOT EXISTS EXTERNAL ACCESS INTEGRATION {integration2}
+    CREATE EXTERNAL ACCESS INTEGRATION IF NOT EXISTS {integration2}
       ALLOWED_NETWORK_RULES = ({rule2})
       ALLOWED_AUTHENTICATION_SECRETS = ({key2})
-      ENABLED = true;
+      ENABLED = true
     """
+        ).collect()
+        session.sql(
+            """CREATE API INTEGRATION IF NOT EXISTS SNOWPARK_PYTHON_TEST_INTEGRATION API_PROVIDER = pypi ENABLED = TRUE"""
+        ).collect()
+        session.sql(
+            """CREATE ARTIFACT REPOSITORY IF NOT EXISTS SNOWPARK_PYTHON_TEST_REPOSITORY TYPE = pip API_INTEGRATION = SNOWPARK_PYTHON_TEST_INTEGRATION"""
         ).collect()
         CONNECTION_PARAMETERS["external_access_rule1"] = rule1
         CONNECTION_PARAMETERS["external_access_rule2"] = rule2

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -61,10 +61,15 @@ def set_up_external_access_integration_resources(
     session, rule1, rule2, key1, key2, integration1, integration2
 ):
     session.sql(
-        """CREATE API INTEGRATION IF NOT EXISTS SNOWPARK_PYTHON_TEST_INTEGRATION API_PROVIDER = pypi ENABLED = TRUE"""
+        "CREATE API INTEGRATION IF NOT EXISTS "
+        "SNOWPARK_PYTHON_TEST_INTEGRATION API_PROVIDER = pypi "
+        "ENABLED = TRUE"
     ).collect()
+
     session.sql(
-        """CREATE ARTIFACT REPOSITORY IF NOT EXISTS SNOWPARK_PYTHON_TEST_REPOSITORY TYPE = pip API_INTEGRATION = SNOWPARK_PYTHON_TEST_INTEGRATION"""
+        "CREATE ARTIFACT REPOSITORY IF NOT EXISTS "
+        f'{CONNECTION_PARAMETERS["database"]}.{CONNECTION_PARAMETERS["schema"]}.SNOWPARK_PYTHON_TEST_REPOSITORY '
+        "TYPE = pip API_INTEGRATION = SNOWPARK_PYTHON_TEST_INTEGRATION"
     ).collect()
 
     # IMPORTANT SETUP NOTES: the test role needs to be granted the creation privilege

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -129,6 +129,17 @@ CREATE EXTERNAL ACCESS INTEGRATION IF NOT EXISTS {integration2}
     CONNECTION_PARAMETERS["external_access_integration1"] = integration1
     CONNECTION_PARAMETERS["external_access_integration2"] = integration2
 
+    session.sql(
+        "CREATE API INTEGRATION IF NOT EXISTS "
+        "SNOWPARK_PYTHON_TEST_INTEGRATION API_PROVIDER = pypi "
+        "ENABLED = TRUE"
+    ).collect()
+    session.sql(
+        "CREATE ARTIFACT REPOSITORY IF NOT EXISTS "
+        f'{CONNECTION_PARAMETERS["database"]}.{CONNECTION_PARAMETERS["schema"]}.SNOWPARK_PYTHON_TEST_REPOSITORY '
+        "TYPE = pip API_INTEGRATION = SNOWPARK_PYTHON_TEST_INTEGRATION"
+    ).collect()
+
 
 def clean_up_external_access_integration_resources():
     CONNECTION_PARAMETERS.pop("external_access_rule1", None)

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1927,3 +1927,24 @@ def test_register_sproc_after_switch_schema(session):
             Utils.drop_database(session, db)
         session.use_database(current_database)
         session.use_schema(current_schema)
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="artifact repository not supported in local testing",
+)
+@pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+def test_sproc_artifact_repository(session):
+    def artifact_repo_test(_):
+        import urllib3
+
+        return str(urllib3.exceptions.HTTPError("test"))
+
+    artifact_repo_sproc = sproc(
+        artifact_repo_test,
+        session=session,
+        return_type=StringType(),
+        artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+        artifact_repository_packages=["urllib3", "requests"],
+    )
+    assert artifact_repo_sproc(session=session) == "test"

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -15,7 +15,7 @@ from snowflake.snowpark._internal.utils import (
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import udaf
 from snowflake.snowpark.session import Session
-from snowflake.snowpark.types import IntegerType, Variant
+from snowflake.snowpark.types import IntegerType, Variant, StringType
 from tests.utils import IS_IN_STORED_PROC, IS_NOT_ON_GITHUB, TestFiles, Utils
 
 pytestmark = [
@@ -590,3 +590,39 @@ def test_udaf_external_access_integration(session, db_parameters):
         Utils.check_answer(df.agg(external_access_udaf("a")), [Row(4)])
     except KeyError:
         pytest.skip("External Access Integration is not supported on the deployment.")
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="artifact repository not supported in local testing",
+)
+@pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+def test_udaf_artifact_repository(session):
+    class ArtifactRepositoryHandler:
+        def __init__(self) -> None:
+            self._result = ""
+
+        @property
+        def aggregate_state(self):
+            return self._result
+
+        def accumulate(self, input_value):
+            import urllib3
+
+            self._result = str(urllib3.exceptions.HTTPError("test"))
+
+        def merge(self, other_result):
+            self._result += other_result
+
+        def finish(self):
+            return self._result
+
+    ar_udaf = udaf(
+        ArtifactRepositoryHandler,
+        return_type=StringType(),
+        input_types=[IntegerType()],
+        artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+        artifact_repository_packages=["urllib3", "requests"],
+    )
+    df = session.create_dataframe([(1,)], schema=["a"])
+    Utils.check_answer(df.agg(ar_udaf("a")), [Row("test")])

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2825,7 +2825,7 @@ def test_register_artifact_repository(session):
         session.udf.register(
             func=test_urllib,
             name=temp_func_name,
-            artifact_repository="SNOWPARK_PYTHON_TEST_INTEGRATION",
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
             artifact_repository_packages=["urllib3", "requests"],
         )
 

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2854,3 +2854,15 @@ def test_register_artifact_repository_negative(session):
             name=temp_func_name,
             artifact_repository_packages=["urllib3", "requests"],
         )
+
+    with pytest.raises(
+        SnowparkSQLException,
+        match="Cannot create a function with duplicates between packages and artifact repository packages.",
+    ):
+        udf(
+            func=test_nop,
+            name=temp_func_name,
+            packages=["urllib3==2.3.0"],
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3==2.1.0", "requests"],
+        )

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2805,3 +2805,32 @@ def test_access_snowflake_import_directory(session, resources_path):
 
     # clean
     session.clear_imports()
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="artifact repository not supported in local testing",
+)
+@pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+def test_register_artifact_repository(session):
+    def test_urllib() -> str:
+        import urllib3
+
+        return str(urllib3.exceptions.HTTPError("test"))
+
+    temp_func_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
+
+    try:
+        # Test function registration
+        session.udf.register(
+            func=test_urllib,
+            name=temp_func_name,
+            artifact_repository="SNOWPARK_PYTHON_TEST_INTEGRATION",
+            artifact_repository_packages=["urllib3", "requests"],
+        )
+
+        # Test UDF call
+        df = session.create_dataframe([1]).to_df(["a"])
+        Utils.check_answer(df.select(call_udf(temp_func_name)), [Row("test")])
+    finally:
+        session._run_query(f"drop function if exists {temp_func_name}(int)")

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2834,3 +2834,23 @@ def test_register_artifact_repository(session):
         Utils.check_answer(df.select(call_udf(temp_func_name)), [Row("test")])
     finally:
         session._run_query(f"drop function if exists {temp_func_name}(int)")
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="artifact repository not supported in local testing",
+)
+def test_register_artifact_repository_negative(session):
+    def test_nop() -> str:
+        pass
+
+    temp_func_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
+    with pytest.raises(
+        ValueError,
+        match="artifact_repository must be specified when artifact_repository_packages has been specified",
+    ):
+        udf(
+            func=test_nop,
+            name=temp_func_name,
+            artifact_repository_packages=["urllib3", "requests"],
+        )

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2822,7 +2822,7 @@ def test_register_artifact_repository(session):
 
     try:
         # Test function registration
-        session.udf.register(
+        udf(
             func=test_urllib,
             name=temp_func_name,
             artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1708509

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR adds two new arguments to functions `udf`, `udtf`, `udaf`, and `sproc` calls as well as their corresponding registration functions. The arguments include:
   - artifact_repository: Specifies an artifact repository integration to get packages from.
   - artifact_repository_packages: Packages that should be added to the udxf or sproc from the artifact repository.

  This feature feature has not been rolled out yet, but we do have access to it in our test account. Access to the arguments is being provided through kwargs on each affect function so that they don't show up in docs yet. 