### PR TITLE
SNOW-1950580: Fix bug in snowpark concat ws ignore nulls

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -3768,42 +3768,21 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
         ...     [None, None, None],
         ...     ['Hello', None, None],
         ... ], schema=['a', 'b', 'c'])
-        >>> df.select(_concat_ws_ignore_nulls(',', df.a, df.b, df.c)).show()
-        ----------------------------------------------------
-        |"CONCAT_WS_IGNORE_NULLS(',', ""A"",""B"",""C"")"  |
-        ----------------------------------------------------
-        |Hello,World                                       |
-        |                                                  |
-        |Hello                                             |
-        ----------------------------------------------------
-        <BLANKLINE>
+        >>> df.select(_concat_ws_ignore_nulls(',', df.a, df.b, df.c).as_("ans")).collect()
+        [Row(ANS='Hello,World'), Row(ANS=''), Row(ANS='Hello')]
 
-        >>> df.select(_concat_ws_ignore_nulls('--', df.a, df.b, df.c)).show()
-        -----------------------------------------------------
-        |"CONCAT_WS_IGNORE_NULLS('--', ""A"",""B"",""C"")"  |
-        -----------------------------------------------------
-        |Hello--World                                       |
-        |                                                   |
-        |Hello                                              |
-        -----------------------------------------------------
-        <BLANKLINE>
+        >>> df.select(_concat_ws_ignore_nulls('--', df.a, df.b, df.c).as_("ans")).collect()
+        [Row(ANS='Hello--World'), Row(ANS=''), Row(ANS='Hello')]
 
         >>> df = session.create_dataframe([
         ...     (['Hello', 'World', None], None, '!'),
         ...     (['Hi', 'World', "."], "I'm Dad", '.'),
         ... ], schema=['a', 'b', 'c'])
-        >>> df.select(_concat_ws_ignore_nulls(", ", "a", "b", "c")).show()
-        -----------------------------------------------------
-        |"CONCAT_WS_IGNORE_NULLS(', ', ""A"",""B"",""C"")"  |
-        -----------------------------------------------------
-        |Hello, World, !                                    |
-        |Hi, World, ., I'm Dad, .                           |
-        -----------------------------------------------------
-        <BLANKLINE>
+        >>> df.select(_concat_ws_ignore_nulls(", ", "a", "b", "c").as_("ans")).collect()
+        [Row(ANS='Hello, World, !'), Row(ANS="Hi, World, ., I'm Dad, .")]
     """
     # TODO: SNOW-1831917 create ast
     columns = [_to_col_if_str(c, "_concat_ws_ignore_nulls") for c in cols]
-    names = ",".join([c.get_name() for c in columns])
 
     # The implementation of this function is as follows with example input of
     # sep = "," and row = [a, NULL], b, NULL, c:
@@ -3815,7 +3794,7 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
     #   [a, NULL, b, c]
     # 4. Filter out nulls (array_remove_nulls).
     #   [a, b, c]
-    # 5. Concatenate the non-null values into a single string (concat_strings_with_sep).
+    # 5. Concatenate the non-null values into a single string (array_to_string).
     #   "a,b,c"
 
     def array_remove_nulls(col: Column) -> Column:
@@ -3824,21 +3803,8 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
             col, sql_expr("x -> NOT IS_NULL_VALUE(x)", _emit_ast=False)
         )
 
-    def concat_strings_with_sep(col: Column) -> Column:
-        """
-        Expects an array of strings and returns a single string
-        with the values concatenated with the separator.
-        """
-        return substring(
-            builtin("reduce", _emit_ast=False)(
-                col, lit(""), sql_expr(f"(l, r) -> l || '{sep}' || r", _emit_ast=False)
-            ),
-            len(sep) + 1,
-            _emit_ast=False,
-        )
-
-    return concat_strings_with_sep(
-        array_remove_nulls(
+    return array_to_string(
+        array=array_remove_nulls(
             array_flatten(
                 array_construct_compact(
                     *[c.cast(ArrayType(), _emit_ast=False) for c in columns],
@@ -3846,8 +3812,10 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
                 ),
                 _emit_ast=False,
             )
-        )
-    ).alias(f"CONCAT_WS_IGNORE_NULLS('{sep}', {names})", _emit_ast=False)
+        ),
+        separator=lit(sep, _emit_ast=False),
+        _emit_ast=False,
+    )
 
 
 @publicapi

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -110,6 +110,7 @@ from snowflake.snowpark.functions import (
     lit,
     ln,
     log,
+    month,
     months_between,
     negate,
     not_,
@@ -159,6 +160,7 @@ from snowflake.snowpark.functions import (
     vector_cosine_distance,
     vector_inner_product,
     vector_l2_distance,
+    year,
 )
 from snowflake.snowpark.types import (
     ArrayType,
@@ -417,6 +419,33 @@ def test__concat_ws_ignore_nulls(session, structured_type_semantics):
                 Row("R : H : TD : 4 : 5"),
                 Row(""),
                 Row(""),
+            ],
+        )
+
+        df = session.create_dataframe(
+            [(datetime.date(2021, 12, 21),), (datetime.date(1969, 12, 31),)],
+            schema=["year_month"],
+        )
+
+        Utils.check_answer(
+            df.select(
+                _concat_ws_ignore_nulls("-", year("year_month"), month("year_month"))
+            ),
+            [
+                Row("2021-12"),
+                Row("1969-12"),
+            ],
+        )
+
+        Utils.check_answer(
+            df.select(
+                _concat_ws_ignore_nulls(
+                    "-", year("year_month"), month("year_month")
+                ).alias("year_month")
+            ),
+            [
+                Row(YEAR_MONTH="2021-12"),
+                Row(YEAR_MONTH="1969-12"),
             ],
         )
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1950580

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   i. Fixed a bug in `_concat_ws_ignore_nulls` function which failed with `col.get_name()` returns None.
   ii. Improved the implementation by using `array_to_string` which is already supported in snowflake instead of custom implementation of `concat_strings_with_sep` function using `reduce` and `substring`
