### PR TITLE
SNOW-1758760: Unpin modin/pandas versions in sproc tests

### DIFF
--- a/tests/integ/modin/test_modin_stored_procedures.py
+++ b/tests/integ/modin/test_modin_stored_procedures.py
@@ -6,21 +6,15 @@
 
 import modin.pandas as pd
 import pandas as native_pd
-import pytest
-from packaging import version
 
 from snowflake.snowpark import Session
 from snowflake.snowpark.functions import sproc
 from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import multithreaded_run
 
-pytestmark = pytest.mark.skipif(
-    version.parse(native_pd.__version__) != version.parse("2.2.1"),
-    reason="SNOW-1758760: modin stored procedure test must pin pandas==2.2.1 and modin==0.28.1",
-)
 
 # Must pin modin version to match version available in Snowflake Anaconda
-SPROC_MODIN_VERSION = "0.28.1"
+SPROC_MODIN_VERSION = "0.30.1"
 
 PACKAGE_LIST = [
     # modin 0.30.1 supports any pandas 2.2.x, so just pick whichever one is installed in the client.


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1758760

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Some sproc tests were previously skipped while updating from modin 0.28.1 -> 0.30.1, and we neglected to restore them. Because Snowpark 1.29.0 now requires modin to be 0.30.1 if present, this started causing failures in the daily test where we were pinning the older version of modin (https://github.com/snowflakedb/snowpark-python/actions/runs/13720319594/job/38374328285).