### PR TITLE
SNOW-1918334: Various fixes to capture user code more accurately

### DIFF
--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -116,7 +116,22 @@ def extract_assign_targets(
     # in this function we only care about extracting <left>.
     # For this reason, when '=' is found, replace <right> with w.l.o.g. None.
     if "=" in source_line:
-        source_line = source_line[: source_line.find("=")] + " = None"
+        equal_loc = source_line.find("=")
+        expr = source_line[equal_loc + 1 :]
+        source_line = source_line[:equal_loc] + " = None"
+
+    # When list or dict comprehension is used on the right side of the assignment, we don't want to extract the
+    # symbols from the assignment. The target is the symbol inside the dict or list comprehension, which needs
+    # to be extracted properly.
+    try:
+        expr_tree = ast.parse(expr.strip())
+        if isinstance(expr_tree.body[0], ast.Expr) and isinstance(
+            expr_tree.body[0].value,
+            (ast.ListComp, ast.DictComp, ast.GeneratorExp),
+        ):
+            return None
+    except Exception:
+        pass
 
     try:
         tree = ast.parse(source_line.strip())
@@ -400,25 +415,22 @@ def build_view_name(expr: proto.NameRef, name: Union[str, Iterable[str]]) -> Non
 def build_function_expr(
     builtin_name: str,
     args: List[Any],
-    ignore_null_args: bool = False,
 ) -> proto.Expr:
     """
     Creates AST encoding for the methods in function.py.
     Args:
         builtin_name: Name of the builtin function to call.
         args: Positional arguments to pass to function, in the form of a list.
-        ignore_null_args: If True, null arguments will be ignored.
     Returns:
         The AST encoding of the function.
     """
     ast = proto.Expr()
-    args_list = [arg for arg in args if arg is not None] if ignore_null_args else args
     build_builtin_fn_apply(
         ast,
         builtin_name,
         *tuple(
             snowpark_expression_to_ast(arg) if isinstance(arg, Expression) else arg
-            for arg in args_list
+            for arg in args
         ),
     )
     return ast

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -1017,7 +1017,7 @@ message DataframeNaDrop_Python {
   Expr df = 1;
   string how = 2;
   SrcPosition src = 3;
-  List_String subset = 4;
+  ExprArgList subset = 4;
   google.protobuf.Int64Value thresh = 5;
 }
 
@@ -1033,7 +1033,7 @@ message DataframeNaDrop_Scala {
 message DataframeNaFill {
   Expr df = 1;
   SrcPosition src = 2;
-  List_String subset = 3;
+  ExprArgList subset = 3;
   Expr value = 4;
   repeated Tuple_String_Expr value_map = 5;
 }
@@ -1043,7 +1043,7 @@ message DataframeNaReplace {
   Expr df = 1;
   repeated Tuple_Expr_Expr replacement_map = 2;
   SrcPosition src = 3;
-  List_String subset = 4;
+  ExprArgList subset = 4;
   repeated Expr to_replace_list = 5;
   Expr to_replace_value = 6;
   Expr value = 7;
@@ -1165,7 +1165,7 @@ message DataframeSort {
 
 // dataframe-stat.ir:1
 message DataframeStatApproxQuantile {
-  repeated Expr cols = 1;
+  ExprArgList cols = 1;
   VarId id = 2;
   repeated double percentile = 3;
   SrcPosition src = 4;

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -1459,7 +1459,7 @@ def check_flatten_mode(mode: str) -> None:
         raise ValueError("mode must be one of ('OBJECT', 'ARRAY', 'BOTH')")
 
 
-def check_create_map_parameter(*cols: Any) -> None:
+def check_create_map_parameter(*cols: Any) -> bool:
     """Helper function to check parameter cols for create_map function."""
 
     error_message = "The 'create_map' function requires an even number of parameters but the actual number is {}"
@@ -1472,6 +1472,8 @@ def check_create_map_parameter(*cols: Any) -> None:
 
     if not len(cols) % 2 == 0:
         raise ValueError(error_message.format(len(cols)))
+
+    return len(cols) == 1 and isinstance(cols, (tuple, list))
 
 
 def is_valid_tuple_for_agg(e: Union[list, tuple]) -> bool:

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -193,9 +193,12 @@ class DataFrameNaFunctions:
             if thresh is not None:
                 ast.thresh.value = thresh
             if isinstance(subset, str):
-                ast.subset.list.append(subset)
+                ast.subset.variadic = True
+                build_expr_from_python_val(ast.subset.args.add(), subset)
             elif isinstance(subset, Iterable):
-                ast.subset.list.extend(subset)
+                ast.subset.variadic = False
+                for col in subset:
+                    build_expr_from_python_val(ast.subset.args.add(), col)
             self._dataframe._set_ast_ref(ast.df)
 
         # if subset is not provided, drop will be applied to all columns
@@ -386,9 +389,12 @@ class DataFrameNaFunctions:
             else:
                 build_expr_from_python_val(ast.value, value)
             if isinstance(subset, str):
-                ast.subset.list.append(subset)
+                ast.subset.variadic = True
+                build_expr_from_python_val(ast.subset.args.add(), subset)
             elif isinstance(subset, Iterable):
-                ast.subset.list.extend(subset)
+                ast.subset.variadic = False
+                for col in subset:
+                    build_expr_from_python_val(ast.subset.args.add(), col)
 
         if subset is None:
             subset = self._dataframe.columns
@@ -600,9 +606,12 @@ class DataFrameNaFunctions:
                 build_expr_from_python_val(ast.value, value)
 
             if isinstance(subset, str):
-                ast.subset.list.append(subset)
+                ast.subset.variadic = True
+                build_expr_from_python_val(ast.subset.args.add(), subset)
             elif isinstance(subset, Iterable):
-                ast.subset.list.extend(subset)
+                ast.subset.variadic = False
+                for col in subset:
+                    build_expr_from_python_val(ast.subset.args.add(), col)
 
         # Modify subset.
         if subset is None:

--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -97,10 +97,12 @@ class DataFrameStatFunctions:
             expr.id.bitfield1 = self._dataframe._ast_id
 
             if isinstance(col, Iterable) and not isinstance(col, str):
+                expr.cols.variadic = False
                 for c in col:
-                    build_expr_from_snowpark_column_or_col_name(expr.cols.add(), c)
+                    build_expr_from_snowpark_column_or_col_name(expr.cols.args.add(), c)
             else:
-                build_expr_from_snowpark_column_or_col_name(expr.cols.add(), col)
+                expr.cols.variadic = True
+                build_expr_from_snowpark_column_or_col_name(expr.cols.args.add(), col)
 
             # Because we build AST at beginning, error out if not iterable.
             if not isinstance(percentile, Iterable):

--- a/src/snowflake/snowpark/modin/plugin/_internal/session.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/session.py
@@ -47,9 +47,10 @@ class SnowpandasSessionHolder(ModuleType):
         try:
             quoted_identifiers_ignore_case = (
                 session.sql(
-                    "SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE' IN SESSION"
+                    "SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE' IN SESSION",
+                    _emit_ast=False,
                 )
-                .collect()[0]
+                .collect(_emit_ast=False)[0]
                 .value
             )
             if quoted_identifiers_ignore_case.lower() == "true":

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -13,7 +13,7 @@ df.count(block=False, statement_params={"SF_PARTNER": "FAKE_PARTNER"})
 
 ## EXPECTED UNPARSER OUTPUT
 
-df = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType(fields=[StructField("\"A\"", StringType(16777216), nullable=True), StructField("\"B\"", LongType(), nullable=True)], structured=False))
+df = session.create_dataframe(pandas.DataFrame(<not shown>), schema=StructType(fields=[StructField("\"A\"", StringType(16777216), nullable=True), StructField("\"B\"", LongType(), nullable=True)], structured=False))
 
 df.count()
 

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -48,13 +48,9 @@ df.copy_into_table(["test_db", "test_schema", "table2"], files=["file1", "file2"
 
 df3 = df.cache_result()
 
-df3 = df.write
-
 df4 = df.cache_result(statement_params={"foo": "bar"})
 
-df4 = df.write
-
-res6 = df.create_or_replace_dynamic_table("test_dyn_table", warehouse="test_wh", lag="1 hour", comment="foo", mode="overwrite"])
+res6 = df.create_or_replace_dynamic_table("test_dyn_table", warehouse="test_wh", lag="1 hour", comment="foo", mode="overwrite")
 
 ## EXPECTED ENCODED AST
 
@@ -486,35 +482,6 @@ body {
 body {
   assign {
     expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 31
-          end_line: 51
-          file: 2
-          start_column: 14
-          start_line: 51
-        }
-      }
-    }
-    symbol {
-      value: "df3"
-    }
-    uid: 9
-    var_id {
-      bitfield1: 9
-    }
-  }
-}
-body {
-  assign {
-    expr {
       dataframe_cache_result {
         df {
           dataframe_ref {
@@ -539,38 +506,9 @@ body {
     symbol {
       value: "df4"
     }
-    uid: 10
+    uid: 9
     var_id {
-      bitfield1: 10
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 62
-          end_line: 53
-          file: 2
-          start_column: 14
-          start_line: 53
-        }
-      }
-    }
-    symbol {
-      value: "df4"
-    }
-    uid: 11
-    var_id {
-      bitfield1: 11
+      bitfield1: 9
     }
   }
 }
@@ -611,9 +549,9 @@ body {
     }
     symbol {
     }
-    uid: 12
+    uid: 10
     var_id {
-      bitfield1: 12
+      bitfield1: 10
     }
   }
 }

--- a/tests/ast/data/DataFrame.flatten.test
+++ b/tests/ast/data/DataFrame.flatten.test
@@ -10,7 +10,7 @@ df2 = df.flatten(col("NUM"), recursive=True, mode="ARRAY")
 
 df = session.table("table1")
 
-df1 = df.flatten("STR", Some("path"), True, False, "BOTH")
+df1 = df.flatten("STR", "path", True, False, "BOTH")
 
 df2 = df.flatten(col("NUM"), None, False, True, "ARRAY")
 

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -32,7 +32,7 @@ sample_df = df.stat.sample_by("name", fractions)
 
 df = session.table("table1")
 
-df2 = df.stat.approx_quantile(["NUM"], [0.5])
+df2 = df.stat.approx_quantile("NUM", [0.5])
 
 df2
 
@@ -116,16 +116,19 @@ body {
     expr {
       dataframe_stat_approx_quantile {
         cols {
-          string_val {
-            src {
-              end_column: 51
-              end_line: 27
-              file: 2
-              start_column: 14
-              start_line: 27
+          args {
+            string_val {
+              src {
+                end_column: 51
+                end_line: 27
+                file: 2
+                start_column: 14
+                start_line: 27
+              }
+              v: "NUM"
             }
-            v: "NUM"
           }
+          variadic: true
         }
         id {
           bitfield1: 1
@@ -162,27 +165,29 @@ body {
     expr {
       dataframe_stat_approx_quantile {
         cols {
-          string_val {
-            src {
-              end_column: 96
-              end_line: 29
-              file: 2
-              start_column: 14
-              start_line: 29
+          args {
+            string_val {
+              src {
+                end_column: 96
+                end_line: 29
+                file: 2
+                start_column: 14
+                start_line: 29
+              }
+              v: "NUM"
             }
-            v: "NUM"
           }
-        }
-        cols {
-          string_val {
-            src {
-              end_column: 96
-              end_line: 29
-              file: 2
-              start_column: 14
-              start_line: 29
+          args {
+            string_val {
+              src {
+                end_column: 96
+                end_line: 29
+                file: 2
+                start_column: 14
+                start_line: 29
+              }
+              v: "NUM"
             }
-            v: "NUM"
           }
         }
         id {

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -23,15 +23,11 @@ df.to_local_iterator()
 
 df.to_local_iterator(block=False)
 
-rows = df.select("*")
-
-rows.to_local_iterator()
+df.select("*").to_local_iterator()
 
 df.to_local_iterator(statement_params={"SF_PARTNER": "FAKE_PARTNER"})
 
-rows = df.filter(df["num"] > 1)
-
-rows.to_local_iterator(block=False)
+df.filter(df["num"] > 1).to_local_iterator(block=False)
 
 df.to_local_iterator(statement_params={"SF_PARTNER": "FAKE_PARTNER"}, case_sensitive=False)
 
@@ -181,7 +177,6 @@ body {
       }
     }
     symbol {
-      value: "rows"
     }
     uid: 6
     var_id {
@@ -324,7 +319,6 @@ body {
       }
     }
     symbol {
-      value: "rows"
     }
     uid: 11
     var_id {

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -44,7 +44,7 @@ drop2 = df.na.drop("all")
 
 drop3 = df.na.drop("any", 42)
 
-drop4 = df.na.drop("any", ["STR"])
+drop4 = df.na.drop("any", "STR")
 
 drop5 = df.na.drop("all", ["NUM", "STR"])
 
@@ -56,7 +56,7 @@ fill1 = df.na.fill(42)
 
 fill2 = df.na.fill({"NUM": 42, "STR": "abc"})
 
-fill3 = df.na.fill(42, ["NUM"])
+fill3 = df.na.fill(42, "NUM")
 
 fill4 = df.na.fill("def", ["STR"])
 
@@ -226,7 +226,19 @@ body {
           start_line: 33
         }
         subset {
-          list: "STR"
+          args {
+            string_val {
+              src {
+                end_column: 40
+                end_line: 33
+                file: 2
+                start_column: 16
+                start_line: 33
+              }
+              v: "STR"
+            }
+          }
+          variadic: true
         }
       }
     }
@@ -259,8 +271,30 @@ body {
           start_line: 35
         }
         subset {
-          list: "NUM"
-          list: "STR"
+          args {
+            string_val {
+              src {
+                end_column: 60
+                end_line: 35
+                file: 2
+                start_column: 16
+                start_line: 35
+              }
+              v: "NUM"
+            }
+          }
+          args {
+            string_val {
+              src {
+                end_column: 60
+                end_line: 35
+                file: 2
+                start_column: 16
+                start_line: 35
+              }
+              v: "STR"
+            }
+          }
         }
       }
     }
@@ -293,7 +327,18 @@ body {
           start_line: 37
         }
         subset {
-          list: "NUM"
+          args {
+            string_val {
+              src {
+                end_column: 64
+                end_line: 37
+                file: 2
+                start_column: 16
+                start_line: 37
+              }
+              v: "NUM"
+            }
+          }
         }
         thresh {
           value: 42
@@ -460,7 +505,19 @@ body {
           start_line: 45
         }
         subset {
-          list: "NUM"
+          args {
+            string_val {
+              src {
+                end_column: 44
+                end_line: 45
+                file: 2
+                start_column: 16
+                start_line: 45
+              }
+              v: "NUM"
+            }
+          }
+          variadic: true
         }
         value {
           int64_val {
@@ -504,7 +561,18 @@ body {
           start_line: 47
         }
         subset {
-          list: "STR"
+          args {
+            string_val {
+              src {
+                end_column: 49
+                end_line: 47
+                file: 2
+                start_column: 16
+                start_line: 47
+              }
+              v: "STR"
+            }
+          }
         }
         value {
           string_val {
@@ -760,7 +828,18 @@ body {
           start_line: 55
         }
         subset {
-          list: "NUM"
+          args {
+            string_val {
+              src {
+                end_column: 55
+                end_line: 55
+                file: 2
+                start_column: 19
+                start_line: 55
+              }
+              v: "NUM"
+            }
+          }
         }
         to_replace_value {
           int64_val {

--- a/tests/ast/data/Session.create_dataframe_from_pandas.test
+++ b/tests/ast/data/Session.create_dataframe_from_pandas.test
@@ -13,9 +13,9 @@ df2 = session.create_dataframe(pd.DataFrame([(99, 98)], columns=["a", "b"]), sch
 
 ## EXPECTED UNPARSER OUTPUT
 
-df = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType(fields=[StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True), StructField("\"c\"", LongType(), nullable=True), StructField("\"d\"", LongType(), nullable=True)], structured=False))
+df = session.create_dataframe(pandas.DataFrame(<not shown>), schema=StructType(fields=[StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True), StructField("\"c\"", LongType(), nullable=True), StructField("\"d\"", LongType(), nullable=True)], structured=False))
 
-df2 = session.create_dataframe(pandas.DataFrame(<not shown>)), schema=StructType(fields=[StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True)], structured=False))
+df2 = session.create_dataframe(pandas.DataFrame(<not shown>), schema=StructType(fields=[StructField("\"a\"", LongType(), nullable=True), StructField("\"b\"", LongType(), nullable=True)], structured=False))
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/Session.flatten.test
+++ b/tests/ast/data/Session.flatten.test
@@ -6,7 +6,7 @@ df2 = session.flatten(col("NUM"), recursive=True, mode="ARRAY")
 
 ## EXPECTED UNPARSER OUTPUT
 
-df1 = session.flatten(parse_json(lit("{\"a\": [1,2]}")), Some("a"), False, False, "BOTH")
+df1 = session.flatten(parse_json(lit("{\"a\": [1,2]}")), "a", False, False, "BOTH")
 
 df2 = session.flatten(col("NUM"), None, False, True, "ARRAY")
 

--- a/tests/ast/data/col_within_group.test
+++ b/tests/ast/data/col_within_group.test
@@ -12,9 +12,9 @@ df = df.select(listagg("a").within_group(["a", "b", col("c")]))
 
 df = session.table("table1")
 
-df = df.select(array_agg("a").within_group("b"))
+df = df.select(array_agg("a", False).within_group("b"))
 
-df = df.select(array_agg("a").within_group("a", col("b")))
+df = df.select(array_agg("a", False).within_group("a", col("b")))
 
 df = df.select(listagg("a", "", False).within_group(["a", "b", col("c")]))
 
@@ -91,6 +91,17 @@ body {
                         start_line: 27
                       }
                       v: "a"
+                    }
+                  }
+                  pos_args {
+                    bool_val {
+                      src {
+                        end_column: 37
+                        end_line: 27
+                        file: 2
+                        start_column: 23
+                        start_line: 27
+                      }
                     }
                   }
                   src {
@@ -176,6 +187,17 @@ body {
                         start_line: 29
                       }
                       v: "a"
+                    }
+                  }
+                  pos_args {
+                    bool_val {
+                      src {
+                        end_column: 37
+                        end_line: 29
+                        file: 2
+                        start_column: 23
+                        start_line: 29
+                      }
                     }
                   }
                   src {

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -358,9 +358,9 @@ df27 = df.select(bitshiftright("A", col("B")), bitshiftright("A", -10), bitshift
 
 df28 = df.select(bround("A", 10), bround("A", 2), bround(col("A"), col("B")))
 
-df29 = df.select(convert_timezone("A", col("B")), convert_timezone(col("A"), "B"), convert_timezone("A", "B"), convert_timezone(col("A"), col("B")), convert_timezone("A", "B"), convert_timezone("A", "B", "A"))
+df29 = df.select(convert_timezone("A", col("B"), None), convert_timezone(col("A"), "B", None), convert_timezone("A", "B", None), convert_timezone(col("A"), col("B"), None), convert_timezone("A", "B", None), convert_timezone("A", "B", "A"))
 
-df30 = df.select(convert_timezone(lit("UTC"), col("a")), convert_timezone(lit("UTC"), col("b"), lit("Asia/Shanghai")))
+df30 = df.select(convert_timezone(lit("UTC"), col("a"), None), convert_timezone(lit("UTC"), col("b"), lit("Asia/Shanghai")))
 
 df31 = df.select(approx_count_distinct("A"), approx_count_distinct(col("A")))
 
@@ -376,9 +376,9 @@ df36 = df.select(covar_pop("A", col("B")))
 
 df37 = df.select(covar_samp("A", "B"))
 
-df38 = df.select(create_map("A", "B"))
+df38 = df.select(create_map(["A", "B"]))
 
-df39 = df.select(create_map("A", "B", "A", "B"))
+df39 = df.select(create_map(("A", "B", "A", "B")))
 
 df40 = df.select(create_map("A", "B"))
 
@@ -436,7 +436,7 @@ df66 = df.select(not_("A"))
 
 df67 = df.select(random(), random(), random(10))
 
-df68 = df.select(uniform("A", "B", "A"), uniform(lit(10), lit(13.0).cast(FloatType()), col("A")), uniform(lit(0.2).cast(FloatType()), lit(2), lit(0.2)))
+df68 = df.select(uniform("A", "B", "A"), uniform(10, 13.0, col("A")), uniform(0.2, 2, 0.2))
 
 df69 = df.select(seq1(0), seq1(10), seq1(-10))
 
@@ -550,7 +550,7 @@ df123 = df111.select(regexp_replace("A", "B", "", 1, 0), regexp_replace(col("A")
 
 df124 = df111.select(replace(col("A"), "", ""), replace("A", "B", "ahsgj"))
 
-df125 = df111.select(charindex("A", "B", 20), charindex("A", "B", col("C")))
+df125 = df111.select(charindex(col("A"), col("B"), None), charindex("A", "B", None), charindex("A", "B", 20), charindex("A", "B", col("C")))
 
 df126 = df111.select(collate(col("A"), "sp-upper"))
 
@@ -576,7 +576,7 @@ df136 = df111.select(right("A", col("B")), right(col("A"), 10))
 
 df137 = df111.select(char("A"))
 
-df138 = df111.select(to_char("A", "bcd"))
+df138 = df111.select(to_char("A", None), to_char(col("B"), None), to_char("A", "bcd"))
 
 df139 = df111.select(date_format(col("A"), col("B")), date_format("A", "YYYY"))
 
@@ -3433,6 +3433,17 @@ body {
                   }
                 }
               }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 56
+                    end_line: 85
+                    file: 2
+                    start_column: 25
+                    start_line: 85
+                  }
+                }
+              }
               src {
                 end_column: 56
                 end_line: 85
@@ -3501,6 +3512,17 @@ body {
                   v: "B"
                 }
               }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 89
+                    end_line: 85
+                    file: 2
+                    start_column: 58
+                    start_line: 85
+                  }
+                }
+              }
               src {
                 end_column: 89
                 end_line: 85
@@ -3545,6 +3567,17 @@ body {
                     start_line: 85
                   }
                   v: "B"
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 117
+                    end_line: 85
+                    file: 2
+                    start_column: 91
+                    start_line: 85
+                  }
                 }
               }
               src {
@@ -3637,6 +3670,17 @@ body {
                   }
                 }
               }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 155
+                    end_line: 85
+                    file: 2
+                    start_column: 119
+                    start_line: 85
+                  }
+                }
+              }
               src {
                 end_column: 155
                 end_line: 85
@@ -3681,6 +3725,17 @@ body {
                     start_line: 85
                   }
                   v: "B"
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 187
+                    end_line: 85
+                    file: 2
+                    start_column: 157
+                    start_line: 85
+                  }
                 }
               }
               src {
@@ -3859,6 +3914,17 @@ body {
                     end_line: 87
                     file: 2
                     start_column: 54
+                    start_line: 87
+                  }
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 63
+                    end_line: 87
+                    file: 2
+                    start_column: 25
                     start_line: 87
                   }
                 }
@@ -4912,7 +4978,7 @@ body {
                 }
               }
               pos_args {
-                string_val {
+                list_val {
                   src {
                     end_column: 47
                     end_line: 103
@@ -4920,19 +4986,30 @@ body {
                     start_column: 25
                     start_line: 103
                   }
-                  v: "A"
-                }
-              }
-              pos_args {
-                string_val {
-                  src {
-                    end_column: 47
-                    end_line: 103
-                    file: 2
-                    start_column: 25
-                    start_line: 103
+                  vs {
+                    string_val {
+                      src {
+                        end_column: 47
+                        end_line: 103
+                        file: 2
+                        start_column: 25
+                        start_line: 103
+                      }
+                      v: "A"
+                    }
                   }
-                  v: "B"
+                  vs {
+                    string_val {
+                      src {
+                        end_column: 47
+                        end_line: 103
+                        file: 2
+                        start_column: 25
+                        start_line: 103
+                      }
+                      v: "B"
+                    }
+                  }
                 }
               }
               src {
@@ -4990,7 +5067,7 @@ body {
                 }
               }
               pos_args {
-                string_val {
+                tuple_val {
                   src {
                     end_column: 57
                     end_line: 105
@@ -4998,43 +5075,54 @@ body {
                     start_column: 25
                     start_line: 105
                   }
-                  v: "A"
-                }
-              }
-              pos_args {
-                string_val {
-                  src {
-                    end_column: 57
-                    end_line: 105
-                    file: 2
-                    start_column: 25
-                    start_line: 105
+                  vs {
+                    string_val {
+                      src {
+                        end_column: 57
+                        end_line: 105
+                        file: 2
+                        start_column: 25
+                        start_line: 105
+                      }
+                      v: "A"
+                    }
                   }
-                  v: "B"
-                }
-              }
-              pos_args {
-                string_val {
-                  src {
-                    end_column: 57
-                    end_line: 105
-                    file: 2
-                    start_column: 25
-                    start_line: 105
+                  vs {
+                    string_val {
+                      src {
+                        end_column: 57
+                        end_line: 105
+                        file: 2
+                        start_column: 25
+                        start_line: 105
+                      }
+                      v: "B"
+                    }
                   }
-                  v: "A"
-                }
-              }
-              pos_args {
-                string_val {
-                  src {
-                    end_column: 57
-                    end_line: 105
-                    file: 2
-                    start_column: 25
-                    start_line: 105
+                  vs {
+                    string_val {
+                      src {
+                        end_column: 57
+                        end_line: 105
+                        file: 2
+                        start_column: 25
+                        start_line: 105
+                      }
+                      v: "A"
+                    }
                   }
-                  v: "B"
+                  vs {
+                    string_val {
+                      src {
+                        end_column: 57
+                        end_line: 105
+                        file: 2
+                        start_column: 25
+                        start_line: 105
+                      }
+                      v: "B"
+                    }
+                  }
                 }
               }
               src {
@@ -7395,30 +7483,7 @@ body {
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 75
-                        end_line: 163
-                        file: 2
-                        start_column: 49
-                        start_line: 163
-                      }
-                      v: 10
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 75
                     end_line: 163
@@ -7426,44 +7491,11 @@ body {
                     start_column: 49
                     start_line: 163
                   }
+                  v: 10
                 }
               }
               pos_args {
-                column_cast {
-                  col {
-                    apply_expr {
-                      fn {
-                        builtin_fn {
-                          name {
-                            name {
-                              name_flat {
-                                name: "lit"
-                              }
-                            }
-                          }
-                        }
-                      }
-                      pos_args {
-                        float64_val {
-                          src {
-                            end_column: 75
-                            end_line: 163
-                            file: 2
-                            start_column: 49
-                            start_line: 163
-                          }
-                          v: 13.0
-                        }
-                      }
-                      src {
-                        end_column: 75
-                        end_line: 163
-                        file: 2
-                        start_column: 49
-                        start_line: 163
-                      }
-                    }
-                  }
+                float64_val {
                   src {
                     end_column: 75
                     end_line: 163
@@ -7471,9 +7503,7 @@ body {
                     start_column: 49
                     start_line: 163
                   }
-                  to {
-                    float_type: true
-                  }
+                  v: 13.0
                 }
               }
               pos_args {
@@ -7533,41 +7563,7 @@ body {
                 }
               }
               pos_args {
-                column_cast {
-                  col {
-                    apply_expr {
-                      fn {
-                        builtin_fn {
-                          name {
-                            name {
-                              name_flat {
-                                name: "lit"
-                              }
-                            }
-                          }
-                        }
-                      }
-                      pos_args {
-                        float64_val {
-                          src {
-                            end_column: 97
-                            end_line: 163
-                            file: 2
-                            start_column: 77
-                            start_line: 163
-                          }
-                          v: 0.2
-                        }
-                      }
-                      src {
-                        end_column: 97
-                        end_line: 163
-                        file: 2
-                        start_column: 77
-                        start_line: 163
-                      }
-                    }
-                  }
+                float64_val {
                   src {
                     end_column: 97
                     end_line: 163
@@ -7575,36 +7571,11 @@ body {
                     start_column: 77
                     start_line: 163
                   }
-                  to {
-                    float_type: true
-                  }
+                  v: 0.2
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 97
-                        end_line: 163
-                        file: 2
-                        start_column: 77
-                        start_line: 163
-                      }
-                      v: 2
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 97
                     end_line: 163
@@ -7612,33 +7583,11 @@ body {
                     start_column: 77
                     start_line: 163
                   }
+                  v: 2
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    float64_val {
-                      src {
-                        end_column: 97
-                        end_line: 163
-                        file: 2
-                        start_column: 77
-                        start_line: 163
-                      }
-                      v: 0.2
-                    }
-                  }
+                float64_val {
                   src {
                     end_column: 97
                     end_line: 163
@@ -7646,6 +7595,7 @@ body {
                     start_column: 77
                     start_line: 163
                   }
+                  v: 0.2
                 }
               }
               src {
@@ -15422,6 +15372,164 @@ body {
                 }
               }
               pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 44
+                        end_line: 277
+                        file: 2
+                        start_column: 36
+                        start_line: 277
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 44
+                    end_line: 277
+                    file: 2
+                    start_column: 36
+                    start_line: 277
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 54
+                        end_line: 277
+                        file: 2
+                        start_column: 46
+                        start_line: 277
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 54
+                    end_line: 277
+                    file: 2
+                    start_column: 46
+                    start_line: 277
+                  }
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 55
+                    end_line: 277
+                    file: 2
+                    start_column: 26
+                    start_line: 277
+                  }
+                }
+              }
+              src {
+                end_column: 55
+                end_line: 277
+                file: 2
+                start_column: 26
+                start_line: 277
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "charindex"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 82
+                    end_line: 277
+                    file: 2
+                    start_column: 57
+                    start_line: 277
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 82
+                    end_line: 277
+                    file: 2
+                    start_column: 57
+                    start_line: 277
+                  }
+                  v: "B"
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 82
+                    end_line: 277
+                    file: 2
+                    start_column: 57
+                    start_line: 277
+                  }
+                }
+              }
+              src {
+                end_column: 82
+                end_line: 277
+                file: 2
+                start_column: 57
+                start_line: 277
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "charindex"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
                 string_val {
                   src {
                     end_column: 107
@@ -17100,6 +17208,118 @@ body {
     expr {
       dataframe_select {
         cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "to_char"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 38
+                    end_line: 303
+                    file: 2
+                    start_column: 26
+                    start_line: 303
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 38
+                    end_line: 303
+                    file: 2
+                    start_column: 26
+                    start_line: 303
+                  }
+                }
+              }
+              src {
+                end_column: 38
+                end_line: 303
+                file: 2
+                start_column: 26
+                start_line: 303
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "to_char"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 56
+                        end_line: 303
+                        file: 2
+                        start_column: 48
+                        start_line: 303
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 56
+                    end_line: 303
+                    file: 2
+                    start_column: 48
+                    start_line: 303
+                  }
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 63
+                    end_line: 303
+                    file: 2
+                    start_column: 40
+                    start_line: 303
+                  }
+                }
+              }
+              src {
+                end_column: 63
+                end_line: 303
+                file: 2
+                start_column: 40
+                start_line: 303
+              }
+            }
+          }
           args {
             apply_expr {
               fn {

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -526,7 +526,7 @@ df226 = df.select(parse_xml("A"))
 
 df227 = df.select(strip_null_value("A"))
 
-df228 = df.select(array_agg("A"), array_agg(col("A")))
+df228 = df.select(array_agg("A", False), array_agg(col("A"), True))
 
 df229 = df.select(array_append("A", lit(1)), array_append("A", "B"), array_append(col("A"), col("B")))
 
@@ -10660,6 +10660,17 @@ body {
                   v: "A"
                 }
               }
+              pos_args {
+                bool_val {
+                  src {
+                    end_column: 47
+                    end_line: 171
+                    file: 2
+                    start_column: 26
+                    start_line: 171
+                  }
+                }
+              }
               src {
                 end_column: 47
                 end_line: 171
@@ -10714,6 +10725,18 @@ body {
                     start_column: 59
                     start_line: 171
                   }
+                }
+              }
+              pos_args {
+                bool_val {
+                  src {
+                    end_column: 74
+                    end_line: 171
+                    file: 2
+                    start_column: 49
+                    start_line: 171
+                  }
+                  v: true
                 }
               }
               src {

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -20,6 +20,8 @@ user_schema = StructType([StructField("a", IntegerType()), StructField("b", Stri
 
 df9 = session.read.with_metadata(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE_LAST_MODIFIED").schema(user_schema).csv("@testCSVheader.csv")
 
+df10 = session.read.table(tables.table1)
+
 ## EXPECTED UNPARSER OUTPUT
 
 df1 = session.read.csv("@resources/iris.csv")
@@ -39,6 +41,8 @@ df7 = session.read.option("INFER_SCHEMA", True).option("PARSE_HEADER", True).csv
 df8 = session.read.options({"INFER_SCHEMA": True, "PARSE_HEADER": True}).csv("@testCSVheader.csv")
 
 df9 = session.read.with_metadata(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE_LAST_MODIFIED").schema(StructType(fields=[StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True), StructField("c", FloatType(), nullable=True)], structured=False)).csv("@testCSVheader.csv")
+
+df10 = session.read.table("table1")
 
 ## EXPECTED ENCODED AST
 
@@ -552,6 +556,46 @@ body {
     uid: 9
     var_id {
       bitfield1: 9
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_table {
+        name {
+          name {
+            name_flat {
+              name: "table1"
+            }
+          }
+        }
+        reader {
+          dataframe_reader_init {
+            src {
+              end_column: 27
+              end_line: 45
+              file: 2
+              start_column: 15
+              start_line: 45
+            }
+          }
+        }
+        src {
+          end_column: 48
+          end_line: 45
+          file: 2
+          start_column: 15
+          start_line: 45
+        }
+      }
+    }
+    symbol {
+      value: "df10"
+    }
+    uid: 10
+    var_id {
+      bitfield1: 10
     }
   }
 }

--- a/tests/ast/data/session_generator.test
+++ b/tests/ast/data/session_generator.test
@@ -12,9 +12,9 @@ df3 = session.generator(seq8(0), uniform(1, 10, 2), timelimit=1)
 
 df1 = session.generator(col("A"), col("B"), rowcount=0, timelimit=0)
 
-df2 = session.generator(seq1(1), uniform(lit(1), lit(10), lit(2)), rowcount=3, timelimit=0)
+df2 = session.generator(seq1(1), uniform(1, 10, 2), rowcount=3, timelimit=0)
 
-df3 = session.generator(seq8(0), uniform(lit(1), lit(10), lit(2)), rowcount=0, timelimit=1)
+df3 = session.generator(seq8(0), uniform(1, 10, 2), rowcount=0, timelimit=1)
 
 ## EXPECTED ENCODED AST
 
@@ -173,30 +173,7 @@ body {
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 58
-                        end_line: 29
-                        file: 2
-                        start_column: 41
-                        start_line: 29
-                      }
-                      v: 1
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 58
                     end_line: 29
@@ -204,33 +181,11 @@ body {
                     start_column: 41
                     start_line: 29
                   }
+                  v: 1
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 58
-                        end_line: 29
-                        file: 2
-                        start_column: 41
-                        start_line: 29
-                      }
-                      v: 10
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 58
                     end_line: 29
@@ -238,33 +193,11 @@ body {
                     start_column: 41
                     start_line: 29
                   }
+                  v: 10
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 58
-                        end_line: 29
-                        file: 2
-                        start_column: 41
-                        start_line: 29
-                      }
-                      v: 2
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 58
                     end_line: 29
@@ -272,6 +205,7 @@ body {
                     start_column: 41
                     start_line: 29
                   }
+                  v: 2
                 }
               }
               src {
@@ -356,30 +290,7 @@ body {
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 58
-                        end_line: 31
-                        file: 2
-                        start_column: 41
-                        start_line: 31
-                      }
-                      v: 1
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 58
                     end_line: 31
@@ -387,33 +298,11 @@ body {
                     start_column: 41
                     start_line: 31
                   }
+                  v: 1
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 58
-                        end_line: 31
-                        file: 2
-                        start_column: 41
-                        start_line: 31
-                      }
-                      v: 10
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 58
                     end_line: 31
@@ -421,33 +310,11 @@ body {
                     start_column: 41
                     start_line: 31
                   }
+                  v: 10
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 58
-                        end_line: 31
-                        file: 2
-                        start_column: 41
-                        start_line: 31
-                      }
-                      v: 2
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 58
                     end_line: 31
@@ -455,6 +322,7 @@ body {
                     start_column: 41
                     start_line: 31
                   }
+                  v: 2
                 }
               }
               src {

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -10,9 +10,9 @@ ans2 = session.write_pandas(df, "test", schema="a", database="b", chunk_size=7, 
 
 ## EXPECTED UNPARSER OUTPUT
 
-ans = session.write_pandas(pandas.DataFrame(<not shown>)), "table1")
+ans = session.write_pandas(pandas.DataFrame(<not shown>), "table1")
 
-ans2 = session.write_pandas(pandas.DataFrame(<not shown>)), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, create_temp_table=True, overwrite=True, table_type="temporary", random=90)
+ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, create_temp_table=True, overwrite=True, table_type="temporary", random=90)
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/shadowed_local_name.test
+++ b/tests/ast/data/shadowed_local_name.test
@@ -18,7 +18,7 @@ df_res1 = df.drop(col("NUM"))
 
 df = df_res1.distinct()
 
-df4 = df_res1.flatten("STR", Some("path"), True, False, "BOTH")
+df4 = df_res1.flatten("STR", "path", True, False, "BOTH")
 
 ## EXPECTED ENCODED AST
 


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-1918334](https://snowflakecomputing.atlassian.net/browse/SNOW-1918334)

   Also fixes [SNOW-1952291](https://snowflakecomputing.atlassian.net/browse/SNOW-1952291)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   The following changes are included in this PR
   - After calls to `Dataframe.cache_result` there were `df.write` lines being generated - fixed with reference to use of `self.write` in `Dataframe.to_snowpark_pandas()`
   - AST capture for several functions was fixed by using helper methods like `build_function_expr` and `build_builtin_fn_apply`
      - `is_distinct` parameter was not being captured in calls to `array_agg`
      - `charindex,to_char` calls were not showing up in the AST, just needed to pass the built AST internally
      - `lit(x)` was being added around parameters `x` in `uniform` and `charindex`
      - `create_map` was flattening its inputs
   - Modify AST generation now that `Dataframe.stat.approx_quantile::cols` and `Dataframe.na.{drop,fill,replace}::subset` are `ExprArgList` typed fields
   - Don't allow any arguments to be ignored by removing the `ignore_nulls` parameter from our `build_function_expr` helper

This PR is accompanied by a [server-side PR](https://github.com/snowflakedb/snowflake/pull/265335). 

[SNOW-1918334]: https://snowflakecomputing.atlassian.net/browse/SNOW-1918334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNOW-1952291]: https://snowflakecomputing.atlassian.net/browse/SNOW-1952291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNOW-1961756]: https://snowflakecomputing.atlassian.net/browse/SNOW-1961756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ