### PR TITLE
SNOW-1941024: Unify DataframeSelect variants and DataframeUnion variants

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -84,7 +84,7 @@ message ColumnAliasFn {
   }
 }
 
-// type.ir:31
+// type.ir:32
 message ColumnRef {
   oneof sealed_value {
     ColumnIdentifier column_identifier = 1;
@@ -92,12 +92,12 @@ message ColumnRef {
   }
 }
 
-// type.ir:32
+// type.ir:33
 message ColumnIdentifier {
   string name = 1;
 }
 
-// type.ir:33
+// type.ir:34
 message ColumnName {
   string name = 1;
 }
@@ -112,23 +112,24 @@ message DataType {
     bool date_type = 5;
     DecimalType decimal_type = 6;
     bool double_type = 7;
-    bool float_type = 8;
-    bool geography_type = 9;
-    bool geometry_type = 10;
-    bool integer_type = 11;
-    bool long_type = 12;
-    MapType map_type = 13;
-    bool null_type = 14;
-    PandasDataFrameType pandas_data_frame_type = 15;
-    PandasSeriesType pandas_series_type = 16;
-    bool short_type = 17;
-    StringType string_type = 18;
-    StructField struct_field = 19;
-    StructType struct_type = 20;
-    bool time_type = 21;
-    TimestampType timestamp_type = 22;
-    bool variant_type = 23;
-    VectorType vector_type = 24;
+    bool file_type = 8;
+    bool float_type = 9;
+    bool geography_type = 10;
+    bool geometry_type = 11;
+    bool integer_type = 12;
+    bool long_type = 13;
+    MapType map_type = 14;
+    bool null_type = 15;
+    PandasDataFrameType pandas_data_frame_type = 16;
+    PandasSeriesType pandas_series_type = 17;
+    bool short_type = 18;
+    StringType string_type = 19;
+    StructField struct_field = 20;
+    StructType struct_type = 21;
+    bool time_type = 22;
+    TimestampType timestamp_type = 23;
+    bool variant_type = 24;
+    VectorType vector_type = 25;
   }
 }
 
@@ -144,48 +145,48 @@ message DecimalType {
   int64 scale = 2;
 }
 
-// type.ir:15
+// type.ir:16
 message MapType {
   DataType key_ty = 1;
   bool structured = 2;
   DataType value_ty = 3;
 }
 
-// type.ir:18
+// type.ir:19
 message StringType {
   google.protobuf.Int64Value length = 1;
 }
 
-// type.ir:19
+// type.ir:20
 message StructField {
   ColumnRef column_identifier = 1;
   DataType data_type = 2;
   bool nullable = 3;
 }
 
-// type.ir:20
+// type.ir:21
 message StructType {
   List_StructField fields = 1;
   bool structured = 2;
 }
 
-// type.ir:22
+// type.ir:23
 message TimestampType {
   TimestampTimeZone time_zone = 1;
 }
 
-// type.ir:24
+// type.ir:25
 message VectorType {
   int64 dimension = 1;
   DataType ty = 2;
 }
 
-// type.ir:26
+// type.ir:27
 message PandasSeriesType {
   DataType el_ty = 1;
 }
 
-// type.ir:27
+// type.ir:28
 message PandasDataFrameType {
   repeated string col_names = 1;
   repeated DataType col_types = 2;
@@ -215,7 +216,7 @@ message DataframeData_Pandas {
   StagedPandasDataframe v = 1;
 }
 
-// type.ir:43
+// type.ir:44
 message DataframeSchema {
   oneof sealed_value {
     DataframeSchema_List dataframe_schema__list = 1;
@@ -223,12 +224,12 @@ message DataframeSchema {
   }
 }
 
-// type.ir:44
+// type.ir:45
 message DataframeSchema_List {
   repeated string vs = 1;
 }
 
-// type.ir:45
+// type.ir:46
 message DataframeSchema_Struct {
   StructType v = 1;
 }
@@ -364,7 +365,7 @@ message TableVariant {
   }
 }
 
-// type.ir:36
+// type.ir:37
 message TimestampTimeZone {
   oneof variant {
     bool timestamp_time_zone_default = 1;
@@ -1155,21 +1156,16 @@ message DataframeSample {
   Expr df = 1;
   google.protobuf.Int64Value num = 2;
   google.protobuf.DoubleValue probability_fraction = 3;
-  SrcPosition src = 4;
+  google.protobuf.Int64Value seed = 4;
+  SrcPosition src = 5;
 }
 
 // dataframe.ir:297
-message DataframeSelect_Columns {
+message DataframeSelect {
   ExprArgList cols = 1;
   Expr df = 2;
-  SrcPosition src = 3;
-}
-
-// dataframe.ir:302
-message DataframeSelect_Exprs {
-  Expr df = 1;
-  ExprArgList exprs = 2;
-  SrcPosition src = 3;
+  bool expr_variant = 3;
+  SrcPosition src = 4;
 }
 
 // dataframe.ir:8
@@ -1179,7 +1175,7 @@ message DataframeShow {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:307
+// dataframe.ir:304
 message DataframeSort {
   Expr ascending = 1;
   ExprArgList cols = 2;
@@ -1263,32 +1259,14 @@ message DataframeToPandasBatches {
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe.ir:314
+// dataframe.ir:310
 message DataframeUnion {
-  Expr df = 1;
-  Expr other = 2;
-  SrcPosition src = 3;
-}
-
-// dataframe.ir:319
-message DataframeUnionAll {
-  Expr df = 1;
-  Expr other = 2;
-  SrcPosition src = 3;
-}
-
-// dataframe.ir:324
-message DataframeUnionAllByName {
-  Expr df = 1;
-  Expr other = 2;
-  SrcPosition src = 3;
-}
-
-// dataframe.ir:329
-message DataframeUnionByName {
-  Expr df = 1;
-  Expr other = 2;
-  SrcPosition src = 3;
+  bool all = 1;
+  bool allow_missing_columns = 2;
+  bool by_name = 3;
+  Expr df = 4;
+  Expr other = 5;
+  SrcPosition src = 6;
 }
 
 // dataframe.ir:269
@@ -1301,7 +1279,7 @@ message DataframeUnpivot {
   string value_column = 6;
 }
 
-// dataframe.ir:334
+// dataframe.ir:318
 message DataframeWithColumn {
   Expr col = 1;
   string col_name = 2;
@@ -1309,7 +1287,7 @@ message DataframeWithColumn {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:340
+// dataframe.ir:324
 message DataframeWithColumnRenamed {
   Expr col = 1;
   Expr df = 2;
@@ -1317,7 +1295,7 @@ message DataframeWithColumnRenamed {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:346
+// dataframe.ir:330
 message DataframeWithColumns {
   repeated string col_names = 1;
   Expr df = 2;
@@ -1489,100 +1467,96 @@ message Expr {
     DataframeRename dataframe_rename = 89;
     DataframeRollup dataframe_rollup = 90;
     DataframeSample dataframe_sample = 91;
-    DataframeSelect_Columns dataframe_select__columns = 92;
-    DataframeSelect_Exprs dataframe_select__exprs = 93;
-    DataframeShow dataframe_show = 94;
-    DataframeSort dataframe_sort = 95;
-    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 96;
-    DataframeStatCorr dataframe_stat_corr = 97;
-    DataframeStatCov dataframe_stat_cov = 98;
-    DataframeStatCrossTab dataframe_stat_cross_tab = 99;
-    DataframeStatSampleBy dataframe_stat_sample_by = 100;
-    DataframeToDf dataframe_to_df = 101;
-    DataframeToLocalIterator dataframe_to_local_iterator = 102;
-    DataframeToPandas dataframe_to_pandas = 103;
-    DataframeToPandasBatches dataframe_to_pandas_batches = 104;
-    DataframeUnion dataframe_union = 105;
-    DataframeUnionAll dataframe_union_all = 106;
-    DataframeUnionAllByName dataframe_union_all_by_name = 107;
-    DataframeUnionByName dataframe_union_by_name = 108;
-    DataframeUnpivot dataframe_unpivot = 109;
-    DataframeWithColumn dataframe_with_column = 110;
-    DataframeWithColumnRenamed dataframe_with_column_renamed = 111;
-    DataframeWithColumns dataframe_with_columns = 112;
-    DataframeWrite dataframe_write = 113;
-    DatatypeVal datatype_val = 114;
-    Div div = 115;
-    Eq eq = 116;
-    Flatten flatten = 117;
-    Float64Val float64_val = 118;
-    FnRef fn_ref = 119;
-    Generator generator = 120;
-    Geq geq = 121;
-    GroupingSets grouping_sets = 122;
-    Gt gt = 123;
-    IndirectTableFnIdRef indirect_table_fn_id_ref = 124;
-    IndirectTableFnNameRef indirect_table_fn_name_ref = 125;
-    Int64Val int64_val = 126;
-    Leq leq = 127;
-    ListVal list_val = 128;
-    Lt lt = 129;
-    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 130;
-    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 131;
-    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 132;
-    Mod mod = 133;
-    Mul mul = 134;
-    Neg neg = 135;
-    Neq neq = 136;
-    Not not = 137;
-    NullVal null_val = 138;
-    ObjectGetItem object_get_item = 139;
-    Or or = 140;
-    Pow pow = 141;
-    PythonDateVal python_date_val = 142;
-    PythonTimeVal python_time_val = 143;
-    PythonTimestampVal python_timestamp_val = 144;
-    Range range = 145;
-    ReadAvro read_avro = 146;
-    ReadCsv read_csv = 147;
-    ReadJson read_json = 148;
-    ReadOrc read_orc = 149;
-    ReadParquet read_parquet = 150;
-    ReadTable read_table = 151;
-    ReadXml read_xml = 152;
-    RedactedConst redacted_const = 153;
-    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 154;
-    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 155;
-    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 156;
-    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 157;
-    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 158;
-    Row row = 159;
-    SeqMapVal seq_map_val = 160;
-    SessionTableFunction session_table_function = 161;
-    Sql sql = 162;
-    SqlExpr sql_expr = 163;
-    StoredProcedure stored_procedure = 164;
-    StringVal string_val = 165;
-    Sub sub = 166;
-    Table table = 167;
-    TableDelete table_delete = 168;
-    TableDropTable table_drop_table = 169;
-    TableFnCallAlias table_fn_call_alias = 170;
-    TableFnCallOver table_fn_call_over = 171;
-    TableMerge table_merge = 172;
-    TableSample table_sample = 173;
-    TableUpdate table_update = 174;
-    ToSnowparkPandas to_snowpark_pandas = 175;
-    TupleVal tuple_val = 176;
-    Udaf udaf = 177;
-    Udf udf = 178;
-    Udtf udtf = 179;
-    WriteCopyIntoLocation write_copy_into_location = 180;
-    WriteCsv write_csv = 181;
-    WriteJson write_json = 182;
-    WritePandas write_pandas = 183;
-    WriteParquet write_parquet = 184;
-    WriteTable write_table = 185;
+    DataframeSelect dataframe_select = 92;
+    DataframeShow dataframe_show = 93;
+    DataframeSort dataframe_sort = 94;
+    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 95;
+    DataframeStatCorr dataframe_stat_corr = 96;
+    DataframeStatCov dataframe_stat_cov = 97;
+    DataframeStatCrossTab dataframe_stat_cross_tab = 98;
+    DataframeStatSampleBy dataframe_stat_sample_by = 99;
+    DataframeToDf dataframe_to_df = 100;
+    DataframeToLocalIterator dataframe_to_local_iterator = 101;
+    DataframeToPandas dataframe_to_pandas = 102;
+    DataframeToPandasBatches dataframe_to_pandas_batches = 103;
+    DataframeUnion dataframe_union = 104;
+    DataframeUnpivot dataframe_unpivot = 105;
+    DataframeWithColumn dataframe_with_column = 106;
+    DataframeWithColumnRenamed dataframe_with_column_renamed = 107;
+    DataframeWithColumns dataframe_with_columns = 108;
+    DataframeWrite dataframe_write = 109;
+    DatatypeVal datatype_val = 110;
+    Div div = 111;
+    Eq eq = 112;
+    Flatten flatten = 113;
+    Float64Val float64_val = 114;
+    FnRef fn_ref = 115;
+    Generator generator = 116;
+    Geq geq = 117;
+    GroupingSets grouping_sets = 118;
+    Gt gt = 119;
+    IndirectTableFnIdRef indirect_table_fn_id_ref = 120;
+    IndirectTableFnNameRef indirect_table_fn_name_ref = 121;
+    Int64Val int64_val = 122;
+    Leq leq = 123;
+    ListVal list_val = 124;
+    Lt lt = 125;
+    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 126;
+    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 127;
+    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 128;
+    Mod mod = 129;
+    Mul mul = 130;
+    Neg neg = 131;
+    Neq neq = 132;
+    Not not = 133;
+    NullVal null_val = 134;
+    ObjectGetItem object_get_item = 135;
+    Or or = 136;
+    Pow pow = 137;
+    PythonDateVal python_date_val = 138;
+    PythonTimeVal python_time_val = 139;
+    PythonTimestampVal python_timestamp_val = 140;
+    Range range = 141;
+    ReadAvro read_avro = 142;
+    ReadCsv read_csv = 143;
+    ReadJson read_json = 144;
+    ReadOrc read_orc = 145;
+    ReadParquet read_parquet = 146;
+    ReadTable read_table = 147;
+    ReadXml read_xml = 148;
+    RedactedConst redacted_const = 149;
+    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 150;
+    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 151;
+    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 152;
+    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 153;
+    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 154;
+    Row row = 155;
+    SeqMapVal seq_map_val = 156;
+    SessionTableFunction session_table_function = 157;
+    Sql sql = 158;
+    SqlExpr sql_expr = 159;
+    StoredProcedure stored_procedure = 160;
+    StringVal string_val = 161;
+    Sub sub = 162;
+    Table table = 163;
+    TableDelete table_delete = 164;
+    TableDropTable table_drop_table = 165;
+    TableFnCallAlias table_fn_call_alias = 166;
+    TableFnCallOver table_fn_call_over = 167;
+    TableMerge table_merge = 168;
+    TableSample table_sample = 169;
+    TableUpdate table_update = 170;
+    ToSnowparkPandas to_snowpark_pandas = 171;
+    TupleVal tuple_val = 172;
+    Udaf udaf = 173;
+    Udf udf = 174;
+    Udtf udtf = 175;
+    WriteCopyIntoLocation write_copy_into_location = 176;
+    WriteCsv write_csv = 177;
+    WriteJson write_json = 178;
+    WritePandas write_pandas = 179;
+    WriteParquet write_parquet = 180;
+    WriteTable write_table = 181;
   }
 }
 
@@ -1674,7 +1648,7 @@ message Geq {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:352
+// dataframe.ir:336
 message GroupingSets {
   ExprArgList sets = 1;
   SrcPosition src = 2;
@@ -1783,106 +1757,102 @@ message HasSrcPosition {
     DataframeRename dataframe_rename = 92;
     DataframeRollup dataframe_rollup = 93;
     DataframeSample dataframe_sample = 94;
-    DataframeSelect_Columns dataframe_select__columns = 95;
-    DataframeSelect_Exprs dataframe_select__exprs = 96;
-    DataframeShow dataframe_show = 97;
-    DataframeSort dataframe_sort = 98;
-    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 99;
-    DataframeStatCorr dataframe_stat_corr = 100;
-    DataframeStatCov dataframe_stat_cov = 101;
-    DataframeStatCrossTab dataframe_stat_cross_tab = 102;
-    DataframeStatSampleBy dataframe_stat_sample_by = 103;
-    DataframeToDf dataframe_to_df = 104;
-    DataframeToLocalIterator dataframe_to_local_iterator = 105;
-    DataframeToPandas dataframe_to_pandas = 106;
-    DataframeToPandasBatches dataframe_to_pandas_batches = 107;
-    DataframeUnion dataframe_union = 108;
-    DataframeUnionAll dataframe_union_all = 109;
-    DataframeUnionAllByName dataframe_union_all_by_name = 110;
-    DataframeUnionByName dataframe_union_by_name = 111;
-    DataframeUnpivot dataframe_unpivot = 112;
-    DataframeWithColumn dataframe_with_column = 113;
-    DataframeWithColumnRenamed dataframe_with_column_renamed = 114;
-    DataframeWithColumns dataframe_with_columns = 115;
-    DataframeWrite dataframe_write = 116;
-    DatatypeVal datatype_val = 117;
-    Div div = 118;
-    Eq eq = 119;
-    Flatten flatten = 120;
-    Float64Val float64_val = 121;
-    FnRef fn_ref = 122;
-    Generator generator = 123;
-    Geq geq = 124;
-    GroupingSets grouping_sets = 125;
-    Gt gt = 126;
-    IndirectTableFnIdRef indirect_table_fn_id_ref = 127;
-    IndirectTableFnNameRef indirect_table_fn_name_ref = 128;
-    Int64Val int64_val = 129;
-    Leq leq = 130;
-    ListVal list_val = 131;
-    Lt lt = 132;
-    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 133;
-    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 134;
-    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 135;
-    Mod mod = 136;
-    Mul mul = 137;
-    NameRef name_ref = 138;
-    Neg neg = 139;
-    Neq neq = 140;
-    Not not = 141;
-    NullVal null_val = 142;
-    ObjectGetItem object_get_item = 143;
-    Or or = 144;
-    Pow pow = 145;
-    PythonDateVal python_date_val = 146;
-    PythonTimeVal python_time_val = 147;
-    PythonTimestampVal python_timestamp_val = 148;
-    Range range = 149;
-    ReadAvro read_avro = 150;
-    ReadCsv read_csv = 151;
-    ReadJson read_json = 152;
-    ReadOrc read_orc = 153;
-    ReadParquet read_parquet = 154;
-    ReadTable read_table = 155;
-    ReadXml read_xml = 156;
-    RedactedConst redacted_const = 157;
-    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 158;
-    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 159;
-    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 160;
-    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 161;
-    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 162;
-    Row row = 163;
-    SeqMapVal seq_map_val = 164;
-    SessionTableFunction session_table_function = 165;
-    Sql sql = 166;
-    SqlExpr sql_expr = 167;
-    StoredProcedure stored_procedure = 168;
-    StringVal string_val = 169;
-    Sub sub = 170;
-    Table table = 171;
-    TableDelete table_delete = 172;
-    TableDropTable table_drop_table = 173;
-    TableFnCallAlias table_fn_call_alias = 174;
-    TableFnCallOver table_fn_call_over = 175;
-    TableMerge table_merge = 176;
-    TableSample table_sample = 177;
-    TableUpdate table_update = 178;
-    ToSnowparkPandas to_snowpark_pandas = 179;
-    TupleVal tuple_val = 180;
-    Udaf udaf = 181;
-    Udf udf = 182;
-    Udtf udtf = 183;
-    WindowSpecEmpty window_spec_empty = 184;
-    WindowSpecOrderBy window_spec_order_by = 185;
-    WindowSpecPartitionBy window_spec_partition_by = 186;
-    WindowSpecRangeBetween window_spec_range_between = 187;
-    WindowSpecRowsBetween window_spec_rows_between = 188;
-    WriteCopyIntoLocation write_copy_into_location = 189;
-    WriteCsv write_csv = 190;
-    WriteJson write_json = 191;
-    WritePandas write_pandas = 192;
-    WriteParquet write_parquet = 193;
-    WriteTable write_table = 194;
+    DataframeSelect dataframe_select = 95;
+    DataframeShow dataframe_show = 96;
+    DataframeSort dataframe_sort = 97;
+    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 98;
+    DataframeStatCorr dataframe_stat_corr = 99;
+    DataframeStatCov dataframe_stat_cov = 100;
+    DataframeStatCrossTab dataframe_stat_cross_tab = 101;
+    DataframeStatSampleBy dataframe_stat_sample_by = 102;
+    DataframeToDf dataframe_to_df = 103;
+    DataframeToLocalIterator dataframe_to_local_iterator = 104;
+    DataframeToPandas dataframe_to_pandas = 105;
+    DataframeToPandasBatches dataframe_to_pandas_batches = 106;
+    DataframeUnion dataframe_union = 107;
+    DataframeUnpivot dataframe_unpivot = 108;
+    DataframeWithColumn dataframe_with_column = 109;
+    DataframeWithColumnRenamed dataframe_with_column_renamed = 110;
+    DataframeWithColumns dataframe_with_columns = 111;
+    DataframeWrite dataframe_write = 112;
+    DatatypeVal datatype_val = 113;
+    Div div = 114;
+    Eq eq = 115;
+    Flatten flatten = 116;
+    Float64Val float64_val = 117;
+    FnRef fn_ref = 118;
+    Generator generator = 119;
+    Geq geq = 120;
+    GroupingSets grouping_sets = 121;
+    Gt gt = 122;
+    IndirectTableFnIdRef indirect_table_fn_id_ref = 123;
+    IndirectTableFnNameRef indirect_table_fn_name_ref = 124;
+    Int64Val int64_val = 125;
+    Leq leq = 126;
+    ListVal list_val = 127;
+    Lt lt = 128;
+    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 129;
+    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 130;
+    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 131;
+    Mod mod = 132;
+    Mul mul = 133;
+    NameRef name_ref = 134;
+    Neg neg = 135;
+    Neq neq = 136;
+    Not not = 137;
+    NullVal null_val = 138;
+    ObjectGetItem object_get_item = 139;
+    Or or = 140;
+    Pow pow = 141;
+    PythonDateVal python_date_val = 142;
+    PythonTimeVal python_time_val = 143;
+    PythonTimestampVal python_timestamp_val = 144;
+    Range range = 145;
+    ReadAvro read_avro = 146;
+    ReadCsv read_csv = 147;
+    ReadJson read_json = 148;
+    ReadOrc read_orc = 149;
+    ReadParquet read_parquet = 150;
+    ReadTable read_table = 151;
+    ReadXml read_xml = 152;
+    RedactedConst redacted_const = 153;
+    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 154;
+    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 155;
+    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 156;
+    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 157;
+    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 158;
+    Row row = 159;
+    SeqMapVal seq_map_val = 160;
+    SessionTableFunction session_table_function = 161;
+    Sql sql = 162;
+    SqlExpr sql_expr = 163;
+    StoredProcedure stored_procedure = 164;
+    StringVal string_val = 165;
+    Sub sub = 166;
+    Table table = 167;
+    TableDelete table_delete = 168;
+    TableDropTable table_drop_table = 169;
+    TableFnCallAlias table_fn_call_alias = 170;
+    TableFnCallOver table_fn_call_over = 171;
+    TableMerge table_merge = 172;
+    TableSample table_sample = 173;
+    TableUpdate table_update = 174;
+    ToSnowparkPandas to_snowpark_pandas = 175;
+    TupleVal tuple_val = 176;
+    Udaf udaf = 177;
+    Udf udf = 178;
+    Udtf udtf = 179;
+    WindowSpecEmpty window_spec_empty = 180;
+    WindowSpecOrderBy window_spec_order_by = 181;
+    WindowSpecPartitionBy window_spec_partition_by = 182;
+    WindowSpecRangeBetween window_spec_range_between = 183;
+    WindowSpecRowsBetween window_spec_rows_between = 184;
+    WriteCopyIntoLocation write_copy_into_location = 185;
+    WriteCsv write_csv = 186;
+    WriteJson write_json = 187;
+    WritePandas write_pandas = 188;
+    WriteParquet write_parquet = 189;
+    WriteTable write_table = 190;
   }
 }
 
@@ -2332,7 +2302,7 @@ message TableUpdate {
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe.ir:356
+// dataframe.ir:340
 message ToSnowparkPandas {
   List_String columns = 1;
   Expr df = 2;

--- a/tests/ast/data/DataFrame.cross_join.lsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.lsuffix.test
@@ -130,7 +130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.cross_join.rsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.rsuffix.test
@@ -130,7 +130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.cross_join.suffix.test
+++ b/tests/ast/data/DataFrame.cross_join.suffix.test
@@ -133,7 +133,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.indexers.test
+++ b/tests/ast/data/DataFrame.indexers.test
@@ -64,7 +64,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -115,7 +115,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -166,7 +166,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {

--- a/tests/ast/data/DataFrame.join.inner.column.test
+++ b/tests/ast/data/DataFrame.join.inner.column.test
@@ -145,7 +145,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {

--- a/tests/ast/data/DataFrame.join.inner.column_list.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list.test
@@ -161,7 +161,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
@@ -242,7 +242,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {

--- a/tests/ast/data/DataFrame.join.inner.predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate.test
@@ -182,7 +182,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {

--- a/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
@@ -245,7 +245,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.join.left_outer.column.test
+++ b/tests/ast/data/DataFrame.join.left_outer.column.test
@@ -161,7 +161,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.join.right_outer.predicate.test
+++ b/tests/ast/data/DataFrame.join.right_outer.predicate.test
@@ -182,7 +182,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.natural_join.test
+++ b/tests/ast/data/DataFrame.natural_join.test
@@ -130,7 +130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/DataFrame.select_expr.test
+++ b/tests/ast/data/DataFrame.select_expr.test
@@ -69,15 +69,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__exprs {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        exprs {
+      dataframe_select {
+        cols {
           args {
             string_val {
               src {
@@ -92,6 +85,14 @@ body {
           }
           variadic: true
         }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        expr_variant: true
         src {
           end_column: 33
           end_line: 27
@@ -113,15 +114,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__exprs {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 2
-            }
-          }
-        }
-        exprs {
+      dataframe_select {
+        cols {
           args {
             string_val {
               src {
@@ -135,6 +129,14 @@ body {
             }
           }
         }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
+        }
+        expr_variant: true
         src {
           end_column: 35
           end_line: 29
@@ -156,15 +158,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__exprs {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 3
-            }
-          }
-        }
-        exprs {
+      dataframe_select {
+        cols {
           args {
             string_val {
               src {
@@ -239,6 +234,14 @@ body {
           }
           variadic: true
         }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
+        }
+        expr_variant: true
         src {
           end_column: 100
           end_line: 31
@@ -260,15 +263,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__exprs {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 4
-            }
-          }
-        }
-        exprs {
+      dataframe_select {
+        cols {
           args {
             string_val {
               src {
@@ -342,6 +338,14 @@ body {
             }
           }
         }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 4
+            }
+          }
+        }
+        expr_variant: true
         src {
           end_column: 102
           end_line: 33

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -148,7 +148,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sql_expr {

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -60,7 +60,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -163,7 +163,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -351,7 +351,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {

--- a/tests/ast/data/Table.init.test
+++ b/tests/ast/data/Table.init.test
@@ -56,7 +56,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/case_when.test
+++ b/tests/ast/data/case_when.test
@@ -95,7 +95,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -193,7 +193,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -413,7 +413,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -611,7 +611,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -741,7 +741,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -1015,7 +1015,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -1235,7 +1235,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -1399,7 +1399,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {

--- a/tests/ast/data/col_alias.test
+++ b/tests/ast/data/col_alias.test
@@ -70,7 +70,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -151,7 +151,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -232,7 +232,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -313,7 +313,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {

--- a/tests/ast/data/col_asc.test
+++ b/tests/ast/data/col_asc.test
@@ -66,7 +66,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_asc {
@@ -146,7 +146,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_asc {
@@ -226,7 +226,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_asc {

--- a/tests/ast/data/col_between.test
+++ b/tests/ast/data/col_between.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_between {

--- a/tests/ast/data/col_binops.test
+++ b/tests/ast/data/col_binops.test
@@ -109,7 +109,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             eq {
@@ -220,7 +220,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             neq {
@@ -331,7 +331,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             gt {
@@ -442,7 +442,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             lt {
@@ -553,7 +553,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             geq {
@@ -664,7 +664,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             leq {
@@ -775,7 +775,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -886,7 +886,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sub {
@@ -997,7 +997,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             mul {
@@ -1108,7 +1108,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             div {
@@ -1219,7 +1219,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             mod {
@@ -1330,7 +1330,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             pow {
@@ -1441,7 +1441,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             and {
@@ -1552,7 +1552,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             or {

--- a/tests/ast/data/col_bitops.test
+++ b/tests/ast/data/col_bitops.test
@@ -65,7 +65,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             bit_and {
@@ -176,7 +176,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             bit_or {
@@ -287,7 +287,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             bit_xor {

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -176,7 +176,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -256,7 +256,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -336,7 +336,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -416,7 +416,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -496,7 +496,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -579,7 +579,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -659,7 +659,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -739,7 +739,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -819,7 +819,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -899,7 +899,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -979,7 +979,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1059,7 +1059,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1143,7 +1143,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1223,7 +1223,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1310,7 +1310,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1394,7 +1394,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1487,7 +1487,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1572,7 +1572,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1653,7 +1653,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1736,7 +1736,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1830,7 +1830,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1910,7 +1910,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -1990,7 +1990,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2070,7 +2070,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2150,7 +2150,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2230,7 +2230,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2310,7 +2310,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2390,7 +2390,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2472,7 +2472,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -2554,7 +2554,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -89,7 +89,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -173,7 +173,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -257,7 +257,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -341,7 +341,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -425,7 +425,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -510,7 +510,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -598,7 +598,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {
@@ -683,7 +683,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_cast {

--- a/tests/ast/data/col_desc.test
+++ b/tests/ast/data/col_desc.test
@@ -64,7 +64,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_desc {
@@ -144,7 +144,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_desc {
@@ -224,7 +224,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_desc {

--- a/tests/ast/data/col_getitem.test
+++ b/tests/ast/data/col_getitem.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_apply__int {

--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -64,7 +64,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_in {
@@ -170,7 +170,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_in {
@@ -247,7 +247,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_in {

--- a/tests/ast/data/col_lit.test
+++ b/tests/ast/data/col_lit.test
@@ -58,7 +58,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {

--- a/tests/ast/data/col_literal.test
+++ b/tests/ast/data/col_literal.test
@@ -197,7 +197,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -285,7 +285,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -374,7 +374,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -462,7 +462,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -551,7 +551,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -640,7 +640,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -729,7 +729,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -818,7 +818,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -907,7 +907,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1008,7 +1008,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1109,7 +1109,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1210,7 +1210,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1301,7 +1301,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1399,7 +1399,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1497,7 +1497,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1595,7 +1595,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1684,7 +1684,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sub {
@@ -1773,7 +1773,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1862,7 +1862,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -1951,7 +1951,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2040,7 +2040,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2129,7 +2129,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2219,7 +2219,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2309,7 +2309,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2398,7 +2398,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2487,7 +2487,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2576,7 +2576,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2667,7 +2667,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2758,7 +2758,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2849,7 +2849,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -2940,7 +2940,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -3031,7 +3031,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -3122,7 +3122,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -3340,7 +3340,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -3574,7 +3574,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {

--- a/tests/ast/data/col_null_nan.test
+++ b/tests/ast/data/col_null_nan.test
@@ -69,7 +69,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_equal_null {
@@ -180,7 +180,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_equal_nan {
@@ -257,7 +257,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_is_null {
@@ -334,7 +334,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_is_not_null {

--- a/tests/ast/data/col_rbinops.test
+++ b/tests/ast/data/col_rbinops.test
@@ -85,7 +85,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -174,7 +174,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             sub {
@@ -263,7 +263,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             mul {
@@ -352,7 +352,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             div {
@@ -441,7 +441,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             mod {
@@ -530,7 +530,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             pow {
@@ -619,7 +619,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             and {
@@ -708,7 +708,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             or {

--- a/tests/ast/data/col_star.test
+++ b/tests/ast/data/col_star.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {

--- a/tests/ast/data/col_string.test
+++ b/tests/ast/data/col_string.test
@@ -81,7 +81,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_string_like {
@@ -170,7 +170,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_regexp {
@@ -259,7 +259,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_string_starts_with {
@@ -348,7 +348,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_string_ends_with {
@@ -437,7 +437,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_string_substr {
@@ -582,7 +582,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_string_collate {
@@ -671,7 +671,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_string_contains {

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -161,7 +161,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -241,7 +241,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -321,7 +321,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -401,7 +401,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -481,7 +481,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -564,7 +564,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -644,7 +644,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -724,7 +724,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -804,7 +804,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -884,7 +884,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -964,7 +964,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1044,7 +1044,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1128,7 +1128,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1208,7 +1208,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1295,7 +1295,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1388,7 +1388,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1473,7 +1473,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1556,7 +1556,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1636,7 +1636,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1716,7 +1716,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1796,7 +1796,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1876,7 +1876,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -1956,7 +1956,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -2036,7 +2036,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -2116,7 +2116,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -2198,7 +2198,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {
@@ -2280,7 +2280,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_try_cast {

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -172,7 +172,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -355,7 +355,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -695,7 +695,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {

--- a/tests/ast/data/col_unary_ops.test
+++ b/tests/ast/data/col_unary_ops.test
@@ -61,7 +61,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             neg {
@@ -138,7 +138,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             not {

--- a/tests/ast/data/col_within_group.test
+++ b/tests/ast/data/col_within_group.test
@@ -64,7 +64,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_within_group {
@@ -149,7 +149,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_within_group {
@@ -268,7 +268,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_within_group {

--- a/tests/ast/data/df_col.test
+++ b/tests/ast/data/df_col.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {

--- a/tests/ast/data/df_limit.test
+++ b/tests/ast/data/df_limit.test
@@ -64,7 +64,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -160,7 +160,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -381,7 +381,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             gt {

--- a/tests/ast/data/df_sample.test
+++ b/tests/ast/data/df_sample.test
@@ -10,9 +10,9 @@ df = df.sample(frac=0.5)
 
 df = session.table("table1")
 
-df = df.sample(None, 3)
+df = df.sample(None, 3, None)
 
-df = df.sample(0.5, None)
+df = df.sample(0.5, None, None)
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/df_union.test
+++ b/tests/ast/data/df_union.test
@@ -16,6 +16,10 @@ df5 = df1.union_by_name(df2)
 
 df6 = df1.union_all_by_name(df2)
 
+df7 = df1.union_by_name(df2, allow_missing_columns=True)
+
+df8 = df1.union_all_by_name(df2, allow_missing_columns=True)
+
 ## EXPECTED UNPARSER OUTPUT
 
 df1 = session.table("df1")
@@ -33,6 +37,10 @@ df2 = session.table("df4")
 df5 = df1.union_by_name(df2)
 
 df6 = df1.union_all_by_name(df2)
+
+df7 = df1.union_by_name(df2, allow_missing_columns=True)
+
+df8 = df1.union_all_by_name(df2, allow_missing_columns=True)
 
 ## EXPECTED ENCODED AST
 
@@ -148,7 +156,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_union_all {
+      dataframe_union {
+        all: true
         df {
           dataframe_ref {
             id {
@@ -248,7 +257,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_union_by_name {
+      dataframe_union {
+        by_name: true
         df {
           dataframe_ref {
             id {
@@ -284,7 +294,9 @@ body {
 body {
   assign {
     expr {
-      dataframe_union_all_by_name {
+      dataframe_union {
+        all: true
+        by_name: true
         df {
           dataframe_ref {
             id {
@@ -314,6 +326,83 @@ body {
     uid: 8
     var_id {
       bitfield1: 8
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_union {
+        allow_missing_columns: true
+        by_name: true
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 5
+            }
+          }
+        }
+        other {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
+        }
+        src {
+          end_column: 64
+          end_line: 41
+          file: 2
+          start_column: 14
+          start_line: 41
+        }
+      }
+    }
+    symbol {
+      value: "df7"
+    }
+    uid: 9
+    var_id {
+      bitfield1: 9
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_union {
+        all: true
+        allow_missing_columns: true
+        by_name: true
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 5
+            }
+          }
+        }
+        other {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
+        }
+        src {
+          end_column: 68
+          end_line: 43
+          file: 2
+          start_column: 14
+          start_line: 43
+        }
+      }
+    }
+    symbol {
+      value: "df8"
+    }
+    uid: 10
+    var_id {
+      bitfield1: 10
     }
   }
 }

--- a/tests/ast/data/functions.table_functions.test
+++ b/tests/ast/data/functions.table_functions.test
@@ -384,7 +384,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -601,7 +601,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1165,7 +1165,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -1233,7 +1233,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {
@@ -1428,7 +1428,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -1496,7 +1496,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {
@@ -1743,7 +1743,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -1811,7 +1811,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -642,7 +642,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -708,7 +708,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -786,7 +786,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -852,7 +852,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -918,7 +918,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -996,7 +996,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1062,7 +1062,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1416,7 +1416,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1482,7 +1482,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1536,7 +1536,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1590,7 +1590,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1644,7 +1644,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1698,7 +1698,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1752,7 +1752,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1806,7 +1806,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1860,7 +1860,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1914,7 +1914,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1968,7 +1968,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2022,7 +2022,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2076,7 +2076,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2130,7 +2130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2208,7 +2208,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2308,7 +2308,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2430,7 +2430,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2552,7 +2552,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2730,7 +2730,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2944,7 +2944,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3158,7 +3158,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3372,7 +3372,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3780,7 +3780,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4026,7 +4026,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4148,7 +4148,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4270,7 +4270,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4348,7 +4348,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4504,7 +4504,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4718,7 +4718,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4818,7 +4818,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4896,7 +4896,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4974,7 +4974,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5076,7 +5076,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5154,7 +5154,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5256,7 +5256,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5322,7 +5322,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5478,7 +5478,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5544,7 +5544,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5610,7 +5610,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5676,7 +5676,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5742,7 +5742,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5808,7 +5808,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5874,7 +5874,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5940,7 +5940,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6006,7 +6006,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6072,7 +6072,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6138,7 +6138,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6204,7 +6204,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6270,7 +6270,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6336,7 +6336,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6481,7 +6481,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6547,7 +6547,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6625,7 +6625,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6691,7 +6691,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6803,7 +6803,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6947,7 +6947,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7013,7 +7013,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7079,7 +7079,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7145,7 +7145,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7211,7 +7211,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7321,7 +7321,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7687,7 +7687,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7820,7 +7820,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7886,7 +7886,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7952,7 +7952,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8018,7 +8018,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8188,7 +8188,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8468,7 +8468,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8797,7 +8797,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8863,7 +8863,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8929,7 +8929,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8995,7 +8995,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9061,7 +9061,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9127,7 +9127,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9205,7 +9205,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9271,7 +9271,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9337,7 +9337,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9403,7 +9403,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9469,7 +9469,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9535,7 +9535,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9601,7 +9601,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9747,7 +9747,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9813,7 +9813,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9879,7 +9879,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9945,7 +9945,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10011,7 +10011,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10077,7 +10077,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10143,7 +10143,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10209,7 +10209,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10275,7 +10275,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10420,7 +10420,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10587,7 +10587,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10653,7 +10653,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10889,7 +10889,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10955,7 +10955,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11021,7 +11021,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11315,7 +11315,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11573,7 +11573,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11867,7 +11867,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12125,7 +12125,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12339,7 +12339,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12405,7 +12405,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12471,7 +12471,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12729,7 +12729,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12795,7 +12795,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13053,7 +13053,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13187,7 +13187,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13379,7 +13379,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13571,7 +13571,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13761,7 +13761,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13827,7 +13827,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13995,7 +13995,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14310,7 +14310,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14502,7 +14502,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14774,7 +14774,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14864,7 +14864,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15238,7 +15238,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15406,7 +15406,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15576,7 +15576,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15676,7 +15676,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15742,7 +15742,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15876,7 +15876,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15988,7 +15988,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16202,7 +16202,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16280,7 +16280,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16358,7 +16358,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16436,7 +16436,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16696,7 +16696,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16864,7 +16864,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17032,7 +17032,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17098,7 +17098,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17176,7 +17176,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17344,7 +17344,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17546,7 +17546,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17736,7 +17736,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18016,7 +18016,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18296,7 +18296,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18576,7 +18576,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18766,7 +18766,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18956,7 +18956,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -746,7 +746,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -800,7 +800,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -854,7 +854,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -908,7 +908,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -974,7 +974,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1232,7 +1232,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1298,7 +1298,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1466,7 +1466,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1634,7 +1634,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1700,7 +1700,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1766,7 +1766,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1832,7 +1832,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1898,7 +1898,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1964,7 +1964,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2018,7 +2018,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2254,7 +2254,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2320,7 +2320,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2386,7 +2386,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2554,7 +2554,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2620,7 +2620,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -2856,7 +2856,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3083,7 +3083,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3149,7 +3149,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3215,7 +3215,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3281,7 +3281,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3506,7 +3506,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3652,7 +3652,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -3878,7 +3878,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4126,7 +4126,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4407,7 +4407,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4688,7 +4688,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -4880,7 +4880,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5048,7 +5048,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5308,7 +5308,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5500,7 +5500,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5646,7 +5646,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -5932,7 +5932,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6078,7 +6078,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6144,7 +6144,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6210,7 +6210,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6276,7 +6276,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6342,7 +6342,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6408,7 +6408,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6474,7 +6474,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6540,7 +6540,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6606,7 +6606,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6672,7 +6672,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6738,7 +6738,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6804,7 +6804,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6870,7 +6870,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -6936,7 +6936,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7002,7 +7002,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7068,7 +7068,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7134,7 +7134,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7200,7 +7200,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7266,7 +7266,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7332,7 +7332,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7593,7 +7593,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -7829,7 +7829,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8289,7 +8289,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8505,7 +8505,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -8954,7 +8954,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9382,7 +9382,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9875,7 +9875,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -9941,7 +9941,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10007,7 +10007,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10073,7 +10073,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10139,7 +10139,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10375,7 +10375,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10441,7 +10441,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10507,7 +10507,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10573,7 +10573,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10695,7 +10695,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -10931,7 +10931,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11167,7 +11167,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11233,7 +11233,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11423,7 +11423,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11613,7 +11613,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11781,7 +11781,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -11995,7 +11995,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12162,7 +12162,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12352,7 +12352,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12418,7 +12418,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12632,7 +12632,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12800,7 +12800,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -12866,7 +12866,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13012,7 +13012,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13226,7 +13226,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13440,7 +13440,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13622,7 +13622,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -13848,7 +13848,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14030,7 +14030,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14130,7 +14130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14230,7 +14230,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14308,7 +14308,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14374,7 +14374,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14440,7 +14440,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14506,7 +14506,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14572,7 +14572,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14638,7 +14638,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14704,7 +14704,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14770,7 +14770,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14836,7 +14836,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14902,7 +14902,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -14968,7 +14968,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15034,7 +15034,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15160,7 +15160,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15286,7 +15286,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15567,7 +15567,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15848,7 +15848,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15914,7 +15914,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -15980,7 +15980,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16046,7 +16046,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16112,7 +16112,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16178,7 +16178,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16244,7 +16244,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16310,7 +16310,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16376,7 +16376,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16556,7 +16556,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16622,7 +16622,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16688,7 +16688,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16754,7 +16754,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16820,7 +16820,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16886,7 +16886,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -16986,7 +16986,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17052,7 +17052,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17380,7 +17380,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17458,7 +17458,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -17786,7 +17786,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_case_expr {
@@ -17951,7 +17951,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18152,7 +18152,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18490,7 +18490,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18544,7 +18544,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18598,7 +18598,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18652,7 +18652,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18706,7 +18706,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -18760,7 +18760,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -19202,7 +19202,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -19644,7 +19644,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -19834,7 +19834,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -20024,7 +20024,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -20180,7 +20180,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -20246,7 +20246,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -20496,7 +20496,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -20746,7 +20746,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21027,7 +21027,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21195,7 +21195,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21407,7 +21407,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21687,7 +21687,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21809,7 +21809,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21897,7 +21897,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -21974,7 +21974,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22052,7 +22052,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22130,7 +22130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22208,7 +22208,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22274,7 +22274,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22340,7 +22340,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22406,7 +22406,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22484,7 +22484,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22710,7 +22710,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22856,7 +22856,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -22922,7 +22922,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23182,7 +23182,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23362,7 +23362,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23508,7 +23508,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23630,7 +23630,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23752,7 +23752,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23874,7 +23874,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -23996,7 +23996,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -24086,7 +24086,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -24152,7 +24152,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -24230,7 +24230,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -24308,7 +24308,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {

--- a/tests/ast/data/interval.test
+++ b/tests/ast/data/interval.test
@@ -222,7 +222,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -456,7 +456,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -555,7 +555,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -744,7 +744,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {
@@ -978,7 +978,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             add {

--- a/tests/ast/data/select.test
+++ b/tests/ast/data/select.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_dq_abs_l.test
+++ b/tests/ast/data/session_table_dq_abs_l.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_dq_abs_s.test
+++ b/tests/ast/data/session_table_dq_abs_s.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_dq_rs_l.test
+++ b/tests/ast/data/session_table_dq_rs_l.test
@@ -56,7 +56,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_dq_rs_s.test
+++ b/tests/ast/data/session_table_dq_rs_s.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_dq_rt_l.test
+++ b/tests/ast/data/session_table_dq_rt_l.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_dq_rt_s.test
+++ b/tests/ast/data/session_table_dq_rt_s.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -93,7 +93,8 @@ body {
 body {
   assign {
     expr {
-      dataframe_union_all {
+      dataframe_union {
+        all: true
         df {
           dataframe_ref {
             id {
@@ -129,7 +130,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_uq_abs_l.test
+++ b/tests/ast/data/session_table_uq_abs_l.test
@@ -57,7 +57,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_uq_abs_s.test
+++ b/tests/ast/data/session_table_uq_abs_s.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_uq_rs_l.test
+++ b/tests/ast/data/session_table_uq_rs_l.test
@@ -56,7 +56,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_uq_rs_s.test
+++ b/tests/ast/data/session_table_uq_rs_s.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_uq_rt_l.test
+++ b/tests/ast/data/session_table_uq_rt_l.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/session_table_uq_rt_s.test
+++ b/tests/ast/data/session_table_uq_rt_s.test
@@ -55,7 +55,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -1391,7 +1391,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             apply_expr {
@@ -1606,7 +1606,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             dataframe_col {
@@ -1786,7 +1786,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             string_val {

--- a/tests/ast/data/windows.test
+++ b/tests/ast/data/windows.test
@@ -124,7 +124,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -254,7 +254,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {
@@ -580,7 +580,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -691,7 +691,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -814,7 +814,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -925,7 +925,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1036,7 +1036,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1166,7 +1166,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1297,7 +1297,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1427,7 +1427,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1558,7 +1558,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1663,7 +1663,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1768,7 +1768,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1873,7 +1873,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -1978,7 +1978,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_over {
@@ -2055,7 +2055,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_select__columns {
+      dataframe_select {
         cols {
           args {
             column_alias {


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-1941024](https://snowflakecomputing.atlassian.net/browse/SNOW-1941024)
   [SNOW-1936164](https://snowflakecomputing.atlassian.net/browse/SNOW-1936164)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

    This PR contains the client side changes needed to unify the `DataframeSelect_{Columns,Exprs}` AST entities as well as the `DataframeUnion{ByName,All,AllByName}` AST entities. 

    Also adds new `allow_missing_columns` parameter to the `DataframeUnion` AST and expectation tests for this.

    Expectation tests have also been updated and this PR is accompanied by this [server-side PR](https://github.com/snowflakedb/snowflake/pull/260468). 

[SNOW-1941024]: https://snowflakecomputing.atlassian.net/browse/SNOW-1941024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNOW-1936164]: https://snowflakecomputing.atlassian.net/browse/SNOW-1936164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ