### PR TITLE
NO-SNOW: Fix flakiness giving RuntimeError

### DIFF
--- a/tests/integ/test_multithreading.py
+++ b/tests/integ/test_multithreading.py
@@ -816,7 +816,9 @@ def test_temp_name_placeholder_for_sync(db_parameters, thread_safe_enabled):
             df = session.create_dataframe([[1, 2], [3, 4]], ["A", "B"])
 
             with session.query_history() as history:
-                with ThreadPoolExecutor(max_workers=5) as executor:
+                with ThreadPoolExecutor(
+                    max_workers=(5 if thread_safe_enabled else 1)
+                ) as executor:
                     futures = []
                     for i in range(10):
                         futures.append(executor.submit(process_data, df, i))


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Example failure like [this](https://github.com/snowflakedb/snowpark-python/actions/runs/13510272232/job/37748997923?pr=3049) happens because a non-thread-safe session is running multi-threaded code. Update the test so that we only run one thread when multithreading is disabled.
