### PR TITLE
SNOW-1960273: Set statement parameters for UDxF creation job from apply

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -40,6 +40,7 @@ from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
 from snowflake.snowpark.modin.plugin._internal.utils import (
     TempObjectType,
     generate_snowflake_quoted_identifiers_helper,
+    get_default_snowpark_pandas_statement_params,
     parse_object_construct_snowflake_quoted_identifier_and_extract_pandas_label,
     parse_snowflake_object_construct_identifier_to_map,
 )
@@ -303,6 +304,7 @@ def create_udtf_for_apply_axis_1(
         # We have to use the current pandas version to ensure the behavior consistency
         packages=[native_pd] + packages,
         session=session,
+        statement_params=get_default_snowpark_pandas_statement_params(),
     )
 
     return func_udtf
@@ -683,6 +685,7 @@ def create_udtf_for_groupby_transform(
         # behavior is consistent with client-side pandas behavior.
         packages=[native_pd] + list(session.get_packages().values()),
         session=session,
+        statement_params=get_default_snowpark_pandas_statement_params(),
     )
 
 
@@ -947,6 +950,7 @@ def create_udtf_for_groupby_apply(
         # behavior is consistent with client-side pandas behavior.
         packages=[native_pd] + list(session.get_packages().values()),
         session=session,
+        statement_params=get_default_snowpark_pandas_statement_params(),
     )
 
 
@@ -1019,6 +1023,7 @@ def create_udf_for_series_apply(
         strict=bool(na_action == "ignore"),
         session=session,
         packages=packages,
+        statement_params=get_default_snowpark_pandas_statement_params(),
     )
     return func_udf
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1960273

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Add default statement params to UDxF creation jobs. Mainly snowpark_api = pandas which we use to identify pandas queries.
