### PR TITLE
SNOW-1906574: Skip creating CTE on SelectFromFileNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
+
 ## 1.29.0 (TBD)
 
 ### Snowpark Python API Updates
+
+#### Bug Fixed
+
+- Fixed a bug where `df.describe` raised internal SQL execution error when the dataframe is created from reading a stage file and CTE optimization is enabled.
 
 ### Snowpark pandas API Updates
 

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -134,8 +134,6 @@ def find_duplicate_subtrees(
                 for parent_id in id_parents_map[child_id]:
                     invalid_ids_for_deduplication.add(parent_id)
                     next_level.append(parent_id)
-                    for node in id_node_map[parent_id]:
-                        node._invalid_for_with_query_block_child = True
             current_level = next_level
 
     def is_duplicate_subtree(encoded_node_id_with_query: str) -> bool:

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -148,7 +148,7 @@ def find_duplicate_subtrees(
             return False
 
         # when a node is marked to be considered invalid for any reason
-        # we do not
+        # we do not create a CTE on top of it even it is duplicated.
         if encoded_node_id_with_query in invalid_ids_for_deduplication:
             return False
 

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -11,6 +11,7 @@ from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     get_complexity_score,
 )
 from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
+    SelectFromFileNode,
     SnowflakeTable,
     WithQueryBlock,
 )
@@ -50,6 +51,9 @@ def find_duplicate_subtrees(
     """
     id_node_map = defaultdict(list)
     id_parents_map = defaultdict(set)
+    # set of encoded node ids which are ineligible to be deduplicated
+    # during this process
+    invalid_ids_for_deduplication = set()
 
     from snowflake.snowpark._internal.analyzer.select_statement import (
         Selectable,
@@ -86,15 +90,34 @@ def find_duplicate_subtrees(
 
         return False
 
+    def is_select_from_file_node(node: "TreeNode") -> bool:
+        """
+        Check if the current node is a SelectFromFileNode. Currently, we do not support
+        deduplication for SelectFromFileNode due to SNOW-1911967.
+        """
+        if isinstance(node, SnowflakePlan) and (node.source_plan is not None):
+            return isinstance(node.source_plan, SelectFromFileNode)
+
+        if isinstance(node, SelectSnowflakePlan):
+            return is_select_from_file_node(node.snowflake_plan)
+
+        return False
+
     def traverse(root: "TreeNode") -> None:
         """
         This function uses an iterative approach to avoid hitting Python's maximum recursion depth limit.
         """
+        # Top down level order traversal to populate the
+        # id_parents_map and encoded id_node_map
         current_level = [root]
         while len(current_level) > 0:
             next_level = []
             for node in current_level:
                 id_node_map[node.encoded_node_id_with_query].append(node)
+
+                if is_select_from_file_node(node):
+                    invalid_ids_for_deduplication.add(node.encoded_node_id_with_query)
+
                 for child in node.children_plan_nodes:
                     id_parents_map[child.encoded_node_id_with_query].add(
                         node.encoded_node_id_with_query
@@ -102,13 +125,33 @@ def find_duplicate_subtrees(
                     next_level.append(child)
             current_level = next_level
 
+        # Bottom-up level order traversal to mark parent nodes
+        # invalid for deduplication
+        current_level = list(invalid_ids_for_deduplication)
+        while len(current_level) > 0:
+            next_level = []
+            for child_id in current_level:
+                for parent_id in id_parents_map[child_id]:
+                    invalid_ids_for_deduplication.add(parent_id)
+                    next_level.append(parent_id)
+                    for node in id_node_map[parent_id]:
+                        node._invalid_for_with_query_block_child = True
+            current_level = next_level
+
     def is_duplicate_subtree(encoded_node_id_with_query: str) -> bool:
         # when a sql query is a select statement, its encoded_node_id_with_query
         # contains _, which is used to separate the query id and node type name.
-        is_valid_candidate = "_" in encoded_node_id_with_query
-        if not is_valid_candidate or is_simple_select_entity(
-            id_node_map[encoded_node_id_with_query][0]
-        ):
+        if "_" not in encoded_node_id_with_query:
+            return False
+
+        # when a node is a select * from entity, then we do not create a CTE
+        # on top of it even it is duplicated.
+        if is_simple_select_entity(id_node_map[encoded_node_id_with_query][0]):
+            return False
+
+        # when a node is marked to be considered invalid for any reason
+        # we do not
+        if encoded_node_id_with_query in invalid_ids_for_deduplication:
             return False
 
         is_duplicate_node = len(id_node_map[encoded_node_id_with_query]) > 1


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1906574

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   In this PR we update duplicate node detection logic where we invalidate any `WithQueryBlock` to contain a `SelectFromFileNode` as a child in its subtree. We do this by detecting `SelectFromFileNode` as a leaf and doing a bottom-up traversal, marking all parent as invalid in the deduplication logic.
