### PR TITLE
SNOW-1906574: Skip creating CTE nodes if subtree contains SelectFromFileNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
+
 ## 1.29.0 (TBD)
 
 ### Snowpark Python API Updates
+
+#### Bug Fixed
+
+- Fixed a bug where `df.describe` raised internal SQL execution error when the dataframe is created from reading a stage file and CTE optimization is enabled.
 
 ### Snowpark pandas API Updates
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -102,7 +102,7 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     Limit,
     LogicalPlan,
     Range,
-    SelectFromFileNode,
+    ReadFileNode,
     SnowflakeCreateTable,
     SnowflakeTable,
     SnowflakeValues,
@@ -1208,7 +1208,7 @@ class Analyzer:
                 iceberg_config=logical_plan.iceberg_config,
             )
 
-        if isinstance(logical_plan, SelectFromFileNode):
+        if isinstance(logical_plan, ReadFileNode):
             return self.plan_builder.read_file(
                 path=logical_plan.path,
                 format=logical_plan.format,

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -93,6 +93,8 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     DynamicTableCreateMode,
     LogicalPlan,
     SaveMode,
+    SelectFromFileNode,
+    SelectWithCopyIntoTableNode,
     TableCreationSource,
     WithQueryBlock,
 )
@@ -1340,7 +1342,7 @@ class SnowflakePlanBuilder:
                 schema_value_statement((metadata_schema or []) + schema),
                 post_queries,
                 {},
-                source_plan,
+                SelectFromFileNode.from_read_file_node(source_plan),
                 session=self.session,
             )
         else:  # otherwise use COPY
@@ -1423,7 +1425,7 @@ class SnowflakePlanBuilder:
                 schema_value_statement(schema),
                 post_actions,
                 {},
-                source_plan,
+                SelectWithCopyIntoTableNode.from_read_file_node(source_plan),
                 session=self.session,
             )
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -329,6 +329,28 @@ class ReadFileNode(LeafNode):
         self.metadata_schema = metadata_schema
         self.use_user_schema = use_user_schema
 
+    @classmethod
+    def from_read_file_node(cls, read_file_node: "ReadFileNode"):
+        return cls(
+            read_file_node.path,
+            read_file_node.format,
+            read_file_node.options,
+            read_file_node.schema,
+            read_file_node.schema_to_cast,
+            read_file_node.transformations,
+            read_file_node.metadata_project,
+            read_file_node.metadata_schema,
+            read_file_node.use_user_schema,
+        )
+
+
+class SelectFromFileNode(ReadFileNode):
+    pass
+
+
+class SelectWithCopyIntoTableNode(ReadFileNode):
+    pass
+
 
 class CopyIntoTableNode(LeafNode):
     def __init__(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan_node.py
@@ -305,7 +305,7 @@ class Limit(LogicalPlan):
         )
 
 
-class SelectFromFileNode(LeafNode):
+class ReadFileNode(LeafNode):
     def __init__(
         self,
         path: str,

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -11,6 +11,7 @@ from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     get_complexity_score,
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    SelectFromFileNode,
     SnowflakeTable,
     WithQueryBlock,
 )
@@ -50,6 +51,9 @@ def find_duplicate_subtrees(
     """
     id_node_map = defaultdict(list)
     id_parents_map = defaultdict(set)
+    # set of encoded node ids which are ineligible to be deduplicated
+    # during this process
+    invalid_ids_for_deduplication = set()
 
     from snowflake.snowpark._internal.analyzer.select_statement import (
         Selectable,
@@ -86,29 +90,68 @@ def find_duplicate_subtrees(
 
         return False
 
+    def is_read_file_node(node: "TreeNode") -> bool:
+        """
+        Check if the current node is a SelectFromFileNode. Currently, we do not support
+        deduplication for SelectFromFileNode due to SNOW-1911967.
+        """
+        if isinstance(node, SnowflakePlan) and (node.source_plan is not None):
+            return isinstance(node.source_plan, SelectFromFileNode)
+
+        if isinstance(node, SelectSnowflakePlan):
+            return is_read_file_node(node.snowflake_plan)
+
+        return False
+
     def traverse(root: "TreeNode") -> None:
         """
         This function uses an iterative approach to avoid hitting Python's maximum recursion depth limit.
         """
+        # Top down level order traversal to populate parent map
+        # and encoded id node map
         current_level = [root]
         while len(current_level) > 0:
             next_level = []
             for node in current_level:
                 id_node_map[node.encoded_node_id_with_query].append(node)
-                for child in node.children_plan_nodes:
-                    id_parents_map[child.encoded_node_id_with_query].add(
+
+                if is_read_file_node(node):
+                    invalid_ids_for_deduplication.add(node.encoded_node_id_with_query)
+
+                for child_id in node.children_plan_nodes:
+                    id_parents_map[child_id.encoded_node_id_with_query].add(
                         node.encoded_node_id_with_query
                     )
-                    next_level.append(child)
+                    next_level.append(child_id)
+            current_level = next_level
+
+        # Bottom-up level order traversal to mark parent nodes
+        # invalid for deduplication
+        current_level = list(invalid_ids_for_deduplication)
+        while len(current_level) > 0:
+            next_level = []
+            for child_id in current_level:
+                for parent_id in id_parents_map[child_id]:
+                    invalid_ids_for_deduplication.add(parent_id)
+                    next_level.append(parent_id)
+                    for node in id_node_map[parent_id]:
+                        node._invalid_for_with_query_block_child = True
             current_level = next_level
 
     def is_duplicate_subtree(encoded_node_id_with_query: str) -> bool:
         # when a sql query is a select statement, its encoded_node_id_with_query
         # contains _, which is used to separate the query id and node type name.
-        is_valid_candidate = "_" in encoded_node_id_with_query
-        if not is_valid_candidate or is_simple_select_entity(
-            id_node_map[encoded_node_id_with_query][0]
-        ):
+        if "_" not in encoded_node_id_with_query:
+            return False
+
+        # when a node is a select * from entity, then we do not create a CTE
+        # on top of it even it is duplicated.
+        if is_simple_select_entity(id_node_map[encoded_node_id_with_query][0]):
+            return False
+
+        # when a node is marked to be considered invalid for any reason
+        # we do not
+        if encoded_node_id_with_query in invalid_ids_for_deduplication:
             return False
 
         is_duplicate_node = len(id_node_map[encoded_node_id_with_query]) > 1

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -107,8 +107,13 @@ def find_duplicate_subtrees(
         """
         This function uses an iterative approach to avoid hitting Python's maximum recursion depth limit.
         """
+<<<<<<< HEAD
         # Top down level order traversal to populate the
         # id_parents_map and encoded id_node_map
+=======
+        # Top down level order traversal to populate parent map
+        # and encoded id node map
+>>>>>>> 9e186e7c0 (Stack PR)
         current_level = [root]
         while len(current_level) > 0:
             next_level = []
@@ -118,11 +123,29 @@ def find_duplicate_subtrees(
                 if is_read_file_node(node):
                     invalid_ids_for_deduplication.add(node.encoded_node_id_with_query)
 
+<<<<<<< HEAD
                 for child in node.children_plan_nodes:
                     id_parents_map[child.encoded_node_id_with_query].add(
+=======
+                for child_id in node.children_plan_nodes:
+                    id_parents_map[child_id.encoded_node_id_with_query].add(
+>>>>>>> 9e186e7c0 (Stack PR)
                         node.encoded_node_id_with_query
                     )
-                    next_level.append(child)
+                    next_level.append(child_id)
+            current_level = next_level
+
+        # Bottom-up level order traversal to mark parent nodes
+        # invalid for deduplication
+        current_level = list(invalid_ids_for_deduplication)
+        while len(current_level) > 0:
+            next_level = []
+            for child_id in current_level:
+                for parent_id in id_parents_map[child_id]:
+                    invalid_ids_for_deduplication.add(parent_id)
+                    next_level.append(parent_id)
+                    for node in id_node_map[parent_id]:
+                        node._invalid_for_with_query_block_child = True
             current_level = next_level
 
         # Bottom-up level order traversal to mark parent nodes

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -107,8 +107,8 @@ def find_duplicate_subtrees(
         """
         This function uses an iterative approach to avoid hitting Python's maximum recursion depth limit.
         """
-        # Top down level order traversal to populate parent map
-        # and encoded id node map
+        # Top down level order traversal to populate the
+        # id_parents_map and encoded id_node_map
         current_level = [root]
         while len(current_level) > 0:
             next_level = []
@@ -118,15 +118,15 @@ def find_duplicate_subtrees(
                 if is_read_file_node(node):
                     invalid_ids_for_deduplication.add(node.encoded_node_id_with_query)
 
-                for child_id in node.children_plan_nodes:
-                    id_parents_map[child_id.encoded_node_id_with_query].add(
+                for child in node.children_plan_nodes:
+                    id_parents_map[child.encoded_node_id_with_query].add(
                         node.encoded_node_id_with_query
                     )
-                    next_level.append(child_id)
+                    next_level.append(child)
             current_level = next_level
 
         # Bottom-up level order traversal to mark parent nodes
-        # invalid for deduplication
+        # invalid for deduplication if the child is marked
         current_level = list(invalid_ids_for_deduplication)
         while len(current_level) > 0:
             next_level = []

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -90,7 +90,7 @@ def find_duplicate_subtrees(
 
         return False
 
-    def is_read_file_node(node: "TreeNode") -> bool:
+    def is_select_from_file_node(node: "TreeNode") -> bool:
         """
         Check if the current node is a SelectFromFileNode. Currently, we do not support
         deduplication for SelectFromFileNode due to SNOW-1911967.
@@ -99,7 +99,7 @@ def find_duplicate_subtrees(
             return isinstance(node.source_plan, SelectFromFileNode)
 
         if isinstance(node, SelectSnowflakePlan):
-            return is_read_file_node(node.snowflake_plan)
+            return is_select_from_file_node(node.snowflake_plan)
 
         return False
 
@@ -107,32 +107,22 @@ def find_duplicate_subtrees(
         """
         This function uses an iterative approach to avoid hitting Python's maximum recursion depth limit.
         """
-<<<<<<< HEAD
         # Top down level order traversal to populate the
         # id_parents_map and encoded id_node_map
-=======
-        # Top down level order traversal to populate parent map
-        # and encoded id node map
->>>>>>> 9e186e7c0 (Stack PR)
         current_level = [root]
         while len(current_level) > 0:
             next_level = []
             for node in current_level:
                 id_node_map[node.encoded_node_id_with_query].append(node)
 
-                if is_read_file_node(node):
+                if is_select_from_file_node(node):
                     invalid_ids_for_deduplication.add(node.encoded_node_id_with_query)
 
-<<<<<<< HEAD
                 for child in node.children_plan_nodes:
                     id_parents_map[child.encoded_node_id_with_query].add(
-=======
-                for child_id in node.children_plan_nodes:
-                    id_parents_map[child_id.encoded_node_id_with_query].add(
->>>>>>> 9e186e7c0 (Stack PR)
                         node.encoded_node_id_with_query
                     )
-                    next_level.append(child_id)
+                    next_level.append(child)
             current_level = next_level
 
         # Bottom-up level order traversal to mark parent nodes

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import snowflake.snowpark
-from snowflake.snowpark._internal.analyzer.snowflake_plan_node import SelectFromFileNode
+from snowflake.snowpark._internal.analyzer.snowflake_plan_node import ReadFileNode
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     create_file_format_statement,
@@ -584,7 +584,7 @@ class DataFrameReader:
                 self._session,
                 self._session._analyzer.create_select_statement(
                     from_=self._session._analyzer.create_select_snowflake_plan(
-                        SelectFromFileNode(
+                        ReadFileNode(
                             path,
                             self._file_type,
                             self._cur_options,
@@ -602,7 +602,7 @@ class DataFrameReader:
         else:
             df = DataFrame(
                 self._session,
-                SelectFromFileNode(
+                ReadFileNode(
                     path,
                     self._file_type,
                     self._cur_options,
@@ -990,7 +990,7 @@ class DataFrameReader:
                 self._session,
                 self._session._analyzer.create_select_statement(
                     from_=self._session._analyzer.create_select_snowflake_plan(
-                        SelectFromFileNode(
+                        ReadFileNode(
                             path,
                             format,
                             self._cur_options,
@@ -1009,7 +1009,7 @@ class DataFrameReader:
         else:
             df = DataFrame(
                 self._session,
-                SelectFromFileNode(
+                ReadFileNode(
                     path,
                     format,
                     self._cur_options,

--- a/src/snowflake/snowpark/mock/_analyzer.py
+++ b/src/snowflake/snowpark/mock/_analyzer.py
@@ -82,7 +82,7 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     Limit,
     LogicalPlan,
     Range,
-    SelectFromFileNode,
+    ReadFileNode,
     SnowflakeCreateTable,
     SnowflakeTable,
     SnowflakeValues,
@@ -927,7 +927,7 @@ class MockAnalyzer:
         if isinstance(logical_plan, CreateViewCommand):
             return MockExecutionPlan(logical_plan, self.session)
 
-        if isinstance(logical_plan, SelectFromFileNode):
+        if isinstance(logical_plan, ReadFileNode):
             return self.plan_builder.read_file(
                 path=logical_plan.path,
                 format=logical_plan.format,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -836,7 +836,7 @@ def test_df_reader(session, mode, resources_path):
     check_result(
         session,
         df_result,
-        expect_cte_optimized=True,
+        expect_cte_optimized=False,
         query_count=expected_query_count,
         describe_count=0,
         union_count=1,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -826,24 +826,24 @@ def test_df_reader(session, mode, resources_path):
 
     1.
                         UNION (invalid)
-                ________/    |________
+                ________/    |_________
                 |                      |
         SelectFromFileNode        SelectFromFileNode
 
     2.
                         UNION (invalid)
-                ________/    |________
+                ________/    |_________
                 |                      |
-        WithColumn (invalid)           WithColumn (invalid)
+        WithColumn (invalid)        WithColumn (invalid)
                 |                      |
         SelectFromFileNode        SelectFromFileNode
 
     3.
                             UNION (invalid)
-            __________________/    |___________________________
+            __________________/    |____________________________
             |                                                  |
         UNION (invalid)                                 UNION (invalid)
-         /     |____________                             ____/    |____________
+         /     |_____________                             ____/    |____________
         |                   |                           |                      |
     WithColumn(invalid)    WithColumn(valid)        WithColumn(invalid)    WithColumn (valid)
         |                     |                         |                       |
@@ -873,7 +873,7 @@ def test_df_reader(session, mode, resources_path):
     check_result(
         session,
         df_result,
-        expect_cte_optimized=False,
+        expect_cte_optimized=(mode == "copy"),
         query_count=expected_query_count,
         describe_count=0,
         union_count=1,
@@ -887,7 +887,7 @@ def test_df_reader(session, mode, resources_path):
     check_result(
         session,
         df_result,
-        expect_cte_optimized=False,
+        expect_cte_optimized=(mode == "copy"),
         query_count=expected_query_count,
         describe_count=0,
         union_count=1,
@@ -902,36 +902,7 @@ def test_df_reader(session, mode, resources_path):
     check_result(
         session,
         df_result,
-        expect_cte_optimized=False,
-        query_count=expected_query_count,
-        describe_count=0,
-        union_count=3,
-        join_count=0,
-    )
-
-    # Case 2
-    df_with_column1 = df_reader.with_column("a1", col("a") + 1)
-    df_result = df_with_column1.union_by_name(df_with_column1)
-    expected_query_count = 4 if mode == "copy" else 3
-    check_result(
-        session,
-        df_result,
-        expect_cte_optimized=False,
-        query_count=expected_query_count,
-        describe_count=0,
-        union_count=1,
-        join_count=0,
-    )
-
-    # Case 3
-    df_with_column2 = df_select.filter(col("a") == 3).with_column("a1", col("a") + 1)
-    df_union = df_with_column1.union_by_name(df_with_column2)
-    df_result = df_union.union_by_name(df_union)
-    expected_query_count = 4 if mode == "copy" else 3
-    check_result(
-        session,
-        df_result,
-        expect_cte_optimized=False,
+        expect_cte_optimized=True,
         query_count=expected_query_count,
         describe_count=0,
         union_count=3,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -902,7 +902,7 @@ def test_df_reader(session, mode, resources_path):
     check_result(
         session,
         df_result,
-        expect_cte_optimized=True,
+        expect_cte_optimized=False,
         query_count=expected_query_count,
         describe_count=0,
         union_count=3,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -821,6 +821,36 @@ def test_aggregate(session, action):
 @pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="need resources")
 @pytest.mark.parametrize("mode", ["select", "copy"])
 def test_df_reader(session, mode, resources_path):
+    """
+    Test the following cases for reader:
+
+    1.
+                        UNION (invalid)
+                ________/    |________
+                |                      |
+        SelectFromFileNode        SelectFromFileNode
+
+    2.
+                        UNION (invalid)
+                ________/    |________
+                |                      |
+        WithColumn (invalid)           WithColumn (invalid)
+                |                      |
+        SelectFromFileNode        SelectFromFileNode
+
+    3.
+                            UNION (invalid)
+            __________________/    |___________________________
+            |                                                  |
+        UNION (invalid)                                 UNION (invalid)
+         /     |____________                             ____/    |____________
+        |                   |                           |                      |
+    WithColumn(invalid)    WithColumn(valid)        WithColumn(invalid)    WithColumn (valid)
+        |                     |                         |                       |
+    SelectFromFileNode      Filter (valid)          SelectFromFileNode      Filter (valid)
+                               |                                                |
+                          Select (valid)                                  Select (valid)
+    """
     reader = get_reader(session, mode)
     session_stage = session.get_session_stage()
     test_files = TestFiles(resources_path)
@@ -828,11 +858,18 @@ def test_df_reader(session, mode, resources_path):
     Utils.upload_to_stage(
         session, session_stage, test_files.test_file_csv, compress=False
     )
-    df = reader.option("INFER_SCHEMA", True).csv(test_file_on_stage)
-    df_result = df.union_by_name(df)
-    expected_query_count = 3
-    if mode == "copy":
-        expected_query_count = 4
+    table_name = Utils.random_table_name()
+    session.create_dataframe(
+        [[3, "three", 3.3], [4, "four", 4.4]], schema=["a", "b", "c"]
+    ).write.save_as_table(table_name, table_type="temp")
+    df_reader = (
+        reader.option("INFER_SCHEMA", True).csv(test_file_on_stage).to_df("a", "b", "c")
+    )
+    df_select = session.table(table_name).select("a", "b", "c")
+
+    # Case 1
+    df_result = df_reader.union_by_name(df_reader)
+    expected_query_count = 4 if mode == "copy" else 3
     check_result(
         session,
         df_result,
@@ -840,6 +877,35 @@ def test_df_reader(session, mode, resources_path):
         query_count=expected_query_count,
         describe_count=0,
         union_count=1,
+        join_count=0,
+    )
+
+    # Case 2
+    df_with_column1 = df_reader.with_column("a1", col("a") + 1)
+    df_result = df_with_column1.union_by_name(df_with_column1)
+    expected_query_count = 4 if mode == "copy" else 3
+    check_result(
+        session,
+        df_result,
+        expect_cte_optimized=False,
+        query_count=expected_query_count,
+        describe_count=0,
+        union_count=1,
+        join_count=0,
+    )
+
+    # Case 3
+    df_with_column2 = df_select.filter(col("a") == 3).with_column("a1", col("a") + 1)
+    df_union = df_with_column1.union_by_name(df_with_column2)
+    df_result = df_union.union_by_name(df_union)
+    expected_query_count = 4 if mode == "copy" else 3
+    check_result(
+        session,
+        df_result,
+        expect_cte_optimized=True,
+        query_count=expected_query_count,
+        describe_count=0,
+        union_count=3,
         join_count=0,
     )
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1906574

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   In this PR, we when traversing the plan, we detect if child contains a `SelectFromFileNode` node. If it does, it marks all its parent ineligible to be detected as valid duplicate nodes. 
