### PR TITLE
SNOW-1945131: Bug Fix: Duplicate column error in get_dummies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 #### Bug Fixes
 - Fixed a bug where `pd.get_dummies` didn't ignore NULL/NaN values by default.
+- Fixed a bug where repeated calls to `pd.get_dummies` results in 'Duplicated column name error'.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/get_dummies_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/get_dummies_utils.py
@@ -161,7 +161,22 @@ def single_get_dummies_pivot(
         index_column_types=None,
     )
 
-    return result_internal_frame
+    # Rename the pivot result column to avoid duplicated column names. Snowpark
+    # dataframe can have duplicate columns names if multiple columns are pivoted,
+    # and they have at least one common value (including null).
+    pivot_result_column_new_snowflake_quoted_identifiers = (
+        pivoted_ordered_dataframe.generate_snowflake_quoted_identifiers(
+            pandas_labels=pivot_result_column_pandas_labels
+        )
+    )
+    return result_internal_frame.rename_snowflake_identifiers(
+        dict(
+            zip(
+                pivot_result_column_snowflake_quoted_identifiers,
+                pivot_result_column_new_snowflake_quoted_identifiers,
+            )
+        )
+    )
 
 
 def get_dummies_helper(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1945131

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Calling `pd.get_dummies` multiple times on the same DataFrame resulted in a 'Duplicated column name error'.
   This happens when pivoted columns have at least one common value (including NULL). This PR fixed issue by renaming snowflake identifiers to avoid duplicated column names.
