### PR TITLE
SNOW-1941023: Remove optionality for collections

### DIFF
--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -209,7 +209,7 @@ def build_expr_from_python_val(
         ast = with_src_position(expr_builder.row)  # type: ignore[arg-type] # TODO(SNOW-1491199) # Argument 1 to "with_src_position" has incompatible type "Row"; expected "Expr"
         if hasattr(obj, "_named_values") and obj._named_values is not None:
             for field in obj._fields:
-                ast.names.list.append(field)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "names"
+                ast.names.append(field)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "names"
                 build_expr_from_python_val(ast.vs.add(), obj._named_values[field])  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "vs"
         else:
             for field in obj:
@@ -339,7 +339,7 @@ def build_proto_from_struct_type(
 
     expr.structured = schema.structured
     for field in schema.fields:
-        ast_field = expr.fields.list.add()
+        ast_field = expr.fields.add()
         if isinstance(field.original_column_identifier, str):
             ast_field.column_identifier.column_name.name = (
                 field.original_column_identifier
@@ -1166,7 +1166,7 @@ def build_udf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function i
         return_type._fill_ast(ast.return_type)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     if input_types is not None and len(input_types) != 0:
         for input_type in input_types:
-            input_type._fill_ast(ast.input_types.list.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
+            input_type._fill_ast(ast.input_types.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     ast.is_permanent = is_permanent
     if stage_location is not None:
         ast.stage_location = stage_location
@@ -1255,7 +1255,7 @@ def build_udaf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function 
         return_type._fill_ast(ast.return_type)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     if input_types is not None and len(input_types) != 0:
         for input_type in input_types:
-            input_type._fill_ast(ast.input_types.list.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
+            input_type._fill_ast(ast.input_types.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     ast.is_permanent = is_permanent
     if stage_location is not None:
         ast.stage_location.value = stage_location
@@ -1352,7 +1352,7 @@ def build_udtf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function 
 
     if input_types is not None and len(input_types) != 0:
         for input_type in input_types:
-            input_type._fill_ast(ast.input_types.list.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
+            input_type._fill_ast(ast.input_types.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     ast.is_permanent = is_permanent
     if stage_location is not None:
         ast.stage_location = stage_location
@@ -1464,7 +1464,7 @@ def build_sproc(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function
         return_type._fill_ast(ast.return_type)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     if input_types is not None and len(input_types) != 0:
         for input_type in input_types:
-            input_type._fill_ast(ast.input_types.list.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
+            input_type._fill_ast(ast.input_types.add())  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "DataType" has no attribute "_fill_ast"
     ast.is_permanent = is_permanent
     if stage_location is not None:
         ast.stage_location = stage_location

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -19,28 +19,8 @@ message InternedValueTable {
   map<int32, string> string_values = 1;
 }
 
-message List_DataType {
-  repeated DataType list = 1;
-}
-
-message List_Expr {
-  repeated Expr list = 1;
-}
-
 message List_String {
   repeated string list = 1;
-}
-
-message List_StructField {
-  repeated StructField list = 1;
-}
-
-message Map_Expr_Expr {
-  repeated Tuple_Expr_Expr list = 1;
-}
-
-message Map_String_Expr {
-  repeated Tuple_String_Expr list = 1;
 }
 
 message Tuple_Expr_Expr {
@@ -166,7 +146,7 @@ message StructField {
 
 // type.ir:21
 message StructType {
-  List_StructField fields = 1;
+  repeated StructField fields = 1;
   bool structured = 2;
 }
 
@@ -243,7 +223,7 @@ message FlattenMode {
   }
 }
 
-// dataframe.ir:231
+// dataframe.ir:230
 message JoinType {
   oneof variant {
     bool join_type__asof = 1;
@@ -760,14 +740,14 @@ message CreateDataframe {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:164
+// dataframe.ir:163
 message DataframeAgg {
   Expr df = 1;
   ExprArgList exprs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:169
+// dataframe.ir:168
 message DataframeAlias {
   Expr df = 1;
   string name = 2;
@@ -881,7 +861,7 @@ message DataframeCount {
 
 // dataframe-io.ir:149
 message DataframeCreateOrReplaceDynamicTable {
-  List_Expr clustering_keys = 1;
+  repeated Expr clustering_keys = 1;
   google.protobuf.StringValue comment = 2;
   google.protobuf.Int64Value data_retention_time = 3;
   Expr df = 4;
@@ -907,7 +887,7 @@ message DataframeCreateOrReplaceView {
   repeated Tuple_String_String statement_params = 6;
 }
 
-// dataframe.ir:174
+// dataframe.ir:173
 message DataframeCrossJoin {
   Expr lhs = 1;
   google.protobuf.StringValue lsuffix = 2;
@@ -923,48 +903,48 @@ message DataframeCube {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:181
+// dataframe.ir:180
 message DataframeDescribe {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:186
+// dataframe.ir:185
 message DataframeDistinct {
   Expr df = 1;
   SrcPosition src = 2;
 }
 
-// dataframe.ir:190
+// dataframe.ir:189
 message DataframeDrop {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:195
+// dataframe.ir:194
 message DataframeDropDuplicates {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:200
+// dataframe.ir:199
 message DataframeExcept {
   Expr df = 1;
   Expr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:205
+// dataframe.ir:204
 message DataframeFilter {
   Expr condition = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:219
+// dataframe.ir:218
 message DataframeFirst {
   bool block = 1;
   Expr df = 2;
@@ -973,7 +953,7 @@ message DataframeFirst {
   repeated Tuple_String_String statement_params = 5;
 }
 
-// dataframe.ir:210
+// dataframe.ir:209
 message DataframeFlatten {
   Expr df = 1;
   Expr input = 2;
@@ -998,14 +978,14 @@ message DataframeGroupByGroupingSets {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:226
+// dataframe.ir:225
 message DataframeIntersect {
   Expr df = 1;
   Expr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:242
+// dataframe.ir:241
 message DataframeJoin {
   Expr join_expr = 1;
   JoinType join_type = 2;
@@ -1017,14 +997,14 @@ message DataframeJoin {
   SrcPosition src = 8;
 }
 
-// dataframe.ir:252
+// dataframe.ir:251
 message DataframeJoinTableFunction {
   Expr fn = 1;
   Expr lhs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:257
+// dataframe.ir:256
 message DataframeLimit {
   Expr df = 1;
   int64 n = 2;
@@ -1032,7 +1012,7 @@ message DataframeLimit {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:136
+// dataframe.ir:135
 message DataframeNaDrop_Python {
   Expr df = 1;
   string how = 2;
@@ -1041,7 +1021,7 @@ message DataframeNaDrop_Python {
   google.protobuf.Int64Value thresh = 5;
 }
 
-// dataframe.ir:130
+// dataframe.ir:129
 message DataframeNaDrop_Scala {
   repeated string cols = 1;
   Expr df = 2;
@@ -1049,28 +1029,28 @@ message DataframeNaDrop_Scala {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:143
+// dataframe.ir:142
 message DataframeNaFill {
   Expr df = 1;
   SrcPosition src = 2;
   List_String subset = 3;
   Expr value = 4;
-  Map_String_Expr value_map = 5;
+  repeated Tuple_String_Expr value_map = 5;
 }
 
-// dataframe.ir:150
+// dataframe.ir:149
 message DataframeNaReplace {
   Expr df = 1;
-  Map_Expr_Expr replacement_map = 2;
+  repeated Tuple_Expr_Expr replacement_map = 2;
   SrcPosition src = 3;
   List_String subset = 4;
-  List_Expr to_replace_list = 5;
+  repeated Expr to_replace_list = 5;
   Expr to_replace_value = 6;
   Expr value = 7;
-  List_Expr values = 8;
+  repeated Expr values = 8;
 }
 
-// dataframe.ir:263
+// dataframe.ir:262
 message DataframeNaturalJoin {
   JoinType join_type = 1;
   Expr lhs = 2;
@@ -1087,7 +1067,7 @@ message DataframePivot {
   PivotValue values = 5;
 }
 
-// dataframe.ir:277
+// dataframe.ir:276
 message DataframeRandomSplit {
   Expr df = 1;
   google.protobuf.Int64Value seed = 2;
@@ -1136,7 +1116,7 @@ message DataframeRef {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:284
+// dataframe.ir:283
 message DataframeRename {
   Expr col_or_mapper = 1;
   Expr df = 2;
@@ -1151,7 +1131,7 @@ message DataframeRollup {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:290
+// dataframe.ir:289
 message DataframeSample {
   Expr df = 1;
   google.protobuf.Int64Value num = 2;
@@ -1160,7 +1140,7 @@ message DataframeSample {
   SrcPosition src = 5;
 }
 
-// dataframe.ir:297
+// dataframe.ir:296
 message DataframeSelect {
   ExprArgList cols = 1;
   Expr df = 2;
@@ -1175,7 +1155,7 @@ message DataframeShow {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:304
+// dataframe.ir:303
 message DataframeSort {
   Expr ascending = 1;
   ExprArgList cols = 2;
@@ -1259,7 +1239,7 @@ message DataframeToPandasBatches {
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe.ir:310
+// dataframe.ir:309
 message DataframeUnion {
   bool all = 1;
   bool allow_missing_columns = 2;
@@ -1269,7 +1249,7 @@ message DataframeUnion {
   SrcPosition src = 6;
 }
 
-// dataframe.ir:269
+// dataframe.ir:268
 message DataframeUnpivot {
   repeated Expr column_list = 1;
   Expr df = 2;
@@ -1279,7 +1259,7 @@ message DataframeUnpivot {
   string value_column = 6;
 }
 
-// dataframe.ir:318
+// dataframe.ir:317
 message DataframeWithColumn {
   Expr col = 1;
   string col_name = 2;
@@ -1287,7 +1267,7 @@ message DataframeWithColumn {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:324
+// dataframe.ir:323
 message DataframeWithColumnRenamed {
   Expr col = 1;
   Expr df = 2;
@@ -1295,7 +1275,7 @@ message DataframeWithColumnRenamed {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:330
+// dataframe.ir:329
 message DataframeWithColumns {
   repeated string col_names = 1;
   Expr df = 2;
@@ -1648,7 +1628,7 @@ message Geq {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:336
+// dataframe.ir:335
 message GroupingSets {
   ExprArgList sets = 1;
   SrcPosition src = 2;
@@ -1903,8 +1883,8 @@ message MergeDeleteWhenMatchedClause {
 // table.ir:48
 message MergeInsertWhenNotMatchedClause {
   Expr condition = 1;
-  List_Expr insert_keys = 2;
-  List_Expr insert_values = 3;
+  repeated Expr insert_keys = 2;
+  repeated Expr insert_values = 3;
   SrcPosition src = 4;
 }
 
@@ -1912,7 +1892,7 @@ message MergeInsertWhenNotMatchedClause {
 message MergeUpdateWhenMatchedClause {
   Expr condition = 1;
   SrcPosition src = 2;
-  Map_Expr_Expr update_assignments = 3;
+  repeated Tuple_Expr_Expr update_assignments = 3;
 }
 
 // op.ir:50
@@ -2139,7 +2119,7 @@ message Result {
 
 // expr.ir:19
 message Row {
-  List_String names = 1;
+  repeated string names = 1;
   SrcPosition src = 2;
   repeated Expr vs = 3;
 }
@@ -2201,7 +2181,7 @@ message StoredProcedure {
   Callable func = 4;
   bool if_not_exists = 5;
   repeated NameRef imports = 6;
-  List_DataType input_types = 7;
+  repeated DataType input_types = 7;
   bool is_permanent = 8;
   repeated Tuple_String_Expr kwargs = 9;
   google.protobuf.BoolValue log_on_exception = 10;
@@ -2302,11 +2282,11 @@ message TableUpdate {
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe.ir:340
+// dataframe.ir:339
 message ToSnowparkPandas {
-  List_String columns = 1;
+  repeated string columns = 1;
   Expr df = 2;
-  List_String index_col = 3;
+  repeated string index_col = 3;
   SrcPosition src = 4;
 }
 
@@ -2330,7 +2310,7 @@ message Udaf {
   bool if_not_exists = 4;
   bool immutable = 5;
   repeated NameRef imports = 6;
-  List_DataType input_types = 7;
+  repeated DataType input_types = 7;
   bool is_permanent = 8;
   repeated Tuple_String_Expr kwargs = 9;
   NameRef name = 10;
@@ -2352,7 +2332,7 @@ message Udf {
   bool if_not_exists = 4;
   bool immutable = 5;
   repeated NameRef imports = 6;
-  List_DataType input_types = 7;
+  repeated DataType input_types = 7;
   bool is_permanent = 8;
   repeated Tuple_String_Expr kwargs = 9;
   google.protobuf.Int64Value max_batch_size = 10;
@@ -2378,7 +2358,7 @@ message Udtf {
   bool if_not_exists = 4;
   bool immutable = 5;
   repeated NameRef imports = 6;
-  List_DataType input_types = 7;
+  repeated DataType input_types = 7;
   bool is_permanent = 8;
   repeated Tuple_String_Expr kwargs = 9;
   NameRef name = 10;
@@ -2531,7 +2511,7 @@ message WriteParquet {
 message WriteTable {
   bool block = 1;
   google.protobuf.BoolValue change_tracking = 2;
-  List_Expr clustering_keys = 3;
+  repeated Expr clustering_keys = 3;
   string column_order = 4;
   google.protobuf.StringValue comment = 5;
   bool copy_grants = 6;

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -217,7 +217,7 @@ class DataFrameNaFunctions:
             new_df = copy.copy(self._dataframe)
             add_api_call(new_df, "DataFrameNaFunctions.drop")
             if _emit_ast:
-                self._dataframe._ast_id = stmt.var_id.bitfield1
+                new_df._ast_id = stmt.var_id.bitfield1
             return self._dataframe
         # if thresh is greater than the number of columns,
         # drop a row only if all its values are null
@@ -381,7 +381,7 @@ class DataFrameNaFunctions:
                 for k, v in value.items():
                     # N.B. In Phase 1, error checking will be incorporated directly here.
                     if isinstance(k, str):
-                        entry = ast.value_map.list.add()
+                        entry = ast.value_map.add()
                         entry._1 = k
                         build_expr_from_python_val(entry._2, v)
             else:
@@ -583,24 +583,26 @@ class DataFrameNaFunctions:
 
             if isinstance(to_replace, dict):
                 for k, v in to_replace.items():
-                    entry = ast.replacement_map.list.add()
+                    entry = ast.replacement_map.add()
                     build_expr_from_python_val(entry._1, k)
                     build_expr_from_python_val(entry._2, v)
             elif isinstance(to_replace, Iterable):
                 for v in to_replace:
-                    entry = ast.to_replace_list.list.add()
+                    entry = ast.to_replace_list.add()
                     build_expr_from_python_val(entry, v)
             else:
                 build_expr_from_python_val(ast.to_replace_value, to_replace)
 
             if isinstance(value, Iterable):
                 for v in value:
-                    entry = ast.values.list.add()
+                    entry = ast.values.add()
                     build_expr_from_python_val(entry, v)
             else:
                 build_expr_from_python_val(ast.value, value)
 
-            if subset is not None:
+            if isinstance(subset, str):
+                ast.subset.list.append(subset)
+            elif isinstance(subset, Iterable):
                 ast.subset.list.extend(subset)
 
         # Modify subset.

--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -465,7 +465,6 @@ class DataFrameStatFunctions:
 
         if _emit_ast:
             res_df._ast_id = stmt.var_id.bitfield1
-            self._dataframe._session._ast_batch.eval(stmt)
 
         return res_df
 

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -353,7 +353,7 @@ class DataFrameWriter:
             if clustering_keys is not None:
                 for col_or_name in clustering_keys:
                     build_expr_from_snowpark_column_or_col_name(
-                        expr.clustering_keys.list.add(), col_or_name
+                        expr.clustering_keys.add(), col_or_name
                     )
 
             if statement_params is not None:

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -792,13 +792,8 @@ class StructType(DataType):
 
     def _fill_ast(self, ast: proto.DataType) -> None:
         ast.struct_type.structured = self.structured
-        if self.fields is None:
-            return
-        elif len(self.fields) > 0:
-            for field in self.fields:
-                field._fill_ast(ast.struct_type.fields.list.add())
-        else:
-            ast.struct_type.fields.list.extend([])
+        for field in self.fields or []:
+            field._fill_ast(ast.struct_type.fields.add())
 
 
 class VariantType(DataType):

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -13,7 +13,7 @@ df.count(block=False, statement_params={"SF_PARTNER": "FAKE_PARTNER"})
 
 ## EXPECTED UNPARSER OUTPUT
 
-df = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType([StructField("\"A\"", StringType(16777216), nullable=True), StructField("\"B\"", LongType(), nullable=True)], structured=False))
+df = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType(fields=[StructField("\"A\"", StringType(16777216), nullable=True), StructField("\"B\"", LongType(), nullable=True)], structured=False))
 
 df.count()
 
@@ -46,32 +46,30 @@ body {
           dataframe_schema__struct {
             v {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"A\""
-                    }
+                column_identifier {
+                  column_name {
+                    name: "\"A\""
                   }
-                  data_type {
-                    string_type {
-                      length {
-                        value: 16777216
-                      }
-                    }
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"B\""
+                data_type {
+                  string_type {
+                    length {
+                      value: 16777216
                     }
                   }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "\"B\""
+                  }
+                }
+                data_type {
+                  long_type: true
+                }
+                nullable: true
               }
             }
           }

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -68,8 +68,6 @@ df = session.create_dataframe([("Bob", 17), ("Alice", 10), ("Nico", 8), ("Bob", 
 
 sample_df = df.stat.sample_by("name", {"Bob": 0.5, "Nico": 1.0})
 
-sample_df
-
 ## EXPECTED ENCODED AST
 
 interned_value_table {
@@ -1213,14 +1211,6 @@ body {
       value: "sample_df"
     }
     uid: 19
-    var_id {
-      bitfield1: 19
-    }
-  }
-}
-body {
-  eval {
-    uid: 20
     var_id {
       bitfield1: 19
     }

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -380,50 +380,48 @@ body {
       write_table {
         block: true
         clustering_keys {
-          list {
-            string_val {
-              src {
-                end_column: 231
-                end_line: 35
-                file: 2
-                start_column: 8
-                start_line: 35
-              }
-              v: "STR"
+          string_val {
+            src {
+              end_column: 231
+              end_line: 35
+              file: 2
+              start_column: 8
+              start_line: 35
             }
+            v: "STR"
           }
-          list {
-            apply_expr {
-              fn {
-                builtin_fn {
+        }
+        clustering_keys {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
                   name {
-                    name {
-                      name_flat {
-                        name: "col"
-                      }
+                    name_flat {
+                      name: "col"
                     }
                   }
                 }
               }
-              pos_args {
-                string_val {
-                  src {
-                    end_column: 173
-                    end_line: 35
-                    file: 2
-                    start_column: 162
-                    start_line: 35
-                  }
-                  v: "num1"
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 173
+                  end_line: 35
+                  file: 2
+                  start_column: 162
+                  start_line: 35
                 }
+                v: "num1"
               }
-              src {
-                end_column: 173
-                end_line: 35
-                file: 2
-                start_column: 162
-                start_line: 35
-              }
+            }
+            src {
+              end_column: 173
+              end_line: 35
+              file: 2
+              start_column: 162
+              start_line: 35
             }
           }
         }

--- a/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
+++ b/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
@@ -25,7 +25,7 @@ unique_df = df.drop_duplicates(["name", "age"])
 
 ## EXPECTED UNPARSER OUTPUT
 
-df = session.create_dataframe([{"id": 1, "name": "Alice", "age": 30}, {"id": 2, "name": "Bob", "age": 25}, {"id": 3, "name": "Alice", "age": 30}, {"id": 4, "name": "Charlie", "age": 35}], schema=StructType([StructField("id", IntegerType(), nullable=False), StructField("name", StringType(), nullable=True), StructField("age", IntegerType(), nullable=True)], structured=False))
+df = session.create_dataframe([{"id": 1, "name": "Alice", "age": 30}, {"id": 2, "name": "Bob", "age": 25}, {"id": 3, "name": "Alice", "age": 30}, {"id": 4, "name": "Charlie", "age": 35}], schema=StructType(fields=[StructField("id", IntegerType(), nullable=False), StructField("name", StringType(), nullable=True), StructField("age", IntegerType(), nullable=True)], structured=False))
 
 unique_df = df.drop_duplicates(["name", "age"])
 
@@ -408,41 +408,39 @@ body {
           dataframe_schema__struct {
             v {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "id"
-                    }
-                  }
-                  data_type {
-                    integer_type: true
+                column_identifier {
+                  column_name {
+                    name: "id"
                   }
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "name"
-                    }
-                  }
-                  data_type {
-                    string_type {
-                      length {
-                      }
-                    }
-                  }
-                  nullable: true
+                data_type {
+                  integer_type: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "age"
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "name"
+                  }
+                }
+                data_type {
+                  string_type {
+                    length {
                     }
                   }
-                  data_type {
-                    integer_type: true
-                  }
-                  nullable: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "age"
+                  }
+                }
+                data_type {
+                  integer_type: true
+                }
+                nullable: true
               }
             }
           }

--- a/tests/ast/data/Dataframe.to_snowpark_pandas.test
+++ b/tests/ast/data/Dataframe.to_snowpark_pandas.test
@@ -106,9 +106,7 @@ body {
             }
           }
         }
-        index_col {
-          list: "A"
-        }
+        index_col: "A"
         src {
           end_column: 65
           end_line: 29
@@ -131,10 +129,8 @@ body {
   assign {
     expr {
       to_snowpark_pandas {
-        columns {
-          list: "B"
-          list: "A"
-        }
+        columns: "B"
+        columns: "A"
         df {
           dataframe_ref {
             id {
@@ -164,10 +160,8 @@ body {
   assign {
     expr {
       to_snowpark_pandas {
-        columns {
-          list: "C"
-          list: "B"
-        }
+        columns: "C"
+        columns: "B"
         df {
           dataframe_ref {
             id {
@@ -175,9 +169,7 @@ body {
             }
           }
         }
-        index_col {
-          list: "A"
-        }
+        index_col: "A"
         src {
           end_column: 87
           end_line: 33

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -14,6 +14,8 @@ drop5 = df.na.drop(how="all", subset=["NUM", "STR"])
 
 drop6 = df.na.drop(how="any", thresh=42, subset=["NUM"])
 
+drop7 = df.na.drop(subset=[])
+
 fill1 = df.na.fill(42)
 
 fill2 = df.na.fill({"NUM": 42, "STR": "abc"})
@@ -22,11 +24,15 @@ fill3 = df.na.fill(42, subset="NUM")
 
 fill4 = df.na.fill("def", subset=["STR"])
 
+fill5 = df.na.fill(42, subset=[])
+
 replace1 = df.na.replace({1: 10, "three": "trzy"})
 
 replace2 = df.na.replace([1, 2], [10, 20])
 
 replace3 = df.na.replace(1, 10, subset=["NUM"])
+
+replace4 = df.na.replace(1, 10, subset=[])
 
 ## EXPECTED UNPARSER OUTPUT
 
@@ -44,6 +50,8 @@ drop5 = df.na.drop("all", ["NUM", "STR"])
 
 drop6 = df.na.drop("any", 42, ["NUM"])
 
+drop7 = df.na.drop("any", [])
+
 fill1 = df.na.fill(42)
 
 fill2 = df.na.fill({"NUM": 42, "STR": "abc"})
@@ -52,11 +60,15 @@ fill3 = df.na.fill(42, ["NUM"])
 
 fill4 = df.na.fill("def", ["STR"])
 
+fill5 = df.na.fill(42, [])
+
 replace1 = df.na.replace({1: 10, "three": "trzy"}, None)
 
 replace2 = df.na.replace([1, 2], [10, 20])
 
 replace3 = df.na.replace(1, 10, ["NUM"])
+
+replace4 = df.na.replace(1, 10, [])
 
 ## EXPECTED ENCODED AST
 
@@ -300,7 +312,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_na_fill {
+      dataframe_na_drop__python {
         df {
           dataframe_ref {
             id {
@@ -308,29 +320,20 @@ body {
             }
           }
         }
+        how: "any"
         src {
-          end_column: 30
+          end_column: 37
           end_line: 39
           file: 2
           start_column: 16
           start_line: 39
         }
-        value {
-          int64_val {
-            src {
-              end_column: 30
-              end_line: 39
-              file: 2
-              start_column: 16
-              start_line: 39
-            }
-            v: 42
-          }
+        subset {
         }
       }
     }
     symbol {
-      value: "fill1"
+      value: "drop7"
     }
     uid: 8
     var_id {
@@ -350,48 +353,28 @@ body {
           }
         }
         src {
-          end_column: 53
+          end_column: 30
           end_line: 41
           file: 2
           start_column: 16
           start_line: 41
         }
-        value_map {
-          list {
-            _1: "NUM"
-            _2 {
-              int64_val {
-                src {
-                  end_column: 53
-                  end_line: 41
-                  file: 2
-                  start_column: 16
-                  start_line: 41
-                }
-                v: 42
-              }
+        value {
+          int64_val {
+            src {
+              end_column: 30
+              end_line: 41
+              file: 2
+              start_column: 16
+              start_line: 41
             }
-          }
-          list {
-            _1: "STR"
-            _2 {
-              string_val {
-                src {
-                  end_column: 53
-                  end_line: 41
-                  file: 2
-                  start_column: 16
-                  start_line: 41
-                }
-                v: "abc"
-              }
-            }
+            v: 42
           }
         }
       }
     }
     symbol {
-      value: "fill2"
+      value: "fill1"
     }
     uid: 9
     var_id {
@@ -411,31 +394,46 @@ body {
           }
         }
         src {
-          end_column: 44
+          end_column: 53
           end_line: 43
           file: 2
           start_column: 16
           start_line: 43
         }
-        subset {
-          list: "NUM"
-        }
-        value {
-          int64_val {
-            src {
-              end_column: 44
-              end_line: 43
-              file: 2
-              start_column: 16
-              start_line: 43
+        value_map {
+          _1: "NUM"
+          _2 {
+            int64_val {
+              src {
+                end_column: 53
+                end_line: 43
+                file: 2
+                start_column: 16
+                start_line: 43
+              }
+              v: 42
             }
-            v: 42
+          }
+        }
+        value_map {
+          _1: "STR"
+          _2 {
+            string_val {
+              src {
+                end_column: 53
+                end_line: 43
+                file: 2
+                start_column: 16
+                start_line: 43
+              }
+              v: "abc"
+            }
           }
         }
       }
     }
     symbol {
-      value: "fill3"
+      value: "fill2"
     }
     uid: 10
     var_id {
@@ -455,31 +453,31 @@ body {
           }
         }
         src {
-          end_column: 49
+          end_column: 44
           end_line: 45
           file: 2
           start_column: 16
           start_line: 45
         }
         subset {
-          list: "STR"
+          list: "NUM"
         }
         value {
-          string_val {
+          int64_val {
             src {
-              end_column: 49
+              end_column: 44
               end_line: 45
               file: 2
               start_column: 16
               start_line: 45
             }
-            v: "def"
+            v: 42
           }
         }
       }
     }
     symbol {
-      value: "fill4"
+      value: "fill3"
     }
     uid: 11
     var_id {
@@ -490,7 +488,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_na_replace {
+      dataframe_na_fill {
         df {
           dataframe_ref {
             id {
@@ -498,82 +496,32 @@ body {
             }
           }
         }
-        replacement_map {
-          list {
-            _1 {
-              int64_val {
-                src {
-                  end_column: 58
-                  end_line: 47
-                  file: 2
-                  start_column: 19
-                  start_line: 47
-                }
-                v: 1
-              }
-            }
-            _2 {
-              int64_val {
-                src {
-                  end_column: 58
-                  end_line: 47
-                  file: 2
-                  start_column: 19
-                  start_line: 47
-                }
-                v: 10
-              }
-            }
-          }
-          list {
-            _1 {
-              string_val {
-                src {
-                  end_column: 58
-                  end_line: 47
-                  file: 2
-                  start_column: 19
-                  start_line: 47
-                }
-                v: "three"
-              }
-            }
-            _2 {
-              string_val {
-                src {
-                  end_column: 58
-                  end_line: 47
-                  file: 2
-                  start_column: 19
-                  start_line: 47
-                }
-                v: "trzy"
-              }
-            }
-          }
-        }
         src {
-          end_column: 58
+          end_column: 49
           end_line: 47
           file: 2
-          start_column: 19
+          start_column: 16
           start_line: 47
         }
+        subset {
+          list: "STR"
+        }
         value {
-          null_val {
+          string_val {
             src {
-              end_column: 58
+              end_column: 49
               end_line: 47
               file: 2
-              start_column: 19
+              start_column: 16
               start_line: 47
             }
+            v: "def"
           }
         }
       }
     }
     symbol {
-      value: "replace1"
+      value: "fill4"
     }
     uid: 12
     var_id {
@@ -584,7 +532,7 @@ body {
 body {
   assign {
     expr {
-      dataframe_na_replace {
+      dataframe_na_fill {
         df {
           dataframe_ref {
             id {
@@ -593,68 +541,30 @@ body {
           }
         }
         src {
-          end_column: 50
+          end_column: 41
           end_line: 49
           file: 2
-          start_column: 19
+          start_column: 16
           start_line: 49
         }
-        to_replace_list {
-          list {
-            int64_val {
-              src {
-                end_column: 50
-                end_line: 49
-                file: 2
-                start_column: 19
-                start_line: 49
-              }
-              v: 1
-            }
-          }
-          list {
-            int64_val {
-              src {
-                end_column: 50
-                end_line: 49
-                file: 2
-                start_column: 19
-                start_line: 49
-              }
-              v: 2
-            }
-          }
+        subset {
         }
-        values {
-          list {
-            int64_val {
-              src {
-                end_column: 50
-                end_line: 49
-                file: 2
-                start_column: 19
-                start_line: 49
-              }
-              v: 10
+        value {
+          int64_val {
+            src {
+              end_column: 41
+              end_line: 49
+              file: 2
+              start_column: 16
+              start_line: 49
             }
-          }
-          list {
-            int64_val {
-              src {
-                end_column: 50
-                end_line: 49
-                file: 2
-                start_column: 19
-                start_line: 49
-              }
-              v: 20
-            }
+            v: 42
           }
         }
       }
     }
     symbol {
-      value: "replace2"
+      value: "fill5"
     }
     uid: 13
     var_id {
@@ -673,12 +583,181 @@ body {
             }
           }
         }
+        replacement_map {
+          _1 {
+            int64_val {
+              src {
+                end_column: 58
+                end_line: 51
+                file: 2
+                start_column: 19
+                start_line: 51
+              }
+              v: 1
+            }
+          }
+          _2 {
+            int64_val {
+              src {
+                end_column: 58
+                end_line: 51
+                file: 2
+                start_column: 19
+                start_line: 51
+              }
+              v: 10
+            }
+          }
+        }
+        replacement_map {
+          _1 {
+            string_val {
+              src {
+                end_column: 58
+                end_line: 51
+                file: 2
+                start_column: 19
+                start_line: 51
+              }
+              v: "three"
+            }
+          }
+          _2 {
+            string_val {
+              src {
+                end_column: 58
+                end_line: 51
+                file: 2
+                start_column: 19
+                start_line: 51
+              }
+              v: "trzy"
+            }
+          }
+        }
         src {
-          end_column: 55
+          end_column: 58
           end_line: 51
           file: 2
           start_column: 19
           start_line: 51
+        }
+        value {
+          null_val {
+            src {
+              end_column: 58
+              end_line: 51
+              file: 2
+              start_column: 19
+              start_line: 51
+            }
+          }
+        }
+      }
+    }
+    symbol {
+      value: "replace1"
+    }
+    uid: 14
+    var_id {
+      bitfield1: 14
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_na_replace {
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 50
+          end_line: 53
+          file: 2
+          start_column: 19
+          start_line: 53
+        }
+        to_replace_list {
+          int64_val {
+            src {
+              end_column: 50
+              end_line: 53
+              file: 2
+              start_column: 19
+              start_line: 53
+            }
+            v: 1
+          }
+        }
+        to_replace_list {
+          int64_val {
+            src {
+              end_column: 50
+              end_line: 53
+              file: 2
+              start_column: 19
+              start_line: 53
+            }
+            v: 2
+          }
+        }
+        values {
+          int64_val {
+            src {
+              end_column: 50
+              end_line: 53
+              file: 2
+              start_column: 19
+              start_line: 53
+            }
+            v: 10
+          }
+        }
+        values {
+          int64_val {
+            src {
+              end_column: 50
+              end_line: 53
+              file: 2
+              start_column: 19
+              start_line: 53
+            }
+            v: 20
+          }
+        }
+      }
+    }
+    symbol {
+      value: "replace2"
+    }
+    uid: 15
+    var_id {
+      bitfield1: 15
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_na_replace {
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 55
+          end_line: 55
+          file: 2
+          start_column: 19
+          start_line: 55
         }
         subset {
           list: "NUM"
@@ -687,10 +766,10 @@ body {
           int64_val {
             src {
               end_column: 55
-              end_line: 51
+              end_line: 55
               file: 2
               start_column: 19
-              start_line: 51
+              start_line: 55
             }
             v: 1
           }
@@ -699,10 +778,10 @@ body {
           int64_val {
             src {
               end_column: 55
-              end_line: 51
+              end_line: 55
               file: 2
               start_column: 19
-              start_line: 51
+              start_line: 55
             }
             v: 10
           }
@@ -712,9 +791,64 @@ body {
     symbol {
       value: "replace3"
     }
-    uid: 14
+    uid: 16
     var_id {
-      bitfield1: 14
+      bitfield1: 16
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_na_replace {
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 50
+          end_line: 57
+          file: 2
+          start_column: 19
+          start_line: 57
+        }
+        subset {
+        }
+        to_replace_value {
+          int64_val {
+            src {
+              end_column: 50
+              end_line: 57
+              file: 2
+              start_column: 19
+              start_line: 57
+            }
+            v: 1
+          }
+        }
+        value {
+          int64_val {
+            src {
+              end_column: 50
+              end_line: 57
+              file: 2
+              start_column: 19
+              start_line: 57
+            }
+            v: 10
+          }
+        }
+      }
+    }
+    symbol {
+      value: "replace4"
+    }
+    uid: 17
+    var_id {
+      bitfield1: 17
     }
   }
 }

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -47,7 +47,7 @@ df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 
 
 res10 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
-df.group_by("location").apply_in_pandas(convert, StructType([StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
+df.group_by("location").apply_in_pandas(convert, StructType(fields=[StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 
 df = session.create_dataframe([(1, "A", 10000, "JAN"), (1, "B", 400, "JAN"), (1, "B", 5000, "FEB")], schema=["empid", "team", "amount", "month"])
 
@@ -887,15 +887,13 @@ body {
           }
         }
         input_types {
-          list {
-            string_type {
-              length {
-              }
+          string_type {
+            length {
             }
           }
-          list {
-            float_type: true
-          }
+        }
+        input_types {
+          float_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -1052,42 +1050,40 @@ body {
         }
         output_schema {
           fields {
-            list {
-              column_identifier {
-                column_name {
-                  name: "location"
-                }
+            column_identifier {
+              column_name {
+                name: "location"
               }
-              data_type {
-                string_type {
-                  length {
-                  }
-                }
-              }
-              nullable: true
             }
-            list {
-              column_identifier {
-                column_name {
-                  name: "temp_c"
+            data_type {
+              string_type {
+                length {
                 }
               }
-              data_type {
-                float_type: true
-              }
-              nullable: true
             }
-            list {
-              column_identifier {
-                column_name {
-                  name: "temp_f"
-                }
+            nullable: true
+          }
+          fields {
+            column_identifier {
+              column_name {
+                name: "temp_c"
               }
-              data_type {
-                float_type: true
-              }
-              nullable: true
             }
+            data_type {
+              float_type: true
+            }
+            nullable: true
+          }
+          fields {
+            column_identifier {
+              column_name {
+                name: "temp_f"
+              }
+            }
+            data_type {
+              float_type: true
+            }
+            nullable: true
           }
         }
         src {

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -53,34 +53,32 @@ body {
           }
         }
         input_types {
-          list {
-            long_type: true
-          }
-          list {
-            string_type {
-              length {
-              }
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
             }
           }
-          list {
-            map_type {
-              key_ty {
-                string_type {
-                  length {
-                  }
-                }
-              }
-              value_ty {
-                string_type {
-                  length {
-                  }
+        }
+        input_types {
+          map_type {
+            key_ty {
+              string_type {
+                length {
                 }
               }
             }
+            value_ty {
+              string_type {
+                length {
+                }
+              }
+            }
           }
-          list {
-            boolean_type: true
-          }
+        }
+        input_types {
+          boolean_type: true
         }
         name {
           name {

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -32,7 +32,7 @@ df2 = session.create_dataframe([Row(1, 3, 2), Row(1, 2, 3), Row(3, 2, 1)])
 
 df3 = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df4 = session.create_dataframe([[1, "snow"], [3, "flake"]], schema=StructType([StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True)], structured=False))
+df4 = session.create_dataframe([[1, "snow"], [3, "flake"]], schema=StructType(fields=[StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True)], structured=False))
 
 df5 = session.create_dataframe([1, 2, 3, 4], schema=["a"])
 
@@ -63,11 +63,9 @@ body {
           dataframe_data__list {
             vs {
               row {
-                names {
-                  list: "a"
-                  list: "b"
-                  list: "c"
-                }
+                names: "a"
+                names: "b"
+                names: "c"
                 src {
                   end_column: 74
                   end_line: 29
@@ -115,10 +113,8 @@ body {
             }
             vs {
               row {
-                names {
-                  list: "c"
-                  list: "a"
-                }
+                names: "c"
+                names: "a"
                 src {
                   end_column: 74
                   end_line: 29
@@ -523,31 +519,29 @@ body {
           dataframe_schema__struct {
             v {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "a"
-                    }
+                column_identifier {
+                  column_name {
+                    name: "a"
                   }
-                  data_type {
-                    integer_type: true
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "b"
-                    }
-                  }
-                  data_type {
-                    string_type {
-                      length {
-                      }
-                    }
-                  }
-                  nullable: true
+                data_type {
+                  integer_type: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "b"
+                  }
+                }
+                data_type {
+                  string_type {
+                    length {
+                    }
+                  }
+                }
+                nullable: true
               }
             }
           }
@@ -852,12 +846,10 @@ body {
           dataframe_data__list {
             vs {
               row {
-                names {
-                  list: "a"
-                  list: "b"
-                  list: "c"
-                  list: "d"
-                }
+                names: "a"
+                names: "b"
+                names: "c"
+                names: "d"
                 src {
                   end_column: 65
                   end_line: 45

--- a/tests/ast/data/Session.create_dataframe_from_pandas.test
+++ b/tests/ast/data/Session.create_dataframe_from_pandas.test
@@ -13,9 +13,9 @@ df2 = session.create_dataframe(pd.DataFrame([(99, 98)], columns=["a", "b"]), sch
 
 ## EXPECTED UNPARSER OUTPUT
 
-df = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType([StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True), StructField("\"c\"", LongType(), nullable=True), StructField("\"d\"", LongType(), nullable=True)], structured=False))
+df = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType(fields=[StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True), StructField("\"c\"", LongType(), nullable=True), StructField("\"d\"", LongType(), nullable=True)], structured=False))
 
-df2 = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType([StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True)], structured=False))
+df2 = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType(fields=[StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True)], structured=False))
 
 ## EXPECTED ENCODED AST
 
@@ -42,50 +42,48 @@ body {
           dataframe_schema__struct {
             v {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"a\""
-                    }
+                column_identifier {
+                  column_name {
+                    name: "\"a\""
                   }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"b\""
-                    }
-                  }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
+                data_type {
+                  long_type: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"c\""
-                    }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "\"b\""
                   }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"d\""
-                    }
-                  }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
+                data_type {
+                  long_type: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "\"c\""
+                  }
+                }
+                data_type {
+                  long_type: true
+                }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "\"d\""
+                  }
+                }
+                data_type {
+                  long_type: true
+                }
+                nullable: true
               }
             }
           }
@@ -122,28 +120,26 @@ body {
           dataframe_schema__struct {
             v {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"a\""
-                    }
+                column_identifier {
+                  column_name {
+                    name: "\"a\""
                   }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "\"b\""
-                    }
-                  }
-                  data_type {
-                    long_type: true
-                  }
-                  nullable: true
+                data_type {
+                  long_type: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "\"b\""
+                  }
+                }
+                data_type {
+                  long_type: true
+                }
+                nullable: true
               }
             }
           }

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -80,18 +80,16 @@ body {
           }
         }
         input_types {
-          list {
-            long_type: true
-          }
-          list {
-            string_type {
-              length {
-              }
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
             }
           }
-          list {
-            boolean_type: true
-          }
+        }
+        input_types {
+          boolean_type: true
         }
         name {
           name {
@@ -146,18 +144,16 @@ body {
           }
         }
         input_types {
-          list {
-            long_type: true
-          }
-          list {
-            string_type {
-              length {
-              }
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
             }
           }
-          list {
-            boolean_type: true
-          }
+        }
+        input_types {
+          boolean_type: true
         }
         name {
           name {

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -43,7 +43,7 @@ target.merge(source, join_expr=(target["num"] == source["num"]), clauses=[when_m
 
 ## EXPECTED UNPARSER OUTPUT
 
-source = session.create_dataframe([(1, "one"), (2, "two"), (3, "three")], schema=StructType([StructField("num", IntegerType(), nullable=True), StructField("str", StringType(), nullable=True)], structured=False))
+source = session.create_dataframe([(1, "one"), (2, "two"), (3, "three")], schema=StructType(fields=[StructField("num", IntegerType(), nullable=True), StructField("str", StringType(), nullable=True)], structured=False))
 
 target = Table("test_table_1", session)
 
@@ -201,31 +201,29 @@ body {
           dataframe_schema__struct {
             v {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "num"
-                    }
+                column_identifier {
+                  column_name {
+                    name: "num"
                   }
-                  data_type {
-                    integer_type: true
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "str"
-                    }
-                  }
-                  data_type {
-                    string_type {
-                      length {
-                      }
-                    }
-                  }
-                  nullable: true
+                data_type {
+                  integer_type: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "str"
+                  }
+                }
+                data_type {
+                  string_type {
+                    length {
+                    }
+                  }
+                }
+                nullable: true
               }
             }
           }
@@ -288,30 +286,28 @@ body {
         clauses {
           merge_update_when_matched_clause {
             update_assignments {
-              list {
-                _1 {
-                  string_val {
-                    src {
-                      end_column: 136
-                      end_line: 34
-                      file: 2
-                      start_column: 8
-                      start_line: 34
-                    }
-                    v: "str"
+              _1 {
+                string_val {
+                  src {
+                    end_column: 136
+                    end_line: 34
+                    file: 2
+                    start_column: 8
+                    start_line: 34
                   }
+                  v: "str"
                 }
-                _2 {
-                  string_val {
-                    src {
-                      end_column: 136
-                      end_line: 34
-                      file: 2
-                      start_column: 8
-                      start_line: 34
-                    }
-                    v: "value"
+              }
+              _2 {
+                string_val {
+                  src {
+                    end_column: 136
+                    end_line: 34
+                    file: 2
+                    start_column: 8
+                    start_line: 34
                   }
+                  v: "value"
                 }
               }
             }
@@ -536,30 +532,28 @@ body {
               }
             }
             update_assignments {
-              list {
-                _1 {
-                  string_val {
-                    src {
-                      end_column: 167
-                      end_line: 39
-                      file: 2
-                      start_column: 8
-                      start_line: 39
-                    }
-                    v: "str"
+              _1 {
+                string_val {
+                  src {
+                    end_column: 167
+                    end_line: 39
+                    file: 2
+                    start_column: 8
+                    start_line: 39
                   }
+                  v: "str"
                 }
-                _2 {
-                  string_val {
-                    src {
-                      end_column: 167
-                      end_line: 39
-                      file: 2
-                      start_column: 8
-                      start_line: 39
-                    }
-                    v: "value2"
+              }
+              _2 {
+                string_val {
+                  src {
+                    end_column: 167
+                    end_line: 39
+                    file: 2
+                    start_column: 8
+                    start_line: 39
                   }
+                  v: "value2"
                 }
               }
             }
@@ -568,30 +562,28 @@ body {
         clauses {
           merge_update_when_matched_clause {
             update_assignments {
-              list {
-                _1 {
-                  string_val {
-                    src {
-                      end_column: 167
-                      end_line: 39
-                      file: 2
-                      start_column: 8
-                      start_line: 39
-                    }
-                    v: "num"
+              _1 {
+                string_val {
+                  src {
+                    end_column: 167
+                    end_line: 39
+                    file: 2
+                    start_column: 8
+                    start_line: 39
                   }
+                  v: "num"
                 }
-                _2 {
-                  int64_val {
-                    src {
-                      end_column: 167
-                      end_line: 39
-                      file: 2
-                      start_column: 8
-                      start_line: 39
-                    }
-                    v: 123
+              }
+              _2 {
+                int64_val {
+                  src {
+                    end_column: 167
+                    end_line: 39
+                    file: 2
+                    start_column: 8
+                    start_line: 39
                   }
+                  v: 123
                 }
               }
             }
@@ -714,31 +706,27 @@ body {
         clauses {
           merge_insert_when_not_matched_clause {
             insert_keys {
-              list {
-                string_val {
-                  src {
-                    end_column: 140
-                    end_line: 44
-                    file: 2
-                    start_column: 8
-                    start_line: 44
-                  }
-                  v: "str"
+              string_val {
+                src {
+                  end_column: 140
+                  end_line: 44
+                  file: 2
+                  start_column: 8
+                  start_line: 44
                 }
+                v: "str"
               }
             }
             insert_values {
-              list {
-                string_val {
-                  src {
-                    end_column: 140
-                    end_line: 44
-                    file: 2
-                    start_column: 8
-                    start_line: 44
-                  }
-                  v: "value"
+              string_val {
+                src {
+                  end_column: 140
+                  end_line: 44
+                  file: 2
+                  start_column: 8
+                  start_line: 44
                 }
+                v: "value"
               }
             }
           }
@@ -962,7 +950,35 @@ body {
               }
             }
             insert_keys {
-              list {
+              string_val {
+                src {
+                  end_column: 175
+                  end_line: 49
+                  file: 2
+                  start_column: 8
+                  start_line: 49
+                }
+                v: "str"
+              }
+            }
+            insert_values {
+              string_val {
+                src {
+                  end_column: 175
+                  end_line: 49
+                  file: 2
+                  start_column: 8
+                  start_line: 49
+                }
+                v: "value"
+              }
+            }
+          }
+        }
+        clauses {
+          merge_update_when_matched_clause {
+            update_assignments {
+              _1 {
                 string_val {
                   src {
                     end_column: 175
@@ -974,9 +990,7 @@ body {
                   v: "str"
                 }
               }
-            }
-            insert_values {
-              list {
+              _2 {
                 string_val {
                   src {
                     end_column: 175
@@ -985,39 +999,7 @@ body {
                     start_column: 8
                     start_line: 49
                   }
-                  v: "value"
-                }
-              }
-            }
-          }
-        }
-        clauses {
-          merge_update_when_matched_clause {
-            update_assignments {
-              list {
-                _1 {
-                  string_val {
-                    src {
-                      end_column: 175
-                      end_line: 49
-                      file: 2
-                      start_column: 8
-                      start_line: 49
-                    }
-                    v: "str"
-                  }
-                }
-                _2 {
-                  string_val {
-                    src {
-                      end_column: 175
-                      end_line: 49
-                      file: 2
-                      start_column: 8
-                      start_line: 49
-                    }
-                    v: "value3"
-                  }
+                  v: "value3"
                 }
               }
             }

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -106,9 +106,9 @@ df = df.select(col("A").cast(VectorType(FloatType(), 42)))
 
 df = df.select(col("A").cast(StructType(structured=False)))
 
-df = df.select(col("A").cast(StructType([], structured=False)))
+df = df.select(col("A").cast(StructType(structured=False)))
 
-df = df.select(col("A").cast(StructType([StructField("B", IntegerType(), nullable=True)], structured=False)))
+df = df.select(col("A").cast(StructType(fields=[StructField("B", IntegerType(), nullable=True)], structured=False)))
 
 df = df.select(col("A").cast(VariantType()))
 
@@ -1700,8 +1700,6 @@ body {
               }
               to {
                 struct_type {
-                  fields {
-                  }
                 }
               }
             }
@@ -1784,17 +1782,15 @@ body {
               to {
                 struct_type {
                   fields {
-                    list {
-                      column_identifier {
-                        column_name {
-                          name: "B"
-                        }
+                    column_identifier {
+                      column_name {
+                        name: "B"
                       }
-                      data_type {
-                        integer_type: true
-                      }
-                      nullable: true
                     }
+                    data_type {
+                      integer_type: true
+                    }
+                    nullable: true
                   }
                 }
               }

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -41,7 +41,7 @@ df = df.select(col("A").cast(MapType(GeographyType(), VariantType(), structured=
 
 df = df.select(col("A").cast(VectorType(IntegerType(), 64)))
 
-df = df.select(col("A").cast(StructType([StructField(ColumnIdentifier("test1"), StringType(), nullable=False), StructField("test2", IntegerType(), nullable=True), StructField(ColumnIdentifier("test3"), ArrayType(LongType(), structured=False), nullable=True), StructField("test4", MapType(DecimalType(42, 23), VectorType(FloatType(), 64), structured=False), nullable=True)], structured=True)))
+df = df.select(col("A").cast(StructType(fields=[StructField(ColumnIdentifier("test1"), StringType(), nullable=False), StructField("test2", IntegerType(), nullable=True), StructField(ColumnIdentifier("test3"), ArrayType(LongType(), structured=False), nullable=True), StructField("test4", MapType(DecimalType(42, 23), VectorType(FloatType(), 64), structured=False), nullable=True)], structured=True)))
 
 ## EXPECTED ENCODED AST
 
@@ -731,71 +731,69 @@ body {
               to {
                 struct_type {
                   fields {
-                    list {
+                    column_identifier {
                       column_identifier {
-                        column_identifier {
-                          name: "test1"
+                        name: "test1"
+                      }
+                    }
+                    data_type {
+                      string_type {
+                        length {
                         }
                       }
-                      data_type {
-                        string_type {
-                          length {
+                    }
+                  }
+                  fields {
+                    column_identifier {
+                      column_name {
+                        name: "test2"
+                      }
+                    }
+                    data_type {
+                      integer_type: true
+                    }
+                    nullable: true
+                  }
+                  fields {
+                    column_identifier {
+                      column_identifier {
+                        name: "test3"
+                      }
+                    }
+                    data_type {
+                      array_type {
+                        ty {
+                          long_type: true
+                        }
+                      }
+                    }
+                    nullable: true
+                  }
+                  fields {
+                    column_identifier {
+                      column_name {
+                        name: "test4"
+                      }
+                    }
+                    data_type {
+                      map_type {
+                        key_ty {
+                          decimal_type {
+                            precision: 42
+                            scale: 23
                           }
                         }
-                      }
-                    }
-                    list {
-                      column_identifier {
-                        column_name {
-                          name: "test2"
-                        }
-                      }
-                      data_type {
-                        integer_type: true
-                      }
-                      nullable: true
-                    }
-                    list {
-                      column_identifier {
-                        column_identifier {
-                          name: "test3"
-                        }
-                      }
-                      data_type {
-                        array_type {
-                          ty {
-                            long_type: true
-                          }
-                        }
-                      }
-                      nullable: true
-                    }
-                    list {
-                      column_identifier {
-                        column_name {
-                          name: "test4"
-                        }
-                      }
-                      data_type {
-                        map_type {
-                          key_ty {
-                            decimal_type {
-                              precision: 42
-                              scale: 23
+                        value_ty {
+                          vector_type {
+                            dimension: 64
+                            ty {
+                              float_type: true
                             }
                           }
-                          value_ty {
-                            vector_type {
-                              dimension: 64
-                              ty {
-                                float_type: true
-                              }
-                            }
-                          }
                         }
                       }
-                      nullable: true
                     }
+                    nullable: true
                   }
                   structured: true
                 }

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -93,7 +93,7 @@ df = df.select(col("A").try_cast(MapType(StringType(), StringType(), structured=
 
 df = df.select(col("A").try_cast(VectorType(FloatType(), 42)))
 
-df = df.select(col("A").try_cast(StructType([], structured=False)))
+df = df.select(col("A").try_cast(StructType(structured=False)))
 
 df = df.select(col("A").try_cast(VariantType()))
 
@@ -1520,8 +1520,6 @@ body {
               }
               to {
                 struct_type {
-                  fields {
-                  }
                 }
               }
             }

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -75,9 +75,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         parallel: 4
         return_type {
@@ -317,9 +315,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         name {
           name {
@@ -528,12 +524,10 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            float_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          float_type: true
         }
         is_permanent: true
         kwargs {
@@ -625,12 +619,10 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            float_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          float_type: true
         }
         is_permanent: true
         kwargs {

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -38,7 +38,7 @@ df7 = session.read.option("INFER_SCHEMA", True).option("PARSE_HEADER", True).csv
 
 df8 = session.read.options({"INFER_SCHEMA": True, "PARSE_HEADER": True}).csv("@testCSVheader.csv")
 
-df9 = session.read.with_metadata(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE_LAST_MODIFIED").schema(StructType([StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True), StructField("c", FloatType(), nullable=True)], structured=False)).csv("@testCSVheader.csv")
+df9 = session.read.with_metadata(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE_LAST_MODIFIED").schema(StructType(fields=[StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True), StructField("c", FloatType(), nullable=True)], structured=False)).csv("@testCSVheader.csv")
 
 ## EXPECTED ENCODED AST
 
@@ -492,42 +492,40 @@ body {
             }
             schema {
               fields {
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "a"
-                    }
+                column_identifier {
+                  column_name {
+                    name: "a"
                   }
-                  data_type {
-                    integer_type: true
-                  }
-                  nullable: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "b"
-                    }
-                  }
-                  data_type {
-                    string_type {
-                      length {
-                      }
-                    }
-                  }
-                  nullable: true
+                data_type {
+                  integer_type: true
                 }
-                list {
-                  column_identifier {
-                    column_name {
-                      name: "c"
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "b"
+                  }
+                }
+                data_type {
+                  string_type {
+                    length {
                     }
                   }
-                  data_type {
-                    float_type: true
-                  }
-                  nullable: true
                 }
+                nullable: true
+              }
+              fields {
+                column_identifier {
+                  column_name {
+                    name: "c"
+                  }
+                }
+                data_type {
+                  float_type: true
+                }
+                nullable: true
               }
             }
             src {

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -171,15 +171,15 @@ session.sql("call mul_sp(5, 6)").collect()
 
 sproc("sin_sp", return_type=FloatType(), input_types=[FloatType()], packages=["snowflake-snowpark-python", "numpy"], statement_params={"SF_PARTNER": "FAKE_PARTNER"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1.5707963267948966)
 
-res34 = sproc("select_sp", return_type=StructType([StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res34 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res38 = sproc("select_sp", return_type=StructType([], structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res38 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res42 = sproc("select_sp", return_type=StructType([], structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res42 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
@@ -213,21 +213,19 @@ body {
           }
         }
         input_types {
-          list {
-            string_type {
-              length {
-              }
+          string_type {
+            length {
             }
           }
-          list {
-            string_type {
-              length {
-              }
+        }
+        input_types {
+          string_type {
+            length {
             }
           }
-          list {
-            long_type: true
-          }
+        }
+        input_types {
+          long_type: true
         }
         name {
           name {
@@ -1121,9 +1119,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         parallel: 2
         return_type {
@@ -1382,12 +1378,10 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            integer_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          integer_type: true
         }
         is_permanent: true
         name {
@@ -1496,12 +1490,10 @@ body {
         }
         if_not_exists: true
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            integer_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          integer_type: true
         }
         is_permanent: true
         name {
@@ -1609,12 +1601,10 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            integer_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          integer_type: true
         }
         is_permanent: true
         name {
@@ -1731,9 +1721,7 @@ body {
           }
         }
         input_types {
-          list {
-            float_type: true
-          }
+          float_type: true
         }
         packages: "snowflake-snowpark-python"
         packages: "numpy"
@@ -1828,39 +1816,35 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            integer_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          integer_type: true
         }
         parallel: 4
         return_type {
           struct_type {
             fields {
-              list {
-                column_identifier {
-                  column_name {
-                    name: "A"
-                  }
+              column_identifier {
+                column_name {
+                  name: "A"
                 }
-                data_type {
-                  integer_type: true
-                }
-                nullable: true
               }
-              list {
-                column_identifier {
-                  column_name {
-                    name: "B"
-                  }
-                }
-                data_type {
-                  integer_type: true
-                }
-                nullable: true
+              data_type {
+                integer_type: true
               }
+              nullable: true
+            }
+            fields {
+              column_identifier {
+                column_name {
+                  name: "B"
+                }
+              }
+              data_type {
+                integer_type: true
+              }
+              nullable: true
             }
           }
         }
@@ -1999,18 +1983,14 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            integer_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          integer_type: true
         }
         parallel: 4
         return_type {
           struct_type {
-            fields {
-            }
           }
         }
         src {
@@ -2147,18 +2127,14 @@ body {
           }
         }
         input_types {
-          list {
-            long_type: true
-          }
-          list {
-            long_type: true
-          }
+          long_type: true
+        }
+        input_types {
+          long_type: true
         }
         parallel: 4
         return_type {
           struct_type {
-            fields {
-            }
           }
         }
         source_code_display: true

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -127,9 +127,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -520,9 +518,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         is_permanent: true
         kwargs {

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -101,29 +101,29 @@ df.select("a", twoxsix_udtf("a").alias("double", "six_x"), "c").collect()
 
 ## EXPECTED UNPARSER OUTPUT
 
-prime_udtf = udtf("PrimeSieve", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+prime_udtf = udtf("PrimeSieve", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(prime_udtf(lit(20))).collect()
 
 df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df.with_column("total", udtf("sum_udtf", output_schema=StructType([StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
+df.with_column("total", udtf("sum_udtf", output_schema=StructType(fields=[StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
 
-generator_udtf = udtf("GeneratorUDTF", output_schema=StructType([StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+generator_udtf = udtf("GeneratorUDTF", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(generator_udtf(lit(3))).collect()
 
-foo = udtf("Foo", output_schema=StructType([StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", copy_grants=False, force_inline_code=True, _registered_object_name="foo")
+foo = udtf("Foo", output_schema=StructType(fields=[StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", copy_grants=False, force_inline_code=True, _registered_object_name="foo")
 
 df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
 
 df = df.to_df(["a", "b", "c"])
 
-twox_udtf = udtf("TwoXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twox_udtf = udtf("TwoXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select((twox_udtf("a"))).collect()
 
-twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType([StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 
@@ -155,9 +155,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -178,17 +176,15 @@ body {
             return_type {
               struct_type {
                 fields {
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "number"
-                      }
+                  column_identifier {
+                    column_name {
+                      name: "number"
                     }
-                    data_type {
-                      integer_type: true
-                    }
-                    nullable: true
                   }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
                 }
               }
             }
@@ -364,12 +360,10 @@ body {
           }
         }
         input_types {
-          list {
-            long_type: true
-          }
-          list {
-            long_type: true
-          }
+          long_type: true
+        }
+        input_types {
+          long_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -390,17 +384,15 @@ body {
             return_type {
               struct_type {
                 fields {
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "number"
-                      }
+                  column_identifier {
+                    column_name {
+                      name: "number"
                     }
-                    data_type {
-                      long_type: true
-                    }
-                    nullable: true
                   }
+                  data_type {
+                    long_type: true
+                  }
+                  nullable: true
                 }
               }
             }
@@ -703,9 +695,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -726,17 +716,15 @@ body {
             return_type {
               struct_type {
                 fields {
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "number"
-                      }
+                  column_identifier {
+                    column_name {
+                      name: "number"
                     }
-                    data_type {
-                      integer_type: true
-                    }
-                    nullable: true
                   }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
                 }
               }
             }
@@ -932,12 +920,10 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
-          list {
-            long_type: true
-          }
+          integer_type: true
+        }
+        input_types {
+          long_type: true
         }
         is_permanent: true
         kwargs {
@@ -981,28 +967,26 @@ body {
             return_type {
               struct_type {
                 fields {
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "a"
-                      }
+                  column_identifier {
+                    column_name {
+                      name: "a"
                     }
-                    data_type {
-                      long_type: true
-                    }
-                    nullable: true
                   }
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "b"
-                      }
-                    }
-                    data_type {
-                      long_type: true
-                    }
-                    nullable: true
+                  data_type {
+                    long_type: true
                   }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "b"
+                    }
+                  }
+                  data_type {
+                    long_type: true
+                  }
+                  nullable: true
                 }
               }
             }
@@ -1290,9 +1274,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -1313,17 +1295,15 @@ body {
             return_type {
               struct_type {
                 fields {
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "two_x"
-                      }
+                  column_identifier {
+                    column_name {
+                      name: "two_x"
                     }
-                    data_type {
-                      integer_type: true
-                    }
-                    nullable: true
                   }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
                 }
               }
             }
@@ -1487,9 +1467,7 @@ body {
           }
         }
         input_types {
-          list {
-            integer_type: true
-          }
+          integer_type: true
         }
         kwargs {
           _1: "copy_grants"
@@ -1510,28 +1488,26 @@ body {
             return_type {
               struct_type {
                 fields {
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "two_x"
-                      }
+                  column_identifier {
+                    column_name {
+                      name: "two_x"
                     }
-                    data_type {
-                      integer_type: true
-                    }
-                    nullable: true
                   }
-                  list {
-                    column_identifier {
-                      column_name {
-                        name: "six_x"
-                      }
-                    }
-                    data_type {
-                      integer_type: true
-                    }
-                    nullable: true
+                  data_type {
+                    integer_type: true
                   }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "six_x"
+                    }
+                  }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
                 }
               }
             }


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-1941023](https://snowflakecomputing.atlassian.net/browse/SNOW-1941023)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR contains the necessary changes to ensure correct AST generation after removing optionality from all `Option[List[T]]` and `Option[Map[T1, T2]]` type fields. We use an empty collection as an indicator of a missing value.

   Slight modifications were made to make `StructType` AST building more concise.

   It also removes the `eval` statement generation from `dataframe.stat.sample_by` which is not an eager API.

   This PR is accompanied by [a server-side PR](https://github.com/snowflakedb/snowflake/pull/261101).


[SNOW-1941023]: https://snowflakecomputing.atlassian.net/browse/SNOW-1941023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ