### PR TITLE
SNOW-856100: pd.Grouper support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### New Features
 
 - Added support for list values in `Series.str.__getitem__` (`Series.str[...]`).
+- Added support for `pd.Grouper` objects in group by operations. When `freq` is specified, the default values of the `sort`, `closed`, `label`, and `convention` arguments are supported; `origin` is supported when it is `start` or `start_day`.
 
 #### Improvements
 

--- a/docs/source/modin/supported/dataframe_supported.rst
+++ b/docs/source/modin/supported/dataframe_supported.rst
@@ -196,8 +196,9 @@ Methods
 | ``get``                     | Y                               |                                  |                                                    |
 +-----------------------------+---------------------------------+----------------------------------+----------------------------------------------------+
 | ``groupby``                 | P                               | ``observed`` is ignored since    | ``Y``, support ``axis == 0`` and ``by`` is column  |
-|                             |                                 | Categoricals are not implemented | label or Series from the current DataFrame;        |
-|                             |                                 | yet                              | otherwise ``N``;                                   |
+|                             |                                 | Categoricals are not implemented | label or Series from the current DataFrame, or a   |
+|                             |                                 | yet                              | ``pd.Grouper`` object with labels from the         |
+|                             |                                 |                                  | current DataFrame; otherwise ``N``.                |
 |                             |                                 |                                  | Note that supported functions are agg, count,      |
 |                             |                                 |                                  | cumcount, cummax, cummin, cumsum, first, last,     |
 |                             |                                 |                                  | max, mean, median, min, quantile, shift, size,     |

--- a/docs/source/modin/supported/dataframe_supported.rst
+++ b/docs/source/modin/supported/dataframe_supported.rst
@@ -197,8 +197,14 @@ Methods
 +-----------------------------+---------------------------------+----------------------------------+----------------------------------------------------+
 | ``groupby``                 | P                               | ``observed`` is ignored since    | ``Y``, support ``axis == 0`` and ``by`` is column  |
 |                             |                                 | Categoricals are not implemented | label or Series from the current DataFrame, or a   |
-|                             |                                 | yet                              | ``pd.Grouper`` object with labels from the         |
-|                             |                                 |                                  | current DataFrame; otherwise ``N``.                |
+|                             |                                 | yet                              | ``pd.Grouper`` object; otherwise ``N``.            |
+|                             |                                 |                                  |                                                    |
+|                             |                                 |                                  | If a ``pd.Grouper`` object is passed, then only    |
+|                             |                                 |                                  | the default values of the ``sort``, ``closed``,    |
+|                             |                                 |                                  | ``label``, and ``convention`` arguments are        |
+|                             |                                 |                                  | supported. The ``origin`` argument currently       |
+|                             |                                 |                                  | supports ``"start_day"`` and ``"start"``.          |
+|                             |                                 |                                  |                                                    |
 |                             |                                 |                                  | Note that supported functions are agg, count,      |
 |                             |                                 |                                  | cumcount, cummax, cummin, cumsum, first, last,     |
 |                             |                                 |                                  | max, mean, median, min, quantile, shift, size,     |

--- a/docs/source/modin/supported/series_supported.rst
+++ b/docs/source/modin/supported/series_supported.rst
@@ -211,8 +211,14 @@ Methods
 +-----------------------------+---------------------------------+----------------------------------+----------------------------------------------------+
 | ``groupby``                 | P                               | ``observed`` is ignored since    | ``Y``, support ``axis == 0`` and ``by`` is column  |
 |                             |                                 | Categoricals are not implemented | label or Series from the current DataFrame, or a   |
-|                             |                                 | yet                              | ``pd.Grouper`` object with labels from the         |
-|                             |                                 |                                  | current DataFrame; otherwise ``N``.                |
+|                             |                                 | yet                              | ``pd.Grouper`` object; otherwise ``N``.            |
+|                             |                                 |                                  |                                                    |
+|                             |                                 |                                  | If a ``pd.Grouper`` object is passed, then only    |
+|                             |                                 |                                  | the default values of the ``sort``, ``closed``,    |
+|                             |                                 |                                  | ``label``, and ``convention`` arguments are        |
+|                             |                                 |                                  | supported. The ``origin`` argument currently       |
+|                             |                                 |                                  | supports ``"start_day"`` and ``"start"``.          |
+|                             |                                 |                                  |                                                    |
 |                             |                                 |                                  | Note that supported functions are agg, count,      |
 |                             |                                 |                                  | cumcount, cummax, cummin, cumsum, first, last,     |
 |                             |                                 |                                  | max, mean, median, min, quantile, shift, size,     |

--- a/docs/source/modin/supported/series_supported.rst
+++ b/docs/source/modin/supported/series_supported.rst
@@ -209,9 +209,10 @@ Methods
 +-----------------------------+---------------------------------+----------------------------------+----------------------------------------------------+
 | ``get``                     | Y                               |                                  |                                                    |
 +-----------------------------+---------------------------------+----------------------------------+----------------------------------------------------+
-| ``groupby``                 | P                               | ``observed`` is ignored since    | ``Y`` when ``axis == 0`` and ``by`` is column      |
-|                             |                                 | Categoricals are not implemented | label or Series from the current DataFrame;        |
-|                             |                                 | yet                              | otherwise ``N``;                                   |
+| ``groupby``                 | P                               | ``observed`` is ignored since    | ``Y``, support ``axis == 0`` and ``by`` is column  |
+|                             |                                 | Categoricals are not implemented | label or Series from the current DataFrame, or a   |
+|                             |                                 | yet                              | ``pd.Grouper`` object with labels from the         |
+|                             |                                 |                                  | current DataFrame; otherwise ``N``.                |
 |                             |                                 |                                  | Note that supported functions are agg, count,      |
 |                             |                                 |                                  | cumcount, cummax, cummin, cumsum, first, last,     |
 |                             |                                 |                                  | max, mean, median, min, quantile, shift, size,     |

--- a/src/snowflake/snowpark/modin/plugin/_internal/cumulative_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cumulative_utils.py
@@ -17,7 +17,7 @@ from snowflake.snowpark.modin.plugin._internal.aggregation_utils import (
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.groupby_utils import (
     check_is_groupby_supported_by_snowflake,
-    extract_groupby_column_pandas_labels,
+    resample_and_extract_groupby_column_pandas_labels,
 )
 from snowflake.snowpark.modin.plugin._internal.utils import pandas_lit
 from snowflake.snowpark.modin.plugin.compiler import snowflake_query_compiler
@@ -123,9 +123,10 @@ def get_groupby_cumagg_frame_axis0(
             f"GroupBy {cumagg_func_name} with level = {level} is not supported yet in Snowpark pandas."
         )
 
-    by_list = extract_groupby_column_pandas_labels(query_compiler, by, level)
+    qc, by_list = resample_and_extract_groupby_column_pandas_labels(
+        query_compiler, by, level
+    )
 
-    qc = query_compiler
     if numeric_only:
         qc = drop_non_numeric_data_columns(query_compiler, by_list)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
@@ -664,7 +664,9 @@ def get_frame_with_groupby_columns_as_index(
     2000-10-01 23:08:00    2
     2000-10-01 23:12:00    3
     2000-10-01 23:16:00    4
-    Freq: 4min, dtype: int64
+    Freq: None, dtype: int64
+
+    (Snowpark pandas drops the freq field)
 
     Upsampling will fill other columns with NULL values, under the assumption that they will be
     coalesced away by the resulting groupby operation:

--- a/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/groupby_utils.py
@@ -671,7 +671,7 @@ def get_frame_with_groupby_columns_as_index(
     Upsampling will fill other columns with NULL values, under the assumption that they will be
     coalesced away by the resulting groupby operation:
 
-    >>> get_frame_with_groupby_columns_as_index(ts._query_compiler, pd.Grouper(freq="2min"), None, True)
+    get_frame_with_groupby_columns_as_index(ts._query_compiler, pd.Grouper(freq="2min"), None, True)
     +----------------------+-------------+
     |       __index__      | __reduced__ |
     +----------------------+-------------+
@@ -690,7 +690,7 @@ def get_frame_with_groupby_columns_as_index(
     that they belong to the same bin. Note that in this example, the bins are shifted because the
     Grouper defaults to origin="start_date".
 
-    >>> get_frame_with_groupby_columns_as_index(ts._query_compiler, pd.Grouper(freq="8min"), None, True)
+    get_frame_with_groupby_columns_as_index(ts._query_compiler, pd.Grouper(freq="8min"), None, True)
     +----------------------+-------------+
     |       __index__      | __reduced__ |
     +----------------------+-------------+

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -21,7 +21,6 @@ from snowflake.snowpark.functions import (
     date_trunc,
     max as max_,
     min as min_,
-    pandas_lit,
 )
 from snowflake.snowpark.modin.plugin._internal import join_utils
 from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
@@ -30,6 +29,7 @@ from snowflake.snowpark.modin.plugin._internal.join_utils import (
     MatchComparator,
     join,
 )
+from snowflake.snowpark.modin.plugin._internal.utils import pandas_lit
 from snowflake.snowpark.modin.plugin.utils.error_message import ErrorMessage
 from snowflake.snowpark.types import DateType, TimestampType
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -422,7 +422,7 @@ def perform_resample_binning_on_frame(
     slice_width: int,
     slice_unit: str,
     *,
-    resample_output_col_identifier: Optional[str],
+    resample_output_col_identifier: Optional[str] = None,
 ) -> InternalFrame:
     """
     Returns a new dataframe where each item of the index column

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -6,7 +6,7 @@ import datetime as dt
 from typing import Any, Literal, NoReturn, Optional, Union
 
 import modin.pandas as pd
-from pandas._libs.lib import no_default
+from pandas._libs.lib import no_default, NoDefault
 from pandas._libs.tslibs import to_offset
 from pandas._typing import Frequency
 
@@ -590,7 +590,11 @@ def perform_resample_binning_on_frame(
 
 
 def get_expected_resample_bins_frame(
-    rule: str, start_date: str, end_date: str, *, index_label: Optional[str] = None
+    rule: str,
+    start_date: str,
+    end_date: str,
+    *,
+    index_label: Union[str, None, NoDefault] = no_default,
 ) -> InternalFrame:
     """
     Returns an InternalFrame with a single DatetimeIndex column that holds the
@@ -606,9 +610,10 @@ def get_expected_resample_bins_frame(
     end_date : str
         The latest date in the timeseries data.
 
-    index_label : Optional[str], default None
+    index_label : Optional[str] | NoDefault, default no_default
         The value to use as the pandas label of the resampled column. Defaults to RESAMPLE_INDEX_LABEL
         if left unspecified.
+        Note that a None value is a valid pandas label, which will be used if explicitly specified.
 
     Returns
     -------
@@ -634,7 +639,7 @@ def get_expected_resample_bins_frame(
         data_column_pandas_labels=[],
         data_column_snowflake_quoted_identifiers=[],
         index_column_pandas_labels=[
-            RESAMPLE_INDEX_LABEL if index_label is None else index_label
+            RESAMPLE_INDEX_LABEL if index_label == no_default else index_label
         ],
         index_column_snowflake_quoted_identifiers=expected_resample_bins_snowpark_frame.index_column_snowflake_quoted_identifiers,
         data_column_pandas_index_names=[None],

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -590,7 +590,7 @@ def perform_resample_binning_on_frame(
 
 
 def get_expected_resample_bins_frame(
-    rule: str, start_date: str, end_date: str
+    rule: str, start_date: str, end_date: str, *, index_label: Optional[str] = None
 ) -> InternalFrame:
     """
     Returns an InternalFrame with a single DatetimeIndex column that holds the
@@ -604,7 +604,11 @@ def get_expected_resample_bins_frame(
         The earliest date in the timeseries data.
 
     end_date : str
-         The latest date in the timeseries data.
+        The latest date in the timeseries data.
+
+    index_label : Optional[str], default None
+        The value to use as the pandas label of the resampled column. Defaults to RESAMPLE_INDEX_LABEL
+        if left unspecified.
 
     Returns
     -------
@@ -629,7 +633,9 @@ def get_expected_resample_bins_frame(
         ordered_dataframe=expected_resample_bins_snowpark_frame.ordered_dataframe,
         data_column_pandas_labels=[],
         data_column_snowflake_quoted_identifiers=[],
-        index_column_pandas_labels=[RESAMPLE_INDEX_LABEL],
+        index_column_pandas_labels=[
+            RESAMPLE_INDEX_LABEL if index_label is None else index_label
+        ],
         index_column_snowflake_quoted_identifiers=expected_resample_bins_snowpark_frame.index_column_snowflake_quoted_identifiers,
         data_column_pandas_index_names=[None],
         data_column_types=None,

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -224,7 +224,7 @@ from snowflake.snowpark.modin.plugin._internal.frame import (
 )
 from snowflake.snowpark.modin.plugin._internal.groupby_utils import (
     check_is_groupby_supported_by_snowflake,
-    extract_groupby_column_pandas_labels,
+    resample_and_extract_groupby_column_pandas_labels,
     get_frame_with_groupby_columns_as_index,
     get_groups_for_ordered_dataframe,
     make_groupby_rank_col_for_method,
@@ -4052,29 +4052,33 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         dropna = groupby_kwargs.get("dropna", True)
         group_keys = groupby_kwargs.get("group_keys", False)
 
-        by_pandas_labels = (
-            []
-            if force_single_group
-            else extract_groupby_column_pandas_labels(self, by, level)
-        )
+        if force_single_group:
+            query_compiler, by_pandas_labels = self, []
+        else:
+            (
+                query_compiler,
+                by_pandas_labels,
+            ) = resample_and_extract_groupby_column_pandas_labels(self, by, level)
+
+        _modin_frame = query_compiler._modin_frame
 
         by_snowflake_quoted_identifiers_list = (
             []
             if force_single_group
             else [
                 quoted_identifier
-                for entry in self._modin_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
+                for entry in _modin_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
                     by_pandas_labels
                 )
                 for quoted_identifier in entry
             ]
         )
 
-        snowflake_type_map = self._modin_frame.quoted_identifier_to_snowflake_type()
+        snowflake_type_map = _modin_frame.quoted_identifier_to_snowflake_type()
         input_data_column_positions = [
             i
             for i, identifier in enumerate(
-                self._modin_frame.data_column_snowflake_quoted_identifiers
+                _modin_frame.data_column_snowflake_quoted_identifiers
             )
             if (
                 (
@@ -4084,8 +4088,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     # the last data column, so take just that column.
                     # include_groups has no effect.
                     i
-                    == len(self._modin_frame.data_column_snowflake_quoted_identifiers)
-                    - 1
+                    == len(_modin_frame.data_column_snowflake_quoted_identifiers) - 1
                 )
                 if series_groupby
                 else (
@@ -4098,14 +4101,14 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
         ]
         input_data_column_identifiers = [
-            self._modin_frame.data_column_snowflake_quoted_identifiers[i]
+            _modin_frame.data_column_snowflake_quoted_identifiers[i]
             for i in input_data_column_positions
         ]
 
         # TODO(SNOW-1210489): When type hints show that `agg_func` returns a
         # scalar, we can use a vUDF instead of a vUDTF and we can skip the
         # pivot.
-        data_columns_index = self._modin_frame.data_columns_index[
+        data_columns_index = _modin_frame.data_columns_index[
             input_data_column_positions
         ]
         is_transform = groupby_kwargs.get("apply_op") == "transform"
@@ -4114,16 +4117,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             agg_args,
             agg_kwargs,
             data_column_index=data_columns_index,
-            index_column_names=self._modin_frame.index_column_pandas_labels,
+            index_column_names=_modin_frame.index_column_pandas_labels,
             input_data_column_types=[
                 snowflake_type_map[quoted_identifier]
                 for quoted_identifier in input_data_column_identifiers
             ],
             input_index_column_types=[
                 snowflake_type_map[quoted_identifier]
-                for quoted_identifier in self._modin_frame.index_column_snowflake_quoted_identifiers
+                for quoted_identifier in _modin_frame.index_column_snowflake_quoted_identifiers
             ],
-            session=self._modin_frame.ordered_dataframe.session,
+            session=_modin_frame.ordered_dataframe.session,
             series_groupby=series_groupby,
             by_labels=by_pandas_labels,
             by_types=[]
@@ -4132,12 +4135,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 snowflake_type_map[quoted_identifier]
                 for quoted_identifier in by_snowflake_quoted_identifiers_list
             ],
-            existing_identifiers=self._modin_frame.ordered_dataframe._dataframe_ref.snowflake_quoted_identifiers,
+            existing_identifiers=_modin_frame.ordered_dataframe._dataframe_ref.snowflake_quoted_identifiers,
             force_list_like_to_series=force_list_like_to_series,
             is_transform=is_transform,
         )
 
-        new_internal_df = self._modin_frame.ensure_row_position_column()
+        new_internal_df = _modin_frame.ensure_row_position_column()
 
         # drop the rows if any value in groupby key is NaN
         ordered_dataframe = new_internal_df.ordered_dataframe
@@ -4214,13 +4217,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 InternalFrame.create(
                     ordered_dataframe=ordered_dataframe,
                     data_column_pandas_labels=data_col_labels,
-                    data_column_pandas_index_names=self._modin_frame.data_column_pandas_index_names,
+                    data_column_pandas_index_names=_modin_frame.data_column_pandas_index_names,
                     data_column_snowflake_quoted_identifiers=ids[
-                        1 + self._modin_frame.num_index_levels() :
+                        1 + _modin_frame.num_index_levels() :
                     ],
-                    index_column_pandas_labels=self._modin_frame.index_column_pandas_labels,
+                    index_column_pandas_labels=_modin_frame.index_column_pandas_labels,
                     index_column_snowflake_quoted_identifiers=ids[
-                        1 : 1 + self._modin_frame.num_index_levels()
+                        1 : 1 + _modin_frame.num_index_levels()
                     ],
                     data_column_types=None,
                     index_column_types=None,
@@ -4510,7 +4513,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         sort = groupby_kwargs.get("sort", True)
         as_index = groupby_kwargs.get("as_index", True)
         fillna_method = "bfill" if method == "first" else "ffill"
-        by_list = extract_groupby_column_pandas_labels(self, by, level)
+        query_compiler, by_list = resample_and_extract_groupby_column_pandas_labels(
+            self, by, level
+        )
         by_snowflake_quoted_identifiers_list = [
             entry[0]
             for entry in self._modin_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
@@ -4519,10 +4524,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ]
         if not agg_kwargs.get("skipna", True):
             # If we don't skip nulls, we don't need to fillna.
-            result = self
+            result = query_compiler
         else:
             result = SnowflakeQueryCompiler(
-                self._modin_frame.update_snowflake_quoted_identifiers_with_expressions(
+                query_compiler._modin_frame.update_snowflake_quoted_identifiers_with_expressions(
                     quoted_identifier_to_column_map=self._fill_null_values_in_groupby(
                         fillna_method, by_snowflake_quoted_identifiers_list
                     ),
@@ -4701,7 +4706,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             original_frame.ordering_column_snowflake_quoted_identifiers
         )
 
-        by_list = extract_groupby_column_pandas_labels(self, by, level)
+        query_compiler, by_list = resample_and_extract_groupby_column_pandas_labels(
+            self, by, level
+        )
         by_snowflake_quoted_identifiers_list = [
             entry[0]
             for entry in original_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
@@ -4753,7 +4760,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 partition_list.remove(col_ident)
 
         return SnowflakeQueryCompiler(
-            self._modin_frame.project_columns(pandas_labels, new_cols)
+            query_compiler._modin_frame.project_columns(pandas_labels, new_cols)
         )
 
     def groupby_shift(
@@ -4894,16 +4901,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 + "level != None, sort, dropna or observed is not supported yet in Snowpark pandas."
             )
 
-        by_list = extract_groupby_column_pandas_labels(self, by, level)
+        query_compiler, by_list = resample_and_extract_groupby_column_pandas_labels(
+            self, by, level
+        )
+        _modin_frame = query_compiler._modin_frame
 
         # TODO: SNOW-1006626 should fix this.
         if (
             not is_series_groupby
-            and self._modin_frame.index_column_pandas_labels is not None
+            and _modin_frame.index_column_pandas_labels is not None
             and by_list is not None
             and len(by_list) > 0
             and any(
-                by_column in self._modin_frame.index_column_pandas_labels
+                by_column in _modin_frame.index_column_pandas_labels
                 for by_column in by_list
             )
         ):
@@ -4916,7 +4926,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         by_snowflake_quoted_identifiers_list = [
             entry[0]
-            for entry in self._modin_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
+            for entry in _modin_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
                 by_list
             )
         ]
@@ -4925,8 +4935,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if periods != 0:
             new_columns = []
             for pandas_label, snowflake_quoted_identifier in zip(
-                self._modin_frame.data_column_pandas_labels,
-                self._modin_frame.data_column_snowflake_quoted_identifiers,
+                _modin_frame.data_column_pandas_labels,
+                _modin_frame.data_column_snowflake_quoted_identifiers,
             ):
                 if (
                     snowflake_quoted_identifier
@@ -4935,7 +4945,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     window = Window.partition_by(
                         by_snowflake_quoted_identifiers_list
                     ).order_by(
-                        self._modin_frame.ordered_dataframe.ordering_column_snowflake_quoted_identifiers
+                        _modin_frame.ordered_dataframe.ordering_column_snowflake_quoted_identifiers
                     )
 
                     new_col = func(
@@ -4945,21 +4955,21 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     pandas_labels.append(pandas_label)
                     new_columns.append(new_col)
             return SnowflakeQueryCompiler(
-                self._modin_frame.project_columns(pandas_labels, new_columns)
+                _modin_frame.project_columns(pandas_labels, new_columns)
             )
 
         snowflake_quoted_identifiers = []
         for pandas_label, col_name in zip(
-            self._modin_frame.data_column_pandas_labels,
-            self._modin_frame.data_column_snowflake_quoted_identifiers,
+            _modin_frame.data_column_pandas_labels,
+            _modin_frame.data_column_snowflake_quoted_identifiers,
         ):
             if col_name not in by_snowflake_quoted_identifiers_list:
                 snowflake_quoted_identifiers.append(col_name)
                 pandas_labels.append(pandas_label)
 
-        new_ordered_dataframe = self._modin_frame.ordered_dataframe.select(
+        new_ordered_dataframe = _modin_frame.ordered_dataframe.select(
             snowflake_quoted_identifiers
-            + self._modin_frame.index_column_snowflake_quoted_identifiers
+            + _modin_frame.index_column_snowflake_quoted_identifiers
         )
         return SnowflakeQueryCompiler(
             InternalFrame.create(
@@ -5726,9 +5736,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             fill_axis = 0
 
         if level is not None:
-            by = extract_groupby_column_pandas_labels(self, by, level)
+            query_compiler, by = resample_and_extract_groupby_column_pandas_labels(
+                self, by, level
+            )
 
-        frame = self._modin_frame
+        frame = query_compiler._modin_frame
 
         data_column_group_keys = [
             pandas_label
@@ -5765,7 +5777,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if method is None:
             # If there's no method, then the fill is same as dataframe.fillna with fill value.  Skip any group by
             # data columns in the fill.
-            qc = self._fillna_with_masking(
+            qc = query_compiler._fillna_with_masking(
                 value=value,
                 self_is_series=False,
                 method=None,
@@ -5827,7 +5839,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
             if fill_axis == 0:
                 # Fill the groups row-wise with values.
-                columns_to_fillna_expr = self._fill_null_values_in_groupby(
+                columns_to_fillna_expr = query_compiler._fill_null_values_in_groupby(
                     method, by_list_snowflake_quoted_identifiers, limit
                 )
 
@@ -5968,10 +5980,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             by_labels = [by]
 
         if level is not None:
-            by_labels = extract_groupby_column_pandas_labels(self, by, level)
+            qc, by_labels = resample_and_extract_groupby_column_pandas_labels(
+                self, by, level
+            )
+        else:
+            qc = self
 
         # Perform fillna before pct_change to account for filling within the group.
-        qc = self
         if fill_method is not None:
             qc = qc.groupby_fillna(
                 by=by,
@@ -17570,7 +17585,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             return SnowflakeQueryCompiler(original_frame.filter(pandas_lit(False)))
 
         # STEP 1: Extract the column(s) used to group the data by.
-        by_list = extract_groupby_column_pandas_labels(self, by, level)
+        query_compiler, by_list = resample_and_extract_groupby_column_pandas_labels(
+            self, by, level
+        )
+        original_frame = query_compiler._modin_frame
         by_snowflake_quoted_identifiers_list = [
             entry[0]
             for entry in original_frame.get_snowflake_quoted_identifiers_group_by_pandas_labels(
@@ -19834,7 +19852,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         compiler = SnowflakeQueryCompiler(
             self._modin_frame.ensure_row_position_column()
         )
-        by_list = extract_groupby_column_pandas_labels(
+        by_list = resample_and_extract_groupby_column_pandas_labels(
             compiler, by, groupby_kwargs.get("level", None)
         )
         by_snowflake_quoted_identifiers_list = []

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -5739,6 +5739,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             query_compiler, by = resample_and_extract_groupby_column_pandas_labels(
                 self, by, level
             )
+        else:
+            query_compiler = self
 
         frame = query_compiler._modin_frame
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -413,7 +413,7 @@ _logger = logging.getLogger(__name__)
 # For now, limit number of quantiles supported df.quantiles to avoid producing recursion limit failure in Snowpark.
 MAX_QUANTILES_SUPPORTED: int = 16
 
-_GROUPBY_UNSUPPORTED_GROUPING_MESSAGE = "does not yet support pd.Grouper, axis == 1, by != None and level != None, or by containing any non-pandas hashable labels."
+_GROUPBY_UNSUPPORTED_GROUPING_MESSAGE = "does not yet support axis == 1, by != None and level != None, or by containing any non-pandas hashable labels."
 
 QUARTER_START_MONTHS = [1, 4, 7, 10]
 

--- a/tests/integ/modin/groupby/test_groupby_default2pandas.py
+++ b/tests/integ/modin/groupby/test_groupby_default2pandas.py
@@ -271,22 +271,6 @@ def test_std_var_ddof_unsupported(basic_snowpark_pandas_df, grp_agg, agg_name, b
         grp_agg(snowpark_pandas_group)
 
 
-@pytest.mark.parametrize(
-    "by, query_count",
-    [
-        (native_pd.Grouper(key="col1"), 0),
-        (["col5", native_pd.Grouper(key="col1")], 1),
-    ],
-)
-def test_grouper_unsupported(basic_snowpark_pandas_df, by, query_count):
-    with SqlCounter(query_count=query_count):
-        snowpark_pandas_group = basic_snowpark_pandas_df.groupby(by)
-        with pytest.raises(
-            NotImplementedError, match=AGGREGATE_UNSUPPORTED_GROUPING_ERROR_PATTERN
-        ):
-            snowpark_pandas_group.max()
-
-
 @sql_count_checker(query_count=0)
 def test_groupby_ngroups_axis_1():
     by = "x"

--- a/tests/integ/modin/groupby/test_groupby_get_group.py
+++ b/tests/integ/modin/groupby/test_groupby_get_group.py
@@ -8,7 +8,7 @@ import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.integ.modin.utils import eval_snowpark_pandas_result, create_test_series
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
@@ -96,7 +96,12 @@ def test_groupby_get_group_with_list():
 
 
 @sql_count_checker(query_count=0)
-def test_error_checking():
-    s = pd.Series(list("abc") * 4)
-    with pytest.raises(NotImplementedError):
-        s.groupby(pd.Grouper("b")).get_group("b")
+def test_error_message():
+    eval_snowpark_pandas_result(
+        *create_test_series(list("abc") * 4),
+        lambda s: s.groupby(pd.Grouper("b")).get_group("b"),
+        expect_exception=True,
+        expect_exception_type=KeyError,
+        expect_exception_match=False,
+        assert_exception_equal=False,
+    )

--- a/tests/integ/modin/groupby/test_groupby_series.py
+++ b/tests/integ/modin/groupby/test_groupby_series.py
@@ -11,11 +11,8 @@ import pytest
 from pandas.errors import SpecificationError
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.modin.utils import (
-    eval_snowpark_pandas_result,
-    create_test_series,
-)
-from tests.integ.utils.sql_counter import sql_count_checker, SqlCounter
+from tests.integ.modin.utils import eval_snowpark_pandas_result
+from tests.integ.utils.sql_counter import sql_count_checker
 
 
 @pytest.mark.parametrize("by", ["a", ["b"], ["a", "b"]])
@@ -170,13 +167,3 @@ def test_groupby_series_single_index():
     eval_snowpark_pandas_result(
         snow_ser, native_ser, lambda ser: ser.groupby(level=0).mean()
     )
-
-
-@pytest.mark.parametrize("freq", ["45s", "1m", "3m", "4m", "8m", "9m"])
-def test_groupby_series_datetime_sum(freq):
-    with SqlCounter(query_count=1, join_count=1):
-        dates = pd.date_range("2000-10-01 23:00:00", "2000-10-01 23:16:00", freq="4min")
-        eval_snowpark_pandas_result(
-            *create_test_series(np.arange(len(dates)), index=dates),
-            lambda ser: ser.groupby(pd.Grouper(freq=freq)).sum(),
-        )

--- a/tests/integ/modin/groupby/test_groupby_series.py
+++ b/tests/integ/modin/groupby/test_groupby_series.py
@@ -13,8 +13,9 @@ from pandas.errors import SpecificationError
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
+    create_test_series,
 )
-from tests.integ.utils.sql_counter import sql_count_checker
+from tests.integ.utils.sql_counter import sql_count_checker, SqlCounter
 
 
 @pytest.mark.parametrize("by", ["a", ["b"], ["a", "b"]])
@@ -169,3 +170,13 @@ def test_groupby_series_single_index():
     eval_snowpark_pandas_result(
         snow_ser, native_ser, lambda ser: ser.groupby(level=0).mean()
     )
+
+
+@pytest.mark.parametrize("freq", ["45s", "1m", "3m", "4m", "8m", "9m"])
+def test_groupby_series_datetime_sum(freq):
+    with SqlCounter(query_count=1, join_count=1):
+        dates = pd.date_range("2000-10-01 23:00:00", "2000-10-01 23:16:00", freq="4min")
+        eval_snowpark_pandas_result(
+            *create_test_series(np.arange(len(dates)), index=dates),
+            lambda ser: ser.groupby(pd.Grouper(freq=freq)).sum(),
+        )

--- a/tests/integ/modin/groupby/test_groupby_size.py
+++ b/tests/integ/modin/groupby/test_groupby_size.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import re
+
 import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
@@ -176,6 +178,17 @@ def test_error_checking():
     s = pd.Series(list("abc") * 4)
     with pytest.raises(NotImplementedError):
         s.groupby(s).size()
+
+
+@sql_count_checker(query_count=0)
+def test_multiindex_negative():
+    # Because of internal calls to reset_index, attempting to perform groupby_size with
+    # a level parameter in a MultiIndex frame will fail.
+    df = pd.DataFrame(
+        {"a": list(range(10)), "b": list(range(10)), "c": list(range(10))}
+    ).set_index(["a", "b"])
+    with pytest.raises(KeyError, match=re.escape("['a'] not in index")):
+        df.groupby(pd.Grouper(level=0)).size()
 
 
 @pytest.mark.parametrize("by", ["A", "B"])

--- a/tests/integ/modin/groupby/test_groupby_with_grouper.py
+++ b/tests/integ/modin/groupby/test_groupby_with_grouper.py
@@ -1,0 +1,229 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+#
+
+"""
+Tests for groupby operations that involve `pd.Grouper` objects, including resampling operations.
+
+To avoid blowing up runtime too exponentially, these tests cover a mixture of groupby operations
+and arguments rather than every possible operation-argument combination.
+"""
+
+import re
+
+import modin.pandas as pd
+import numpy as np
+import pandas as native_pd
+import pytest
+
+from snowflake.snowpark.exceptions import SnowparkSQLException
+import snowflake.snowpark.modin.plugin  # noqa: F401
+from tests.integ.utils.sql_counter import sql_count_checker, SqlCounter
+from tests.integ.modin.utils import (
+    eval_snowpark_pandas_result,
+    create_test_series,
+    create_test_dfs,
+)
+
+DT_SORTED_INDEX_LEVEL = 0
+DT_UNSORTED_INDEX_LEVEL = 1
+STRING_INDEX_LEVEL = 2
+NUMERIC_INDEX_LEVEL = 3
+
+
+@pytest.fixture
+def dfs_with_datetime_cols_and_mi() -> tuple[pd.DataFrame, native_pd.DataFrame]:
+    # Returns a native DF with datetime columns and a 2-level multi-index.
+    rng = np.random.default_rng(0)
+    row_count = 8
+    # Use a mixture of frequencies and start dates
+    dts_sorted_index = native_pd.date_range(
+        start="2000-01-01 00:45:50", periods=row_count, freq="45s"
+    ).to_numpy()
+    dts_unsorted_index = native_pd.date_range(
+        start="2030-11-19 16:39:00", periods=row_count, freq="1ME"
+    ).to_numpy()
+    rng.shuffle(dts_unsorted_index)
+    dts_sorted_data = native_pd.date_range(
+        start="1800-05-22 08:30:21", periods=row_count, freq="1h"
+    ).to_numpy()
+    dts_unsorted_data = native_pd.date_range(
+        start="2013-10-08 22:33:00", periods=row_count, freq="2min"
+    ).to_numpy()
+    rng.shuffle(dts_unsorted_data)
+    data = {
+        "datetimes_sorted_index": dts_sorted_index,
+        "datetimes_unsorted_index": dts_unsorted_index,
+        "string_index": [f"s_index_{i % 2}" for i in range(row_count)],
+        "numeric_index": [i % 3 for i in range(row_count)],
+        "datetimes_sorted_data": dts_sorted_data,
+        "datetimes_unsorted_data": dts_unsorted_data,
+        "string_data": [f"s_data_{i % 4}" for i in range(row_count)],
+        "numeric_data": [100 + (i % 5) for i in range(row_count)],
+    }
+    idx_list = [
+        "datetimes_sorted_index",
+        "datetimes_unsorted_index",
+        "string_index",
+        "numeric_index",
+    ]
+    return pd.DataFrame(data).set_index(idx_list), native_pd.DataFrame(data).set_index(
+        idx_list
+    )
+
+
+@pytest.mark.parametrize(
+    "by",
+    [
+        # Standalone grouper object with label
+        pd.Grouper(key="string_data"),
+        # Standalone grouper object with level
+        pd.Grouper(level=0),
+        # List containing mix of grouper and string labels
+        [
+            pd.Grouper(level=1),
+            "string_data",
+            "numeric_data",
+        ],
+    ],
+)
+@sql_count_checker(query_count=1)
+def test_groupby_nunique_with_grouper(by, dfs_with_datetime_cols_and_mi):
+    eval_snowpark_pandas_result(
+        *dfs_with_datetime_cols_and_mi, lambda df: df.groupby(by).nunique()
+    )
+
+
+@sql_count_checker(query_count=2, join_count=3)
+def test_groupby_count_implicit_grouper():
+    # If a Grouper is specified without a label or level but has a freq, it implicitly refers to
+    # the frame's index column.
+    dts = native_pd.date_range(start="2000-10-01 23:00:00", freq="5min", periods=10)
+    eval_snowpark_pandas_result(
+        *create_test_dfs(list(range(10)), index=dts),
+        lambda df: df.groupby(pd.Grouper(freq="120s")).count(),
+        test_attrs=False,
+        check_freq=False,
+    )
+
+
+@sql_count_checker(query_count=1, join_count=1)
+def test_groupby_head_no_resample():
+    # native pandas does NOT resample when calling groupby_head or tail.
+    dts = native_pd.date_range(start="2000-10-01 23:00:00", freq="5min", periods=10)
+    eval_snowpark_pandas_result(
+        *create_test_dfs(list(range(10)), index=dts),
+        lambda df: df.groupby(pd.Grouper(freq="120s")).head(),
+        test_attrs=False,
+        check_freq=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "by",
+    [
+        [pd.Grouper(level=DT_SORTED_INDEX_LEVEL, freq="90s")],
+        [
+            pd.Grouper(level=DT_UNSORTED_INDEX_LEVEL, freq="90s"),
+            pd.Grouper(level=DT_SORTED_INDEX_LEVEL, freq="200s", origin="start"),
+        ],
+    ],
+)
+def test_groupby_agg_level_resample(by, dfs_with_datetime_cols_and_mi):
+    # One join is incurred for every resampled column.
+    # One additional query is incurred for every resample column to determine the start/end dates for binning.
+    with SqlCounter(query_count=1 + len(by), join_count=len(by)):
+        eval_snowpark_pandas_result(
+            *dfs_with_datetime_cols_and_mi,
+            lambda df: df.groupby(by).agg("count"),
+            test_attrs=False,
+            check_freq=False,
+        )
+
+
+# TODO: test groupby_apply, since it seems like some timestamp columns get converted to string
+
+
+@pytest.mark.parametrize(
+    "by",
+    [
+        [pd.Grouper(key="datetimes_sorted_data", freq="1ME")],
+        [
+            pd.Grouper(key="datetimes_sorted_data", freq="1ME"),
+            pd.Grouper(key="datetimes_unsorted_data", freq="93s"),
+        ],
+    ],
+)
+def test_groupby_count_named_resample(by, dfs_with_datetime_cols_and_mi):
+    with SqlCounter(query_count=1 + len(by), join_count=len(by)):
+        # Need to reset_index because resampling with a named key is only valid for DatetimeIndex, not MultiIndex
+        eval_snowpark_pandas_result(
+            *dfs_with_datetime_cols_and_mi,
+            lambda df: df.reset_index()
+            .set_index("datetimes_unsorted_index")
+            .groupby(by)
+            .count(),
+            test_attrs=False,
+            check_freq=False,
+        )
+
+
+@pytest.mark.parametrize("freq", ["45s", "3min", "4min", "8min", "17min"])
+@pytest.mark.parametrize(
+    "origin",
+    [
+        None,
+        "start_day",
+        "start",
+    ],
+)
+def test_groupby_series_datetime_sum(freq, origin):
+    dates = native_pd.date_range(
+        "2000-10-01 23:00:00", "2000-10-01 23:16:00", freq="4min"
+    )
+    grouper_kwargs = {"freq": freq}
+    if origin is not None:
+        grouper_kwargs["origin"] = origin
+    with SqlCounter(query_count=2, join_count=1):
+        eval_snowpark_pandas_result(
+            *create_test_series(np.arange(len(dates)), index=dates),
+            lambda ser: ser.groupby(pd.Grouper(**grouper_kwargs)).sum(),
+            check_freq=False,
+        )
+
+
+@sql_count_checker(query_count=0)
+def test_groupby_invalid_resample(dfs_with_datetime_cols_and_mi):
+    # Resamples cannot be performed on non-datetime columns.
+    snow_df, native_df = dfs_with_datetime_cols_and_mi
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Only valid with DatetimeIndex, TimedeltaIndex or PeriodIndex, but got an instance of 'Index'"
+        ),
+    ):
+        native_df.groupby(pd.Grouper(key="numeric_data", freq="120s")).count()
+    with pytest.raises(
+        SnowparkSQLException,
+        match=re.escape(
+            "Function DATE_TRUNC does not support NUMBER(38,0) argument type"
+        ),
+    ):
+        snow_df.groupby(pd.Grouper(key="numeric_data", freq="120s")).count()
+
+
+@sql_count_checker(query_count=0, join_count=0)
+def test_groupby_double_resample_unsupported(dfs_with_datetime_cols_and_mi):
+    snow_df, native_df = dfs_with_datetime_cols_and_mi
+    grouper = [
+        pd.Grouper(key="datetimes_sorted_data", freq="10s"),
+        pd.Grouper(key="datetimes_sorted_data", freq="20s"),
+    ]
+    native_df.groupby(grouper).count()  # no error
+    # Resampling the same column twice is currently unsupported.
+    with pytest.raises(
+        NotImplementedError,
+        match="Resampling the same column multiple times is not yet supported in Snowpark pandas.",
+    ):
+        snow_df.groupby(grouper).count()

--- a/tests/unit/modin/test_groupby_utils.py
+++ b/tests/unit/modin/test_groupby_utils.py
@@ -132,7 +132,7 @@ def test_is_groupby_value_label_like(val, expected_result):
         ),
     ],
 )
-def test_invalid_grouper_parameters(val, invalid_params):
+def test_grouper_parameters(val, invalid_params):
     if len(invalid_params) == 0:
         validate_grouper(val)
     else:

--- a/tests/unit/modin/test_groupby_utils.py
+++ b/tests/unit/modin/test_groupby_utils.py
@@ -14,6 +14,7 @@ from snowflake.snowpark.modin.plugin._internal.frame import InternalFrame
 from snowflake.snowpark.modin.plugin._internal.groupby_utils import (
     check_is_groupby_supported_by_snowflake,
     is_groupby_value_label_like,
+    validate_grouper,
 )
 from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
     SnowflakeQueryCompiler,
@@ -89,8 +90,51 @@ def test_check_groupby_snowflake_execution_by_args_axis_1():
         (None, True),
         (pd.Series(query_compiler=create_series_query_compiler()), False),
         ({"col1": 0, "col2": 1}, False),  # map
-        (pd.Grouper(level=1), False),  # grouper
+        (pd.Grouper(level=1), True),  # grouper identifying a multiindex level
+        (pd.Grouper("col1"), True),  # grouper with explicit label
+        (
+            pd.Grouper(freq="1s"),
+            True,
+        ),  # grouper implicitly referencing a datetime index
+        (pd.Grouper(), False),  # grouper specifying nothing
     ],
 )
 def test_is_groupby_value_label_like(val, expected_result):
     assert is_groupby_value_label_like(val) == expected_result
+
+
+@pytest.mark.parametrize(
+    "val, invalid_params",
+    [
+        (pd.Grouper(freq="1s"), []),  # parameters are valid, don't error
+        (
+            pd.Grouper(level=1, sort=True),
+            ["sort"],
+        ),  # sort=True invalid for non-datetime groupers
+        pytest.param(
+            pd.Grouper(freq="1s", sort=False),
+            ["sort"],
+            marks=pytest.mark.skip(
+                "sort=False is unsupported for datetime groupers, but pandas does not pass the sort argument for some reason"
+            ),
+        ),
+        # non-default values
+        (
+            pd.Grouper(
+                freq="1s",
+                closed="right",
+                label="right",
+                convention="s",
+                origin="end_day",
+                offset="1s",
+            ),
+            ["closed", "label", "convention", "origin", "offset"],
+        ),
+    ],
+)
+def test_invalid_grouper_parameters(val, invalid_params):
+    if len(invalid_params) == 0:
+        validate_grouper(val)
+    else:
+        with pytest.raises(NotImplementedError, match=", ".join(invalid_params)):
+            validate_grouper(val)

--- a/tests/unit/modin/test_groupby_utils.py
+++ b/tests/unit/modin/test_groupby_utils.py
@@ -128,7 +128,7 @@ def test_is_groupby_value_label_like(val, expected_result):
                 origin="end_day",
                 offset="1s",
             ),
-            ["closed", "label", "convention", "origin", "offset"],
+            ["sort", "origin", "offset", "dropna"],
         ),
     ],
 )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-856100

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Adds support for `pd.Grouper` objects in groupby operations. These objects allow specification of individual labels or index levels, and allow resampling via the `freq` argument if the specified column is a datetime/timestamp.

This changes the code paths for almost every query compiler groupby operation. If a column would be resampled by a Grouper object, its values are now replaced by the corresponding bin it belongs to before the grouping operation is performed. Most operations (including all that invoke `groupby_agg`) have been updated to follow this behavior; some operations (notably `groupby_apply`, `groupby_size`, `groupby_groups`) have not yet been tested with this new resampling behavior.

This implementation also does not currently support resampling the same column twice (e.g. `df.groupby([pd.Grouper("col0", freq="1s"), pd.Grouper("col0", freq="2s")])` is invalid) because it replaces the original column with the resampled column. This restriction is not strictly necessary as we could theoretically append resampled versions as new columns, but is simpler to implement because existing groupby code assumes all columns involved in a grouping operation existed in the original frame.