### PR TITLE
SNOW-1672561: Session.call AST generation fixes

### DIFF
--- a/src/snowflake/snowpark/mock/_stored_procedure.py
+++ b/src/snowflake/snowpark/mock/_stored_procedure.py
@@ -458,7 +458,12 @@ class MockStoredProcedureRegistration(StoredProcedureRegistration):
                     )
 
             sproc = self._registry[sproc_name]
-            res = sproc(*args, session=session, statement_params=statement_params)
+            res = sproc(
+                *args,
+                session=session,
+                statement_params=statement_params,
+                _emit_ast=_emit_ast,
+            )
             sproc_expr = None
             if _emit_ast and sproc._ast is not None:
                 assert (

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -4076,10 +4076,15 @@ class Session:
                     entry._1 = k
                     build_expr_from_python_val(entry._2, statement_params[k])
             expr.fn.stored_procedure.log_on_exception.value = log_on_exception
+            self._ast_batch.eval(stmt)
 
         if isinstance(self._sp_registration, MockStoredProcedureRegistration):
             return self._sp_registration.call(
-                sproc_name, *args, session=self, statement_params=statement_params
+                sproc_name,
+                *args,
+                session=self,
+                statement_params=statement_params,
+                _emit_ast=False,
             )
 
         validate_object_name(sproc_name)

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -17,11 +17,11 @@ my_sproc_sp = sproc("my_sproc", return_type=StringType(), input_types=[LongType(
 
 df = session.call("my_sproc", 1, "two", {"param1": 10, "param2": "twenty"}, True)
 
-my_sproc_sp(1, "two", {"param1": 10, "param2": "twenty"}, True)
+df
 
 df2 = session.call("my_sproc", 2, "one", {}, False)
 
-my_sproc_sp(2, "one", {}, False)
+df2
 
 ## EXPECTED ENCODED AST
 
@@ -249,137 +249,10 @@ body {
   }
 }
 body {
-  assign {
-    expr {
-      apply_expr {
-        fn {
-          fn_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        pos_args {
-          int64_val {
-            src {
-              end_column: 89
-              end_line: 32
-              file: 2
-              start_column: 13
-              start_line: 32
-            }
-            v: 1
-          }
-        }
-        pos_args {
-          string_val {
-            src {
-              end_column: 89
-              end_line: 32
-              file: 2
-              start_column: 13
-              start_line: 32
-            }
-            v: "two"
-          }
-        }
-        pos_args {
-          seq_map_val {
-            kvs {
-              vs {
-                string_val {
-                  src {
-                    end_column: 89
-                    end_line: 32
-                    file: 2
-                    start_column: 13
-                    start_line: 32
-                  }
-                  v: "param1"
-                }
-              }
-              vs {
-                int64_val {
-                  src {
-                    end_column: 89
-                    end_line: 32
-                    file: 2
-                    start_column: 13
-                    start_line: 32
-                  }
-                  v: 10
-                }
-              }
-            }
-            kvs {
-              vs {
-                string_val {
-                  src {
-                    end_column: 89
-                    end_line: 32
-                    file: 2
-                    start_column: 13
-                    start_line: 32
-                  }
-                  v: "param2"
-                }
-              }
-              vs {
-                string_val {
-                  src {
-                    end_column: 89
-                    end_line: 32
-                    file: 2
-                    start_column: 13
-                    start_line: 32
-                  }
-                  v: "twenty"
-                }
-              }
-            }
-            src {
-              end_column: 89
-              end_line: 32
-              file: 2
-              start_column: 13
-              start_line: 32
-            }
-          }
-        }
-        pos_args {
-          bool_val {
-            src {
-              end_column: 89
-              end_line: 32
-              file: 2
-              start_column: 13
-              start_line: 32
-            }
-            v: true
-          }
-        }
-        src {
-          end_column: 89
-          end_line: 32
-          file: 2
-          start_column: 13
-          start_line: 32
-        }
-      }
-    }
-    symbol {
-    }
+  eval {
     uid: 3
     var_id {
-      bitfield1: 3
-    }
-  }
-}
-body {
-  eval {
-    uid: 4
-    var_id {
-      bitfield1: 3
+      bitfield1: 2
     }
   }
 }
@@ -458,91 +331,17 @@ body {
     symbol {
       value: "df2"
     }
-    uid: 5
+    uid: 4
     var_id {
-      bitfield1: 5
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      apply_expr {
-        fn {
-          fn_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        pos_args {
-          int64_val {
-            src {
-              end_column: 63
-              end_line: 34
-              file: 2
-              start_column: 14
-              start_line: 34
-            }
-            v: 2
-          }
-        }
-        pos_args {
-          string_val {
-            src {
-              end_column: 63
-              end_line: 34
-              file: 2
-              start_column: 14
-              start_line: 34
-            }
-            v: "one"
-          }
-        }
-        pos_args {
-          seq_map_val {
-            src {
-              end_column: 63
-              end_line: 34
-              file: 2
-              start_column: 14
-              start_line: 34
-            }
-          }
-        }
-        pos_args {
-          bool_val {
-            src {
-              end_column: 63
-              end_line: 34
-              file: 2
-              start_column: 14
-              start_line: 34
-            }
-          }
-        }
-        src {
-          end_column: 63
-          end_line: 34
-          file: 2
-          start_column: 14
-          start_line: 34
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 6
-    var_id {
-      bitfield1: 6
+      bitfield1: 4
     }
   }
 }
 body {
   eval {
-    uid: 7
+    uid: 5
     var_id {
-      bitfield1: 6
+      bitfield1: 4
     }
   }
 }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -137,11 +137,9 @@ _ = session.sql("drop table if exists test_to")
 
 _.collect()
 
-res11 = session.call("my_copy_sp", "test_from", "test_to", 10)
+session.call("my_copy_sp", "test_from", "test_to", 10)
 
 session.table("test_from").limit(10, 0).write.save_as_table("test_to", mode="overwrite", table_type="temporary")
-
-my_copy_sp("test_from", "test_to", 10)
 
 session.table("test_to").count()
 
@@ -171,15 +169,15 @@ session.sql("call mul_sp(5, 6)").collect()
 
 sproc("sin_sp", return_type=FloatType(), input_types=[FloatType()], packages=["snowflake-snowpark-python", "numpy"], statement_params={"SF_PARTNER": "FAKE_PARTNER"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1.5707963267948966)
 
-res34 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res33 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res38 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res37 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res42 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res41 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
@@ -834,66 +832,10 @@ body {
   }
 }
 body {
-  assign {
-    expr {
-      apply_expr {
-        fn {
-          fn_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        pos_args {
-          string_val {
-            src {
-              end_column: 62
-              end_line: 55
-              file: 2
-              start_column: 8
-              start_line: 55
-            }
-            v: "test_from"
-          }
-        }
-        pos_args {
-          string_val {
-            src {
-              end_column: 62
-              end_line: 55
-              file: 2
-              start_column: 8
-              start_line: 55
-            }
-            v: "test_to"
-          }
-        }
-        pos_args {
-          int64_val {
-            src {
-              end_column: 62
-              end_line: 55
-              file: 2
-              start_column: 8
-              start_line: 55
-            }
-            v: 10
-          }
-        }
-        src {
-          end_column: 62
-          end_line: 55
-          file: 2
-          start_column: 8
-          start_line: 55
-        }
-      }
-    }
-    symbol {
-    }
+  eval {
     uid: 23
     var_id {
-      bitfield1: 23
+      bitfield1: 22
     }
   }
 }
@@ -1031,14 +973,6 @@ body {
   }
 }
 body {
-  eval {
-    uid: 29
-    var_id {
-      bitfield1: 23
-    }
-  }
-}
-body {
   assign {
     expr {
       table {
@@ -1063,9 +997,9 @@ body {
     }
     symbol {
     }
-    uid: 30
+    uid: 29
     var_id {
-      bitfield1: 30
+      bitfield1: 29
     }
   }
 }
@@ -1075,7 +1009,7 @@ body {
       dataframe_count {
         block: true
         id {
-          bitfield1: 30
+          bitfield1: 29
         }
         src {
           end_column: 40
@@ -1088,17 +1022,17 @@ body {
     }
     symbol {
     }
-    uid: 31
+    uid: 30
     var_id {
-      bitfield1: 31
+      bitfield1: 30
     }
   }
 }
 body {
   eval {
-    uid: 32
+    uid: 31
     var_id {
-      bitfield1: 31
+      bitfield1: 30
     }
   }
 }
@@ -1138,9 +1072,9 @@ body {
     symbol {
       value: "add_one_sp"
     }
-    uid: 33
+    uid: 32
     var_id {
-      bitfield1: 33
+      bitfield1: 32
     }
   }
 }
@@ -1151,7 +1085,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 33
+              bitfield1: 32
             }
           }
         }
@@ -1178,9 +1112,9 @@ body {
     }
     symbol {
     }
-    uid: 34
+    uid: 33
     var_id {
-      bitfield1: 34
+      bitfield1: 33
     }
   }
 }
@@ -1200,9 +1134,9 @@ body {
     }
     symbol {
     }
-    uid: 35
+    uid: 34
     var_id {
-      bitfield1: 35
+      bitfield1: 34
     }
   }
 }
@@ -1213,7 +1147,7 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 35
+          bitfield1: 34
         }
         src {
           end_column: 73
@@ -1226,9 +1160,17 @@ body {
     }
     symbol {
     }
+    uid: 35
+    var_id {
+      bitfield1: 35
+    }
+  }
+}
+body {
+  eval {
     uid: 36
     var_id {
-      bitfield1: 36
+      bitfield1: 35
     }
   }
 }
@@ -1236,15 +1178,7 @@ body {
   eval {
     uid: 37
     var_id {
-      bitfield1: 36
-    }
-  }
-}
-body {
-  eval {
-    uid: 38
-    var_id {
-      bitfield1: 34
+      bitfield1: 33
     }
   }
 }
@@ -1264,9 +1198,9 @@ body {
     }
     symbol {
     }
-    uid: 39
+    uid: 38
     var_id {
-      bitfield1: 39
+      bitfield1: 38
     }
   }
 }
@@ -1277,7 +1211,7 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 39
+          bitfield1: 38
         }
         src {
           end_column: 62
@@ -1290,17 +1224,17 @@ body {
     }
     symbol {
     }
-    uid: 40
+    uid: 39
     var_id {
-      bitfield1: 40
+      bitfield1: 39
     }
   }
 }
 body {
   eval {
-    uid: 41
+    uid: 40
     var_id {
-      bitfield1: 40
+      bitfield1: 39
     }
   }
 }
@@ -1321,9 +1255,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 42
+    uid: 41
     var_id {
-      bitfield1: 42
+      bitfield1: 41
     }
   }
 }
@@ -1334,7 +1268,7 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 42
+          bitfield1: 41
         }
         src {
           end_column: 73
@@ -1347,17 +1281,17 @@ body {
     }
     symbol {
     }
-    uid: 43
+    uid: 42
     var_id {
-      bitfield1: 43
+      bitfield1: 42
     }
   }
 }
 body {
   eval {
-    uid: 44
+    uid: 43
     var_id {
-      bitfield1: 43
+      bitfield1: 42
     }
   }
 }
@@ -1410,9 +1344,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 45
+    uid: 44
     var_id {
-      bitfield1: 45
+      bitfield1: 44
     }
   }
 }
@@ -1432,9 +1366,9 @@ body {
     }
     symbol {
     }
-    uid: 46
+    uid: 45
     var_id {
-      bitfield1: 46
+      bitfield1: 45
     }
   }
 }
@@ -1445,7 +1379,7 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 46
+          bitfield1: 45
         }
         src {
           end_column: 50
@@ -1458,17 +1392,17 @@ body {
     }
     symbol {
     }
-    uid: 47
+    uid: 46
     var_id {
-      bitfield1: 47
+      bitfield1: 46
     }
   }
 }
 body {
   eval {
-    uid: 48
+    uid: 47
     var_id {
-      bitfield1: 47
+      bitfield1: 46
     }
   }
 }
@@ -1521,9 +1455,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 49
+    uid: 48
     var_id {
-      bitfield1: 49
+      bitfield1: 48
     }
   }
 }
@@ -1543,9 +1477,9 @@ body {
     }
     symbol {
     }
-    uid: 50
+    uid: 49
     var_id {
-      bitfield1: 50
+      bitfield1: 49
     }
   }
 }
@@ -1556,7 +1490,7 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 50
+          bitfield1: 49
         }
         src {
           end_column: 50
@@ -1569,17 +1503,17 @@ body {
     }
     symbol {
     }
-    uid: 51
+    uid: 50
     var_id {
-      bitfield1: 51
+      bitfield1: 50
     }
   }
 }
 body {
   eval {
-    uid: 52
+    uid: 51
     var_id {
-      bitfield1: 51
+      bitfield1: 50
     }
   }
 }
@@ -1642,9 +1576,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 53
+    uid: 52
     var_id {
-      bitfield1: 53
+      bitfield1: 52
     }
   }
 }
@@ -1664,9 +1598,9 @@ body {
     }
     symbol {
     }
-    uid: 54
+    uid: 53
     var_id {
-      bitfield1: 54
+      bitfield1: 53
     }
   }
 }
@@ -1677,7 +1611,7 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 54
+          bitfield1: 53
         }
         src {
           end_column: 50
@@ -1690,17 +1624,17 @@ body {
     }
     symbol {
     }
-    uid: 55
+    uid: 54
     var_id {
-      bitfield1: 55
+      bitfield1: 54
     }
   }
 }
 body {
   eval {
-    uid: 56
+    uid: 55
     var_id {
-      bitfield1: 55
+      bitfield1: 54
     }
   }
 }
@@ -1745,9 +1679,9 @@ body {
     }
     symbol {
     }
-    uid: 57
+    uid: 56
     var_id {
-      bitfield1: 57
+      bitfield1: 56
     }
   }
 }
@@ -1758,7 +1692,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 57
+              bitfield1: 56
             }
           }
         }
@@ -1785,17 +1719,17 @@ body {
     }
     symbol {
     }
-    uid: 58
+    uid: 57
     var_id {
-      bitfield1: 58
+      bitfield1: 57
     }
   }
 }
 body {
   eval {
-    uid: 59
+    uid: 58
     var_id {
-      bitfield1: 58
+      bitfield1: 57
     }
   }
 }
@@ -1860,9 +1794,9 @@ body {
     }
     symbol {
     }
-    uid: 60
+    uid: 59
     var_id {
-      bitfield1: 60
+      bitfield1: 59
     }
   }
 }
@@ -1873,7 +1807,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 60
+              bitfield1: 59
             }
           }
         }
@@ -1912,9 +1846,9 @@ body {
     }
     symbol {
     }
-    uid: 61
+    uid: 60
     var_id {
-      bitfield1: 61
+      bitfield1: 60
     }
   }
 }
@@ -1934,9 +1868,9 @@ body {
     }
     symbol {
     }
-    uid: 62
+    uid: 61
     var_id {
-      bitfield1: 62
+      bitfield1: 61
     }
   }
 }
@@ -1945,24 +1879,24 @@ body {
     expr {
       dataframe_show {
         id {
-          bitfield1: 62
+          bitfield1: 61
         }
         n: 10
       }
     }
     symbol {
     }
-    uid: 63
+    uid: 62
     var_id {
-      bitfield1: 63
+      bitfield1: 62
     }
   }
 }
 body {
   eval {
-    uid: 64
+    uid: 63
     var_id {
-      bitfield1: 63
+      bitfield1: 62
     }
   }
 }
@@ -2004,9 +1938,9 @@ body {
     }
     symbol {
     }
-    uid: 65
+    uid: 64
     var_id {
-      bitfield1: 65
+      bitfield1: 64
     }
   }
 }
@@ -2017,7 +1951,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 65
+              bitfield1: 64
             }
           }
         }
@@ -2056,9 +1990,9 @@ body {
     }
     symbol {
     }
-    uid: 66
+    uid: 65
     var_id {
-      bitfield1: 66
+      bitfield1: 65
     }
   }
 }
@@ -2078,9 +2012,9 @@ body {
     }
     symbol {
     }
-    uid: 67
+    uid: 66
     var_id {
-      bitfield1: 67
+      bitfield1: 66
     }
   }
 }
@@ -2089,24 +2023,24 @@ body {
     expr {
       dataframe_show {
         id {
-          bitfield1: 67
+          bitfield1: 66
         }
         n: 10
       }
     }
     symbol {
     }
-    uid: 68
+    uid: 67
     var_id {
-      bitfield1: 68
+      bitfield1: 67
     }
   }
 }
 body {
   eval {
-    uid: 69
+    uid: 68
     var_id {
-      bitfield1: 68
+      bitfield1: 67
     }
   }
 }
@@ -2149,9 +2083,9 @@ body {
     }
     symbol {
     }
-    uid: 70
+    uid: 69
     var_id {
-      bitfield1: 70
+      bitfield1: 69
     }
   }
 }
@@ -2162,7 +2096,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 70
+              bitfield1: 69
             }
           }
         }
@@ -2201,9 +2135,9 @@ body {
     }
     symbol {
     }
-    uid: 71
+    uid: 70
     var_id {
-      bitfield1: 71
+      bitfield1: 70
     }
   }
 }
@@ -2223,9 +2157,9 @@ body {
     }
     symbol {
     }
-    uid: 72
+    uid: 71
     var_id {
-      bitfield1: 72
+      bitfield1: 71
     }
   }
 }
@@ -2234,24 +2168,24 @@ body {
     expr {
       dataframe_show {
         id {
-          bitfield1: 72
+          bitfield1: 71
         }
         n: 10
       }
     }
     symbol {
     }
-    uid: 73
+    uid: 72
     var_id {
-      bitfield1: 73
+      bitfield1: 72
     }
   }
 }
 body {
   eval {
-    uid: 74
+    uid: 73
     var_id {
-      bitfield1: 73
+      bitfield1: 72
     }
   }
 }


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-1672561](https://snowflakecomputing.atlassian.net/browse/SNOW-1672561)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This client-side only PR removes explicit sproc calls generated by the Unparser by correcting the use of `_emit_ast` in `Session.call`. Since `Session.call` is an eager API, instead an `eval` statement is added to the AST batch pointing to the `assign` statement generated by `Session.call`. 

[SNOW-1672561]: https://snowflakecomputing.atlassian.net/browse/SNOW-1672561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ