### PR TITLE
SNOW-1952334: get_dummies should return bool columns instead of int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed a bug where `pd.get_dummies` didn't ignore NULL/NaN values by default.
 - Fixed a bug where repeated calls to `pd.get_dummies` results in 'Duplicated column name error'.
 - Fixed a bug in `pd.get_dummies` where passing list of columns generated incorrect column labels in output DataFrame.
+- Update `pd.get_dummies` to return bool values instead of int.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/get_dummies_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/get_dummies_utils.py
@@ -26,7 +26,7 @@ from snowflake.snowpark.modin.plugin.utils.error_message import ErrorMessage
 
 
 ROW_POSITION_INDEX_COLUMN_PANDAS_LABEL = "row_position_index"
-LIT_ONE_COLUMN_PANDAS_LABEL = "lit_one"
+LIT_TRUE_COLUMN_PANDAS_LABEL = "lit_true"
 NULL_COLUMN_ID = '"NULL"'
 
 
@@ -58,52 +58,52 @@ def single_get_dummies_pivot(
             and the row position column of the original internal_frame as index column.
 
     Example:
-        With the following DataFrame, where lit_one is the dummy lit one column:
+        With the following DataFrame, where lit_true is the dummy lit true column:
 
-             A  C lit_one
-          0  a  1   1
-          1  b  2   1
-          2  a  3   1
+             A  C lit_true
+          0  a  1   True
+          1  b  2   True
+          2  a  3   True
 
         the result of calling single_get_dummies_pivot with ['"C"]' as column_to_keep,
         "A" as prefix, and "_" as prefix_sep will be the following:
 
-            C  A_a  A_b
-         0  1    1    0
-         1  2    0    1
-         2  3    1    0
+            C   A_a     A_b
+         0  1   True   False
+         1  2   False  True
+         2  3   True   False
     """
 
-    # get the row position column and dummy lit one column
+    # get the row position column and dummy lit true column
     assert internal_frame.row_position_snowflake_quoted_identifier is not None
     row_position_snowflake_quoted_identifier = (
         internal_frame.row_position_snowflake_quoted_identifier
     )
-    lit_one_column_snowflake_quoted_identifier = (
+    lit_true_column_snowflake_quoted_identifier = (
         internal_frame.data_column_snowflake_quoted_identifiers[-1]
     )
-    # for the dataframe passed for pivot, we keep the row position column, dummy lit one column,
+    # for the dataframe passed for pivot, we keep the row position column, dummy lit true column,
     # pivot column, and the specified columns_to_keep
     columns_snowflake_quoted_identifier = [
         row_position_snowflake_quoted_identifier,
         pivot_column_snowflake_quoted_identifier,
-        lit_one_column_snowflake_quoted_identifier,
+        lit_true_column_snowflake_quoted_identifier,
     ] + columns_to_keep_snowflake_quoted_identifiers
     ordered_dataframe = internal_frame.ordered_dataframe.select(
         columns_snowflake_quoted_identifier
     )
-    # Perform pivot on the pivot column with dummy lit one column as value column.
+    # Perform pivot on the pivot column with dummy lit true column as value column.
     # With the above example, the result of pivot will be:
     #
-    #    C    a    b
-    # 0  1    1    0
-    # 1  2    0    1
-    # 2  3    1    0
+    #    C    a       b
+    # 0  1    True    False
+    # 1  2   False     True
+    # 2  3    True    False
     pivoted_ordered_dataframe = ordered_dataframe.pivot(
         col(str(pivot_column_snowflake_quoted_identifier)),
         None,
         0,
-        min_(lit_one_column_snowflake_quoted_identifier),
+        min_(lit_true_column_snowflake_quoted_identifier),
     )
     pivoted_ordered_dataframe = pivoted_ordered_dataframe.sort(
         OrderingColumn(row_position_snowflake_quoted_identifier)
@@ -221,9 +221,9 @@ def get_dummies_helper(
                 f"get_dummies with duplicated columns {pandas_label}"
             )
 
-    # append a lit one column as value column for pivot
+    # append a lit true column as value column for pivot
     new_internal_frame = internal_frame.ensure_row_position_column().append_column(
-        LIT_ONE_COLUMN_PANDAS_LABEL, pandas_lit(1)
+        LIT_TRUE_COLUMN_PANDAS_LABEL, pandas_lit(True)
     )
     # the dummy column is appended as the last data column of the new_internal_frame
     row_position_column_snowflake_quoted_identifier = (

--- a/src/snowflake/snowpark/modin/plugin/docstrings/general.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/general.py
@@ -1307,28 +1307,28 @@ def get_dummies():
     >>> s = pd.Series(list('abca'))
 
     >>> pd.get_dummies(s)
-       a  b  c
-    0  1  0  0
-    1  0  1  0
-    2  0  0  1
-    3  1  0  0
+           a      b      c
+    0   True  False  False
+    1  False   True  False
+    2  False  False   True
+    3   True  False  False
 
     >>> df = pd.DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'a', 'c'],
     ...                    'C': [1, 2, 3]})
 
     >>> pd.get_dummies(df, prefix=['col1', 'col2'])
        C  col1_a  col1_b  col2_a  col2_b  col2_c
-    0  1       1       0       0       1       0
-    1  2       0       1       1       0       0
-    2  3       1       0       0       0       1
+    0  1    True   False   False    True   False
+    1  2   False    True    True   False   False
+    2  3    True   False   False   False    True
 
     >>> pd.get_dummies(pd.Series(list('abcaa')))
-       a  b  c
-    0  1  0  0
-    1  0  1  0
-    2  0  0  1
-    3  1  0  0
-    4  1  0  0
+           a      b      c
+    0   True  False  False
+    1  False   True  False
+    2  False  False   True
+    3   True  False  False
+    4   True  False  False
     """
 
 

--- a/tests/integ/modin/strings/test_get_dummies_dataframe.py
+++ b/tests/integ/modin/strings/test_get_dummies_dataframe.py
@@ -40,9 +40,7 @@ def test_get_dummies_madeup(simple_pandas_df, prefix, prefix_sep):
         snow_df, columns=["COL_1"], prefix=prefix, prefix_sep=prefix_sep
     )
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @sql_count_checker(query_count=1)
@@ -55,9 +53,7 @@ def test_get_dummies_prefix_and_column_same(simple_pandas_df):
 
     snow_get_dummies = pd.get_dummies(snow_df, columns=["COL_1"], prefix="COL_1")
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @sql_count_checker(query_count=1)
@@ -68,9 +64,7 @@ def test_get_dummies_no_prefix_column(simple_pandas_df):
 
     snow_get_dummies = pd.get_dummies(snow_df)
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @sql_count_checker(query_count=1)
@@ -90,9 +84,7 @@ def test_get_dummies_with_numeric_column_names(prefix, prefix_sep):
         snow_df, columns=[1], prefix=prefix, prefix_sep=prefix_sep
     )
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @sql_count_checker(query_count=1, join_count=1)
@@ -113,9 +105,7 @@ def test_get_dummies_pandas(prefix_sep):
         snow_df, prefix=["col1", "col2"], prefix_sep=prefix_sep
     )
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @pytest.mark.parametrize("sort_column", ["A", "C", "D"])
@@ -149,9 +139,7 @@ def test_get_dummies_pandas_no_row_pos_col(sort_column):
         prefix_sep="/",
     )
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @pytest.mark.parametrize("sort_column", ["A", "C"])
@@ -181,9 +169,7 @@ def test_get_dummies_pandas_no_row_pos_col_duplicate_values(sort_column):
         prefix_sep="/",
     )
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @sql_count_checker(query_count=1, join_count=2)
@@ -212,9 +198,7 @@ def test_get_dummies_multiple_columns():
         prefix=["colA", "colB", "colD"],
         prefix_sep="_",
     )
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 # https://snowflakecomputing.atlassian.net/browse/SNOW-1050112
@@ -254,9 +238,9 @@ def test_get_dummies_pandas_after_read_snowflake(session):
         prefix_sep="/",
     )
 
-    assert_snowpark_pandas_equal_to_pandas(
-        snow_get_dummies, pandas_get_dummies, check_dtype=False
-    )
+    # The column D is of type int8 in snowpark and int64 in pandas.
+    pandas_get_dummies["D"] = pandas_get_dummies["D"].astype(np.int8)
+    assert_snowpark_pandas_equal_to_pandas(snow_get_dummies, pandas_get_dummies)
 
 
 @sql_count_checker(query_count=0)
@@ -302,7 +286,7 @@ def test_get_dummies_null_values(kwargs, data):
     df = native_pd.DataFrame({"col1": data, "col2": data})
     expected = native_pd.get_dummies(df, **kwargs)
     actual = pd.get_dummies(pd.DataFrame(df), **kwargs)
-    assert_snowpark_pandas_equal_to_pandas(actual, expected, check_dtype=False)
+    assert_snowpark_pandas_equal_to_pandas(actual, expected)
 
 
 @sql_count_checker(query_count=1)
@@ -316,7 +300,7 @@ def test_get_dummies_with_duplicate_column_names():
     for col in native_df.columns:
         snow_df = pd.get_dummies(snow_df, columns=[col])
         native_df = native_pd.get_dummies(native_df, columns=[col])
-    assert_snowpark_pandas_equal_to_pandas(snow_df, native_df, check_dtype=False)
+    assert_snowpark_pandas_equal_to_pandas(snow_df, native_df)
 
 
 @sql_count_checker(query_count=1)
@@ -325,7 +309,7 @@ def test_get_dummies_exclude_columns():
     snow_df = pd.DataFrame(native_df)
     snow_df = pd.get_dummies(snow_df, columns=["col2"])
     native_df = native_pd.get_dummies(native_df, columns=["col2"])
-    assert_snowpark_pandas_equal_to_pandas(snow_df, native_df, check_dtype=False)
+    assert_snowpark_pandas_equal_to_pandas(snow_df, native_df)
 
 
 @sql_count_checker(query_count=0)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1952334

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

native pandas made get_dummies() return bools instead of ints in pandas 2: https://github.com/pandas-dev/pandas/issues/45848
This PR updates snowpark pandas to return bool columns instead of int columns in get_dummies().

