### PR TITLE
SNOW-1976643: Allow creating multi-session in sprocs if enabled

### DIFF
--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -557,11 +557,12 @@ class Session:
         conn: Union[ServerConnection, MockServerConnection, NopConnection],
         options: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if (len(_active_sessions) >= 1
-                and is_in_stored_procedure()
-                and not conn._get_client_side_session_parameter(
+        if (
+            len(_active_sessions) >= 1
+            and is_in_stored_procedure()
+            and not conn._get_client_side_session_parameter(
                 "ENABLE_CREATE_SESSION_IN_STORED_PROCS", False
-                )
+            )
         ):
             raise SnowparkClientExceptionMessages.DONT_CREATE_SESSION_IN_SP()
         self._conn = conn

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -557,7 +557,12 @@ class Session:
         conn: Union[ServerConnection, MockServerConnection, NopConnection],
         options: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if len(_active_sessions) >= 1 and is_in_stored_procedure():
+        if (len(_active_sessions) >= 1
+                and is_in_stored_procedure()
+                and not conn._get_client_side_session_parameter(
+                "ENABLE_CREATE_SESSION_IN_STORED_PROCS", False
+                )
+        ):
             raise SnowparkClientExceptionMessages.DONT_CREATE_SESSION_IN_SP()
         self._conn = conn
         self._query_tag = None

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -284,9 +284,17 @@ def test_create_session_in_sp(session):
     original_platform = internal_utils.PLATFORM
     internal_utils.PLATFORM = "XP"
     try:
-        with pytest.raises(SnowparkSessionException) as exec_info:
-            Session(session._conn)
-        assert exec_info.value.error_code == "1410"
+        if not session._conn._get_client_side_session_parameter(
+                "ENABLE_CREATE_SESSION_IN_STORED_PROCS", False
+        ):
+            with pytest.raises(SnowparkSessionException) as exec_info:
+                Session(session._conn)
+            assert exec_info.value.error_code == "1410"
+        else:
+            try:
+                Session(session._conn)
+            except SnowparkSessionException as e:
+                pytest.fail(f"Unexpected exception {e} was raised")
     finally:
         internal_utils.PLATFORM = original_platform
 

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -285,7 +285,7 @@ def test_create_session_in_sp(session):
     internal_utils.PLATFORM = "XP"
     try:
         if not session._conn._get_client_side_session_parameter(
-                "ENABLE_CREATE_SESSION_IN_STORED_PROCS", False
+            "ENABLE_CREATE_SESSION_IN_STORED_PROCS", False
         ):
             with pytest.raises(SnowparkSessionException) as exec_info:
                 Session(session._conn)

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -290,7 +290,9 @@ def test_create_session_in_sp(session):
             with pytest.raises(SnowparkSessionException) as exec_info:
                 Session(session._conn)
             assert exec_info.value.error_code == "1410"
-        else:
+        with patch.object(
+            session._conn, "_get_client_side_session_parameter", return_value=True
+        ):
             try:
                 Session(session._conn)
             except SnowparkSessionException as e:


### PR DESCRIPTION
1. Description:
With dbt project, we are planning on supporting multiple session insides procs. So we have added new API to _snowflake to create a pristine cloned version of the default server session. Using this, we will create a new new Snowpark session (a new object with new connection obj) and we will set the session_id of the connection (will be done in C API).  Currently we have a check in Snowpark lib which disallows creating multiple sessions inside sprocs. With this check we will that check the corresponding param is enabled (this param will only be enabled for dbt sprocs).

For more info on the multi-session project see this design doc: https://docs.google.com/document/d/1lwqyykHo549Vx3UWpFLWot1LIdYrwUjGKtGbQGaCnd8/edit?tab=t.0#heading=h.sil75ywnlm6n

An example of how this new API is used:
```
create or replace procedure get_session_sp()
returns string
language python
packages=('snowflake-snowpark-python')
runtime_version=3.8
handler='handler'
as
$$import _snowflake

def handler(session):
  new_session = _snowflake.create_session()
  new_session.sql('select foo')
  return 'done'
$$;
```
3. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)