### PR TITLE
NO SNOW: bump version in main branch to 1.29.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.28.0" %}
+{% set version = "1.29.0" %}
 {% set noarch_build = (os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_NOARCH_BUILD', 'false')) == 'true' %}
 
 package:

--- a/src/snowflake/snowpark/version.py
+++ b/src/snowflake/snowpark/version.py
@@ -2,4 +2,4 @@
 
 
 # Update this for the versions
-VERSION = (1, 28, 0)
+VERSION = (1, 29, 0)

--- a/tests/ast/data/DataFrame.agg.test
+++ b/tests/ast/data/DataFrame.agg.test
@@ -522,5 +522,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.collect.test
+++ b/tests/ast/data/DataFrame.collect.test
@@ -342,5 +342,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.count.test
+++ b/tests/ast/data/DataFrame.count.test
@@ -175,5 +175,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -208,5 +208,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -630,5 +630,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.cross_join.lsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.lsuffix.test
@@ -183,5 +183,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.cross_join.rsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.rsuffix.test
@@ -183,5 +183,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.cross_join.suffix.test
+++ b/tests/ast/data/DataFrame.cross_join.suffix.test
@@ -186,5 +186,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.describe.test
+++ b/tests/ast/data/DataFrame.describe.test
@@ -206,5 +206,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.flatten.test
+++ b/tests/ast/data/DataFrame.flatten.test
@@ -185,5 +185,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.indexers.test
+++ b/tests/ast/data/DataFrame.indexers.test
@@ -227,5 +227,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.inner.column.test
+++ b/tests/ast/data/DataFrame.join.inner.column.test
@@ -259,5 +259,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.inner.column_list.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list.test
@@ -215,5 +215,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
@@ -352,5 +352,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.inner.predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate.test
@@ -311,5 +311,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
@@ -299,5 +299,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.left_outer.column.test
+++ b/tests/ast/data/DataFrame.join.left_outer.column.test
@@ -215,5 +215,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.join.right_outer.predicate.test
+++ b/tests/ast/data/DataFrame.join.right_outer.predicate.test
@@ -236,5 +236,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.natural_join.test
+++ b/tests/ast/data/DataFrame.natural_join.test
@@ -183,5 +183,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.pivot.test
+++ b/tests/ast/data/DataFrame.pivot.test
@@ -780,5 +780,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.select_expr.test
+++ b/tests/ast/data/DataFrame.select_expr.test
@@ -373,5 +373,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -1239,5 +1239,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.to_df.test
+++ b/tests/ast/data/DataFrame.to_df.test
@@ -182,5 +182,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -415,5 +415,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -216,5 +216,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.to_pandas_batch.test
+++ b/tests/ast/data/DataFrame.to_pandas_batch.test
@@ -216,5 +216,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.unpivot.test
+++ b/tests/ast/data/DataFrame.unpivot.test
@@ -243,5 +243,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -1667,5 +1667,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.cube.test
+++ b/tests/ast/data/Dataframe.cube.test
@@ -554,5 +554,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.distinct.test
+++ b/tests/ast/data/Dataframe.distinct.test
@@ -95,5 +95,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.drop_duplicates.test
+++ b/tests/ast/data/Dataframe.drop_duplicates.test
@@ -300,5 +300,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
+++ b/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
@@ -533,5 +533,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.filter.test
+++ b/tests/ast/data/Dataframe.filter.test
@@ -400,5 +400,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -261,5 +261,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.group_by.test
+++ b/tests/ast/data/Dataframe.group_by.test
@@ -554,5 +554,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.group_by_grouping_sets.test
+++ b/tests/ast/data/Dataframe.group_by_grouping_sets.test
@@ -1136,5 +1136,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.join.asof.test
+++ b/tests/ast/data/Dataframe.join.asof.test
@@ -758,5 +758,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -837,5 +837,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.rollup.test
+++ b/tests/ast/data/Dataframe.rollup.test
@@ -554,5 +554,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.show.test
+++ b/tests/ast/data/Dataframe.show.test
@@ -392,5 +392,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Dataframe.with_col_fns.test
+++ b/tests/ast/data/Dataframe.with_col_fns.test
@@ -966,5 +966,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -731,5 +731,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/RelationalGroupedDataFrame.agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.agg.test
@@ -1198,5 +1198,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -1819,5 +1819,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -561,5 +561,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -1048,5 +1048,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Session.flatten.test
+++ b/tests/ast/data/Session.flatten.test
@@ -178,5 +178,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -1000,5 +1000,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Table.delete.test
+++ b/tests/ast/data/Table.delete.test
@@ -578,5 +578,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Table.drop_table.test
+++ b/tests/ast/data/Table.drop_table.test
@@ -98,5 +98,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Table.init.test
+++ b/tests/ast/data/Table.init.test
@@ -144,5 +144,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -1581,5 +1581,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Table.sample.test
+++ b/tests/ast/data/Table.sample.test
@@ -182,5 +182,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/Table.update.test
+++ b/tests/ast/data/Table.update.test
@@ -727,5 +727,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/case_when.test
+++ b/tests/ast/data/case_when.test
@@ -1947,5 +1947,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_alias.test
+++ b/tests/ast/data/col_alias.test
@@ -427,5 +427,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_asc.test
+++ b/tests/ast/data/col_asc.test
@@ -316,5 +316,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_between.test
+++ b/tests/ast/data/col_between.test
@@ -190,5 +190,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_binops.test
+++ b/tests/ast/data/col_binops.test
@@ -1673,5 +1673,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_bitops.test
+++ b/tests/ast/data/col_bitops.test
@@ -408,5 +408,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -2657,5 +2657,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -842,5 +842,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_desc.test
+++ b/tests/ast/data/col_desc.test
@@ -314,5 +314,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_getitem.test
+++ b/tests/ast/data/col_getitem.test
@@ -191,5 +191,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -374,5 +374,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_lit.test
+++ b/tests/ast/data/col_lit.test
@@ -534,5 +534,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_literal.test
+++ b/tests/ast/data/col_literal.test
@@ -3851,5 +3851,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_null_nan.test
+++ b/tests/ast/data/col_null_nan.test
@@ -421,5 +421,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_rbinops.test
+++ b/tests/ast/data/col_rbinops.test
@@ -807,5 +807,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_star.test
+++ b/tests/ast/data/col_star.test
@@ -133,5 +133,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_string.test
+++ b/tests/ast/data/col_string.test
@@ -770,5 +770,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -2383,5 +2383,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -822,5 +822,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_unary_ops.test
+++ b/tests/ast/data/col_unary_ops.test
@@ -225,5 +225,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/col_within_group.test
+++ b/tests/ast/data/col_within_group.test
@@ -423,5 +423,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_alias.test
+++ b/tests/ast/data/df_alias.test
@@ -96,5 +96,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_analytics_functions.test
+++ b/tests/ast/data/df_analytics_functions.test
@@ -1008,5 +1008,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_col.test
+++ b/tests/ast/data/df_col.test
@@ -156,5 +156,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_drop.test
+++ b/tests/ast/data/df_drop.test
@@ -133,5 +133,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_except.test
+++ b/tests/ast/data/df_except.test
@@ -138,5 +138,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_first.test
+++ b/tests/ast/data/df_first.test
@@ -292,5 +292,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_intersect.test
+++ b/tests/ast/data/df_intersect.test
@@ -139,5 +139,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_limit.test
+++ b/tests/ast/data/df_limit.test
@@ -267,5 +267,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -711,5 +711,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_sample.test
+++ b/tests/ast/data/df_sample.test
@@ -134,5 +134,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_sort.test
+++ b/tests/ast/data/df_sort.test
@@ -671,5 +671,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/df_union.test
+++ b/tests/ast/data/df_union.test
@@ -330,5 +330,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -19156,5 +19156,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -24150,5 +24150,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/interval.test
+++ b/tests/ast/data/interval.test
@@ -1101,5 +1101,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/select.test
+++ b/tests/ast/data/select.test
@@ -145,5 +145,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -570,5 +570,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session.sql.test
+++ b/tests/ast/data/session.sql.test
@@ -155,5 +155,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_generator.test
+++ b/tests/ast/data/session_generator.test
@@ -500,5 +500,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_range.test
+++ b/tests/ast/data/session_range.test
@@ -182,5 +182,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_dq_abs_l.test
+++ b/tests/ast/data/session_table_dq_abs_l.test
@@ -111,5 +111,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_dq_abs_s.test
+++ b/tests/ast/data/session_table_dq_abs_s.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_dq_rs_l.test
+++ b/tests/ast/data/session_table_dq_rs_l.test
@@ -110,5 +110,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_dq_rs_s.test
+++ b/tests/ast/data/session_table_dq_rs_s.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_dq_rt_l.test
+++ b/tests/ast/data/session_table_dq_rt_l.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_dq_rt_s.test
+++ b/tests/ast/data/session_table_dq_rt_s.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -183,5 +183,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_uq_abs_l.test
+++ b/tests/ast/data/session_table_uq_abs_l.test
@@ -111,5 +111,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_uq_abs_s.test
+++ b/tests/ast/data/session_table_uq_abs_s.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_uq_rs_l.test
+++ b/tests/ast/data/session_table_uq_rs_l.test
@@ -110,5 +110,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_uq_rs_s.test
+++ b/tests/ast/data/session_table_uq_rs_s.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_uq_rt_l.test
+++ b/tests/ast/data/session_table_uq_rt_l.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_table_uq_rt_s.test
+++ b/tests/ast/data/session_table_uq_rt_s.test
@@ -109,5 +109,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -153,5 +153,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/shadowed_local_name.test
+++ b/tests/ast/data/shadowed_local_name.test
@@ -219,5 +219,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -2292,5 +2292,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -678,5 +678,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -1903,5 +1903,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }

--- a/tests/ast/data/windows.test
+++ b/tests/ast/data/windows.test
@@ -2157,5 +2157,5 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 28
+  minor: 29
 }


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This is meant to bump the version in the main branch to 1.29.0.
   The reason we did this is because since we have already released 1.28.0, new commits in main branch actually belong to 1.29.0 and this would give us a more clear view when we are testing snowpark that we can know which version have issues.
