### PR TITLE
SNOW-1331967: Improve error message for pandas APIs calling UDFs/UDTFs with Snowpark objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 - Improve error message for `pd.to_snowflake`, `DataFrame.to_snowflake`, and `Series.to_snowflake` when the table does not exist.
 - Improve readability of docstring for the `if_exists` parameter in `pd.to_snowflake`, `DataFrame.to_snowflake`, and `Series.to_snowflake`.
+- Improve error message for all pandas functions that use UDFs with Snowpark objects.
 
 ## 1.28.0 (2025-02-20)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -71,6 +71,12 @@ from snowflake.snowpark.window import Window
 
 APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER = '"LABEL"'
 APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER = '"VALUE"'
+APPLY_WITH_SNOWPARK_OBJECT_ERROR_MSG = (
+    "Snowpark pandas only allows native pandas and not Snowpark objects in `apply()`. "
+    + "Instead, try calling `to_pandas()` on any DataFrame or Series objects passed to `apply()`. See Limitations"
+    + "(https://docs.snowflake.com/developer-guide/snowpark/python/pandas-on-snowflake#limitations) section of"
+    + "the Snowpark pandas documentation for more details."
+)
 
 # Default partition size to use when applying a UDTF. A higher value results in less parallelism, less contention and higher batching.
 DEFAULT_UDTF_PARTITION_SIZE = 1000
@@ -289,23 +295,28 @@ def create_udtf_for_apply_axis_1(
     ApplyFunc.end_partition._sf_vectorized_input = native_pd.DataFrame  # type: ignore[attr-defined]
 
     packages = list(session.get_packages().values()) + udf_packages
-    func_udtf = sp_func.udtf(
-        ApplyFunc,
-        output_schema=PandasDataFrameType(
-            [LongType(), StringType(), VariantType()],
-            [
-                row_position_snowflake_quoted_identifier,
-                APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER,
-                APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER,
-            ],
-        ),
-        input_types=[PandasDataFrameType([LongType()] + input_types)],
-        # We have to use the current pandas version to ensure the behavior consistency
-        packages=[native_pd] + packages,
-        session=session,
-    )
-
-    return func_udtf
+    try:
+        func_udtf = sp_func.udtf(
+            ApplyFunc,
+            output_schema=PandasDataFrameType(
+                [LongType(), StringType(), VariantType()],
+                [
+                    row_position_snowflake_quoted_identifier,
+                    APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER,
+                    APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER,
+                ],
+            ),
+            input_types=[PandasDataFrameType([LongType()] + input_types)],
+            # We have to use the current pandas version to ensure the behavior consistency
+            packages=[native_pd] + packages,
+            session=session,
+        )
+        return func_udtf
+    except NotImplementedError:
+        # When a Snowpark object is passed to a UDF, a NotImplementedError with message
+        # 'Snowpark pandas does not yet support the method DataFrame.__reduce__' is raised. Instead,
+        # catch this exception and return a more user-friendly error message.
+        raise ValueError(APPLY_WITH_SNOWPARK_OBJECT_ERROR_MSG)
 
 
 def convert_groupby_apply_dataframe_result_to_standard_schema(
@@ -675,15 +686,21 @@ def create_udtf_for_groupby_transform(
         excluded=existing_identifiers,
         wrap_double_underscore=False,
     )
-    return sp_func.udtf(
-        ApplyFunc,
-        output_schema=PandasDataFrameType(output_col_types, output_col_ids),
-        input_types=[PandasDataFrameType(col_types=input_types)],
-        # We have to specify the local pandas package so that the UDF's pandas
-        # behavior is consistent with client-side pandas behavior.
-        packages=[native_pd] + list(session.get_packages().values()),
-        session=session,
-    )
+    try:
+        return sp_func.udtf(
+            ApplyFunc,
+            output_schema=PandasDataFrameType(output_col_types, output_col_ids),
+            input_types=[PandasDataFrameType(col_types=input_types)],
+            # We have to specify the local pandas package so that the UDF's pandas
+            # behavior is consistent with client-side pandas behavior.
+            packages=[native_pd] + list(session.get_packages().values()),
+            session=session,
+        )
+    except NotImplementedError:
+        # When a Snowpark object is passed to a UDF, a NotImplementedError with message
+        # 'Snowpark pandas does not yet support the method DataFrame.__reduce__' is raised. Instead,
+        # catch this exception and return a more user-friendly error message.
+        raise ValueError(APPLY_WITH_SNOWPARK_OBJECT_ERROR_MSG)
 
 
 def create_udtf_for_groupby_apply(
@@ -936,18 +953,30 @@ def create_udtf_for_groupby_apply(
         excluded=existing_identifiers,
         wrap_double_underscore=False,
     )
-    return sp_func.udtf(
-        ApplyFunc,
-        output_schema=PandasDataFrameType(
-            [StringType(), IntegerType(), VariantType(), IntegerType(), IntegerType()],
-            col_names,
-        ),
-        input_types=[PandasDataFrameType(col_types=input_types)],
-        # We have to specify the local pandas package so that the UDF's pandas
-        # behavior is consistent with client-side pandas behavior.
-        packages=[native_pd] + list(session.get_packages().values()),
-        session=session,
-    )
+    try:
+        return sp_func.udtf(
+            ApplyFunc,
+            output_schema=PandasDataFrameType(
+                [
+                    StringType(),
+                    IntegerType(),
+                    VariantType(),
+                    IntegerType(),
+                    IntegerType(),
+                ],
+                col_names,
+            ),
+            input_types=[PandasDataFrameType(col_types=input_types)],
+            # We have to specify the local pandas package so that the UDF's pandas
+            # behavior is consistent with client-side pandas behavior.
+            packages=[native_pd] + list(session.get_packages().values()),
+            session=session,
+        )
+    except NotImplementedError:
+        # When a Snowpark object is passed to a UDF, a NotImplementedError with message
+        # 'Snowpark pandas does not yet support the method DataFrame.__reduce__' is raised. Instead,
+        # catch this exception and return a more user-friendly error message.
+        raise ValueError(APPLY_WITH_SNOWPARK_OBJECT_ERROR_MSG)
 
 
 def create_udf_for_series_apply(
@@ -1012,15 +1041,21 @@ def create_udf_for_series_apply(
             #  actual type.
             return x.apply(func, args=args, **kwargs)
 
-    func_udf = sp_func.udf(
-        apply_func,
-        return_type=PandasSeriesType(return_type),
-        input_types=[PandasSeriesType(input_type)],
-        strict=bool(na_action == "ignore"),
-        session=session,
-        packages=packages,
-    )
-    return func_udf
+    try:
+        func_udf = sp_func.udf(
+            apply_func,
+            return_type=PandasSeriesType(return_type),
+            input_types=[PandasSeriesType(input_type)],
+            strict=bool(na_action == "ignore"),
+            session=session,
+            packages=packages,
+        )
+        return func_udf
+    except NotImplementedError:
+        # When a Snowpark object is passed to a UDF, a NotImplementedError with message
+        # 'Snowpark pandas does not yet support the method DataFrame.__reduce__' is raised. Instead,
+        # catch this exception and return a more user-friendly error message.
+        raise ValueError(APPLY_WITH_SNOWPARK_OBJECT_ERROR_MSG)
 
 
 def handle_missing_value_in_variant(value: Any) -> Any:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1331967

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

UDFs/UDTFs do not work with Snowpark objects. This also applies to pandas methods like `apply` and `map` that use UDFs/UDTFs in their implementation. Users invoking these functions would receive a NotImplementedError that was hard to decipher: `Snowpark pandas does not yet support the method DataFrame.__reduce__`.

This PR catches that NotImplementedError returns a more user-friendly ValueError message and links to the documentation describing Snowpark pandas limitations when such a case is hit.