### PR TITLE
Adding support for creating literal values from datetime.timedelta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - fl_is_document
   - fl_is_image
   - fl_is_video
+- Added support for datetime.timedelta as a literal value 
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -39,6 +39,7 @@ from snowflake.snowpark.types import (
     _FractionalType,
     _IntegralType,
     _NumericType,
+    _TimeDeltaType,
 )
 
 MILLIS_PER_DAY = 24 * 3600 * 1000
@@ -232,6 +233,10 @@ def to_sql(
 
     if isinstance(datatype, VectorType):
         return f"{value} :: VECTOR({datatype.element_type},{datatype.dimension})"
+
+    if isinstance(datatype, _TimeDeltaType):
+        assert value is not None
+        return f"INTERVAL '{value.total_seconds()} seconds'"
 
     if isinstance(datatype, FileType):
         # TODO: SNOW-1950688: Remove parsing workaround once the server is ready for accepting full stage URI

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -235,7 +235,7 @@ def to_sql(
         return f"{value} :: VECTOR({datatype.element_type},{datatype.dimension})"
 
     if isinstance(datatype, _TimeDeltaType):
-        assert value is not None
+        assert value is not None and isinstance(value, timedelta)
         return f"INTERVAL '{value.total_seconds()} seconds'"
 
     if isinstance(datatype, FileType):

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -235,8 +235,8 @@ def to_sql(
         return f"{value} :: VECTOR({datatype.element_type},{datatype.dimension})"
 
     if isinstance(datatype, _TimeDeltaType):
-        assert value is not None and isinstance(value, timedelta)
-        return f"INTERVAL '{value.total_seconds()} seconds'"
+        if isinstance(value, timedelta):
+            return f"INTERVAL '{value.total_seconds()} seconds'"
 
     if isinstance(datatype, FileType):
         # TODO: SNOW-1950688: Remove parsing workaround once the server is ready for accepting full stage URI

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -236,7 +236,8 @@ def to_sql(
 
     if isinstance(datatype, _TimeDeltaType):
         if isinstance(value, timedelta):
-            return f"INTERVAL '{value.total_seconds()} seconds'"
+            # in timedelta object only days, seconds and microseconds are stored internally
+            return f"INTERVAL '{value.days} days, {value.seconds} seconds, {value.microseconds} microseconds'"
 
     if isinstance(datatype, FileType):
         # TODO: SNOW-1950688: Remove parsing workaround once the server is ready for accepting full stage URI

--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -288,6 +288,12 @@ def build_expr_from_python_val(
         ast.second = obj.second  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "second"
         ast.microsecond = obj.microsecond  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "microsecond"
 
+    elif isinstance(obj, datetime.timedelta):
+        ast = with_src_position(expr_builder.python_timestamp_val)
+        ast.day = obj.days
+        ast.second = obj.seconds
+        ast.microsecond = obj.microseconds
+
     elif isinstance(obj, dict):
         ast = with_src_position(expr_builder.seq_map_val)  # type: ignore[arg-type] # TODO(SNOW-1491199) # Argument 1 to "with_src_position" has incompatible type "SeqMapVal"; expected "Expr"
         for key, value in obj.items():

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -69,6 +69,7 @@ from snowflake.snowpark.types import (
     TimeType,
     Variant,
     VariantType,
+    _TimeDeltaType,
     VectorType,
     _FractionalType,
     _IntegralType,
@@ -363,6 +364,7 @@ VALID_PYTHON_TYPES_FOR_LITERAL_VALUE = (
     list,
     tuple,
     dict,
+    datetime.timedelta,
 )
 VALID_SNOWPARK_TYPES_FOR_LITERAL_VALUE = (
     *PYTHON_TO_SNOW_TYPE_MAPPINGS.values(),
@@ -371,6 +373,7 @@ VALID_SNOWPARK_TYPES_FOR_LITERAL_VALUE = (
     MapType,
     VariantType,
     FileType,
+    _TimeDeltaType,
 )
 
 # Mapping Python array types to DataType
@@ -470,6 +473,8 @@ def infer_type(obj: Any) -> DataType:
             return ArrayType(ARRAY_TYPE_MAPPINGS[obj.typecode]())
         else:
             raise TypeError("not supported type: array(%s)" % obj.typecode)
+    elif isinstance(obj, datetime.timedelta):
+        return _TimeDeltaType()
     else:
         raise TypeError("not supported type: %s" % type(obj))
 

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -230,6 +230,10 @@ class TimeType(_AtomicType):
         ast.time_type = True
 
 
+class _TimeDeltaType(_AtomicType):
+    pass
+
+
 # Numeric types
 class _IntegralType(_NumericType):
     pass

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -1928,6 +1928,24 @@ def test_array_negative(session):
     )
 
 
+def test_lit_with_timedelta(session):
+    df = session.create_dataframe([[1, "snow"]])
+    fixed_date = datetime.date(2025, 3, 1)
+    df = df.with_column(
+        "expiry_date",
+        lit(fixed_date)
+        + lit(
+            datetime.timedelta(
+                days=30, seconds=100, microseconds=1234, milliseconds=3333
+            )
+        ),
+    )
+
+    expected = [Row(1, "snow", datetime.datetime(2025, 3, 31, 0, 1, 43, 334234))]
+    res1 = df.collect()
+    Utils.assert_rows(res1, expected)
+
+
 def test_object_negative(session):
     df = session.create_dataframe([1], schema=["a"])
 

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -40,6 +40,7 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
     VectorType,
+    _TimeDeltaType,
 )
 
 
@@ -165,6 +166,10 @@ def test_to_sql():
     assert (
         to_sql([1, 2, 31234567, -1928, 0, -3], VectorType(int, 5))
         == "[1, 2, 31234567, -1928, 0, -3] :: VECTOR(int,5)"
+    )
+    assert (
+        to_sql(datetime.timedelta(seconds=100), _TimeDeltaType)
+        == "INTERVAL '100 seconds'"
     )
 
 

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -168,8 +168,8 @@ def test_to_sql():
         == "[1, 2, 31234567, -1928, 0, -3] :: VECTOR(int,5)"
     )
     assert (
-        to_sql(datetime.timedelta(seconds=100), _TimeDeltaType)
-        == "INTERVAL '100 seconds'"
+        to_sql(datetime.timedelta(seconds=100), _TimeDeltaType())
+        == "INTERVAL '100.0 seconds'"
     )
 
 

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -169,7 +169,11 @@ def test_to_sql():
     )
     assert (
         to_sql(datetime.timedelta(seconds=100), _TimeDeltaType())
-        == "INTERVAL '100.0 seconds'"
+        == "INTERVAL '0 days, 100 seconds, 0 microseconds'"
+    )
+    assert (
+        to_sql(datetime.timedelta(seconds=1, microseconds=-123456), _TimeDeltaType())
+        == "INTERVAL '0 days, 0 seconds, 876544 microseconds'"
     )
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1920942

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
Now snowpark lit function would recognize datetime.timedelta as value and assign a new type to it which will be processed in to_sql to create the correct query.
