### PR TITLE
SNOW-1947929: Raise warning to unset QUOTED_IDENTIFIERS_IGNORE_CASE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
 - Fixed a bug in `Series.rename_axis` where an `AttributeError` was being raised.
 
+#### Improvements
+
+- Raise a warning whenever `QUOTED_IDENTIFIERS_IGNORE_CASE` is found to be set, ask user to unset it.
+
 
 ## 1.28.0 (2025-02-20)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/session.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/session.py
@@ -5,6 +5,7 @@
 import sys
 from types import ModuleType
 from typing import Any, Callable, Optional
+import warnings
 
 # import the entire context submodule instead of just get_active_session so
 # that we can mock get_active_session
@@ -40,13 +41,32 @@ class SnowpandasSessionHolder(ModuleType):
     value to a module property, e.g. `pd.session = session1`.
     """
 
+    def _warn_if_quoted_identifiers_ignore_case_is_set(self, session: Session) -> None:
+        quoted_identifiers_ignore_case = (
+            session.sql(
+                "SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE' IN SESSION"
+            )
+            .collect()[0]
+            .value
+        )
+        if quoted_identifiers_ignore_case == "true":
+            warnings.warn(
+                "Snowflake parameter 'QUOTED_IDENTIFIERS_IGNORE_CASE' is set to True."
+                + " Snowpark pandas requires it to be set to False."
+                + " Please consider unsetting it for this session using:"
+                + " pd.session.sql('ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = False').collect()",
+                stacklevel=1,
+            )
+
     def _get_active_session(self) -> Session:
         if self._session is not None and self._session in _active_sessions:
+            self._warn_if_quoted_identifiers_ignore_case_is_set(self._session)
             return self._session
 
         try:
             session = snowflake.snowpark.context.get_active_session()
             self._session = session
+            self._warn_if_quoted_identifiers_ignore_case_is_set(self._session)
             return session
         except SnowparkSessionException as ex:
             if ex.error_code == "1409":


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1947929

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Snowpark pandas requires the parameter QUOTED_IDENTIFIERS_IGNORE_CASE to be unset (default value). This PR detects if the parameter is set, and if so warns the user to unset it for the session -- showing how this can be done.
