### PR TITLE
SNOW-1900040: Estimate an upper bound for row counts between operations in OrderedDataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-- Added estimate for row count upper bound to `OrderedDataFrame`.
+- Added estimate for row count upper bound to `OrderedDataFrame` to enable better engine switching. This could potentially result in increased query counts.
 
 ### Snowpark Python API Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.31.0 (YYYY-MM-DD)
 
+### Snowpark pandas API Updates
+
+### Improvements
+
+- Added estimate for row count upper bound to `OrderedDataFrame`.
+
 ### Snowpark Python API Updates
 
 #### New Features

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -738,7 +738,10 @@ class InternalFrame:
         Returns:
             Number of rows in this frame.
         """
-        return count_rows(self.ordered_dataframe)
+        num_rows = count_rows(self.ordered_dataframe)
+        self.ordered_dataframe.row_count = num_rows
+        self.ordered_dataframe.row_count_upper_bound = num_rows
+        return num_rows
 
     def has_unique_index(self, axis: Optional[int] = 0) -> bool:
         """

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1231,6 +1231,7 @@ class OrderedDataFrame:
         original_right_quoted_identifiers = (
             right.projected_column_snowflake_quoted_identifiers
         )
+        original_right_ordered_dataframe = right
         # De-duplicate the column identifiers of right against self (left), so that
         # Snowpark doesn't perform any de-duplication on the result dataframe during join.
         right = right._deduplicate_active_column_snowflake_quoted_identifiers(
@@ -1263,6 +1264,7 @@ class OrderedDataFrame:
                 self,
                 DataFrameOperation.JOIN,
                 args={
+                    "right": original_right_ordered_dataframe,
                     "left_on_cols": left_on_cols,
                     "right_on_cols": right_on_cols,
                     "how": how,
@@ -1352,6 +1354,7 @@ class OrderedDataFrame:
             self,
             DataFrameOperation.JOIN,
             args={
+                "right": original_right_ordered_dataframe,
                 "left_on_cols": left_on_cols,
                 "right_on_cols": right_on_cols,
                 "how": how,

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -432,16 +432,6 @@ class OrderedDataFrame:
             count("*").over().as_(row_count_snowflake_quoted_identifier),
         )
 
-        # Get the row count from the underlying Snowpark dataframe.
-        materialized_row_count = (
-            ordered_dataframe._dataframe_ref.snowpark_dataframe.select(
-                row_count_snowflake_quoted_identifier
-            ).first()[row_count_snowflake_quoted_identifier.strip('"')]
-        )
-        # Set the row count and upper bound to the materialized row count.
-        ordered_dataframe.row_count = materialized_row_count
-        ordered_dataframe.row_count_upper_bound = materialized_row_count
-
         # inplace update so dataframe_ref can be shared. Note that we keep
         # the original ordering columns.
         ordered_dataframe.row_count_snowflake_quoted_identifier = (

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -431,7 +431,6 @@ class OrderedDataFrame:
             *self.projected_column_snowflake_quoted_identifiers,
             count("*").over().as_(row_count_snowflake_quoted_identifier),
         )
-
         # inplace update so dataframe_ref can be shared. Note that we keep
         # the original ordering columns.
         ordered_dataframe.row_count_snowflake_quoted_identifier = (

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -31,6 +31,10 @@ from snowflake.snowpark.functions import (
     sum as sum_,
 )
 from snowflake.snowpark.modin.plugin._typing import AlignTypeLit, JoinTypeLit
+from snowflake.snowpark.modin.plugin._internal.row_count_estimation import (
+    DataFrameOperation,
+    RowCountEstimator,
+)
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.table_function import TableFunctionCall
@@ -296,6 +300,8 @@ class OrderedDataFrame:
         self.row_count_snowflake_quoted_identifier = (
             row_count_snowflake_quoted_identifier
         )
+        self.row_count: Optional[int] = None
+        self.row_count_upper_bound: Optional[int] = None
 
     @property
     def ordering_columns(self) -> list[OrderingColumn]:
@@ -425,6 +431,17 @@ class OrderedDataFrame:
             *self.projected_column_snowflake_quoted_identifiers,
             count("*").over().as_(row_count_snowflake_quoted_identifier),
         )
+
+        # Get the row count from the underlying Snowpark dataframe.
+        materialized_row_count = (
+            ordered_dataframe._dataframe_ref.snowpark_dataframe.select(
+                row_count_snowflake_quoted_identifier
+            ).first()[row_count_snowflake_quoted_identifier.strip('"')]
+        )
+        # Set the row count and upper bound to the materialized row count.
+        ordered_dataframe.row_count = materialized_row_count
+        ordered_dataframe.row_count_upper_bound = materialized_row_count
+
         # inplace update so dataframe_ref can be shared. Note that we keep
         # the original ordering columns.
         ordered_dataframe.row_count_snowflake_quoted_identifier = (
@@ -626,7 +643,12 @@ class OrderedDataFrame:
                 snowpark_dataframe = self._dataframe_ref.snowpark_dataframe.select(
                     *cols
                 )
-                return OrderedDataFrame(DataFrameReference(snowpark_dataframe))
+                new_df = OrderedDataFrame(DataFrameReference(snowpark_dataframe))
+                # Update the row count upper bound
+                new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+                    self, DataFrameOperation.SELECT, args={}
+                )
+                return new_df
             elif isinstance(e, (Column, str)):
                 column_names = self._extract_quoted_identifiers_from_column_or_name(
                     e, active_columns
@@ -660,7 +682,7 @@ class OrderedDataFrame:
                 f"The Snowpark DataFrame in DataFrameReference with id={dataframe_ref._id} is updated"
             )
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             dataframe_ref,
             projected_column_snowflake_quoted_identifiers=new_projected_columns,
             # keep the original ordering columns and row position column
@@ -668,6 +690,12 @@ class OrderedDataFrame:
             row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
             row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
         )
+
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.SELECT, args={}
+        )
+        return new_df
 
     def dropna(
         self,
@@ -693,11 +721,16 @@ class OrderedDataFrame:
         result_column_quoted_identifiers = (
             projected_dataframe_ref.snowflake_quoted_identifiers
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(snowpark_dataframe, result_column_quoted_identifiers),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
             ordering_columns=self.ordering_columns,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.DROPNA, args={}
+        )
+        return new_df
 
     def union_all(self, other: "OrderedDataFrame") -> "OrderedDataFrame":
         """
@@ -720,10 +753,15 @@ class OrderedDataFrame:
         snowpark_dataframe = self_snowpark_dataframe_ref.snowpark_dataframe.union_all(
             other_snowpark_dataframe_ref.snowpark_dataframe
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(snowpark_dataframe, result_column_quoted_identifiers),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.UNION_ALL, args={"other": other}
+        )
+        return new_df
 
     def _extract_aggregation_result_column_quoted_identifiers(
         self,
@@ -775,7 +813,7 @@ class OrderedDataFrame:
             self._extract_aggregation_result_column_quoted_identifiers(*agg_exprs)
         )
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 self._dataframe_ref.snowpark_dataframe.group_by(cols).agg(*agg_exprs),
                 snowflake_quoted_identifiers=result_column_quoted_identifiers,
@@ -783,6 +821,11 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
             ordering_columns=[OrderingColumn(identifier) for identifier in cols],
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.GROUP_BY, args={}
+        )
+        return new_df
 
     def sort(
         self,
@@ -806,7 +849,7 @@ class OrderedDataFrame:
         if ordering_columns == self.ordering_columns:
             return self
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             self._to_projected_snowpark_dataframe_reference(
                 include_row_count_column=True, include_ordering_columns=True
             ),
@@ -817,6 +860,11 @@ class OrderedDataFrame:
             # No need to reset row count, since sorting should not add/drop rows.
             row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.SORT, args={}
+        )
+        return new_df
 
     def pivot(
         self,
@@ -834,7 +882,7 @@ class OrderedDataFrame:
         See detailed docstring in Snowpark DataFrame's pivot.
         """
         snowpark_dataframe = self.to_projected_snowpark_dataframe()
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             # the pivot result columns for dynamic pivot are data dependent, a schema call is required
             # to know all the quoted identifiers for the pivot result.
             DataFrameReference(
@@ -845,6 +893,11 @@ class OrderedDataFrame:
                 ).agg(*agg_exprs)
             )
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.PIVOT, args={}
+        )
+        return new_df
 
     def unpivot(
         self,
@@ -903,7 +956,7 @@ class OrderedDataFrame:
         ]
         # add the name column and value colum to the result
         result_column_quoted_identifiers += [name_column, value_column]
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 projected_dataframe_ref.snowpark_dataframe.unpivot(
                     value_column=value_column,
@@ -915,6 +968,11 @@ class OrderedDataFrame:
             ),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.UNPIVOT, args={"column_list": column_list}
+        )
+        return new_df
 
     def agg(
         self,
@@ -930,10 +988,15 @@ class OrderedDataFrame:
         result_column_quoted_identifiers = (
             self._extract_aggregation_result_column_quoted_identifiers(*exprs)
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(snowpark_dataframe, result_column_quoted_identifiers),
             projected_column_snowflake_quoted_identifiers=result_column_quoted_identifiers,
         )
+        # Update the row count upper bound
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self, DataFrameOperation.AGG, args={}
+        )
+        return new_df
 
     def _deduplicate_active_column_snowflake_quoted_identifiers(
         self,
@@ -1189,13 +1252,26 @@ class OrderedDataFrame:
             # if no join needed, we simply return the deduplicated right frame with the projected columns
             # set to the left.projected_column_snowflake_quoted_identifiers and the deduplicated the right
             # projected_column_snowflake_quoted_identifiers.
-            return OrderedDataFrame(
+            new_df = OrderedDataFrame(
                 right._dataframe_ref,
                 projected_column_snowflake_quoted_identifiers=projected_column_snowflake_quoted_identifiers,
                 ordering_columns=self.ordering_columns,
                 row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
                 row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
             )
+            new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+                self,
+                DataFrameOperation.JOIN,
+                args={
+                    "left_on_cols": left_on_cols,
+                    "right_on_cols": right_on_cols,
+                    "how": how,
+                    "left_match_col": left_match_col,
+                    "right_match_col": right_match_col,
+                    "match_comparator": match_comparator,
+                },
+            )
+            return new_df
 
         # reproject the snowpark dataframe with only necessary columns
         left_snowpark_dataframe_ref = self._to_projected_snowpark_dataframe_reference(
@@ -1262,7 +1338,7 @@ class OrderedDataFrame:
         else:
             ordering_columns = self.ordering_columns + right.ordering_columns
 
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 snowpark_dataframe,
                 # the result of join retains column quoted identifier of both left + right
@@ -1272,6 +1348,19 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=projected_column_snowflake_quoted_identifiers,
             ordering_columns=ordering_columns,
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.JOIN,
+            args={
+                "left_on_cols": left_on_cols,
+                "right_on_cols": right_on_cols,
+                "how": how,
+                "left_match_col": left_match_col,
+                "right_match_col": right_match_col,
+                "match_comparator": match_comparator,
+            },
+        )
+        return new_df
 
     def _has_same_base_ordered_dataframe(self, other: "OrderedDataFrame") -> bool:
         """
@@ -1421,7 +1510,7 @@ class OrderedDataFrame:
                     include_row_count_column=False,
                 )
             )
-            return OrderedDataFrame(
+            new_df = OrderedDataFrame(
                 dataframe_ref=aligned_ordered_frame._dataframe_ref,
                 projected_column_snowflake_quoted_identifiers=self.projected_column_snowflake_quoted_identifiers
                 + aligned_ordered_frame.projected_column_snowflake_quoted_identifiers,
@@ -1429,6 +1518,12 @@ class OrderedDataFrame:
                 row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
                 row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
             )
+            new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+                self,
+                DataFrameOperation.ALIGN,
+                args={"right": right},
+            )
+            return new_df
 
         from snowflake.snowpark.modin.plugin._internal.join_utils import (
             JoinOrAlignOrderedDataframeResultHelper,
@@ -1731,7 +1826,13 @@ class OrderedDataFrame:
 
         # call select to make sure only the result_projected_column_snowflake_quoted_identifiers are projected
         # in the join result
-        return joined_ordered_frame.select(select_list)
+        new_df = joined_ordered_frame.select(select_list)
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.ALIGN,
+            args={"right": right},
+        )
+        return new_df
 
     def filter(self, expr: ColumnOrSqlExpr) -> "OrderedDataFrame":
         """
@@ -1744,7 +1845,7 @@ class OrderedDataFrame:
             include_ordering_columns=True
         )
         snowpark_dataframe = projected_dataframe_ref.snowpark_dataframe.filter(expr)
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 snowpark_dataframe,
                 # same columns are retained after filtering
@@ -1753,6 +1854,12 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=projected_dataframe_ref.snowflake_quoted_identifiers,
             ordering_columns=self.ordering_columns,
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.FILTER,
+            args={},
+        )
+        return new_df
 
     def limit(self, n: int, offset: int = 0, sort: bool = True) -> "OrderedDataFrame":
         """
@@ -1770,7 +1877,7 @@ class OrderedDataFrame:
         snowpark_dataframe = projected_dataframe_ref.snowpark_dataframe.limit(
             n=n, offset=offset
         )
-        return OrderedDataFrame(
+        new_df = OrderedDataFrame(
             DataFrameReference(
                 snowpark_dataframe,
                 # the same columns are retained for limit
@@ -1779,6 +1886,12 @@ class OrderedDataFrame:
             projected_column_snowflake_quoted_identifiers=projected_dataframe_ref.snowflake_quoted_identifiers,
             ordering_columns=self.ordering_columns,
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.LIMIT,
+            args={"n": n},
+        )
+        return new_df
 
     @property
     def write(self) -> DataFrameWriter:
@@ -2009,7 +2122,7 @@ class OrderedDataFrame:
         # df_s = df.sample(frac=0.5)
         # assert df_s.index == df_s.index may fail because both the LHS and RHS will call the sample method during
         # evaluation and the results won't be deterministic.
-        return cache_result(
+        new_df = cache_result(
             OrderedDataFrame(
                 DataFrameReference(
                     snowpark_dataframe,
@@ -2020,3 +2133,9 @@ class OrderedDataFrame:
                 ordering_columns=self.ordering_columns,
             )
         )
+        new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
+            self,
+            DataFrameOperation.SAMPLE,
+            args={"n": n, "frac": frac},
+        )
+        return new_df

--- a/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
@@ -108,7 +108,7 @@ class RowCountEstimator:
         elif operation == DataFrameOperation.LIMIT:
             return args["n"]
 
-        # Sample can cause the row count to be set to n or reduced by a fraction
+        # Sample can cause the row count to be set to n or multiplied by a fraction
         elif operation == DataFrameOperation.SAMPLE:
             n, frac = args.get("n"), args.get("frac")
             if n is not None:

--- a/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+from enum import Enum
+from math import ceil
+
+if TYPE_CHECKING:
+    from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
+        OrderedDataFrame,
+    )
+
+
+class DataFrameOperation(Enum):
+    SELECT = "select"
+    DROPNA = "dropna"
+    UNION_ALL = "union_all"
+    GROUP_BY = "group_by"
+    SORT = "sort"
+    PIVOT = "pivot"
+    UNPIVOT = "unpivot"
+    AGG = "agg"
+    JOIN = "join"
+    ALIGN = "align"
+    FILTER = "filter"
+    LIMIT = "limit"
+    SAMPLE = "sample"
+
+
+class RowCountEstimator:
+    @staticmethod
+    def upper_bound(
+        df: OrderedDataFrame, operation: DataFrameOperation, args: dict[str, Any]
+    ) -> int | None:
+        """
+        Estimate the new upper bound for the row count after performing an operation
+        on the OrderedDataFrame.
+
+        Args:
+            df (OrderedDataFrame): The original dataframe on which the operation is executed
+            operation (DataFrameOperation): The transformation operation performed
+            args (dict): All arguments passed to the operation method
+
+        Returns:
+            int: The estimated upper bound on the number of rows in the resulting dataframe
+        """
+        # Get the current upper bound. If not set, return None
+        current = df.row_count_upper_bound
+        if current is None:
+            return None
+
+        # These operations preserve or reduce the row count, so we can use the current upper bound
+        if operation in {
+            DataFrameOperation.SELECT,
+            DataFrameOperation.DROPNA,
+            DataFrameOperation.GROUP_BY,
+            DataFrameOperation.SORT,
+            DataFrameOperation.PIVOT,
+            DataFrameOperation.FILTER,
+        }:
+            return current
+
+        # Union all combines the row counts of the two dataframes
+        elif operation == DataFrameOperation.UNION_ALL:
+            other: OrderedDataFrame = args["other"]
+            other_bound = other.row_count_upper_bound or other.row_count
+            if other_bound is None:
+                raise ValueError(
+                    "Cannot estimate row count: other DataFrame has no row count information."
+                )
+            return current + other_bound
+
+        # Unpivot creates a new row for each value in the column list
+        elif operation == DataFrameOperation.UNPIVOT:
+            column_list = args["column_list"]
+            return current * len(column_list)
+
+        # Agg aggregates the rows into a single row
+        elif operation == DataFrameOperation.AGG:
+            return 1
+
+        # TODO: Implement a better estimate by having cases for different join types
+        # Join can cause a Cartesian product with the row counts multiplying
+        elif operation == DataFrameOperation.JOIN:
+            right: OrderedDataFrame = args["right"]
+            right_bound = right.row_count_upper_bound or right.row_count
+            if right_bound is None:
+                raise ValueError(
+                    "Cannot estimate row count: right DataFrame has no row count information."
+                )
+            return current * right_bound
+
+        # TODO: Implement a better estimate by having cases for different align types
+        # Align can cause a Cartesian product with the row counts multiplying
+        elif operation == DataFrameOperation.ALIGN:
+            other_df: OrderedDataFrame = args["right"]
+            other_bound = other_df.row_count_upper_bound or other_df.row_count
+            if other_bound is None:
+                raise ValueError(
+                    "Cannot estimate row count: right DataFrame has no row count information."
+                )
+            return current * other_bound
+
+        # Limit sets the upper bound to n rows
+        elif operation == DataFrameOperation.LIMIT:
+            return args["n"]
+
+        # Sample can cause the row count to be set to n or reduced by a fraction
+        elif operation == DataFrameOperation.SAMPLE:
+            n, frac = args.get("n"), args.get("frac")
+            if n is not None:
+                return n
+            elif frac is not None:
+                return ceil(current * frac)
+            else:
+                raise ValueError(
+                    "Either 'n' or 'frac' must be provided for a sample operation"
+                )
+
+        else:
+            raise ValueError(f"Unsupported operation: {operation}")

--- a/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
@@ -68,9 +68,8 @@ class RowCountEstimator:
             other: OrderedDataFrame = args["other"]
             other_bound = other.row_count_upper_bound or other.row_count
             if other_bound is None:
-                raise ValueError(
-                    "Cannot estimate row count: other DataFrame has no row count information."
-                )
+                # Cannot estimate row count: other DataFrame has no row count information
+                return None
             return current + other_bound
 
         # Unpivot creates a new row for each value in the column list
@@ -88,9 +87,8 @@ class RowCountEstimator:
             right: OrderedDataFrame = args["right"]
             right_bound = right.row_count_upper_bound or right.row_count
             if right_bound is None:
-                raise ValueError(
-                    "Cannot estimate row count: right DataFrame has no row count information."
-                )
+                # Cannot estimate row count: other DataFrame has no row count information
+                return None
             return current * right_bound
 
         # TODO: Implement a better estimate by having cases for different align types
@@ -99,9 +97,8 @@ class RowCountEstimator:
             other_df: OrderedDataFrame = args["right"]
             other_bound = other_df.row_count_upper_bound or other_df.row_count
             if other_bound is None:
-                raise ValueError(
-                    "Cannot estimate row count: right DataFrame has no row count information."
-                )
+                # Cannot estimate row count: other DataFrame has no row count information
+                return None
             return current * other_bound
 
         # Limit sets the upper bound to n rows

--- a/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/row_count_estimation.py
@@ -113,9 +113,7 @@ class RowCountEstimator:
             elif frac is not None:
                 return ceil(current * frac)
             else:
-                raise ValueError(
-                    "Either 'n' or 'frac' must be provided for a sample operation"
-                )
+                return None
 
         else:
             raise ValueError(f"Unsupported operation: {operation}")

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -489,6 +489,10 @@ def create_initial_ordered_dataframe(
         row_position_snowflake_quoted_identifier = (
             ordered_dataframe.row_position_snowflake_quoted_identifier
         )
+    # Set the materialized row count
+    materialized_row_count = ordered_dataframe._dataframe_ref.snowpark_dataframe.count()
+    ordered_dataframe.row_count = materialized_row_count
+    ordered_dataframe.row_count_upper_bound = materialized_row_count
     return ordered_dataframe, row_position_snowflake_quoted_identifier
 
 
@@ -1179,12 +1183,16 @@ def create_ordered_dataframe_from_pandas(
             ]
         ),
     )
-    return OrderedDataFrame(
+    ordered_df = OrderedDataFrame(
         DataFrameReference(snowpark_df, snowflake_quoted_identifiers),
         projected_column_snowflake_quoted_identifiers=snowflake_quoted_identifiers,
         ordering_columns=ordering_columns,
         row_position_snowflake_quoted_identifier=row_position_snowflake_quoted_identifier,
     )
+    # Set the materialized row count
+    ordered_df.row_count = df.shape[0]
+    ordered_df.row_count_upper_bound = df.shape[0]
+    return ordered_df
 
 
 def fill_none_in_index_labels(

--- a/tests/integ/modin/frame/test_aggregate.py
+++ b/tests/integ/modin/frame/test_aggregate.py
@@ -812,7 +812,7 @@ def test_sum_min_count(min_count, axis):
     )
 
 
-@sql_count_checker(query_count=3, union_count=4)
+@sql_count_checker(query_count=4, union_count=4)
 def test_agg_valid_variant_col(session, test_table_name):
     pandas_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
@@ -14,7 +14,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import Utils
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=7)
 def test_create_or_replace_dynamic_table_no_relaxed_ordering_raises(session) -> None:
     try:
         # create table
@@ -48,7 +48,7 @@ def test_create_or_replace_dynamic_table_no_relaxed_ordering_raises(session) -> 
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_create_or_replace_dynamic_table_relaxed_ordering(session) -> None:
     try:
         # create table
@@ -84,7 +84,7 @@ def test_create_or_replace_dynamic_table_relaxed_ordering(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,

--- a/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
@@ -131,7 +131,7 @@ def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_index(session, index, index_labels):
     try:
         # create table
@@ -174,7 +174,7 @@ def test_create_or_replace_dynamic_table_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/frame/test_create_or_replace_view.py
+++ b/tests/integ/modin/frame/test_create_or_replace_view.py
@@ -127,7 +127,7 @@ def test_create_or_replace_view_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_index(session, index, index_labels):
     try:
         # create table
@@ -164,7 +164,7 @@ def test_create_or_replace_view_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/frame/test_create_or_replace_view.py
+++ b/tests/integ/modin/frame/test_create_or_replace_view.py
@@ -42,7 +42,7 @@ def test_create_or_replace_view_basic(session, native_pandas_df_basic) -> None:
         Utils.drop_view(session, view_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_multiple_sessions_no_relaxed_ordering_raises(
     session,
     db_parameters,
@@ -85,7 +85,7 @@ def test_create_or_replace_view_multiple_sessions_no_relaxed_ordering_raises(
         pd.session = session
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_create_or_replace_view_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,

--- a/tests/integ/modin/frame/test_describe.py
+++ b/tests/integ/modin/frame/test_describe.py
@@ -349,7 +349,7 @@ def test_describe_duplicate_columns_mixed():
 
 
 @sql_count_checker(
-    query_count=3,
+    query_count=4,
     union_count=8,
 )
 # SNOW-1320296 - pd.concat SQL Compilation ambigious __row_position__ issue

--- a/tests/integ/modin/frame/test_to_dynamic_table.py
+++ b/tests/integ/modin/frame/test_to_dynamic_table.py
@@ -14,7 +14,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import Utils
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=7)
 def test_to_dynamic_table_no_relaxed_ordering_raises(session) -> None:
     try:
         # create table
@@ -48,7 +48,7 @@ def test_to_dynamic_table_no_relaxed_ordering_raises(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_to_dynamic_table_relaxed_ordering(session) -> None:
     try:
         # create table
@@ -84,7 +84,7 @@ def test_to_dynamic_table_relaxed_ordering(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_to_dynamic_table_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,
@@ -131,7 +131,7 @@ def test_to_dynamic_table_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_index(session, index, index_labels):
     try:
         # create table
@@ -174,7 +174,7 @@ def test_to_dynamic_table_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -17,7 +17,7 @@ from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_to_snowflake_index(test_table_name, index, index_labels):
     df = pd.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
@@ -38,7 +38,7 @@ def test_to_snowflake_index(test_table_name, index, index_labels):
     verify_columns(test_table_name, expected_columns)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_multiindex(test_table_name):
     index = native_pd.MultiIndex.from_arrays(
         [[1, 1, 2, 2], ["red", "blue", "red", "blue"]], names=("number", "color")
@@ -94,7 +94,7 @@ def test_to_snowflake_if_exists(session, test_table_name):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
     # Verify new table is created
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df.to_snowflake(test_table_name, if_exists="fail", index=False)
         verify_columns(test_table_name, ["a", "b"])
 
@@ -110,19 +110,19 @@ def test_to_snowflake_if_exists(session, test_table_name):
 
     # Verify existing table is replaced with new data
     df = pd.DataFrame({"a": [1, 2, 3], "c": [4, 5, 6]})
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df.to_snowflake(test_table_name, if_exists="replace", index=False)
         verify_columns(test_table_name, ["a", "c"])
         verify_num_rows(session, test_table_name, 3)
 
     # Verify data is appended to existing table
-    with SqlCounter(query_count=4):
+    with SqlCounter(query_count=5):
         df.to_snowflake(test_table_name, if_exists="append", index=False)
         verify_columns(test_table_name, ["a", "c"])
         verify_num_rows(session, test_table_name, 6)
 
     # Verify pd.to_snowflake operates the same
-    with SqlCounter(query_count=4):
+    with SqlCounter(query_count=5):
         pd.to_snowflake(df, test_table_name, if_exists="append", index=False)
         verify_columns(test_table_name, ["a", "c"])
         verify_num_rows(session, test_table_name, 9)
@@ -156,7 +156,7 @@ def test_to_snowflake_column_names_from_panadas(col_name, test_table_name):
 def test_column_names_with_read_snowflake_and_to_snowflake(
     col_name, if_exists, session
 ):
-    with SqlCounter(query_count=7 if if_exists == "append" else 6):
+    with SqlCounter(query_count=8 if if_exists == "append" else 7):
         # Create a table
         session.sql(f"create or replace table t1 ({col_name} int)").collect()
         session.sql("insert into t1 values (1), (2), (3)").collect()
@@ -173,7 +173,7 @@ def test_column_names_with_read_snowflake_and_to_snowflake(
         assert len(data) == (6 if if_exists == "append" else 3)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_column_with_quotes(session, test_table_name):
     df = pd.DataFrame({'a"b': [1, 2, 3], 'a""b': [4, 5, 6]})
     df.to_snowflake(test_table_name, if_exists="replace", index=False)
@@ -183,13 +183,13 @@ def test_to_snowflake_column_with_quotes(session, test_table_name):
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
 def test_to_snowflake_index_label_none(test_table_name):
     # no index
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         df.to_snowflake(test_table_name, if_exists="replace")
         verify_columns(test_table_name, ["index", "a", "b"])
 
     # named index
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df = pd.DataFrame(
             {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
         )
@@ -197,14 +197,14 @@ def test_to_snowflake_index_label_none(test_table_name):
         verify_columns(test_table_name, ["index", "a", "b"])
 
     # nameless index
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4]))
         df.to_snowflake(test_table_name, if_exists="replace", index_label=[None])
         verify_columns(test_table_name, ["index", "a", "b"])
 
 
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_snowflake_index_label_none_data_column_conflict(test_table_name):
     df = pd.DataFrame({"index": [1, 2, 3], "a": [4, 5, 6]})
     df.to_snowflake(test_table_name, if_exists="replace")
@@ -260,7 +260,7 @@ def verify_num_rows(session, table_name: str, expected: int) -> None:
     assert actual == expected
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_timedelta_to_snowflake_with_read_snowflake(test_table_name, caplog):
     with caplog.at_level(logging.WARNING):
         df = pd.DataFrame(

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -134,7 +134,7 @@ def test_to_snowflake_if_exists(session, test_table_name):
 
 
 @pytest.mark.parametrize("index_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_index_labels(index_label, test_table_name):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     df.to_snowflake(
@@ -144,7 +144,7 @@ def test_to_snowflake_index_labels(index_label, test_table_name):
 
 
 @pytest.mark.parametrize("col_name", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_column_names_from_panadas(col_name, test_table_name):
     df = pd.DataFrame({col_name: [1, 2, 3], "b": [4, 5, 6]})
     df.to_snowflake(test_table_name, if_exists="replace", index=False)

--- a/tests/integ/modin/frame/test_to_snowpark.py
+++ b/tests/integ/modin/frame/test_to_snowpark.py
@@ -50,7 +50,7 @@ def native_pandas_df_basic():
 
 
 @pytest.mark.parametrize("index", [True, False])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowpark_with_read_snowflake(tmp_table_basic, index) -> None:
     snow_dataframe = pd.read_snowflake(tmp_table_basic)
     index_label = None
@@ -146,7 +146,7 @@ def test_to_snowpark_with_multiindex(tmp_table_basic, index, index_labels) -> No
     assert snowpark_df.schema[start + 1].column_identifier.quoted_name == '"b"'
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_to_snowpark_with_operations(session, tmp_table_basic) -> None:
     snowpandas_df = pd.read_snowflake(tmp_table_basic)
     # rename FOOT_SIZE to size and SHOE_MODEL to model
@@ -183,7 +183,7 @@ def test_to_snowpark_with_duplicated_columns_raise(native_pandas_df_basic) -> No
         snow_dataframe.to_snowpark()
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_to_snowpark_with_none_index_label(tmp_table_basic) -> None:
     snowpandas_df = pd.read_snowflake(tmp_table_basic)
 

--- a/tests/integ/modin/frame/test_to_view.py
+++ b/tests/integ/modin/frame/test_to_view.py
@@ -42,7 +42,7 @@ def test_to_view_basic(session, native_pandas_df_basic) -> None:
         Utils.drop_view(session, view_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_multiple_sessions_no_relaxed_ordering_raises(
     session,
     db_parameters,
@@ -85,7 +85,7 @@ def test_to_view_multiple_sessions_no_relaxed_ordering_raises(
         pd.session = session
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_to_view_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,
@@ -127,7 +127,7 @@ def test_to_view_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_index(session, index, index_labels):
     try:
         # create table
@@ -162,7 +162,7 @@ def test_to_view_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/groupby/test_groupby_basic_agg.py
+++ b/tests/integ/modin/groupby/test_groupby_basic_agg.py
@@ -89,7 +89,7 @@ def test_basic_single_group_row_groupby(
         ),
     ],
 )
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_single_group_row_groupby_with_variant(
     session,
     test_table_name,
@@ -127,7 +127,7 @@ def test_single_group_row_groupby_with_variant(
         )
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_groupby_agg_with_decimal_dtype(session, agg_method) -> None:
     # create table
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -149,7 +149,7 @@ def test_groupby_agg_with_decimal_dtype(session, agg_method) -> None:
         eval_snowpark_pandas_result(snowpark_pandas_groupby, pandas_groupby, agg_method)
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_groupby_agg_with_decimal_dtype_named_agg(session) -> None:
     # create table
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -1143,7 +1143,7 @@ def test_groupby_min_count_methods_with_nullable_type(
     )
 
 
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_groupby_agg_on_valid_variant_column(session, test_table_name):
     pandas_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/io/test_read_csv.py
+++ b/tests/integ/modin/io/test_read_csv.py
@@ -48,7 +48,7 @@ def setup(session, resources_path):
     session.sql(f"DROP STAGE IF EXISTS {tmp_stage_name1}").collect()
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv():
     df = native_pd.DataFrame({"c1": [1, 2], "c2": ["qwe", 3], "c3": [4, 5]})
     filename = f"test_read_csv_{str(uuid.uuid4())}"
@@ -69,7 +69,7 @@ def test_read_csv_header_none(resources_path):
 
     filename = test_files.test_file_csv_header
 
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         assert_frame_equal(
             pd.read_csv(filename, header=None),
             native_pd.read_csv(filename, header=None),
@@ -78,7 +78,7 @@ def test_read_csv_header_none(resources_path):
 
 
 @pytest.mark.parametrize("header", [0, 1])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_header_simple(resources_path, header):
     test_files = TestFiles(resources_path)
 
@@ -89,7 +89,7 @@ def test_read_csv_header_simple(resources_path, header):
 
 @pytest.mark.modin_sp_precommit
 @pytest.mark.parametrize("engine", ["c", "python", "pyarrow"])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_engine_local(resources_path, engine):
     test_files = TestFiles(resources_path)
 
@@ -99,7 +99,11 @@ def test_read_csv_engine_local(resources_path, engine):
 
 
 @pytest.mark.modin_sp_precommit
-@sql_count_checker(query_count=9)
+@sql_count_checker(
+    query_count=10,
+    high_count_expected=True,
+    high_count_reason="Expected high count read from Snowflake",
+)
 def test_read_csv_engine_snowflake(resources_path):
     test_files = TestFiles(resources_path)
 
@@ -108,7 +112,7 @@ def test_read_csv_engine_snowflake(resources_path):
     assert_frame_equal(expected, got, check_dtype=False, check_index_type=False)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_header_skiprows(resources_path):
     test_files = TestFiles(resources_path)
 
@@ -137,7 +141,7 @@ def test_read_csv_header_skiprows(resources_path):
         ],
     ],
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_names(resources_path, names):
     test_files = TestFiles(resources_path)
 
@@ -147,7 +151,7 @@ def test_read_csv_names(resources_path, names):
     assert_frame_equal(expected, got, check_dtype=False, check_index_type=False)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_names_overwrite_header(resources_path):
     test_files = TestFiles(resources_path)
 
@@ -178,7 +182,7 @@ def test_read_csv_name_negative(resources_path, names, error_msg, expected_query
             pd.read_csv(test_files.test_file_csv_header, names=names)
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_read_csv_name_invalid_type_negative(resources_path):
     test_files = TestFiles(resources_path)
 
@@ -188,7 +192,7 @@ def test_read_csv_name_invalid_type_negative(resources_path):
         pd.read_csv(test_files.test_file_csv_header, names=names)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_diff_dataypes():
 
     df = native_pd.DataFrame(
@@ -299,7 +303,7 @@ def test_read_csv_diff_dataypes():
     reason="files cannot be named with certain reserved characters in Windows",
 )
 @pytest.mark.parametrize("wildcard", ["*", "?"])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_filepath_glob_pattern(wildcard):
     df = native_pd.DataFrame({"c1": [1, 2], "c2": ["qwe", 3], "c3": [4, 5]})
     filename_a = f"test_read_csv_b_filepath_glob_pattern_{str(uuid.uuid4())}"
@@ -328,7 +332,7 @@ def test_read_csv_filepath_glob_pattern(wildcard):
             os.remove(filename_wildcard)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_filepath_starting_with_stage_symbol():
     df = native_pd.DataFrame({"c1": [1, 2], "c2": ["qwe", 3], "c3": [4, 5]})
     filename = f"@test_read_csv_backslash_{str(uuid.uuid4())}"
@@ -368,7 +372,7 @@ def test_read_csv_filepath_negative():
         ("dtype_backend", "numpy_nullable"),
     ],
 )
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_read_csv_with_warning_params(param, resources_path, arg):
     test_files = TestFiles(resources_path)
     staging_filename = f"@{tmp_stage_name1}/{test_file_csv}"
@@ -381,7 +385,7 @@ def test_read_csv_with_warning_params(param, resources_path, arg):
     )
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_no_sep():
     df = native_pd.DataFrame({"c1": [1, 2], "c2": ["qwe", 3], "c3": [4, 5]})
     filename = f"test_read_csv_no_sep_{str(uuid.uuid4())}"
@@ -398,7 +402,7 @@ def test_read_csv_no_sep():
             os.remove(filename)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_delimiter():
     df = native_pd.DataFrame({"c1": [1, 2], "c2": ["qwe", 3], "c3": [4, 5]})
     filename = f"test_read_csv_delimiter_{str(uuid.uuid4())}"
@@ -424,7 +428,7 @@ def test_read_csv_sep_delimiter_negative(resources_path):
         pd.read_csv(test_files.test_file_csv_colon, sep=";", delimiter=";")
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_misc_parameters(resources_path):
     test_files = TestFiles(resources_path)
     got = pd.read_csv(
@@ -448,7 +452,7 @@ def test_read_csv_misc_parameters(resources_path):
     assert_frame_equal(got, expected, check_dtype=False)
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_read_csv_stage(resources_path):
     got = pd.read_csv(f"@{tmp_stage_name1}/{test_file_csv}")
     test_files = TestFiles(resources_path)
@@ -509,7 +513,7 @@ def test_read_staged_csv_negative(param, arg):
         native_pd.Index(["rating", "id"]),
     ],
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_usecols(resources_path, usecols):
     test_files = TestFiles(resources_path)
 
@@ -537,7 +541,7 @@ def test_read_csv_usecols_empty_negative(resources_path):
         [datetime.date(2021, 1, 9), datetime.datetime(2023, 1, 1, 1, 2, 3)],
     ],
 )
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_read_csv_usecols_invalid_types_negative(resources_path, usecols):
     test_files = TestFiles(resources_path)
 
@@ -552,7 +556,7 @@ def test_read_csv_usecols_invalid_types_negative(resources_path, usecols):
     "usecols",
     [["non_existent_col"], ["rating", "non_existent_col"], [-1], [0, 4], ("rating")],
 )
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_read_csv_usecols_nonexistent_negative(resources_path, usecols):
     test_files = TestFiles(resources_path)
 
@@ -567,7 +571,7 @@ def test_read_csv_usecols_nonexistent_negative(resources_path, usecols):
     "usecols",
     [["c1", "c2"], ["c3"], ["c3", "c2"], [0, 2], [2, 1], [1]],
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_usecols_with_names(resources_path, usecols):
     test_files = TestFiles(resources_path)
 
@@ -594,7 +598,7 @@ def test_read_csv_usecols_with_names(resources_path, usecols):
         [1],
     ],
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_usecols_with_special_names(resources_path, usecols):
     test_files = TestFiles(resources_path)
     names = [
@@ -612,7 +616,7 @@ def test_read_csv_usecols_with_special_names(resources_path, usecols):
 def test_read_csv_usecols_with_names_negative(resources_path):
     test_files = TestFiles(resources_path)
 
-    with SqlCounter(query_count=1):
+    with SqlCounter(query_count=2):
         with pytest.raises(
             ValueError,
             match="'usecols' do not match columns, columns expected but not found",
@@ -623,7 +627,7 @@ def test_read_csv_usecols_with_names_negative(resources_path):
                 usecols=["id"],
             )
 
-    with SqlCounter(query_count=1):
+    with SqlCounter(query_count=2):
         with pytest.raises(
             ValueError,
             match="'usecols' do not match columns, columns expected but not found",
@@ -644,7 +648,7 @@ def test_read_csv_usecols_with_names_negative(resources_path):
         {},
     ],
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_dtype(resources_path, dtype):
     test_files = TestFiles(resources_path)
     expected = native_pd.read_csv(test_files.test_file_csv_header, dtype=dtype)
@@ -703,7 +707,7 @@ def test_read_csv_dtype_usecols_negative(resources_path):
         [-1],
     ],
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_index_col(resources_path, index_col):
     test_files = TestFiles(resources_path)
     expected = native_pd.read_csv(test_files.test_file_csv_header, index_col=index_col)
@@ -716,7 +720,7 @@ def test_read_csv_index_col_name(resources_path):
     expected = native_pd.read_csv(
         test_files.test_file_csv_header, names=["c1", "c2", "c3"], index_col=["c3"]
     )
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         got = pd.read_csv(
             test_files.test_file_csv_header, names=["c1", "c2", "c3"], index_col=["c3"]
         )
@@ -728,7 +732,7 @@ def test_read_csv_index_col_name(resources_path):
         names=["c1", "c2", "c3"],
         index_col=["c3", "c1"],
     )
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         got = pd.read_csv(
             test_files.test_file_csv_header,
             names=["c1", "c2", "c3"],
@@ -752,7 +756,7 @@ def test_read_csv_index_col_name(resources_path):
         ),
     ],
 )
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_read_csv_index_col_frontend_negative(
     resources_path, index_col, expected_error_type, expected_error_msg
 ):
@@ -772,7 +776,7 @@ def test_read_csv_index_col_frontend_negative(
         ([1, "name"], ValueError, "Duplicate columns in index_col are not allowed."),
     ],
 )
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_read_csv_index_col_negative(
     resources_path, index_col, expected_error_type, expected_error_msg
 ):
@@ -782,7 +786,7 @@ def test_read_csv_index_col_negative(
         pd.read_csv(test_files.test_file_csv_header, index_col=index_col).to_pandas()
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_empty_header_snow_1272443():
     # generate a random temp name so these tests can be run in parallel
     temp_file_name = f"test_read_csv_empty_header_{generate_random_alphanumeric(4)}.csv"
@@ -797,7 +801,7 @@ def test_read_csv_empty_header_snow_1272443():
     assert_frame_equal(expected_df, got_df, check_dtype=False, check_index_type=False)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=6)
 def test_read_csv_dateparse():
     # generate a random temp name so these tests can be run in parallel
     temp_file_name = f"test_read_csv_dateparse_{generate_random_alphanumeric(4)}.csv"
@@ -817,7 +821,7 @@ def test_read_csv_dateparse():
     os.remove(temp_file_name)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_read_csv_dateparse_multiple_columns():
     # generate a random temp name so these tests can be run in parallel
     temp_file_name = f"test_read_csv_dateparse_{generate_random_alphanumeric(4)}.csv"

--- a/tests/integ/modin/io/test_read_json.py
+++ b/tests/integ/modin/io/test_read_json.py
@@ -163,7 +163,7 @@ def json_data():
 
 def test_read_json_basic(json_data):
 
-    with SqlCounter(query_count=8):
+    with SqlCounter(query_count=9):
         df = pd.read_json(f"{TEMP_DIR_NAME}/{TEST_JSON_FILE_1}")
 
     expected = native_pd.DataFrame(json_data, index=[0])
@@ -193,7 +193,7 @@ def test_read_json_single_ndjson_file():
     ]
     write_ndjson_file(f"{TEMP_DIR_NAME}/test_read_json_single_ndjson_file.json", data)
 
-    with SqlCounter(query_count=8):
+    with SqlCounter(query_count=9):
         df = pd.read_json(f"{TEMP_DIR_NAME}/test_read_json_single_ndjson_file.json")
 
     expected = native_pd.DataFrame(data, index=[0, 1])
@@ -251,7 +251,7 @@ def test_read_json_ndjson_different_keys(ndjsondata):
         f"{TEMP_DIR_NAME}/test_read_json_single_ndjson_different_keys.json", data
     )
 
-    with SqlCounter(query_count=8):
+    with SqlCounter(query_count=9):
         snow_df = pd.read_json(
             f"{TEMP_DIR_NAME}/test_read_json_single_ndjson_different_keys.json"
         )
@@ -269,7 +269,7 @@ def test_read_json_ndjson_different_keys(ndjsondata):
 
 
 def test_read_json_staged_file(json_data):
-    with SqlCounter(query_count=7):
+    with SqlCounter(query_count=8):
         snow_df = pd.read_json(f"@{tmp_stage_name1}/{TEST_JSON_FILE_1}")
 
     expected = native_pd.DataFrame(json_data, index=[0])
@@ -279,7 +279,7 @@ def test_read_json_staged_file(json_data):
 
 def test_read_json_staged_folder():
 
-    with SqlCounter(query_count=7):
+    with SqlCounter(query_count=8):
         snow_df = pd.read_json(f"@{tmp_stage_name1}")
 
     expected = native_pd.DataFrame(
@@ -344,7 +344,11 @@ def test_read_json_unimplemented_parameter_negative(parameter, argument):
 @pytest.mark.parametrize(
     "parameter, argument", [("storage_options", "random_option"), ("engine", "ujson")]
 )
-@sql_count_checker(query_count=9)
+@sql_count_checker(
+    query_count=10,
+    high_count_expected=True,
+    high_count_reason="Expected high count read_json",
+)
 def test_read_json_warning(caplog, parameter, argument, json_data):
     warning_msg = f"The argument `{parameter}` of `pd.read_json` has been ignored by Snowpark pandas API"
 

--- a/tests/integ/modin/io/test_read_parquet.py
+++ b/tests/integ/modin/io/test_read_parquet.py
@@ -39,7 +39,11 @@ def setup(session, resources_path):
     session.sql(f"DROP STAGE IF EXISTS {tmp_stage_name1}").collect()
 
 
-@sql_count_checker(query_count=9)
+@sql_count_checker(
+    query_count=10,
+    high_count_expected=True,
+    high_count_reason="Expected dtypes with parquet high query count",
+)
 def test_read_parquet_all_dtypes(resources_path):
     test_files = TestFiles(resources_path)
 
@@ -51,7 +55,7 @@ def test_read_parquet_all_dtypes(resources_path):
     assert_frame_equal(snow_df, native_df, check_index_type=False, check_dtype=False)
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_read_parquet_stage_file(resources_path):
     got = pd.read_parquet(f"@{tmp_stage_name1}/{test_file_parquet}")
     test_files = TestFiles(resources_path)
@@ -62,7 +66,11 @@ def test_read_parquet_stage_file(resources_path):
     assert_frame_equal(got, expected, check_dtype=False)
 
 
-@sql_count_checker(query_count=9)
+@sql_count_checker(
+    query_count=10,
+    high_count_expected=True,
+    high_count_reason="Expected special chars parquet high query count",
+)
 def test_read_parquet_special_chars_in_column_names(resources_path):
     test_files = TestFiles(resources_path)
     native_df = native_pd.read_parquet(
@@ -92,7 +100,7 @@ def test_read_parquet_special_chars_in_column_names(resources_path):
         [],
     ],
 )
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_read_parquet_columns(resources_path, columns):
 
     got = pd.read_parquet(f"@{tmp_stage_name1}/{test_file_parquet}", columns=columns)
@@ -133,7 +141,7 @@ def test_read_parquet_columns_invalid_types_negative(resources_path, columns):
     "columns",
     [["Ema!l", "non_existent_col"], ["non_existent_col_in_list"]],
 )
-@sql_count_checker(query_count=7)
+@sql_count_checker(query_count=8)
 def test_read_parquet_columns_non_existent_column_negative(resources_path, columns):
 
     with pytest.raises(
@@ -160,7 +168,11 @@ def test_read_parquet_unimplemented_parameter_negative():
         ("filters", [("foo", "==", "1")]),
     ],
 )
-@sql_count_checker(query_count=9)
+@sql_count_checker(
+    query_count=10,
+    high_count_expected=True,
+    high_count_reason="Expected high query count multiple reads",
+)
 def test_read_parquet_warning(caplog, parameter, argument):
     # generate a random temp name so these tests can be run in parallel
     temp_file_name = (

--- a/tests/integ/modin/io/test_read_snowflake.py
+++ b/tests/integ/modin/io/test_read_snowflake.py
@@ -88,19 +88,19 @@ def read_snowflake_and_verify_snapshot_creation_if_any(
     ]
 
     if relaxed_ordering:
-        assert len(filtered_query_history) == 0
+        assert len(filtered_query_history) == 1
     else:
         if materialization_expected:
             # when materialization happens, two queries are executed during read_snowflake:
             # 1) temp table creation out of the current table or query
             # 2) read only temp table creation
-            assert len(filtered_query_history) == 2
+            assert len(filtered_query_history) == 3
         else:
-            assert len(filtered_query_history) == 1
+            assert len(filtered_query_history) == 2
 
         # test if the scoped snapshot is created
         scoped_pattern = " SCOPED " if session._use_scoped_temp_read_only_table else " "
-        table_create_sql = query_history.queries[-1].sql_text
+        table_create_sql = query_history.queries[-2].sql_text
         table_create_pattern = f"CREATE OR REPLACE{scoped_pattern}TEMPORARY READ ONLY TABLE SNOWPARK_TEMP_TABLE_[0-9A-Z]+.*{READ_ONLY_TABLE_SUFFIX}.*"
         assert re.match(table_create_pattern, table_create_sql) is not None
 
@@ -116,7 +116,7 @@ def read_snowflake_and_verify_snapshot_creation_if_any(
 def test_read_snowflake_basic(
     setup_use_scoped_object, session, as_query, relaxed_ordering
 ):
-    expected_query_count = 5 if not relaxed_ordering else 3
+    expected_query_count = 7 if not relaxed_ordering else 5
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -150,7 +150,7 @@ def test_read_snowflake_basic(
 def test_read_snowflake_semi_structured_types(
     setup_use_scoped_object, session, as_query, relaxed_ordering
 ):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -173,7 +173,7 @@ def test_read_snowflake_semi_structured_types(
 )
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_none_nan(session, as_query, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -197,7 +197,7 @@ def test_read_snowflake_none_nan(session, as_query, relaxed_ordering):
 )
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_column_names(session, col_name, as_query, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -226,7 +226,7 @@ def test_read_snowflake_column_names(session, col_name, as_query, relaxed_orderi
 def test_read_snowflake_index_col(
     session, col_name1, col_name2, as_query, relaxed_ordering
 ):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -257,7 +257,7 @@ def test_read_snowflake_index_col(
 )
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_index_col_multiindex(session, as_query, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 3
+    expected_query_count = 5 if not relaxed_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -473,11 +473,11 @@ def test_read_snowflake_with_views(
     relaxed_ordering,
 ) -> None:
     # create a temporary test table
-    expected_query_count = 6 if not relaxed_ordering else 4
+    expected_query_count = 7 if not relaxed_ordering else 5
     original_table_type = "temporary"
     if table_type in ["", "temporary", "transient"]:
         original_table_type = table_type
-        expected_query_count = 3 if not relaxed_ordering else 2
+        expected_query_count = 4 if not relaxed_ordering else 3
     elif table_type == "MATERIALIZED VIEW":
         original_table_type = ""
     with SqlCounter(query_count=expected_query_count):
@@ -547,7 +547,7 @@ def test_read_snowflake_row_access_policy_table(
         f"alter table {test_table_name} add row access policy no_access_policy on (col1)"
     ).collect()
 
-    expected_query_count = 3 if not relaxed_ordering else 1
+    expected_query_count = 4 if not relaxed_ordering else 2
     with SqlCounter(query_count=expected_query_count):
         df = read_snowflake_and_verify_snapshot_creation_if_any(
             session, test_table_name, as_query, True, relaxed_ordering
@@ -593,7 +593,7 @@ def test_decimal(
     as_query,
     relaxed_ordering,
 ) -> None:
-    expected_query_count = 5 if not relaxed_ordering else 4
+    expected_query_count = 6 if not relaxed_ordering else 5
     with SqlCounter(query_count=expected_query_count):
         colname = "D"
         values_string = ",".join(f"({i})" for i in input_data)
@@ -623,8 +623,12 @@ def test_decimal(
 def test_read_snowflake_with_table_in_different_db(
     setup_use_scoped_object, session, caplog, as_query, relaxed_ordering
 ) -> None:
-    expected_query_count = 9 if not relaxed_ordering else 8
-    with SqlCounter(query_count=expected_query_count):
+    expected_query_count = 10 if not relaxed_ordering else 9
+    with SqlCounter(
+        query_count=expected_query_count,
+        high_count_expected=True,
+        high_count_reason="Expected high count temp table",
+    ):
         db_name = f"testdb_snowpandas_{Utils.random_alphanumeric_str(4)}"
         schema_name = f"testschema_snowpandas_{Utils.random_alphanumeric_str(4)}"
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/io/test_read_snowflake.py
+++ b/tests/integ/modin/io/test_read_snowflake.py
@@ -305,7 +305,7 @@ def test_read_snowflake_index_col_multiindex(session, as_query, relaxed_ordering
 def test_read_snowflake_non_existing(
     session, col_name, non_existing_index_col, index_col_or_columns, relaxed_ordering
 ):
-    expected_query_count = 2 if not relaxed_ordering else 1
+    expected_query_count = 3 if not relaxed_ordering else 2
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/io/test_read_snowflake.py
+++ b/tests/integ/modin/io/test_read_snowflake.py
@@ -331,7 +331,7 @@ def test_read_snowflake_non_existing(
 @pytest.mark.parametrize("col_name", VALID_SNOWFLAKE_COLUMN_NAMES)
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_columns(session, col_name, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -354,7 +354,7 @@ def test_read_snowflake_columns(session, col_name, relaxed_ordering):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_both_index_col_columns(session, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -375,8 +375,12 @@ def test_read_snowflake_both_index_col_columns(session, relaxed_ordering):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_duplicate_columns(session, relaxed_ordering):
-    expected_query_count = 7 if not relaxed_ordering else 3
-    with SqlCounter(query_count=expected_query_count):
+    expected_query_count = 11 if not relaxed_ordering else 7
+    with SqlCounter(
+        query_count=expected_query_count,
+        high_count_expected=True,
+        high_count_reason="Each read creates counts a single row to get an estimated upper bound for hybrid execution",
+    ):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         Utils.create_table(session, table_name, '"X" int, Y int', is_temporary=True)

--- a/tests/integ/modin/io/test_read_snowflake_iceberg.py
+++ b/tests/integ/modin/io/test_read_snowflake_iceberg.py
@@ -47,7 +47,7 @@ def test_read_snowflake_iceberg(session, relaxed_ordering):
         """
         ).collect()
 
-    expected_query_counts = [2, 0] if relaxed_ordering else [4, 2]
+    expected_query_counts = [3, 1] if relaxed_ordering else [6, 4]
 
     with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe directly from iceberg table

--- a/tests/integ/modin/io/test_read_snowflake_iceberg.py
+++ b/tests/integ/modin/io/test_read_snowflake_iceberg.py
@@ -47,7 +47,7 @@ def test_read_snowflake_iceberg(session, relaxed_ordering):
         """
         ).collect()
 
-    expected_query_counts = [3, 1] if relaxed_ordering else [6, 4]
+    expected_query_counts = [3, 1] if relaxed_ordering else [5, 3]
 
     with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe directly from iceberg table
@@ -61,6 +61,8 @@ def test_read_snowflake_iceberg(session, relaxed_ordering):
 
         # compare two dataframes
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
+
+    expected_query_counts = [3, 1] if relaxed_ordering else [6, 4]
 
     with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe from a query referencing an iceberg table

--- a/tests/integ/modin/io/test_read_snowflake_query_call.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_call.py
@@ -30,7 +30,7 @@ from tests.utils import Utils
     ],
 )
 def test_read_snowflake_call_sproc(session, relaxed_ordering):
-    expected_query_count = 7 if not relaxed_ordering else 5
+    expected_query_count = 9 if not relaxed_ordering else 5
     with SqlCounter(query_count=expected_query_count, sproc_count=1):
         session.sql(
             """
@@ -103,7 +103,7 @@ def filter_by_role(session, table_name, role):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_system_function(session, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         df = pd.read_snowflake(
             "SELECT SYSTEM$TYPEOF(TRUE)",

--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -17,8 +17,9 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_basic_cte(session, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
-    with SqlCounter(query_count=expected_query_count, union_count=2):
+    expected_query_count = 6 if not relaxed_ordering else 3
+    expected_union_count = 2 if not relaxed_ordering else 4
+    with SqlCounter(query_count=expected_query_count, union_count=expected_union_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -36,8 +37,9 @@ def test_read_snowflake_query_basic_cte(session, relaxed_ordering):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_recursive_cte(relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 1
-    with SqlCounter(query_count=expected_query_count, union_count=1):
+    expected_query_count = 5 if not relaxed_ordering else 2
+    expected_union_count = 1 if not relaxed_ordering else 2
+    with SqlCounter(query_count=expected_query_count, union_count=expected_union_count):
         SQL_QUERY = """WITH RECURSIVE current_f (current_val, previous_val) AS
                         (
                         SELECT 0, 1
@@ -62,8 +64,14 @@ def test_read_snowflake_query_recursive_cte(relaxed_ordering):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_complex_recursive_cte(session, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
-    with SqlCounter(query_count=expected_query_count, join_count=1, union_count=1):
+    expected_query_count = 6 if not relaxed_ordering else 3
+    expected_join_count = 1 if not relaxed_ordering else 2
+    expected_union_count = 1 if not relaxed_ordering else 2
+    with SqlCounter(
+        query_count=expected_query_count,
+        join_count=expected_join_count,
+        union_count=expected_union_count,
+    ):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.sql(
@@ -152,7 +160,7 @@ def test_read_snowflake_query_complex_recursive_cte(session, relaxed_ordering):
     ],
 )
 def test_read_snowflake_query_cte_with_cross_language_sproc(session, relaxed_ordering):
-    expected_query_count = 5 if not relaxed_ordering else 3
+    expected_query_count = 7 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count, sproc_count=1):
         # create table name
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -207,7 +215,7 @@ def test_read_snowflake_query_cte_with_cross_language_sproc(session, relaxed_ord
 def test_read_snowflake_query_cte_with_python_anonymous_sproc(
     session, relaxed_ordering
 ):
-    expected_query_count = 5 if not relaxed_ordering else 3
+    expected_query_count = 7 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count, sproc_count=1):
         # create table name
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/io/test_read_snowflake_query_order_by.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_order_by.py
@@ -24,7 +24,7 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_select_star_with_order_by(session, caplog, relaxed_ordering):
-    expected_query_count = 6 if not relaxed_ordering else 4
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # This test ensures that the presence of an ORDER BY causes us not to take the fastpath
         # of select * from table, where we just do `pd.read_snowflake("table")` instead.

--- a/tests/integ/modin/io/test_read_snowflake_query_order_by.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_order_by.py
@@ -24,7 +24,7 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_select_star_with_order_by(session, caplog, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # This test ensures that the presence of an ORDER BY causes us not to take the fastpath
         # of select * from table, where we just do `pd.read_snowflake("table")` instead.
@@ -55,7 +55,7 @@ def test_select_star_with_order_by(session, caplog, relaxed_ordering):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_no_order_by_but_column_name_shadows(session, caplog, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 1
+    expected_query_count = 5 if not relaxed_ordering else 2
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -81,7 +81,7 @@ def test_no_order_by_but_column_name_shadows(session, caplog, relaxed_ordering):
 def test_order_by_and_column_name_shadows(
     session, caplog, order_by_col, relaxed_ordering
 ):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         # Want random permutation, but need to make sure that there are no duplicates in the sorting column
@@ -112,7 +112,7 @@ def test_order_by_and_column_name_shadows(
 def test_order_by_as_column_name_should_not_warn_negative(
     session, caplog, relaxed_ordering
 ):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -138,7 +138,7 @@ def test_order_by_as_column_name_should_not_warn_negative(
 def test_inner_order_by_should_be_ignored_and_no_outer_order_by_negative(
     session, caplog, relaxed_ordering
 ):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -166,7 +166,7 @@ def test_inner_order_by_should_be_ignored_and_no_outer_order_by_negative(
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_order_by_with_no_limit_but_colname_shadows(session, caplog, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         native_df = native_pd.DataFrame(
@@ -191,7 +191,7 @@ def test_order_by_with_no_limit_but_colname_shadows(session, caplog, relaxed_ord
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_order_by_with_limit_and_name_shadows(session, caplog, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         native_df = native_pd.DataFrame(
@@ -214,8 +214,9 @@ def test_order_by_with_limit_and_name_shadows(session, caplog, relaxed_ordering)
 def test_read_snowflake_query_complex_query_with_join_and_order_by(
     session, caplog, relaxed_ordering
 ):
-    expected_query_count = 5 if not relaxed_ordering else 3
-    with SqlCounter(query_count=expected_query_count, join_count=1):
+    expected_query_count = 7 if not relaxed_ordering else 4
+    expected_join_count = 1 if not relaxed_ordering else 2
+    with SqlCounter(query_count=expected_query_count, join_count=expected_join_count):
         # create table
         table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -251,7 +252,7 @@ def test_read_snowflake_query_complex_query_with_join_and_order_by(
 @pytest.mark.parametrize("ordinal", [1, 2, 28])
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_order_by_with_position_key(session, ordinal, caplog, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         column_order = [
             "col12",

--- a/tests/integ/modin/io/test_read_snowflake_select_query.py
+++ b/tests/integ/modin/io/test_read_snowflake_select_query.py
@@ -33,7 +33,7 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_basic_query_with_weird_formatting(session, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -70,7 +70,7 @@ def test_read_snowflake_basic_query_with_weird_formatting(session, relaxed_order
 def test_read_snowflake_basic_query_with_comment_preceding_sql_inline_string(
     session, relaxed_ordering
 ):
-    expected_query_count = 5 if not relaxed_ordering else 2
+    expected_query_count = 7 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -120,7 +120,7 @@ def test_read_snowflake_basic_query_with_comment_preceding_sql_inline_string(
 def test_read_snowflake_basic_query_with_comment_preceding_sql_multiline_string(
     session, relaxed_ordering
 ):
-    expected_query_count = 5 if not relaxed_ordering else 2
+    expected_query_count = 7 if not relaxed_ordering else 2
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -160,7 +160,7 @@ def test_read_snowflake_basic_query_with_comment_preceding_sql_multiline_string(
 @pytest.mark.parametrize("only_nulls", [True, False])
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_none_nan_condition(session, only_nulls, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -191,7 +191,7 @@ def test_read_snowflake_query_none_nan_condition(session, only_nulls, relaxed_or
 def test_read_snowflake_query_aliased_columns(
     session, col_name_and_alias_tuple, relaxed_ordering
 ):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         col_name, alias = col_name_and_alias_tuple
@@ -217,7 +217,7 @@ def test_read_snowflake_query_aliased_columns(
 def test_read_snowflake_query_aliased_columns_and_columns_kwarg_specified(
     session, col_name_and_alias_tuple, relaxed_ordering
 ):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         col_name, alias = col_name_and_alias_tuple
@@ -241,7 +241,7 @@ def test_read_snowflake_query_aliased_columns_and_columns_kwarg_specified(
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_with_columns(session, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -263,7 +263,7 @@ def test_read_snowflake_query_with_columns(session, relaxed_ordering):
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_with_index_col_and_columns(session, relaxed_ordering):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -292,7 +292,7 @@ def test_read_snowflake_query_with_index_col_and_columns(session, relaxed_orderi
 def test_read_snowflake_query_with_index_col_and_columns_overlap(
     session, relaxed_ordering
 ):
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -318,7 +318,7 @@ def test_read_snowflake_query_with_index_col_and_columns_overlap(
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_additional_derived_column(session, relaxed_ordering):
-    expected_query_count = 4 if not relaxed_ordering else 2
+    expected_query_count = 6 if not relaxed_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -361,7 +361,7 @@ def test_read_snowflake_query_non_existing(
     non_existing_index_col,
     relaxed_ordering,
 ):
-    expected_query_count = 2 if not relaxed_ordering else 1
+    expected_query_count = 3 if not relaxed_ordering else 2
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -379,7 +379,7 @@ def test_read_snowflake_query_non_existing(
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_duplicate_columns(session, relaxed_ordering):
-    expected_query_count = 5 if not relaxed_ordering else 3
+    expected_query_count = 7 if not relaxed_ordering else 5
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -446,8 +446,9 @@ def test_read_snowflake_query_table_bad_sql_negative(bad_sql, relaxed_ordering) 
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_complex_query_with_join(session, relaxed_ordering):
-    expected_query_count = 5 if not relaxed_ordering else 3
-    with SqlCounter(query_count=expected_query_count, join_count=1):
+    expected_query_count = 7 if not relaxed_ordering else 4
+    expected_join_count = 1 if not relaxed_ordering else 2
+    with SqlCounter(query_count=expected_query_count, join_count=expected_join_count):
         # create table
         table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -485,7 +486,7 @@ def test_read_snowflake_query_complex_query_with_join(session, relaxed_ordering)
 
 @pytest.mark.parametrize("relaxed_ordering", [True, False])
 def test_read_snowflake_query_connect_by(session, relaxed_ordering):
-    expected_query_count = 6 if not relaxed_ordering else 4
+    expected_query_count = 8 if not relaxed_ordering else 5
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/series/test_apply_and_map.py
+++ b/tests/integ/modin/series/test_apply_and_map.py
@@ -288,7 +288,7 @@ class TestApplyOrMapCallable:
                 ),
             },
         ]
-        with SqlCounter(query_count=2):
+        with SqlCounter(query_count=3):
             snow_df = create_snow_df_with_table_and_data(
                 session,
                 random_name_for_temp_object(TempObjectType.TABLE),

--- a/tests/integ/modin/series/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/series/test_create_or_replace_dynamic_table.py
@@ -14,7 +14,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import Utils
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=7)
 def test_create_or_replace_dynamic_table_no_relaxed_ordering_raises(session) -> None:
     try:
         # create table
@@ -48,7 +48,7 @@ def test_create_or_replace_dynamic_table_no_relaxed_ordering_raises(session) -> 
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_create_or_replace_dynamic_table_relaxed_ordering(session) -> None:
     try:
         # create table
@@ -84,7 +84,7 @@ def test_create_or_replace_dynamic_table_relaxed_ordering(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,
@@ -131,7 +131,7 @@ def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_index(session, index, index_labels):
     try:
         # create table
@@ -174,7 +174,7 @@ def test_create_or_replace_dynamic_table_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/series/test_create_or_replace_view.py
+++ b/tests/integ/modin/series/test_create_or_replace_view.py
@@ -34,7 +34,7 @@ def test_create_or_replace_view_basic(session, native_pandas_ser_basic) -> None:
         Utils.drop_view(session, view_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_multiple_sessions_no_relaxed_ordering_raises(
     session,
     db_parameters,
@@ -76,7 +76,7 @@ def test_create_or_replace_view_multiple_sessions_no_relaxed_ordering_raises(
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_create_or_replace_view_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,
@@ -118,7 +118,7 @@ def test_create_or_replace_view_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_index(session, index, index_labels):
     try:
         # create table
@@ -155,7 +155,7 @@ def test_create_or_replace_view_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/series/test_str_accessor.py
+++ b/tests/integ/modin/series/test_str_accessor.py
@@ -624,7 +624,12 @@ def test_str_len_list_coin_base(session, enable_sql_simplifier):
     expected_udf_count = 2
     if session.sql_simplifier_enabled:
         expected_udf_count = 1
-    with SqlCounter(query_count=9, udf_count=expected_udf_count):
+    with SqlCounter(
+        query_count=10,
+        udf_count=expected_udf_count,
+        high_count_expected=True,
+        high_count_reason="Expected high count UDFs",
+    ):
         from tests.utils import Utils
 
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/series/test_to_dynamic_table.py
+++ b/tests/integ/modin/series/test_to_dynamic_table.py
@@ -14,7 +14,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import Utils
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=7)
 def test_to_dynamic_table_no_relaxed_ordering_raises(session) -> None:
     try:
         # create table
@@ -48,7 +48,7 @@ def test_to_dynamic_table_no_relaxed_ordering_raises(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_to_dynamic_table_relaxed_ordering(session) -> None:
     try:
         # create table
@@ -84,7 +84,7 @@ def test_to_dynamic_table_relaxed_ordering(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_to_dynamic_table_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,
@@ -131,7 +131,7 @@ def test_to_dynamic_table_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_index(session, index, index_labels):
     try:
         # create table
@@ -174,7 +174,7 @@ def test_to_dynamic_table_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/series/test_to_snowflake.py
+++ b/tests/integ/modin/series/test_to_snowflake.py
@@ -30,7 +30,7 @@ def _verify_num_rows(session, table_name: str, expected: int) -> None:
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=2, join_count=1)
+@sql_count_checker(query_count=3, join_count=1)
 def test_to_snowflake_index(test_table_name, snow_series, index, index_labels):
     snow_series.to_snowflake(
         test_table_name, if_exists="replace", index=index, index_label=index_labels
@@ -59,14 +59,14 @@ def test_to_snowflake_index_name_conflict_negative(test_table_name, snow_series)
         snow_series.to_snowflake(test_table_name, if_exists="replace", index_label="a")
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_index_label_none(test_table_name):
     snow_series = pd.Series([1, 2, 3], name="a", index=native_pd.Index([4, 5, 6]))
     snow_series.to_snowflake(test_table_name, if_exists="replace", index=True)
     _verify_columns(test_table_name, ["index", "a"])
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_multiindex(test_table_name, snow_series):
     index = native_pd.MultiIndex.from_arrays(
         [[1, 1, 2, 2], ["red", "blue", "red", "blue"]], names=("number", "color")
@@ -88,18 +88,18 @@ def test_to_snowflake_index_label_invalid_length_negative(test_table_name, snow_
 
 def test_to_snowflake_if_exists(session, test_table_name, snow_series):
     # Verify new table is created
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         snow_series.to_snowflake(test_table_name, if_exists="fail", index=False)
         _verify_columns(test_table_name, ["a"])
 
     # Verify existing table is replaced with new data
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         snow_series = pd.Series([4, 5, 6], name="b")
         snow_series.to_snowflake(test_table_name, if_exists="replace", index=False)
         _verify_columns(test_table_name, ["b"])
 
     # Verify data is appended to existing table
-    with SqlCounter(query_count=5):
+    with SqlCounter(query_count=6):
         _verify_num_rows(session, test_table_name, 3)
         snow_series.to_snowflake(test_table_name, if_exists="append", index=False)
         _verify_columns(test_table_name, ["b"])
@@ -125,7 +125,7 @@ def test_to_snowflake_if_exists_negative(session, test_table_name, snow_series):
 
 
 @pytest.mark.parametrize("index_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2, join_count=1)
+@sql_count_checker(query_count=3, join_count=1)
 def test_to_snowflake_index_column_labels(index_label, test_table_name, snow_series):
     snow_series.to_snowflake(
         test_table_name, if_exists="replace", index=True, index_label=index_label
@@ -134,7 +134,7 @@ def test_to_snowflake_index_column_labels(index_label, test_table_name, snow_ser
 
 
 @pytest.mark.parametrize("col_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2, join_count=1)
+@sql_count_checker(query_count=3, join_count=1)
 def test_to_snowflake_data_column_labels(col_label, test_table_name, snow_series):
     snow_series = snow_series.rename(col_label)
     snow_series.to_snowflake(test_table_name, if_exists="replace", index=False)

--- a/tests/integ/modin/series/test_to_view.py
+++ b/tests/integ/modin/series/test_to_view.py
@@ -33,7 +33,7 @@ def test_to_view_basic(session, native_pandas_ser_basic) -> None:
         Utils.drop_view(session, view_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_multiple_sessions_no_relaxed_ordering_raises(
     session,
     db_parameters,
@@ -74,7 +74,7 @@ def test_to_view_multiple_sessions_no_relaxed_ordering_raises(
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_to_view_multiple_sessions_relaxed_ordering(
     session,
     db_parameters,
@@ -115,7 +115,7 @@ def test_to_view_multiple_sessions_relaxed_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_index(session, index, index_labels):
     try:
         # create table
@@ -150,7 +150,7 @@ def test_to_view_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/strings/test_get_dummies_dataframe.py
+++ b/tests/integ/modin/strings/test_get_dummies_dataframe.py
@@ -204,7 +204,7 @@ def test_get_dummies_multiple_columns():
 # https://snowflakecomputing.atlassian.net/browse/SNOW-1050112
 # Customer issue: Calling get_dummies on the result of
 # pd.read_snowflake directly results in a ValueError.
-@sql_count_checker(query_count=3, join_count=2)
+@sql_count_checker(query_count=4, join_count=2)
 def test_get_dummies_pandas_after_read_snowflake(session):
     pandas_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/test_concat.py
+++ b/tests/integ/modin/test_concat.py
@@ -1108,7 +1108,7 @@ def test_concat_none_index_name(index1, index2):
     )
 
 
-@sql_count_checker(query_count=3, union_count=1)
+@sql_count_checker(query_count=5, union_count=1)
 def test_concat_from_file(resources_path):
     test_files = TestFiles(resources_path)
     df1 = native_pd.read_csv(test_files.test_concat_file1_csv)
@@ -1190,7 +1190,7 @@ def test_concat_object_with_same_index_with_dup_sort(join):
     assert_frame_equal(snow_res, expected_result)
 
 
-@sql_count_checker(query_count=4, join_count=0)
+@sql_count_checker(query_count=6, join_count=0)
 def test_concat_series_from_same_df(join):
     num_cols = 4
     select_data = [f'{i} as "{i}"' for i in range(num_cols)]
@@ -1213,7 +1213,7 @@ def test_concat_series_from_same_df(join):
     assert_frame_equal(df, final_df)
 
 
-@sql_count_checker(query_count=4, join_count=0)
+@sql_count_checker(query_count=6, join_count=0)
 def test_df_creation_from_series_from_same_df():
     num_cols = 6
     select_data = [f'{i} as "{i}"' for i in range(num_cols)]

--- a/tests/integ/modin/test_df_to_snowpark_pandas.py
+++ b/tests/integ/modin/test_df_to_snowpark_pandas.py
@@ -50,7 +50,7 @@ def tmp_table_basic(session):
 def test_to_snowpark_pandas_basic(
     session, tmp_table_basic, index_col, columns, relaxed_ordering
 ) -> None:
-    expected_query_count = 3 if not relaxed_ordering else 2
+    expected_query_count = 4 if not relaxed_ordering else 2
     # One less query when we don't have a multi-index
     with SqlCounter(
         query_count=expected_query_count

--- a/tests/integ/modin/test_df_to_snowpark_pandas.py
+++ b/tests/integ/modin/test_df_to_snowpark_pandas.py
@@ -50,7 +50,7 @@ def tmp_table_basic(session):
 def test_to_snowpark_pandas_basic(
     session, tmp_table_basic, index_col, columns, relaxed_ordering
 ) -> None:
-    expected_query_count = 3 if not relaxed_ordering else 1
+    expected_query_count = 3 if not relaxed_ordering else 2
     # One less query when we don't have a multi-index
     with SqlCounter(
         query_count=expected_query_count
@@ -93,7 +93,7 @@ def test_to_snowpark_pandas_basic(
 def test_to_snowpark_pandas_from_views(
     session, tmp_table_basic, relaxed_ordering
 ) -> None:
-    with SqlCounter(query_count=3 if not relaxed_ordering else 1):
+    with SqlCounter(query_count=4 if not relaxed_ordering else 2):
         snowpark_df = session.sql(
             f"SELECT ID, SHOE_MODEL FROM {tmp_table_basic} WHERE ID > 1"
         )
@@ -113,7 +113,7 @@ def test_to_snowpark_pandas_from_views(
 def test_to_snowpark_pandas_with_operations(
     session, tmp_table_basic, relaxed_ordering
 ) -> None:
-    with SqlCounter(query_count=3 if not relaxed_ordering else 1):
+    with SqlCounter(query_count=4 if not relaxed_ordering else 2):
         snowpark_df = session.table(tmp_table_basic)
         snowpark_df = (
             snowpark_df.select(

--- a/tests/integ/modin/test_dtype_mapping.py
+++ b/tests/integ/modin/test_dtype_mapping.py
@@ -336,13 +336,17 @@ def test_read_snowflake_data_types(
     expected_to_pandas,
 ):
     expected_query_count = (
-        9
+        10
         if isinstance(samples, list) and len(samples) > 1
-        else 5
+        else 6
         if "timestamp_tz" in col_name_type
-        else 4
+        else 5
     )
-    with SqlCounter(query_count=expected_query_count):
+    with SqlCounter(
+        query_count=expected_query_count,
+        high_count_expected=True,
+        high_count_reason="Getting table schema",
+    ):
         Utils.create_table(session, test_table_name, col_name_type, is_temporary=True)
         if not isinstance(samples, list):
             samples = [samples]

--- a/tests/integ/modin/test_dtype_mapping.py
+++ b/tests/integ/modin/test_dtype_mapping.py
@@ -403,7 +403,7 @@ def test_read_snowflake_data_types_negative(
     # However, in the future Snowpark's behavior may change to address this large-scale floating point number case
     # in a different way and we should refresh with their current behavior.
 
-    expected_query_count = 9 if isinstance(samples, list) and len(samples) > 1 else 4
+    expected_query_count = 9 if isinstance(samples, list) and len(samples) > 1 else 5
     with SqlCounter(query_count=expected_query_count):
         Utils.create_table(session, test_table_name, col_name_type, is_temporary=True)
         if not isinstance(samples, list):
@@ -486,7 +486,7 @@ def test_read_snowflake_data_types_array_undefined_negative(
     expected_to_pandas_dtype,
     expected_to_pandas,
 ):
-    expected_query_count = 8 if isinstance(samples, list) and len(samples) > 1 else 4
+    expected_query_count = 9 if isinstance(samples, list) and len(samples) > 1 else 5
     with SqlCounter(query_count=expected_query_count):
         Utils.create_table(session, test_table_name, col_name_type, is_temporary=True)
         if not isinstance(samples, list):

--- a/tests/integ/modin/test_from_pandas_to_pandas.py
+++ b/tests/integ/modin/test_from_pandas_to_pandas.py
@@ -477,7 +477,7 @@ def test_from_pandas_duplicate_labels():
         ("transient", 100),
     ],
 )
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_determinism_with_repeated_to_pandas(session, table_type, n_rows) -> None:
     ref_df = native_pd.DataFrame(
         {
@@ -548,7 +548,7 @@ def test_single_row_frame_to_series_to_pandas():
     assert_series_equal(snow_series, expected_series, check_dtype=False)
 
 
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_empty_variant_type_frame_to_pandas(session):
     # Tests type conversion of empty dataframes that have columns with the ARRAY and MAP types.
     # These dataframes must be constructed from pd.read_snowflake to have the correct type, since

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -63,7 +63,7 @@ def _extract_snowpark_pandas_telemetry_log_data(
 @patch(
     "snowflake.snowpark.modin.plugin._internal.telemetry._send_snowpark_pandas_telemetry_helper"
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_snowpark_pandas_telemetry_standalone_function_decorator(
     send_telemetry_mock,
     session,

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -760,7 +760,7 @@ def test_telemetry_cache_result():
     ]
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_telemetry_read_json(tmp_path):
     # read_json is overridden in io_overrides.py
     with open(tmp_path / "file.json", "w") as f:

--- a/tests/integ/modin/test_to_numpy.py
+++ b/tests/integ/modin/test_to_numpy.py
@@ -76,7 +76,7 @@ def test_to_numpy_basic(data, pandas_obj, func):
                 assert r1 == r2
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_tz_aware_data_to_numpy(session):
     table_name = random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(

--- a/tests/integ/modin/test_utils.py
+++ b/tests/integ/modin/test_utils.py
@@ -47,7 +47,7 @@ def test_create_snowpark_dataframe_with_readonly_temp_table(session, columns):
 
 
 @pytest.mark.parametrize("columns", [["A", "b", "C"], ['"a"', '"B"', '"c"']])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_create_snowpark_dataframe_with_no_readonly_temp_table(session, columns):
     num_rows = 10
     data = [[0] * len(columns) for _ in range(num_rows)]

--- a/tests/integ/modin/test_utils.py
+++ b/tests/integ/modin/test_utils.py
@@ -24,7 +24,7 @@ from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
 @pytest.mark.parametrize("columns", [["A", "b", "C"], ['"a"', '"B"', '"c"']])
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_create_snowpark_dataframe_with_readonly_temp_table(session, columns):
     num_rows = 10
     data = [[0] * len(columns) for _ in range(num_rows)]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1900040

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This PR adds a RowCountEstimator utility class to estimate the upper bound row count of an `OrderedDataFrame` after an operation.
