### PR TITLE
SNOW-1916224: Ensure that all APIs have AST support

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -223,7 +223,7 @@ message FlattenMode {
   }
 }
 
-// dataframe.ir:230
+// dataframe.ir:232
 message JoinType {
   oneof variant {
     bool join_type__asof = 1;
@@ -741,14 +741,14 @@ message CreateDataframe {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:163
+// dataframe.ir:165
 message DataframeAgg {
   Expr df = 1;
   ExprArgList exprs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:168
+// dataframe.ir:170
 message DataframeAlias {
   Expr df = 1;
   string name = 2;
@@ -888,7 +888,7 @@ message DataframeCreateOrReplaceView {
   repeated Tuple_String_String statement_params = 6;
 }
 
-// dataframe.ir:173
+// dataframe.ir:175
 message DataframeCrossJoin {
   Expr lhs = 1;
   google.protobuf.StringValue lsuffix = 2;
@@ -904,48 +904,48 @@ message DataframeCube {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:180
+// dataframe.ir:182
 message DataframeDescribe {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:185
+// dataframe.ir:187
 message DataframeDistinct {
   Expr df = 1;
   SrcPosition src = 2;
 }
 
-// dataframe.ir:189
+// dataframe.ir:191
 message DataframeDrop {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:194
+// dataframe.ir:196
 message DataframeDropDuplicates {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:199
+// dataframe.ir:201
 message DataframeExcept {
   Expr df = 1;
   Expr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:204
+// dataframe.ir:206
 message DataframeFilter {
   Expr condition = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:218
+// dataframe.ir:220
 message DataframeFirst {
   bool block = 1;
   Expr df = 2;
@@ -954,7 +954,7 @@ message DataframeFirst {
   repeated Tuple_String_String statement_params = 5;
 }
 
-// dataframe.ir:209
+// dataframe.ir:211
 message DataframeFlatten {
   Expr df = 1;
   Expr input = 2;
@@ -979,14 +979,14 @@ message DataframeGroupByGroupingSets {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:225
+// dataframe.ir:227
 message DataframeIntersect {
   Expr df = 1;
   Expr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:241
+// dataframe.ir:243
 message DataframeJoin {
   Expr join_expr = 1;
   JoinType join_type = 2;
@@ -998,14 +998,14 @@ message DataframeJoin {
   SrcPosition src = 8;
 }
 
-// dataframe.ir:251
+// dataframe.ir:253
 message DataframeJoinTableFunction {
   Expr fn = 1;
   Expr lhs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:256
+// dataframe.ir:258
 message DataframeLimit {
   Expr df = 1;
   int64 n = 2;
@@ -1033,25 +1033,27 @@ message DataframeNaDrop_Scala {
 // dataframe.ir:142
 message DataframeNaFill {
   Expr df = 1;
-  SrcPosition src = 2;
-  ExprArgList subset = 3;
-  Expr value = 4;
-  repeated Tuple_String_Expr value_map = 5;
-}
-
-// dataframe.ir:149
-message DataframeNaReplace {
-  Expr df = 1;
-  repeated Tuple_Expr_Expr replacement_map = 2;
+  bool include_decimal = 2;
   SrcPosition src = 3;
   ExprArgList subset = 4;
-  repeated Expr to_replace_list = 5;
-  Expr to_replace_value = 6;
-  Expr value = 7;
-  repeated Expr values = 8;
+  Expr value = 5;
+  repeated Tuple_String_Expr value_map = 6;
 }
 
-// dataframe.ir:262
+// dataframe.ir:150
+message DataframeNaReplace {
+  Expr df = 1;
+  bool include_decimal = 2;
+  repeated Tuple_Expr_Expr replacement_map = 3;
+  SrcPosition src = 4;
+  ExprArgList subset = 5;
+  repeated Expr to_replace_list = 6;
+  Expr to_replace_value = 7;
+  Expr value = 8;
+  repeated Expr values = 9;
+}
+
+// dataframe.ir:264
 message DataframeNaturalJoin {
   JoinType join_type = 1;
   Expr lhs = 2;
@@ -1068,7 +1070,7 @@ message DataframePivot {
   PivotValue values = 5;
 }
 
-// dataframe.ir:276
+// dataframe.ir:278
 message DataframeRandomSplit {
   Expr df = 1;
   google.protobuf.Int64Value seed = 2;
@@ -1117,7 +1119,7 @@ message DataframeRef {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:283
+// dataframe.ir:285
 message DataframeRename {
   Expr col_or_mapper = 1;
   Expr df = 2;
@@ -1132,7 +1134,7 @@ message DataframeRollup {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:289
+// dataframe.ir:291
 message DataframeSample {
   Expr df = 1;
   google.protobuf.Int64Value num = 2;
@@ -1141,7 +1143,7 @@ message DataframeSample {
   SrcPosition src = 5;
 }
 
-// dataframe.ir:296
+// dataframe.ir:298
 message DataframeSelect {
   ExprArgList cols = 1;
   Expr df = 2;
@@ -1156,7 +1158,7 @@ message DataframeShow {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:303
+// dataframe.ir:305
 message DataframeSort {
   Expr ascending = 1;
   ExprArgList cols = 2;
@@ -1240,7 +1242,7 @@ message DataframeToPandasBatches {
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe.ir:309
+// dataframe.ir:311
 message DataframeUnion {
   bool all = 1;
   bool allow_missing_columns = 2;
@@ -1250,7 +1252,7 @@ message DataframeUnion {
   SrcPosition src = 6;
 }
 
-// dataframe.ir:268
+// dataframe.ir:270
 message DataframeUnpivot {
   repeated Expr column_list = 1;
   Expr df = 2;
@@ -1260,7 +1262,7 @@ message DataframeUnpivot {
   string value_column = 6;
 }
 
-// dataframe.ir:317
+// dataframe.ir:319
 message DataframeWithColumn {
   Expr col = 1;
   string col_name = 2;
@@ -1268,7 +1270,7 @@ message DataframeWithColumn {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:323
+// dataframe.ir:325
 message DataframeWithColumnRenamed {
   Expr col = 1;
   Expr df = 2;
@@ -1276,7 +1278,7 @@ message DataframeWithColumnRenamed {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:329
+// dataframe.ir:331
 message DataframeWithColumns {
   repeated string col_names = 1;
   Expr df = 2;
@@ -1629,7 +1631,7 @@ message Geq {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:335
+// dataframe.ir:337
 message GroupingSets {
   ExprArgList sets = 1;
   SrcPosition src = 2;
@@ -2246,8 +2248,8 @@ message TableFnCallAlias {
 // fn.ir:151
 message TableFnCallOver {
   Expr lhs = 1;
-  repeated Expr order_by = 2;
-  repeated Expr partition_by = 3;
+  ExprArgList order_by = 2;
+  ExprArgList partition_by = 3;
   SrcPosition src = 4;
 }
 
@@ -2283,7 +2285,7 @@ message TableUpdate {
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe.ir:339
+// dataframe.ir:341
 message ToSnowparkPandas {
   repeated string columns = 1;
   Expr df = 2;

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -2213,7 +2213,7 @@ class DataFrame:
                 for c in col_list:
                     build_expr_from_snowpark_column_or_col_name(expr.cols.args.add(), c)
 
-                expr.df.dataframe_ref.id.bitfield1 = self._ast_id
+                self._set_ast_ref(expr.df)
             else:
                 stmt = _ast_stmt
 

--- a/src/snowflake/snowpark/dataframe_na_functions.py
+++ b/src/snowflake/snowpark/dataframe_na_functions.py
@@ -410,6 +410,7 @@ class DataFrameNaFunctions:
                 ast.subset.variadic = False
                 for col in subset:
                     build_expr_from_python_val(ast.subset.args.add(), col)
+            ast.include_decimal = include_decimal
 
         if subset is None:
             subset = self._dataframe.columns
@@ -633,6 +634,7 @@ class DataFrameNaFunctions:
                 ast.subset.variadic = False
                 for col in subset:
                     build_expr_from_python_val(ast.subset.args.add(), col)
+            ast.include_decimal = include_decimal
 
         # Modify subset.
         if subset is None:

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -155,6 +155,7 @@ class DataFrameWriter:
 
         return self
 
+    @publicapi
     def partition_by(
         self, expr: ColumnOrSqlExpr, _emit_ast: bool = True
     ) -> "DataFrameWriter":
@@ -172,6 +173,7 @@ class DataFrameWriter:
 
         return self
 
+    @publicapi
     def option(self, key: str, value: Any, _emit_ast: bool = True) -> "DataFrameWriter":
         """Depending on the ``file_format_type`` specified, you can include more format specific options.
         Use the options documented in the `Format Type Options <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html#format-type-options-formattypeoptions>`__.
@@ -188,7 +190,10 @@ class DataFrameWriter:
 
         return self
 
-    def options(self, configs: Optional[Dict] = None, **kwargs) -> "DataFrameWriter":
+    @publicapi
+    def options(
+        self, configs: Optional[Dict] = None, _emit_ast: bool = True, **kwargs
+    ) -> "DataFrameWriter":
         """Sets multiple specified options for this :class:`DataFrameWriter`.
 
         This method is same as calling :meth:`option` except that you can set multiple options at once.
@@ -203,7 +208,7 @@ class DataFrameWriter:
             configs = kwargs
 
         for k, v in configs.items():
-            self.option(k, v)
+            self.option(k, v, _emit_ast=_emit_ast)
         return self
 
     @overload
@@ -344,7 +349,9 @@ class DataFrameWriter:
             # Add an Assign node that applies WriteTable() to the input, followed by its Eval.
             repr = self._dataframe._session._ast_batch.assign()
             expr = with_src_position(repr.expr.write_table)
-            debug_check_missing_ast(self._ast_stmt, self._dataframe._session, self)
+            debug_check_missing_ast(
+                self._ast_stmt, self._dataframe._session, self._dataframe
+            )
             expr.id.bitfield1 = self._ast_stmt.var_id.bitfield1
 
             # Function signature:
@@ -597,7 +604,9 @@ class DataFrameWriter:
             # Add an Assign node that applies WriteCopyIntoLocation() to the input, followed by its Eval.
             repr = self._dataframe._session._ast_batch.assign()
             expr = with_src_position(repr.expr.write_copy_into_location)
-            debug_check_missing_ast(self._ast_stmt, self._dataframe._session, self)
+            debug_check_missing_ast(
+                self._ast_stmt, self._dataframe._session, self._dataframe
+            )
             expr.id.bitfield1 = self._ast_stmt.var_id.bitfield1
 
             fill_write_file(
@@ -789,7 +798,9 @@ class DataFrameWriter:
             # Add an Assign node that applies WriteCsv() to the input, followed by its Eval.
             repr = self._dataframe._session._ast_batch.assign()
             expr = with_src_position(repr.expr.write_csv)
-            debug_check_missing_ast(self._ast_stmt, self._dataframe._session, self)
+            debug_check_missing_ast(
+                self._ast_stmt, self._dataframe._session, self._dataframe
+            )
             expr.id.bitfield1 = self._ast_stmt.var_id.bitfield1
 
             fill_write_file(
@@ -861,7 +872,9 @@ class DataFrameWriter:
             # Add an Assign node that applies WriteJson() to the input, followed by its Eval.
             repr = self._dataframe._session._ast_batch.assign()
             expr = with_src_position(repr.expr.write_json)
-            debug_check_missing_ast(self._ast_stmt, self._dataframe._session, self)
+            debug_check_missing_ast(
+                self._ast_stmt, self._dataframe._session, self._dataframe
+            )
             expr.id.bitfield1 = self._ast_stmt.var_id.bitfield1
 
             fill_write_file(
@@ -933,7 +946,9 @@ class DataFrameWriter:
             # Add an Assign node that applies WriteParquet() to the input, followed by its Eval.
             repr = self._dataframe._session._ast_batch.assign()
             expr = with_src_position(repr.expr.write_parquet)
-            debug_check_missing_ast(self._ast_stmt, self._dataframe._session, self)
+            debug_check_missing_ast(
+                self._ast_stmt, self._dataframe._session, self._dataframe
+            )
             expr.id.bitfield1 = self._ast_stmt.var_id.bitfield1
 
             fill_write_file(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1376,8 +1376,8 @@ class Session:
             else self._session_stage
         )
         file_list = (
-            self.sql(f"ls {normalized}")
-            .select('"name"')
+            self.sql(f"ls {normalized}", _emit_ast=False)
+            .select('"name"', _emit_ast=False)
             ._internal_collect_with_tag(statement_params=statement_params)
         )
         prefix_length = get_stage_file_prefix_length(stage_location)
@@ -2043,7 +2043,8 @@ class Session:
                     row[0]: row[1] if row[1] else []
                     for row in (
                         self.sql(
-                            f"SELECT t.$1 as signature, t.$2 as packages from {normalized_metadata_path} t"
+                            f"SELECT t.$1 as signature, t.$2 as packages from {normalized_metadata_path} t",
+                            _emit_ast=False,
                         )._internal_collect_with_tag()
                     )
                 }
@@ -2148,9 +2149,10 @@ class Session:
             row[0]: row[1].split("|") if row[1] else []
             for row in (
                 self.sql(
-                    f"SELECT t.$1 as signature, t.$2 as packages from {normalize_remote_file_or_dir(metadata_file_path)} t"
+                    f"SELECT t.$1 as signature, t.$2 as packages from {normalize_remote_file_or_dir(metadata_file_path)} t",
+                    _emit_ast=False,
                 )
-                .filter(col("signature") == environment_signature)
+                .filter(col("signature") == environment_signature, _emit_ast=False)
                 ._internal_collect_with_tag()
             )
         }
@@ -2183,7 +2185,7 @@ class Session:
         package_to_version_mapping = (
             {
                 p[0]: json.loads(p[1])
-                for p in self.table(package_table_name)
+                for p in self.table(package_table_name, _emit_ast=False)
                 .filter(
                     (col("language", _emit_ast=False) == "python")
                     & (
@@ -2240,7 +2242,7 @@ class Session:
         Fetches the current sessions query tag.
         """
         remote_tag_rows = self.sql(
-            "SHOW PARAMETERS LIKE 'QUERY_TAG'"
+            "SHOW PARAMETERS LIKE 'QUERY_TAG'", _emit_ast=False
         )._internal_collect_with_tag_no_telemetry()
 
         # Check if the result has the expected schema
@@ -3330,6 +3332,7 @@ class Session:
                         auto_create_table=True,
                         table_type="temporary",
                         use_logical_type=self._use_logical_type_for_create_df,
+                        _emit_ast=False,
                     )
                     set_api_call_source(table, "Session.create_dataframe[arrow]")
                 else:
@@ -3342,6 +3345,7 @@ class Session:
                         auto_create_table=True,
                         table_type="temporary",
                         use_logical_type=self._use_logical_type_for_create_df,
+                        _emit_ast=False,
                     )
                     set_api_call_source(table, "Session.create_dataframe[pandas]")
 

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -708,6 +708,7 @@ class Table(DataFrame):
         ...  # pragma: no cover
 
     @overload
+    @publicapi
     def merge(
         self,
         source: DataFrame,

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -115,23 +115,27 @@ class TableFunctionCall:
             expr.lhs.CopyFrom(self._ast)
             if partition_by is not None:
                 if isinstance(partition_by, (str, Column)):
+                    expr.partition_by.variadic = True
                     build_expr_from_snowpark_column_or_col_name(
-                        expr.partition_by.add(), partition_by
+                        expr.partition_by.args.add(), partition_by
                     )
                 else:
+                    expr.partition_by.variadic = False
                     for partition_clause in partition_by:
                         build_expr_from_snowpark_column_or_col_name(
-                            expr.partition_by.add(), partition_clause
+                            expr.partition_by.args.add(), partition_clause
                         )
             if order_by is not None:
                 if isinstance(order_by, (str, Column)):
+                    expr.order_by.variadic = True
                     build_expr_from_snowpark_column_or_col_name(
-                        expr.order_by.add(), order_by
+                        expr.order_by.args.add(), order_by
                     )
                 else:
+                    expr.order_by.variadic = False
                     for order_clause in order_by:
                         build_expr_from_snowpark_column_or_col_name(
-                            expr.order_by.add(), order_clause
+                            expr.order_by.args.add(), order_clause
                         )
 
         new_table_function = TableFunctionCall(

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -91,6 +91,7 @@ class UserDefinedAggregateFunction:
         self._ast = _ast
         self._ast_id = _ast_id
 
+    @publicapi
     def __call__(
         self,
         *cols: Union[ColumnOrName, Iterable[ColumnOrName]],
@@ -334,7 +335,8 @@ class UDAFRegistration:
         """
         func_args = [convert_sp_to_sf_type(t) for t in udaf_obj._input_types]
         return self._session.sql(
-            f"describe function {udaf_obj.name}({','.join(func_args)})"
+            f"describe function {udaf_obj.name}({','.join(func_args)})",
+            _emit_ast=False,
         )
 
     # TODO: Support strict/secure once the server side supports these keywords in Python UDAF

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -102,6 +102,7 @@ class UserDefinedFunction:
         self._ast = _ast
         self._ast_id = _ast_id
 
+    @publicapi
     def __call__(
         self, *cols: Union[ColumnOrName, Iterable[ColumnOrName]], _emit_ast: bool = True
     ) -> Column:

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -106,6 +106,7 @@ class UserDefinedTableFunction:
         self._ast = _ast
         self._ast_id = _ast_id
 
+    @publicapi
     def __call__(
         self,
         *arguments: Union[ColumnOrName, Iterable[ColumnOrName]],

--- a/src/snowflake/snowpark/window.py
+++ b/src/snowflake/snowpark/window.py
@@ -105,11 +105,13 @@ class Window:
     currentRow: int = CURRENT_ROW
 
     @staticmethod
+    @publicapi
     def partition_by(
         *cols: Union[
             ColumnOrName,
             Iterable[ColumnOrName],
-        ]
+        ],
+        _emit_ast: bool = True,
     ) -> "WindowSpec":
         """
         Returns a :class:`WindowSpec` object with partition by clause.
@@ -118,7 +120,7 @@ class Window:
             cols: A column, as :class:`str`, :class:`~snowflake.snowpark.column.Column`
                 or a list of those.
         """
-        return Window._spec().partition_by(*cols)
+        return Window._spec().partition_by(*cols, _emit_ast=_emit_ast)
 
     @staticmethod
     @publicapi

--- a/tests/ast/conftest.py
+++ b/tests/ast/conftest.py
@@ -223,3 +223,8 @@ def session(local_testing_mode):
 @pytest.fixture(scope="function")
 def tables(session):
     return TestTables(session)
+
+
+@pytest.fixture(scope="session")
+def resources_path() -> str:
+    return os.path.normpath(os.path.join(os.path.dirname(__file__), "../resources"))

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -20,19 +20,19 @@ fill1 = df.na.fill(42)
 
 fill2 = df.na.fill({"NUM": 42, "STR": "abc"})
 
-fill3 = df.na.fill(42, subset="NUM")
+fill3 = df.na.fill(42, subset="NUM", include_decimal=True)
 
 fill4 = df.na.fill("def", subset=["STR"])
 
-fill5 = df.na.fill(42, subset=[])
+fill5 = df.na.fill(42, subset=[], include_decimal=True)
 
-replace1 = df.na.replace({1: 10, "three": "trzy"})
+replace1 = df.na.replace({1: 10, "three": "trzy"}, include_decimal=True)
 
 replace2 = df.na.replace([1, 2], [10, 20])
 
-replace3 = df.na.replace(1, 10, subset=["NUM"])
+replace3 = df.na.replace(1, 10, subset=["NUM"], include_decimal=True)
 
-replace4 = df.na.replace(1, 10, subset=[])
+replace4 = df.na.replace(1, 10, subset=[], include_decimal=False)
 
 ## EXPECTED UNPARSER OUTPUT
 
@@ -52,23 +52,23 @@ drop6 = df.na.drop("any", 42, ["NUM"])
 
 drop7 = df.na.drop("any", [])
 
-fill1 = df.na.fill(42)
+fill1 = df.na.fill(42, include_decimal=False)
 
-fill2 = df.na.fill({"NUM": 42, "STR": "abc"})
+fill2 = df.na.fill({"NUM": 42, "STR": "abc"}, include_decimal=False)
 
-fill3 = df.na.fill(42, "NUM")
+fill3 = df.na.fill(42, "NUM", include_decimal=True)
 
-fill4 = df.na.fill("def", ["STR"])
+fill4 = df.na.fill("def", ["STR"], include_decimal=False)
 
-fill5 = df.na.fill(42, [])
+fill5 = df.na.fill(42, [], include_decimal=True)
 
-replace1 = df.na.replace({1: 10, "three": "trzy"}, None)
+replace1 = df.na.replace({1: 10, "three": "trzy"}, None, include_decimal=True)
 
-replace2 = df.na.replace([1, 2], [10, 20])
+replace2 = df.na.replace([1, 2], [10, 20], include_decimal=False)
 
-replace3 = df.na.replace(1, 10, ["NUM"])
+replace3 = df.na.replace(1, 10, ["NUM"], include_decimal=True)
 
-replace4 = df.na.replace(1, 10, [])
+replace4 = df.na.replace(1, 10, [], include_decimal=False)
 
 ## EXPECTED ENCODED AST
 
@@ -497,8 +497,9 @@ body {
             }
           }
         }
+        include_decimal: true
         src {
-          end_column: 44
+          end_column: 66
           end_line: 45
           file: 2
           start_column: 16
@@ -508,7 +509,7 @@ body {
           args {
             string_val {
               src {
-                end_column: 44
+                end_column: 66
                 end_line: 45
                 file: 2
                 start_column: 16
@@ -522,7 +523,7 @@ body {
         value {
           int64_val {
             src {
-              end_column: 44
+              end_column: 66
               end_line: 45
               file: 2
               start_column: 16
@@ -608,8 +609,9 @@ body {
             }
           }
         }
+        include_decimal: true
         src {
-          end_column: 41
+          end_column: 63
           end_line: 49
           file: 2
           start_column: 16
@@ -620,7 +622,7 @@ body {
         value {
           int64_val {
             src {
-              end_column: 41
+              end_column: 63
               end_line: 49
               file: 2
               start_column: 16
@@ -651,11 +653,12 @@ body {
             }
           }
         }
+        include_decimal: true
         replacement_map {
           _1 {
             int64_val {
               src {
-                end_column: 58
+                end_column: 80
                 end_line: 51
                 file: 2
                 start_column: 19
@@ -667,7 +670,7 @@ body {
           _2 {
             int64_val {
               src {
-                end_column: 58
+                end_column: 80
                 end_line: 51
                 file: 2
                 start_column: 19
@@ -681,7 +684,7 @@ body {
           _1 {
             string_val {
               src {
-                end_column: 58
+                end_column: 80
                 end_line: 51
                 file: 2
                 start_column: 19
@@ -693,7 +696,7 @@ body {
           _2 {
             string_val {
               src {
-                end_column: 58
+                end_column: 80
                 end_line: 51
                 file: 2
                 start_column: 19
@@ -704,7 +707,7 @@ body {
           }
         }
         src {
-          end_column: 58
+          end_column: 80
           end_line: 51
           file: 2
           start_column: 19
@@ -713,7 +716,7 @@ body {
         value {
           null_val {
             src {
-              end_column: 58
+              end_column: 80
               end_line: 51
               file: 2
               start_column: 19
@@ -820,8 +823,9 @@ body {
             }
           }
         }
+        include_decimal: true
         src {
-          end_column: 55
+          end_column: 77
           end_line: 55
           file: 2
           start_column: 19
@@ -831,7 +835,7 @@ body {
           args {
             string_val {
               src {
-                end_column: 55
+                end_column: 77
                 end_line: 55
                 file: 2
                 start_column: 19
@@ -844,7 +848,7 @@ body {
         to_replace_value {
           int64_val {
             src {
-              end_column: 55
+              end_column: 77
               end_line: 55
               file: 2
               start_column: 19
@@ -856,7 +860,7 @@ body {
         value {
           int64_val {
             src {
-              end_column: 55
+              end_column: 77
               end_line: 55
               file: 2
               start_column: 19
@@ -888,7 +892,7 @@ body {
           }
         }
         src {
-          end_column: 50
+          end_column: 73
           end_line: 57
           file: 2
           start_column: 19
@@ -899,7 +903,7 @@ body {
         to_replace_value {
           int64_val {
             src {
-              end_column: 50
+              end_column: 73
               end_line: 57
               file: 2
               start_column: 19
@@ -911,7 +915,7 @@ body {
         value {
           int64_val {
             src {
-              end_column: 50
+              end_column: 73
               end_line: 57
               file: 2
               start_column: 19

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -2,6 +2,10 @@
 
 df = session.create_dataframe([(1, 1),(1, 2),(2, 1),(2, 2),(3, 1),(3, 2)], schema=["a", "b"])
 
+df.group_by("a").min("b").collect()
+
+df.group_by("a").max("b").collect()
+
 df.group_by("a").median("b").collect()
 
 df.group_by("a").function("avg")("b").collect()
@@ -26,8 +30,7 @@ df.group_by("location").apply_in_pandas(convert,
 
 df = session.create_dataframe([(1, 'A', 10000, 'JAN'), (1, 'B', 400, 'JAN'), (1, 'B', 5000, 'FEB')], schema=['empid', 'team', 'amount', 'month'])
 
-# Does not work because __getitem__ is missing.
-# df.group_by("empid").pivot("month", ['JAN', 'FEB']).sum("amount").sort(df["empid"]).show()
+df.group_by("empid").pivot("month", ['JAN', 'FEB']).sum("amount").sort(df["empid"]).show()
 
 df.group_by("empid").pivot("month", ['JAN', 'FEB']).sum("amount").show()
 
@@ -37,19 +40,25 @@ df.group_by(["empid", "team"]).pivot("month").sum("amount").sort("empid", "team"
 
 df = session.create_dataframe([(1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2)], schema=["a", "b"])
 
+df.group_by("a").min("b").collect()
+
+df.group_by("a").max("b").collect()
+
 df.group_by("a").median("b").collect()
 
 df.group_by("a").avg("b").collect()
 
-res8 = df.group_by("a").count()
+res14 = df.group_by("a").count()
 
 df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)], schema=["location", "temp_c"])
 
-res10 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+res16 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.group_by("location").apply_in_pandas(convert, StructType(fields=[StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 
 df = session.create_dataframe([(1, "A", 10000, "JAN"), (1, "B", 400, "JAN"), (1, "B", 5000, "FEB")], schema=["empid", "team", "amount", "month"])
+
+df.group_by("empid").pivot("month", values=["JAN", "FEB"]).sum("amount").sort(df["empid"]).show()
 
 df.group_by("empid").pivot("month", values=["JAN", "FEB"]).sum("amount").show()
 
@@ -355,12 +364,12 @@ body {
   assign {
     expr {
       relational_grouped_dataframe_builtin {
-        agg_name: "median"
+        agg_name: "min"
         cols {
           args {
             string_val {
               src {
-                end_column: 36
+                end_column: 33
                 end_line: 27
                 file: 2
                 start_column: 8
@@ -379,7 +388,7 @@ body {
           }
         }
         src {
-          end_column: 36
+          end_column: 33
           end_line: 27
           file: 2
           start_column: 8
@@ -405,7 +414,7 @@ body {
           bitfield1: 3
         }
         src {
-          end_column: 46
+          end_column: 43
           end_line: 27
           file: 2
           start_column: 8
@@ -476,12 +485,12 @@ body {
   assign {
     expr {
       relational_grouped_dataframe_builtin {
-        agg_name: "avg"
+        agg_name: "max"
         cols {
           args {
             string_val {
               src {
-                end_column: 45
+                end_column: 33
                 end_line: 29
                 file: 2
                 start_column: 8
@@ -500,7 +509,7 @@ body {
           }
         }
         src {
-          end_column: 45
+          end_column: 33
           end_line: 29
           file: 2
           start_column: 8
@@ -526,7 +535,7 @@ body {
           bitfield1: 7
         }
         src {
-          end_column: 55
+          end_column: 43
           end_line: 29
           file: 2
           start_column: 8
@@ -597,7 +606,22 @@ body {
   assign {
     expr {
       relational_grouped_dataframe_builtin {
-        agg_name: "count"
+        agg_name: "median"
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 36
+                end_line: 31
+                file: 2
+                start_column: 8
+                start_line: 31
+              }
+              v: "b"
+            }
+          }
+          variadic: true
+        }
         grouped_df {
           relational_grouped_dataframe_ref {
             id {
@@ -606,7 +630,7 @@ body {
           }
         }
         src {
-          end_column: 32
+          end_column: 36
           end_line: 31
           file: 2
           start_column: 8
@@ -625,6 +649,233 @@ body {
 body {
   assign {
     expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 11
+        }
+        src {
+          end_column: 46
+          end_line: 31
+          file: 2
+          start_column: 8
+          start_line: 31
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 12
+    var_id {
+      bitfield1: 12
+    }
+  }
+}
+body {
+  eval {
+    uid: 13
+    var_id {
+      bitfield1: 12
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_group_by {
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 24
+                end_line: 33
+                file: 2
+                start_column: 8
+                start_line: 33
+              }
+              v: "a"
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 24
+          end_line: 33
+          file: 2
+          start_column: 8
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 14
+    var_id {
+      bitfield1: 14
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      relational_grouped_dataframe_builtin {
+        agg_name: "avg"
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 45
+                end_line: 33
+                file: 2
+                start_column: 8
+                start_line: 33
+              }
+              v: "b"
+            }
+          }
+          variadic: true
+        }
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 14
+            }
+          }
+        }
+        src {
+          end_column: 45
+          end_line: 33
+          file: 2
+          start_column: 8
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 15
+    var_id {
+      bitfield1: 15
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 15
+        }
+        src {
+          end_column: 55
+          end_line: 33
+          file: 2
+          start_column: 8
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 16
+    var_id {
+      bitfield1: 16
+    }
+  }
+}
+body {
+  eval {
+    uid: 17
+    var_id {
+      bitfield1: 16
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_group_by {
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 24
+                end_line: 35
+                file: 2
+                start_column: 8
+                start_line: 35
+              }
+              v: "a"
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 24
+          end_line: 35
+          file: 2
+          start_column: 8
+          start_line: 35
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 18
+    var_id {
+      bitfield1: 18
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      relational_grouped_dataframe_builtin {
+        agg_name: "count"
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 18
+            }
+          }
+        }
+        src {
+          end_column: 32
+          end_line: 35
+          file: 2
+          start_column: 8
+          start_line: 35
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 19
+    var_id {
+      bitfield1: 19
+    }
+  }
+}
+body {
+  assign {
+    expr {
       create_dataframe {
         data {
           dataframe_data__list {
@@ -632,19 +883,19 @@ body {
               tuple_val {
                 src {
                   end_column: 46
-                  end_line: 41
+                  end_line: 45
                   file: 2
                   start_column: 13
-                  start_line: 40
+                  start_line: 44
                 }
                 vs {
                   string_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: "SF"
                   }
@@ -653,10 +904,10 @@ body {
                   float64_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: 21.0
                   }
@@ -667,19 +918,19 @@ body {
               tuple_val {
                 src {
                   end_column: 46
-                  end_line: 41
+                  end_line: 45
                   file: 2
                   start_column: 13
-                  start_line: 40
+                  start_line: 44
                 }
                 vs {
                   string_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: "SF"
                   }
@@ -688,10 +939,10 @@ body {
                   float64_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: 17.5
                   }
@@ -702,19 +953,19 @@ body {
               tuple_val {
                 src {
                   end_column: 46
-                  end_line: 41
+                  end_line: 45
                   file: 2
                   start_column: 13
-                  start_line: 40
+                  start_line: 44
                 }
                 vs {
                   string_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: "SF"
                   }
@@ -723,10 +974,10 @@ body {
                   float64_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: 24.0
                   }
@@ -737,19 +988,19 @@ body {
               tuple_val {
                 src {
                   end_column: 46
-                  end_line: 41
+                  end_line: 45
                   file: 2
                   start_column: 13
-                  start_line: 40
+                  start_line: 44
                 }
                 vs {
                   string_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: "NY"
                   }
@@ -758,10 +1009,10 @@ body {
                   float64_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: 30.9
                   }
@@ -772,19 +1023,19 @@ body {
               tuple_val {
                 src {
                   end_column: 46
-                  end_line: 41
+                  end_line: 45
                   file: 2
                   start_column: 13
-                  start_line: 40
+                  start_line: 44
                 }
                 vs {
                   string_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: "NY"
                   }
@@ -793,10 +1044,10 @@ body {
                   float64_val {
                     src {
                       end_column: 46
-                      end_line: 41
+                      end_line: 45
                       file: 2
                       start_column: 13
-                      start_line: 40
+                      start_line: 44
                     }
                     v: 33.6
                   }
@@ -813,19 +1064,19 @@ body {
         }
         src {
           end_column: 46
-          end_line: 41
+          end_line: 45
           file: 2
           start_column: 13
-          start_line: 40
+          start_line: 44
         }
       }
     }
     symbol {
       value: "df"
     }
-    uid: 12
+    uid: 20
     var_id {
-      bitfield1: 12
+      bitfield1: 20
     }
   }
 }
@@ -838,10 +1089,10 @@ body {
             string_val {
               src {
                 end_column: 31
-                end_line: 43
+                end_line: 47
                 file: 2
                 start_column: 8
-                start_line: 43
+                start_line: 47
               }
               v: "location"
             }
@@ -851,24 +1102,24 @@ body {
         df {
           dataframe_ref {
             id {
-              bitfield1: 12
+              bitfield1: 20
             }
           }
         }
         src {
           end_column: 31
-          end_line: 43
+          end_line: 47
           file: 2
           start_column: 8
-          start_line: 43
+          start_line: 47
         }
       }
     }
     symbol {
     }
-    uid: 13
+    uid: 21
     var_id {
-      bitfield1: 13
+      bitfield1: 21
     }
   }
 }
@@ -901,10 +1152,10 @@ body {
             bool_val {
               src {
                 end_column: 75
-                end_line: 46
+                end_line: 50
                 file: 2
                 start_column: 8
-                start_line: 43
+                start_line: 47
               }
             }
           }
@@ -935,18 +1186,18 @@ body {
         parallel: 4
         src {
           end_column: 75
-          end_line: 46
+          end_line: 50
           file: 2
           start_column: 8
-          start_line: 43
+          start_line: 47
         }
       }
     }
     symbol {
     }
-    uid: 14
+    uid: 22
     var_id {
-      bitfield1: 14
+      bitfield1: 22
     }
   }
 }
@@ -961,7 +1212,7 @@ body {
         grouped_df {
           relational_grouped_dataframe_ref {
             id {
-              bitfield1: 13
+              bitfield1: 21
             }
           }
         }
@@ -971,10 +1222,10 @@ body {
             list_val {
               src {
                 end_column: 75
-                end_line: 46
+                end_line: 50
                 file: 2
                 start_column: 8
-                start_line: 43
+                start_line: 47
               }
               vs {
                 datatype_val {
@@ -986,10 +1237,10 @@ body {
                   }
                   src {
                     end_column: 75
-                    end_line: 46
+                    end_line: 50
                     file: 2
                     start_column: 8
-                    start_line: 43
+                    start_line: 47
                   }
                 }
               }
@@ -1000,10 +1251,10 @@ body {
                   }
                   src {
                     end_column: 75
-                    end_line: 46
+                    end_line: 50
                     file: 2
                     start_column: 8
-                    start_line: 43
+                    start_line: 47
                   }
                 }
               }
@@ -1016,19 +1267,19 @@ body {
             list_val {
               src {
                 end_column: 75
-                end_line: 46
+                end_line: 50
                 file: 2
                 start_column: 8
-                start_line: 43
+                start_line: 47
               }
               vs {
                 string_val {
                   src {
                     end_column: 75
-                    end_line: 46
+                    end_line: 50
                     file: 2
                     start_column: 8
-                    start_line: 43
+                    start_line: 47
                   }
                   v: "LOCATION"
                 }
@@ -1037,10 +1288,10 @@ body {
                 string_val {
                   src {
                     end_column: 75
-                    end_line: 46
+                    end_line: 50
                     file: 2
                     start_column: 8
-                    start_line: 43
+                    start_line: 47
                   }
                   v: "TEMP_C"
                 }
@@ -1088,18 +1339,18 @@ body {
         }
         src {
           end_column: 75
-          end_line: 46
+          end_line: 50
           file: 2
           start_column: 8
-          start_line: 43
+          start_line: 47
         }
       }
     }
     symbol {
     }
-    uid: 15
+    uid: 23
     var_id {
-      bitfield1: 15
+      bitfield1: 23
     }
   }
 }
@@ -1112,10 +1363,10 @@ body {
             string_val {
               src {
                 end_column: 94
-                end_line: 46
+                end_line: 50
                 file: 2
                 start_column: 76
-                start_line: 46
+                start_line: 50
               }
               v: "temp_c"
             }
@@ -1125,24 +1376,24 @@ body {
         df {
           dataframe_ref {
             id {
-              bitfield1: 15
+              bitfield1: 23
             }
           }
         }
         src {
           end_column: 94
-          end_line: 46
+          end_line: 50
           file: 2
           start_column: 76
-          start_line: 46
+          start_line: 50
         }
       }
     }
     symbol {
     }
-    uid: 16
+    uid: 24
     var_id {
-      bitfield1: 16
+      bitfield1: 24
     }
   }
 }
@@ -1153,30 +1404,30 @@ body {
         block: true
         case_sensitive: true
         id {
-          bitfield1: 16
+          bitfield1: 24
         }
         src {
           end_column: 104
-          end_line: 46
+          end_line: 50
           file: 2
           start_column: 95
-          start_line: 46
+          start_line: 50
         }
       }
     }
     symbol {
     }
-    uid: 17
+    uid: 25
     var_id {
-      bitfield1: 17
+      bitfield1: 25
     }
   }
 }
 body {
   eval {
-    uid: 18
+    uid: 26
     var_id {
-      bitfield1: 17
+      bitfield1: 25
     }
   }
 }
@@ -1190,19 +1441,19 @@ body {
               tuple_val {
                 src {
                   end_column: 153
-                  end_line: 49
+                  end_line: 53
                   file: 2
                   start_column: 13
-                  start_line: 49
+                  start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: 1
                   }
@@ -1211,10 +1462,10 @@ body {
                   string_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: "A"
                   }
@@ -1223,10 +1474,10 @@ body {
                   int64_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: 10000
                   }
@@ -1235,10 +1486,10 @@ body {
                   string_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: "JAN"
                   }
@@ -1249,19 +1500,19 @@ body {
               tuple_val {
                 src {
                   end_column: 153
-                  end_line: 49
+                  end_line: 53
                   file: 2
                   start_column: 13
-                  start_line: 49
+                  start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: 1
                   }
@@ -1270,10 +1521,10 @@ body {
                   string_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: "B"
                   }
@@ -1282,10 +1533,10 @@ body {
                   int64_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: 400
                   }
@@ -1294,10 +1545,10 @@ body {
                   string_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: "JAN"
                   }
@@ -1308,19 +1559,19 @@ body {
               tuple_val {
                 src {
                   end_column: 153
-                  end_line: 49
+                  end_line: 53
                   file: 2
                   start_column: 13
-                  start_line: 49
+                  start_line: 53
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: 1
                   }
@@ -1329,10 +1580,10 @@ body {
                   string_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: "B"
                   }
@@ -1341,10 +1592,10 @@ body {
                   int64_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: 5000
                   }
@@ -1353,10 +1604,10 @@ body {
                   string_val {
                     src {
                       end_column: 153
-                      end_line: 49
+                      end_line: 53
                       file: 2
                       start_column: 13
-                      start_line: 49
+                      start_line: 53
                     }
                     v: "FEB"
                   }
@@ -1375,19 +1626,19 @@ body {
         }
         src {
           end_column: 153
-          end_line: 49
+          end_line: 53
           file: 2
           start_column: 13
-          start_line: 49
+          start_line: 53
         }
       }
     }
     symbol {
       value: "df"
     }
-    uid: 19
+    uid: 27
     var_id {
-      bitfield1: 19
+      bitfield1: 27
     }
   }
 }
@@ -1400,354 +1651,12 @@ body {
             string_val {
               src {
                 end_column: 28
-                end_line: 54
+                end_line: 55
                 file: 2
                 start_column: 8
-                start_line: 54
+                start_line: 55
               }
               v: "empid"
-            }
-          }
-          variadic: true
-        }
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 19
-            }
-          }
-        }
-        src {
-          end_column: 28
-          end_line: 54
-          file: 2
-          start_column: 8
-          start_line: 54
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 20
-    var_id {
-      bitfield1: 20
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      relational_grouped_dataframe_pivot {
-        grouped_df {
-          relational_grouped_dataframe_ref {
-            id {
-              bitfield1: 20
-            }
-          }
-        }
-        pivot_col {
-          string_val {
-            src {
-              end_column: 59
-              end_line: 54
-              file: 2
-              start_column: 8
-              start_line: 54
-            }
-            v: "month"
-          }
-        }
-        src {
-          end_column: 59
-          end_line: 54
-          file: 2
-          start_column: 8
-          start_line: 54
-        }
-        values {
-          pivot_value__expr {
-            v {
-              list_val {
-                src {
-                  end_column: 59
-                  end_line: 54
-                  file: 2
-                  start_column: 8
-                  start_line: 54
-                }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 59
-                      end_line: 54
-                      file: 2
-                      start_column: 8
-                      start_line: 54
-                    }
-                    v: "JAN"
-                  }
-                }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 59
-                      end_line: 54
-                      file: 2
-                      start_column: 8
-                      start_line: 54
-                    }
-                    v: "FEB"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 21
-    var_id {
-      bitfield1: 21
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      relational_grouped_dataframe_builtin {
-        agg_name: "sum"
-        cols {
-          args {
-            string_val {
-              src {
-                end_column: 73
-                end_line: 54
-                file: 2
-                start_column: 8
-                start_line: 54
-              }
-              v: "amount"
-            }
-          }
-          variadic: true
-        }
-        grouped_df {
-          relational_grouped_dataframe_ref {
-            id {
-              bitfield1: 21
-            }
-          }
-        }
-        src {
-          end_column: 73
-          end_line: 54
-          file: 2
-          start_column: 8
-          start_line: 54
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 22
-    var_id {
-      bitfield1: 22
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_show {
-        id {
-          bitfield1: 22
-        }
-        n: 10
-      }
-    }
-    symbol {
-    }
-    uid: 23
-    var_id {
-      bitfield1: 23
-    }
-  }
-}
-body {
-  eval {
-    uid: 24
-    var_id {
-      bitfield1: 23
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_group_by {
-        cols {
-          args {
-            string_val {
-              src {
-                end_column: 38
-                end_line: 56
-                file: 2
-                start_column: 8
-                start_line: 56
-              }
-              v: "empid"
-            }
-          }
-          args {
-            string_val {
-              src {
-                end_column: 38
-                end_line: 56
-                file: 2
-                start_column: 8
-                start_line: 56
-              }
-              v: "team"
-            }
-          }
-        }
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 19
-            }
-          }
-        }
-        src {
-          end_column: 38
-          end_line: 56
-          file: 2
-          start_column: 8
-          start_line: 56
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 25
-    var_id {
-      bitfield1: 25
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      relational_grouped_dataframe_pivot {
-        grouped_df {
-          relational_grouped_dataframe_ref {
-            id {
-              bitfield1: 25
-            }
-          }
-        }
-        pivot_col {
-          string_val {
-            src {
-              end_column: 53
-              end_line: 56
-              file: 2
-              start_column: 8
-              start_line: 56
-            }
-            v: "month"
-          }
-        }
-        src {
-          end_column: 53
-          end_line: 56
-          file: 2
-          start_column: 8
-          start_line: 56
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 26
-    var_id {
-      bitfield1: 26
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      relational_grouped_dataframe_builtin {
-        agg_name: "sum"
-        cols {
-          args {
-            string_val {
-              src {
-                end_column: 67
-                end_line: 56
-                file: 2
-                start_column: 8
-                start_line: 56
-              }
-              v: "amount"
-            }
-          }
-          variadic: true
-        }
-        grouped_df {
-          relational_grouped_dataframe_ref {
-            id {
-              bitfield1: 26
-            }
-          }
-        }
-        src {
-          end_column: 67
-          end_line: 56
-          file: 2
-          start_column: 8
-          start_line: 56
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 27
-    var_id {
-      bitfield1: 27
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_sort {
-        cols {
-          args {
-            string_val {
-              src {
-                end_column: 89
-                end_line: 56
-                file: 2
-                start_column: 8
-                start_line: 56
-              }
-              v: "empid"
-            }
-          }
-          args {
-            string_val {
-              src {
-                end_column: 89
-                end_line: 56
-                file: 2
-                start_column: 8
-                start_line: 56
-              }
-              v: "team"
             }
           }
           variadic: true
@@ -1760,11 +1669,11 @@ body {
           }
         }
         src {
-          end_column: 89
-          end_line: 56
+          end_column: 28
+          end_line: 55
           file: 2
           start_column: 8
-          start_line: 56
+          start_line: 55
         }
       }
     }
@@ -1779,11 +1688,72 @@ body {
 body {
   assign {
     expr {
-      dataframe_show {
-        id {
-          bitfield1: 28
+      relational_grouped_dataframe_pivot {
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 28
+            }
+          }
         }
-        n: 10
+        pivot_col {
+          string_val {
+            src {
+              end_column: 59
+              end_line: 55
+              file: 2
+              start_column: 8
+              start_line: 55
+            }
+            v: "month"
+          }
+        }
+        src {
+          end_column: 59
+          end_line: 55
+          file: 2
+          start_column: 8
+          start_line: 55
+        }
+        values {
+          pivot_value__expr {
+            v {
+              list_val {
+                src {
+                  end_column: 59
+                  end_line: 55
+                  file: 2
+                  start_column: 8
+                  start_line: 55
+                }
+                vs {
+                  string_val {
+                    src {
+                      end_column: 59
+                      end_line: 55
+                      file: 2
+                      start_column: 8
+                      start_line: 55
+                    }
+                    v: "JAN"
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      end_column: 59
+                      end_line: 55
+                      file: 2
+                      start_column: 8
+                      start_line: 55
+                    }
+                    v: "FEB"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
     symbol {
@@ -1795,10 +1765,533 @@ body {
   }
 }
 body {
-  eval {
+  assign {
+    expr {
+      relational_grouped_dataframe_builtin {
+        agg_name: "sum"
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 73
+                end_line: 55
+                file: 2
+                start_column: 8
+                start_line: 55
+              }
+              v: "amount"
+            }
+          }
+          variadic: true
+        }
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 29
+            }
+          }
+        }
+        src {
+          end_column: 73
+          end_line: 55
+          file: 2
+          start_column: 8
+          start_line: 55
+        }
+      }
+    }
+    symbol {
+    }
     uid: 30
     var_id {
-      bitfield1: 29
+      bitfield1: 30
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_sort {
+        cols {
+          args {
+            dataframe_col {
+              col_name: "empid"
+              df {
+                dataframe_ref {
+                  id {
+                    bitfield1: 27
+                  }
+                }
+              }
+              src {
+                end_column: 90
+                end_line: 55
+                file: 2
+                start_column: 79
+                start_line: 55
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 30
+            }
+          }
+        }
+        src {
+          end_column: 91
+          end_line: 55
+          file: 2
+          start_column: 8
+          start_line: 55
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 31
+    var_id {
+      bitfield1: 31
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_show {
+        id {
+          bitfield1: 31
+        }
+        n: 10
+      }
+    }
+    symbol {
+    }
+    uid: 32
+    var_id {
+      bitfield1: 32
+    }
+  }
+}
+body {
+  eval {
+    uid: 33
+    var_id {
+      bitfield1: 32
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_group_by {
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 28
+                end_line: 57
+                file: 2
+                start_column: 8
+                start_line: 57
+              }
+              v: "empid"
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 27
+            }
+          }
+        }
+        src {
+          end_column: 28
+          end_line: 57
+          file: 2
+          start_column: 8
+          start_line: 57
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 34
+    var_id {
+      bitfield1: 34
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      relational_grouped_dataframe_pivot {
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 34
+            }
+          }
+        }
+        pivot_col {
+          string_val {
+            src {
+              end_column: 59
+              end_line: 57
+              file: 2
+              start_column: 8
+              start_line: 57
+            }
+            v: "month"
+          }
+        }
+        src {
+          end_column: 59
+          end_line: 57
+          file: 2
+          start_column: 8
+          start_line: 57
+        }
+        values {
+          pivot_value__expr {
+            v {
+              list_val {
+                src {
+                  end_column: 59
+                  end_line: 57
+                  file: 2
+                  start_column: 8
+                  start_line: 57
+                }
+                vs {
+                  string_val {
+                    src {
+                      end_column: 59
+                      end_line: 57
+                      file: 2
+                      start_column: 8
+                      start_line: 57
+                    }
+                    v: "JAN"
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      end_column: 59
+                      end_line: 57
+                      file: 2
+                      start_column: 8
+                      start_line: 57
+                    }
+                    v: "FEB"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 35
+    var_id {
+      bitfield1: 35
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      relational_grouped_dataframe_builtin {
+        agg_name: "sum"
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 73
+                end_line: 57
+                file: 2
+                start_column: 8
+                start_line: 57
+              }
+              v: "amount"
+            }
+          }
+          variadic: true
+        }
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 35
+            }
+          }
+        }
+        src {
+          end_column: 73
+          end_line: 57
+          file: 2
+          start_column: 8
+          start_line: 57
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 36
+    var_id {
+      bitfield1: 36
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_show {
+        id {
+          bitfield1: 36
+        }
+        n: 10
+      }
+    }
+    symbol {
+    }
+    uid: 37
+    var_id {
+      bitfield1: 37
+    }
+  }
+}
+body {
+  eval {
+    uid: 38
+    var_id {
+      bitfield1: 37
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_group_by {
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 38
+                end_line: 59
+                file: 2
+                start_column: 8
+                start_line: 59
+              }
+              v: "empid"
+            }
+          }
+          args {
+            string_val {
+              src {
+                end_column: 38
+                end_line: 59
+                file: 2
+                start_column: 8
+                start_line: 59
+              }
+              v: "team"
+            }
+          }
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 27
+            }
+          }
+        }
+        src {
+          end_column: 38
+          end_line: 59
+          file: 2
+          start_column: 8
+          start_line: 59
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 39
+    var_id {
+      bitfield1: 39
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      relational_grouped_dataframe_pivot {
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 39
+            }
+          }
+        }
+        pivot_col {
+          string_val {
+            src {
+              end_column: 53
+              end_line: 59
+              file: 2
+              start_column: 8
+              start_line: 59
+            }
+            v: "month"
+          }
+        }
+        src {
+          end_column: 53
+          end_line: 59
+          file: 2
+          start_column: 8
+          start_line: 59
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 40
+    var_id {
+      bitfield1: 40
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      relational_grouped_dataframe_builtin {
+        agg_name: "sum"
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 67
+                end_line: 59
+                file: 2
+                start_column: 8
+                start_line: 59
+              }
+              v: "amount"
+            }
+          }
+          variadic: true
+        }
+        grouped_df {
+          relational_grouped_dataframe_ref {
+            id {
+              bitfield1: 40
+            }
+          }
+        }
+        src {
+          end_column: 67
+          end_line: 59
+          file: 2
+          start_column: 8
+          start_line: 59
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 41
+    var_id {
+      bitfield1: 41
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_sort {
+        cols {
+          args {
+            string_val {
+              src {
+                end_column: 89
+                end_line: 59
+                file: 2
+                start_column: 8
+                start_line: 59
+              }
+              v: "empid"
+            }
+          }
+          args {
+            string_val {
+              src {
+                end_column: 89
+                end_line: 59
+                file: 2
+                start_column: 8
+                start_line: 59
+              }
+              v: "team"
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 41
+            }
+          }
+        }
+        src {
+          end_column: 89
+          end_line: 59
+          file: 2
+          start_column: 8
+          start_line: 59
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 42
+    var_id {
+      bitfield1: 42
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_show {
+        id {
+          bitfield1: 42
+        }
+        n: 10
+      }
+    }
+    symbol {
+    }
+    uid: 43
+    var_id {
+      bitfield1: 43
+    }
+  }
+}
+body {
+  eval {
+    uid: 44
+    var_id {
+      bitfield1: 43
     }
   }
 }

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -31,6 +31,25 @@ param_udf2 = udf(lambda x, y: str(y + x**2), return_type=VariantType(), input_ty
 
 df.select(param_udf(col("A"), col("A")))
 
+# Test registering UDF from file
+mod5_udf = session.udf.register_from_file(
+    test_files.test_udf_py_file,
+    "mod5",
+    return_type=IntegerType(),
+    input_types=[IntegerType()],
+    immutable=True,
+)
+df.select(mod5_udf("a"), mod5_udf("b")).collect()
+
+# Test registeringb vectorized UDF from file
+mod5_pandas_udf = session.udf.register_from_file(
+    test_files.test_pandas_udf_py_file,
+    "pandas_apply_mod5",
+    return_type=IntegerType(),
+    input_types=[IntegerType()],
+)
+df.select(mod5_pandas_udf("a"), mod5_pandas_udf("b")).collect()
+
 ## EXPECTED UNPARSER OUTPUT
 
 add_one = udf("<lambda>", return_type=IntegerType(), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
@@ -48,6 +67,14 @@ param_udf = udf("<lambda [2]>", return_type=VariantType(), input_types=[IntegerT
 param_udf2 = udf("<lambda [3]>", return_type=VariantType(), input_types=[IntegerType(), FloatType()], name="param_udf2", is_permanent=True, stage_location="@", imports=["numpy"], packages=["bla"], if_not_exists=True, parallel=8, max_batch_size=2, source_code_display=False, strict=True, secure=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, immutable=True, comment="some udf", force_inline_code=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"PARAM_UDF2\"")
 
 res5 = df.select(param_udf(col("A"), col("A")))
+
+mod5_udf = udf("mod5", return_type=IntegerType(), input_types=[IntegerType()], max_batch_size=0, immutable=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
+
+df.select(mod5_udf("a"), mod5_udf("b")).collect()
+
+mod5_pandas_udf = udf("pandas_apply_mod5", return_type=IntegerType(), input_types=[IntegerType()], max_batch_size=0, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
+
+df.select(mod5_pandas_udf("a"), mod5_pandas_udf("b")).collect()
 
 ## EXPECTED ENCODED AST
 
@@ -798,6 +825,343 @@ body {
     uid: 12
     var_id {
       bitfield1: 12
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udf {
+        func {
+          id: 4
+          name: "mod5"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\""
+              }
+            }
+          }
+        }
+        immutable: true
+        input_types {
+          integer_type: true
+        }
+        max_batch_size {
+        }
+        parallel: 4
+        return_type {
+          integer_type: true
+        }
+        source_code_display: true
+        src {
+          end_column: 9
+          end_line: 63
+          file: 2
+          start_column: 19
+          start_line: 57
+        }
+      }
+    }
+    symbol {
+      value: "mod5_udf"
+    }
+    uid: 13
+    var_id {
+      bitfield1: 13
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                fn_ref {
+                  id {
+                    bitfield1: 13
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 31
+                    end_line: 64
+                    file: 2
+                    start_column: 18
+                    start_line: 64
+                  }
+                  v: "a"
+                }
+              }
+              src {
+                end_column: 31
+                end_line: 64
+                file: 2
+                start_column: 18
+                start_line: 64
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                fn_ref {
+                  id {
+                    bitfield1: 13
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 64
+                    file: 2
+                    start_column: 33
+                    start_line: 64
+                  }
+                  v: "b"
+                }
+              }
+              src {
+                end_column: 46
+                end_line: 64
+                file: 2
+                start_column: 33
+                start_line: 64
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
+        }
+        src {
+          end_column: 47
+          end_line: 64
+          file: 2
+          start_column: 8
+          start_line: 64
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 14
+    var_id {
+      bitfield1: 14
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 14
+        }
+        src {
+          end_column: 57
+          end_line: 64
+          file: 2
+          start_column: 8
+          start_line: 64
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 15
+    var_id {
+      bitfield1: 15
+    }
+  }
+}
+body {
+  eval {
+    uid: 16
+    var_id {
+      bitfield1: 15
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udf {
+        func {
+          id: 5
+          name: "pandas_apply_mod5"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\""
+              }
+            }
+          }
+        }
+        input_types {
+          integer_type: true
+        }
+        max_batch_size {
+        }
+        parallel: 4
+        return_type {
+          integer_type: true
+        }
+        source_code_display: true
+        src {
+          end_column: 9
+          end_line: 72
+          file: 2
+          start_column: 26
+          start_line: 67
+        }
+      }
+    }
+    symbol {
+      value: "mod5_pandas_udf"
+    }
+    uid: 17
+    var_id {
+      bitfield1: 17
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                fn_ref {
+                  id {
+                    bitfield1: 17
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 38
+                    end_line: 73
+                    file: 2
+                    start_column: 18
+                    start_line: 73
+                  }
+                  v: "a"
+                }
+              }
+              src {
+                end_column: 38
+                end_line: 73
+                file: 2
+                start_column: 18
+                start_line: 73
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                fn_ref {
+                  id {
+                    bitfield1: 17
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 60
+                    end_line: 73
+                    file: 2
+                    start_column: 40
+                    start_line: 73
+                  }
+                  v: "b"
+                }
+              }
+              src {
+                end_column: 60
+                end_line: 73
+                file: 2
+                start_column: 40
+                start_line: 73
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
+        }
+        src {
+          end_column: 61
+          end_line: 73
+          file: 2
+          start_column: 8
+          start_line: 73
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 18
+    var_id {
+      bitfield1: 18
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 18
+        }
+        src {
+          end_column: 71
+          end_line: 73
+          file: 2
+          start_column: 8
+          start_line: 73
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 19
+    var_id {
+      bitfield1: 19
+    }
+  }
+}
+body {
+  eval {
+    uid: 20
+    var_id {
+      bitfield1: 19
     }
   }
 }

--- a/tests/ast/data/df_map.test
+++ b/tests/ast/data/df_map.test
@@ -1,0 +1,2161 @@
+## TEST CASE
+
+from snowflake.snowpark.dataframe import map as map_
+
+df = session.create_dataframe([[10, "a", 22], [20, "b", 22]], schema=["col1", "col2", "col3"])
+
+df1 = map_(df, lambda row: row[0] * row[0], output_types=[IntegerType()])
+
+df2 = map_(df, lambda row: (row[1], row[0] * 3), output_types=[StringType(), IntegerType()])
+
+df3 = map_(
+    df,
+    lambda row: (row[1], row[0] * 3),
+    output_types=[StringType(), IntegerType()],
+    output_column_names=['col1', 'col2']
+)
+
+df4 = map_(df, lambda pdf: pdf['COL1']*3, output_types=[IntegerType()], vectorized=True, packages=["pandas"])
+
+df5 = map_(
+    df,
+    lambda pdf: (pdf['COL1']*3, pdf['COL2']+"b"),
+    output_types=[IntegerType(), StringType()],
+    output_column_names=['A', 'B'],
+    vectorized=True,
+    packages=["pandas"],
+)
+
+df6 = map_(
+    df,
+    lambda pdf: ((pdf.shape[0],) * len(pdf), (pdf.shape[1],) * len(pdf)),
+    output_types=[IntegerType(), IntegerType()],
+    output_column_names=['rows', 'cols'],
+    partition_by="col3",
+    vectorized=True,
+    packages=["pandas"],
+)
+
+## EXPECTED UNPARSER OUTPUT
+
+df = session.create_dataframe([[10, "a", 22], [20, "b", 22]], schema=["col1", "col2", "col3"])
+
+df1 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df1 = df.join_table_function(df1("COL1", "COL2", "COL3").over())
+
+df1 = df1.select(col("$4").alias("c_1"))
+
+df2 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", StringType(), nullable=True), StructField("c1", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df2 = df.join_table_function(df2("COL1", "COL2", "COL3").over())
+
+df2 = df2.select(col("$4").alias("c_1"), col("$5").alias("c_2"))
+
+df3 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", StringType(), nullable=True), StructField("c1", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df3 = df.join_table_function(df3("COL1", "COL2", "COL3").over())
+
+df3 = df3.select(col("$4").alias("col1"), col("$5").alias("col2"))
+
+df4 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), "c0"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df4 = df.join_table_function(df4("COL1", "COL2", "COL3").over())
+
+df4 = df4.select(col("$4").alias("c_1"))
+
+df5 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), StringType(), "c0", "c1"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df5 = df.join_table_function(df5("COL1", "COL2", "COL3").over())
+
+df5 = df5.select(col("$4").alias("A"), col("$5").alias("B"))
+
+df6 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), IntegerType(), "c0", "c1"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df6 = df.join_table_function(df6("COL1", "COL2", "COL3").over(partition_by="col3"))
+
+df6 = df6.select(col("$4").alias("rows"), col("$5").alias("cols"))
+
+## EXPECTED ENCODED AST
+
+interned_value_table {
+  string_values {
+    key: -1
+  }
+  string_values {
+    key: 2
+    value: "SRC_POSITION_TEST_MODE"
+  }
+}
+body {
+  assign {
+    expr {
+      create_dataframe {
+        data {
+          dataframe_data__list {
+            vs {
+              list_val {
+                src {
+                  end_column: 102
+                  end_line: 27
+                  file: 2
+                  start_column: 13
+                  start_line: 27
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 102
+                      end_line: 27
+                      file: 2
+                      start_column: 13
+                      start_line: 27
+                    }
+                    v: 10
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      end_column: 102
+                      end_line: 27
+                      file: 2
+                      start_column: 13
+                      start_line: 27
+                    }
+                    v: "a"
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 102
+                      end_line: 27
+                      file: 2
+                      start_column: 13
+                      start_line: 27
+                    }
+                    v: 22
+                  }
+                }
+              }
+            }
+            vs {
+              list_val {
+                src {
+                  end_column: 102
+                  end_line: 27
+                  file: 2
+                  start_column: 13
+                  start_line: 27
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 102
+                      end_line: 27
+                      file: 2
+                      start_column: 13
+                      start_line: 27
+                    }
+                    v: 20
+                  }
+                }
+                vs {
+                  string_val {
+                    src {
+                      end_column: 102
+                      end_line: 27
+                      file: 2
+                      start_column: 13
+                      start_line: 27
+                    }
+                    v: "b"
+                  }
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 102
+                      end_line: 27
+                      file: 2
+                      start_column: 13
+                      start_line: 27
+                    }
+                    v: 22
+                  }
+                }
+              }
+            }
+          }
+        }
+        schema {
+          dataframe_schema__list {
+            vs: "col1"
+            vs: "col2"
+            vs: "col3"
+          }
+        }
+        src {
+          end_column: 102
+          end_line: 27
+          file: 2
+          start_column: 13
+          start_line: 27
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 1
+    var_id {
+      bitfield1: 1
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          name: "_MapFunc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 81
+                end_line: 29
+                file: 2
+                start_column: 14
+                start_line: 29
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              struct_type {
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "c0"
+                    }
+                  }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        packages: "snowflake-snowpark-python"
+        parallel: 4
+        src {
+          end_column: 81
+          end_line: 29
+          file: 2
+          start_column: 14
+          start_line: 29
+        }
+      }
+    }
+    symbol {
+      value: "df1"
+    }
+    uid: 2
+    var_id {
+      bitfield1: 2
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              fn_ref {
+                id {
+                  bitfield1: 2
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 81
+                  end_line: 29
+                  file: 2
+                  start_column: 14
+                  start_line: 29
+                }
+                v: "COL1"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 81
+                  end_line: 29
+                  file: 2
+                  start_column: 14
+                  start_line: 29
+                }
+                v: "COL2"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 81
+                  end_line: 29
+                  file: 2
+                  start_column: 14
+                  start_line: 29
+                }
+                v: "COL3"
+              }
+            }
+            src {
+              end_column: 81
+              end_line: 29
+              file: 2
+              start_column: 14
+              start_line: 29
+            }
+          }
+        }
+        src {
+          end_column: 81
+          end_line: 29
+          file: 2
+          start_column: 14
+          start_line: 29
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 3
+    var_id {
+      bitfield1: 3
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_join_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 3
+                }
+              }
+            }
+            src {
+              end_column: 81
+              end_line: 29
+              file: 2
+              start_column: 14
+              start_line: 29
+            }
+          }
+        }
+        lhs {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 81
+          end_line: 29
+          file: 2
+          start_column: 14
+          start_line: 29
+        }
+      }
+    }
+    symbol {
+      value: "df1"
+    }
+    uid: 4
+    var_id {
+      bitfield1: 4
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 81
+                        end_line: 29
+                        file: 2
+                        start_column: 14
+                        start_line: 29
+                      }
+                      v: "$4"
+                    }
+                  }
+                  src {
+                    end_column: 81
+                    end_line: 29
+                    file: 2
+                    start_column: 14
+                    start_line: 29
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "c_1"
+              src {
+                end_column: 81
+                end_line: 29
+                file: 2
+                start_column: 14
+                start_line: 29
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 4
+            }
+          }
+        }
+        src {
+          end_column: 81
+          end_line: 29
+          file: 2
+          start_column: 14
+          start_line: 29
+        }
+      }
+    }
+    symbol {
+      value: "df1"
+    }
+    uid: 5
+    var_id {
+      bitfield1: 5
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 1
+          name: "_MapFunc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 100
+                end_line: 31
+                file: 2
+                start_column: 14
+                start_line: 31
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              struct_type {
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "c0"
+                    }
+                  }
+                  data_type {
+                    string_type {
+                      length {
+                      }
+                    }
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "c1"
+                    }
+                  }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        packages: "snowflake-snowpark-python"
+        parallel: 4
+        src {
+          end_column: 100
+          end_line: 31
+          file: 2
+          start_column: 14
+          start_line: 31
+        }
+      }
+    }
+    symbol {
+      value: "df2"
+    }
+    uid: 6
+    var_id {
+      bitfield1: 6
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              fn_ref {
+                id {
+                  bitfield1: 6
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 100
+                  end_line: 31
+                  file: 2
+                  start_column: 14
+                  start_line: 31
+                }
+                v: "COL1"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 100
+                  end_line: 31
+                  file: 2
+                  start_column: 14
+                  start_line: 31
+                }
+                v: "COL2"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 100
+                  end_line: 31
+                  file: 2
+                  start_column: 14
+                  start_line: 31
+                }
+                v: "COL3"
+              }
+            }
+            src {
+              end_column: 100
+              end_line: 31
+              file: 2
+              start_column: 14
+              start_line: 31
+            }
+          }
+        }
+        src {
+          end_column: 100
+          end_line: 31
+          file: 2
+          start_column: 14
+          start_line: 31
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 7
+    var_id {
+      bitfield1: 7
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_join_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 7
+                }
+              }
+            }
+            src {
+              end_column: 100
+              end_line: 31
+              file: 2
+              start_column: 14
+              start_line: 31
+            }
+          }
+        }
+        lhs {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 100
+          end_line: 31
+          file: 2
+          start_column: 14
+          start_line: 31
+        }
+      }
+    }
+    symbol {
+      value: "df2"
+    }
+    uid: 8
+    var_id {
+      bitfield1: 8
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 100
+                        end_line: 31
+                        file: 2
+                        start_column: 14
+                        start_line: 31
+                      }
+                      v: "$4"
+                    }
+                  }
+                  src {
+                    end_column: 100
+                    end_line: 31
+                    file: 2
+                    start_column: 14
+                    start_line: 31
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "c_1"
+              src {
+                end_column: 100
+                end_line: 31
+                file: 2
+                start_column: 14
+                start_line: 31
+              }
+            }
+          }
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 100
+                        end_line: 31
+                        file: 2
+                        start_column: 14
+                        start_line: 31
+                      }
+                      v: "$5"
+                    }
+                  }
+                  src {
+                    end_column: 100
+                    end_line: 31
+                    file: 2
+                    start_column: 14
+                    start_line: 31
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "c_2"
+              src {
+                end_column: 100
+                end_line: 31
+                file: 2
+                start_column: 14
+                start_line: 31
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 8
+            }
+          }
+        }
+        src {
+          end_column: 100
+          end_line: 31
+          file: 2
+          start_column: 14
+          start_line: 31
+        }
+      }
+    }
+    symbol {
+      value: "df2"
+    }
+    uid: 9
+    var_id {
+      bitfield1: 9
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 2
+          name: "_MapFunc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 38
+                file: 2
+                start_column: 14
+                start_line: 33
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              struct_type {
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "c0"
+                    }
+                  }
+                  data_type {
+                    string_type {
+                      length {
+                      }
+                    }
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "c1"
+                    }
+                  }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        packages: "snowflake-snowpark-python"
+        parallel: 4
+        src {
+          end_column: 9
+          end_line: 38
+          file: 2
+          start_column: 14
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+      value: "df3"
+    }
+    uid: 10
+    var_id {
+      bitfield1: 10
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              fn_ref {
+                id {
+                  bitfield1: 10
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 38
+                  file: 2
+                  start_column: 14
+                  start_line: 33
+                }
+                v: "COL1"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 38
+                  file: 2
+                  start_column: 14
+                  start_line: 33
+                }
+                v: "COL2"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 38
+                  file: 2
+                  start_column: 14
+                  start_line: 33
+                }
+                v: "COL3"
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 38
+              file: 2
+              start_column: 14
+              start_line: 33
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 38
+          file: 2
+          start_column: 14
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 11
+    var_id {
+      bitfield1: 11
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_join_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 11
+                }
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 38
+              file: 2
+              start_column: 14
+              start_line: 33
+            }
+          }
+        }
+        lhs {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 38
+          file: 2
+          start_column: 14
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+      value: "df3"
+    }
+    uid: 12
+    var_id {
+      bitfield1: 12
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 9
+                        end_line: 38
+                        file: 2
+                        start_column: 14
+                        start_line: 33
+                      }
+                      v: "$4"
+                    }
+                  }
+                  src {
+                    end_column: 9
+                    end_line: 38
+                    file: 2
+                    start_column: 14
+                    start_line: 33
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "col1"
+              src {
+                end_column: 9
+                end_line: 38
+                file: 2
+                start_column: 14
+                start_line: 33
+              }
+            }
+          }
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 9
+                        end_line: 38
+                        file: 2
+                        start_column: 14
+                        start_line: 33
+                      }
+                      v: "$5"
+                    }
+                  }
+                  src {
+                    end_column: 9
+                    end_line: 38
+                    file: 2
+                    start_column: 14
+                    start_line: 33
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "col2"
+              src {
+                end_column: 9
+                end_line: 38
+                file: 2
+                start_column: 14
+                start_line: 33
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 12
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 38
+          file: 2
+          start_column: 14
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+      value: "df3"
+    }
+    uid: 13
+    var_id {
+      bitfield1: 13
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 3
+          name: "_MapFunc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 117
+                end_line: 40
+                file: 2
+                start_column: 14
+                start_line: 40
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              pandas_data_frame_type {
+                col_names: "c0"
+                col_types {
+                  integer_type: true
+                }
+              }
+            }
+          }
+        }
+        packages: "pandas"
+        packages: "snowflake-snowpark-python"
+        parallel: 4
+        src {
+          end_column: 117
+          end_line: 40
+          file: 2
+          start_column: 14
+          start_line: 40
+        }
+      }
+    }
+    symbol {
+      value: "df4"
+    }
+    uid: 14
+    var_id {
+      bitfield1: 14
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              fn_ref {
+                id {
+                  bitfield1: 14
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 117
+                  end_line: 40
+                  file: 2
+                  start_column: 14
+                  start_line: 40
+                }
+                v: "COL1"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 117
+                  end_line: 40
+                  file: 2
+                  start_column: 14
+                  start_line: 40
+                }
+                v: "COL2"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 117
+                  end_line: 40
+                  file: 2
+                  start_column: 14
+                  start_line: 40
+                }
+                v: "COL3"
+              }
+            }
+            src {
+              end_column: 117
+              end_line: 40
+              file: 2
+              start_column: 14
+              start_line: 40
+            }
+          }
+        }
+        src {
+          end_column: 117
+          end_line: 40
+          file: 2
+          start_column: 14
+          start_line: 40
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 15
+    var_id {
+      bitfield1: 15
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_join_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 15
+                }
+              }
+            }
+            src {
+              end_column: 117
+              end_line: 40
+              file: 2
+              start_column: 14
+              start_line: 40
+            }
+          }
+        }
+        lhs {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 117
+          end_line: 40
+          file: 2
+          start_column: 14
+          start_line: 40
+        }
+      }
+    }
+    symbol {
+      value: "df4"
+    }
+    uid: 16
+    var_id {
+      bitfield1: 16
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 117
+                        end_line: 40
+                        file: 2
+                        start_column: 14
+                        start_line: 40
+                      }
+                      v: "$4"
+                    }
+                  }
+                  src {
+                    end_column: 117
+                    end_line: 40
+                    file: 2
+                    start_column: 14
+                    start_line: 40
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "c_1"
+              src {
+                end_column: 117
+                end_line: 40
+                file: 2
+                start_column: 14
+                start_line: 40
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 16
+            }
+          }
+        }
+        src {
+          end_column: 117
+          end_line: 40
+          file: 2
+          start_column: 14
+          start_line: 40
+        }
+      }
+    }
+    symbol {
+      value: "df4"
+    }
+    uid: 17
+    var_id {
+      bitfield1: 17
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 4
+          name: "_MapFunc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 49
+                file: 2
+                start_column: 14
+                start_line: 42
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              pandas_data_frame_type {
+                col_names: "c0"
+                col_names: "c1"
+                col_types {
+                  integer_type: true
+                }
+                col_types {
+                  string_type {
+                    length {
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        packages: "pandas"
+        packages: "snowflake-snowpark-python"
+        parallel: 4
+        src {
+          end_column: 9
+          end_line: 49
+          file: 2
+          start_column: 14
+          start_line: 42
+        }
+      }
+    }
+    symbol {
+      value: "df5"
+    }
+    uid: 18
+    var_id {
+      bitfield1: 18
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              fn_ref {
+                id {
+                  bitfield1: 18
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 49
+                  file: 2
+                  start_column: 14
+                  start_line: 42
+                }
+                v: "COL1"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 49
+                  file: 2
+                  start_column: 14
+                  start_line: 42
+                }
+                v: "COL2"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 49
+                  file: 2
+                  start_column: 14
+                  start_line: 42
+                }
+                v: "COL3"
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 49
+              file: 2
+              start_column: 14
+              start_line: 42
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 49
+          file: 2
+          start_column: 14
+          start_line: 42
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 19
+    var_id {
+      bitfield1: 19
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_join_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 19
+                }
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 49
+              file: 2
+              start_column: 14
+              start_line: 42
+            }
+          }
+        }
+        lhs {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 49
+          file: 2
+          start_column: 14
+          start_line: 42
+        }
+      }
+    }
+    symbol {
+      value: "df5"
+    }
+    uid: 20
+    var_id {
+      bitfield1: 20
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 9
+                        end_line: 49
+                        file: 2
+                        start_column: 14
+                        start_line: 42
+                      }
+                      v: "$4"
+                    }
+                  }
+                  src {
+                    end_column: 9
+                    end_line: 49
+                    file: 2
+                    start_column: 14
+                    start_line: 42
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "A"
+              src {
+                end_column: 9
+                end_line: 49
+                file: 2
+                start_column: 14
+                start_line: 42
+              }
+            }
+          }
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 9
+                        end_line: 49
+                        file: 2
+                        start_column: 14
+                        start_line: 42
+                      }
+                      v: "$5"
+                    }
+                  }
+                  src {
+                    end_column: 9
+                    end_line: 49
+                    file: 2
+                    start_column: 14
+                    start_line: 42
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "B"
+              src {
+                end_column: 9
+                end_line: 49
+                file: 2
+                start_column: 14
+                start_line: 42
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 20
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 49
+          file: 2
+          start_column: 14
+          start_line: 42
+        }
+      }
+    }
+    symbol {
+      value: "df5"
+    }
+    uid: 21
+    var_id {
+      bitfield1: 21
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 5
+          name: "_MapFunc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 59
+                file: 2
+                start_column: 14
+                start_line: 51
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              pandas_data_frame_type {
+                col_names: "c0"
+                col_names: "c1"
+                col_types {
+                  integer_type: true
+                }
+                col_types {
+                  integer_type: true
+                }
+              }
+            }
+          }
+        }
+        packages: "pandas"
+        packages: "snowflake-snowpark-python"
+        parallel: 4
+        src {
+          end_column: 9
+          end_line: 59
+          file: 2
+          start_column: 14
+          start_line: 51
+        }
+      }
+    }
+    symbol {
+      value: "df6"
+    }
+    uid: 22
+    var_id {
+      bitfield1: 22
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              fn_ref {
+                id {
+                  bitfield1: 22
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 59
+                  file: 2
+                  start_column: 14
+                  start_line: 51
+                }
+                v: "COL1"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 59
+                  file: 2
+                  start_column: 14
+                  start_line: 51
+                }
+                v: "COL2"
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 9
+                  end_line: 59
+                  file: 2
+                  start_column: 14
+                  start_line: 51
+                }
+                v: "COL3"
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 59
+              file: 2
+              start_column: 14
+              start_line: 51
+            }
+          }
+        }
+        partition_by {
+          args {
+            string_val {
+              src {
+                end_column: 9
+                end_line: 59
+                file: 2
+                start_column: 14
+                start_line: 51
+              }
+              v: "col3"
+            }
+          }
+          variadic: true
+        }
+        src {
+          end_column: 9
+          end_line: 59
+          file: 2
+          start_column: 14
+          start_line: 51
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 23
+    var_id {
+      bitfield1: 23
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_join_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 23
+                }
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 59
+              file: 2
+              start_column: 14
+              start_line: 51
+            }
+          }
+        }
+        lhs {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 59
+          file: 2
+          start_column: 14
+          start_line: 51
+        }
+      }
+    }
+    symbol {
+      value: "df6"
+    }
+    uid: 24
+    var_id {
+      bitfield1: 24
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 9
+                        end_line: 59
+                        file: 2
+                        start_column: 14
+                        start_line: 51
+                      }
+                      v: "$4"
+                    }
+                  }
+                  src {
+                    end_column: 9
+                    end_line: 59
+                    file: 2
+                    start_column: 14
+                    start_line: 51
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "rows"
+              src {
+                end_column: 9
+                end_line: 59
+                file: 2
+                start_column: 14
+                start_line: 51
+              }
+            }
+          }
+          args {
+            column_alias {
+              col {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 9
+                        end_line: 59
+                        file: 2
+                        start_column: 14
+                        start_line: 51
+                      }
+                      v: "$5"
+                    }
+                  }
+                  src {
+                    end_column: 9
+                    end_line: 59
+                    file: 2
+                    start_column: 14
+                    start_line: 51
+                  }
+                }
+              }
+              fn {
+                column_alias_fn_alias: true
+              }
+              name: "cols"
+              src {
+                end_column: 9
+                end_line: 59
+                file: 2
+                start_column: 14
+                start_line: 51
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 24
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 59
+          file: 2
+          start_column: 14
+          start_line: 51
+        }
+      }
+    }
+    symbol {
+      value: "df6"
+    }
+    uid: 25
+    var_id {
+      bitfield1: 25
+    }
+  }
+}
+client_ast_version: 1
+client_language {
+  python_language {
+    version {
+      label: "final"
+      major: 3
+      minor: 9
+      patch: 1
+    }
+  }
+}
+client_version {
+  major: 1
+  minor: 29
+  patch: 1
+}

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -4,7 +4,7 @@ df = session.table(tables.table1)
 
 # Single weight means returning the dataframe itself.
 
-# df, = df.random_split([0.7])
+df, = df.random_split([0.7])
 
 weights = [0.1, 0.2, 0.3]
 
@@ -24,29 +24,31 @@ t[0].collect()
 
 df = session.table("table1")
 
-res1 = df.random_split([0.1, 0.2, 0.3], None)
+res1 = df.random_split([0.7], None)
 
-df1 = res1[0]
+res2 = df.random_split([0.1, 0.2, 0.3], None)
 
-df2 = res1[1]
+df1 = res2[0]
 
-df3 = res1[2]
+df2 = res2[1]
 
-res2 = df.random_split([0.1, 0.2, 0.3], 24)
+df3 = res2[2]
 
-df3 = res2[0]
+res3 = df.random_split([0.1, 0.2, 0.3], 24)
 
-df1 = res2[1]
+df3 = res3[0]
 
-df2 = res2[2]
+df1 = res3[1]
+
+df2 = res3[2]
 
 df1.select(col("NUM") > lit(10)).collect()
 
 t = df.random_split([0.1, 0.2, 0.3], 24)
 
-res6 = t[1]
+res7 = t[1]
 
-res7 = t[2]
+res8 = t[2]
 
 t[0].collect()
 
@@ -105,15 +107,13 @@ body {
           }
         }
         src {
-          end_column: 48
-          end_line: 33
+          end_column: 36
+          end_line: 29
           file: 2
-          start_column: 24
-          start_line: 33
+          start_column: 14
+          start_line: 29
         }
-        weights: 0.1
-        weights: 0.2
-        weights: 0.3
+        weights: 0.7
       }
     }
     symbol {
@@ -127,20 +127,13 @@ body {
 body {
   assign {
     expr {
-      object_get_item {
-        args {
-          int64_val {
-            src {
-              end_column: 48
-              end_line: 33
-              file: 2
-              start_column: 24
-              start_line: 33
+      dataframe_random_split {
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
             }
           }
-        }
-        obj {
-          bitfield1: 2
         }
         src {
           end_column: 48
@@ -149,10 +142,12 @@ body {
           start_column: 24
           start_line: 33
         }
+        weights: 0.1
+        weights: 0.2
+        weights: 0.3
       }
     }
     symbol {
-      value: "df1"
     }
     uid: 3
     var_id {
@@ -173,11 +168,10 @@ body {
               start_column: 24
               start_line: 33
             }
-            v: 1
           }
         }
         obj {
-          bitfield1: 2
+          bitfield1: 3
         }
         src {
           end_column: 48
@@ -189,7 +183,7 @@ body {
       }
     }
     symbol {
-      value: "df2"
+      value: "df1"
     }
     uid: 4
     var_id {
@@ -210,11 +204,48 @@ body {
               start_column: 24
               start_line: 33
             }
+            v: 1
+          }
+        }
+        obj {
+          bitfield1: 3
+        }
+        src {
+          end_column: 48
+          end_line: 33
+          file: 2
+          start_column: 24
+          start_line: 33
+        }
+      }
+    }
+    symbol {
+      value: "df2"
+    }
+    uid: 5
+    var_id {
+      bitfield1: 5
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      object_get_item {
+        args {
+          int64_val {
+            src {
+              end_column: 48
+              end_line: 33
+              file: 2
+              start_column: 24
+              start_line: 33
+            }
             v: 2
           }
         }
         obj {
-          bitfield1: 2
+          bitfield1: 3
         }
         src {
           end_column: 48
@@ -228,9 +259,9 @@ body {
     symbol {
       value: "df3"
     }
-    uid: 5
+    uid: 6
     var_id {
-      bitfield1: 5
+      bitfield1: 6
     }
   }
 }
@@ -262,42 +293,6 @@ body {
     }
     symbol {
     }
-    uid: 6
-    var_id {
-      bitfield1: 6
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      object_get_item {
-        args {
-          int64_val {
-            src {
-              end_column: 57
-              end_line: 37
-              file: 2
-              start_column: 24
-              start_line: 37
-            }
-          }
-        }
-        obj {
-          bitfield1: 6
-        }
-        src {
-          end_column: 57
-          end_line: 37
-          file: 2
-          start_column: 24
-          start_line: 37
-        }
-      }
-    }
-    symbol {
-      value: "df3"
-    }
     uid: 7
     var_id {
       bitfield1: 7
@@ -317,11 +312,10 @@ body {
               start_column: 24
               start_line: 37
             }
-            v: 1
           }
         }
         obj {
-          bitfield1: 6
+          bitfield1: 7
         }
         src {
           end_column: 57
@@ -333,7 +327,7 @@ body {
       }
     }
     symbol {
-      value: "df1"
+      value: "df3"
     }
     uid: 8
     var_id {
@@ -354,11 +348,48 @@ body {
               start_column: 24
               start_line: 37
             }
+            v: 1
+          }
+        }
+        obj {
+          bitfield1: 7
+        }
+        src {
+          end_column: 57
+          end_line: 37
+          file: 2
+          start_column: 24
+          start_line: 37
+        }
+      }
+    }
+    symbol {
+      value: "df1"
+    }
+    uid: 9
+    var_id {
+      bitfield1: 9
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      object_get_item {
+        args {
+          int64_val {
+            src {
+              end_column: 57
+              end_line: 37
+              file: 2
+              start_column: 24
+              start_line: 37
+            }
             v: 2
           }
         }
         obj {
-          bitfield1: 6
+          bitfield1: 7
         }
         src {
           end_column: 57
@@ -372,9 +403,9 @@ body {
     symbol {
       value: "df2"
     }
-    uid: 9
+    uid: 10
     var_id {
-      bitfield1: 9
+      bitfield1: 10
     }
   }
 }
@@ -467,38 +498,12 @@ body {
         df {
           dataframe_ref {
             id {
-              bitfield1: 8
+              bitfield1: 9
             }
           }
         }
         src {
           end_column: 40
-          end_line: 39
-          file: 2
-          start_column: 8
-          start_line: 39
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 10
-    var_id {
-      bitfield1: 10
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_collect {
-        block: true
-        case_sensitive: true
-        id {
-          bitfield1: 10
-        }
-        src {
-          end_column: 50
           end_line: 39
           file: 2
           start_column: 8
@@ -515,10 +520,36 @@ body {
   }
 }
 body {
-  eval {
+  assign {
+    expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 11
+        }
+        src {
+          end_column: 50
+          end_line: 39
+          file: 2
+          start_column: 8
+          start_line: 39
+        }
+      }
+    }
+    symbol {
+    }
     uid: 12
     var_id {
-      bitfield1: 11
+      bitfield1: 12
+    }
+  }
+}
+body {
+  eval {
+    uid: 13
+    var_id {
+      bitfield1: 12
     }
   }
 }
@@ -551,41 +582,6 @@ body {
     symbol {
       value: "t"
     }
-    uid: 13
-    var_id {
-      bitfield1: 13
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      object_get_item {
-        args {
-          int64_val {
-            src {
-              end_column: 48
-              end_line: 41
-              file: 2
-              start_column: 12
-              start_line: 41
-            }
-          }
-        }
-        obj {
-          bitfield1: 13
-        }
-        src {
-          end_column: 48
-          end_line: 41
-          file: 2
-          start_column: 12
-          start_line: 41
-        }
-      }
-    }
-    symbol {
-    }
     uid: 14
     var_id {
       bitfield1: 14
@@ -605,11 +601,10 @@ body {
               start_column: 12
               start_line: 41
             }
-            v: 1
           }
         }
         obj {
-          bitfield1: 13
+          bitfield1: 14
         }
         src {
           end_column: 48
@@ -641,11 +636,11 @@ body {
               start_column: 12
               start_line: 41
             }
-            v: 2
+            v: 1
           }
         }
         obj {
-          bitfield1: 13
+          bitfield1: 14
         }
         src {
           end_column: 48
@@ -667,18 +662,28 @@ body {
 body {
   assign {
     expr {
-      dataframe_collect {
-        block: true
-        case_sensitive: true
-        id {
+      object_get_item {
+        args {
+          int64_val {
+            src {
+              end_column: 48
+              end_line: 41
+              file: 2
+              start_column: 12
+              start_line: 41
+            }
+            v: 2
+          }
+        }
+        obj {
           bitfield1: 14
         }
         src {
-          end_column: 22
-          end_line: 43
+          end_column: 48
+          end_line: 41
           file: 2
-          start_column: 8
-          start_line: 43
+          start_column: 12
+          start_line: 41
         }
       }
     }
@@ -691,10 +696,36 @@ body {
   }
 }
 body {
-  eval {
+  assign {
+    expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 15
+        }
+        src {
+          end_column: 22
+          end_line: 43
+          file: 2
+          start_column: 8
+          start_line: 43
+        }
+      }
+    }
+    symbol {
+    }
     uid: 18
     var_id {
-      bitfield1: 17
+      bitfield1: 18
+    }
+  }
+}
+body {
+  eval {
+    uid: 19
+    var_id {
+      bitfield1: 18
     }
   }
 }

--- a/tests/ast/data/functions.table_functions.test
+++ b/tests/ast/data/functions.table_functions.test
@@ -9,7 +9,7 @@ df1 = session.create_dataframe(
 )
 df2 = df1.select(df1.idx, explode(df1.lists)).sort(col("idx"))
 
-df3 = df1.select(explode("maps").as_("primo", "secundo")).sort(col("primo"))
+df3 = df1.select(explode_outer("maps").as_("primo", "secundo")).sort(col("primo"))
 
 df4 = session.create_dataframe(
     [
@@ -39,6 +39,10 @@ df7 = (
     .sort("strs", "value")
 )
 
+df8 = df1.select(df1.idx, explode(df1.lists).over(partition_by="idx", order_by="idx"))
+
+df9 = df1.select(df1.idx, explode_outer(df1.maps).over(partition_by=["idx"], order_by=["idx"]))
+
 ## EXPECTED UNPARSER OUTPUT
 
 df1 = session.create_dataframe([[1, [1, 2, 3], {"Ashi Garami": "Single Leg X"}, "Kimura"], [2, [11, 22], {"Sankaku": "Triangle"}, "Coffee"]], schema=["idx", "lists", "maps", "strs"])
@@ -47,7 +51,7 @@ df2 = df1.select(df1["idx"], (explode(df1["lists"])))
 
 df2 = df2.sort(col("idx"))
 
-df3 = df1.select((explode("maps").alias("primo", "secundo")))
+df3 = df1.select((explode_outer("maps").alias("primo", "secundo")))
 
 df3 = df3.sort(col("primo"))
 
@@ -58,6 +62,10 @@ res6 = df4.select(df4["idx"], (flatten(df4["lists"], "", True, False, "both"))).
 res11 = df4.select(df4["strs"], (flatten(df4["maps"], "", False, True, "both"))).select("strs", "key", "value").filter("key is not NULL").sort("strs")
 
 res16 = df4.select(df4["strs"], (flatten(df4["maps"], "", False, True, "both"))).select("strs", "key", "value").filter("key is NULL").sort("strs", "value")
+
+df8 = df1.select(df1["idx"], (explode(df1["lists"]).over(partition_by="idx", order_by="idx")))
+
+df9 = df1.select(df1["idx"], (explode_outer(df1["maps"]).over(partition_by=["idx"], order_by=["idx"])))
 
 ## EXPECTED ENCODED AST
 
@@ -524,7 +532,7 @@ body {
           args {
             string_val {
               src {
-                end_column: 64
+                end_column: 70
                 end_line: 34
                 file: 2
                 start_column: 25
@@ -536,7 +544,7 @@ body {
           args {
             string_val {
               src {
-                end_column: 64
+                end_column: 70
                 end_line: 34
                 file: 2
                 start_column: 25
@@ -554,7 +562,7 @@ body {
                 name {
                   name {
                     name_flat {
-                      name: "explode"
+                      name: "explode_outer"
                     }
                   }
                 }
@@ -563,7 +571,7 @@ body {
             pos_args {
               string_val {
                 src {
-                  end_column: 40
+                  end_column: 46
                   end_line: 34
                   file: 2
                   start_column: 25
@@ -573,7 +581,7 @@ body {
               }
             }
             src {
-              end_column: 40
+              end_column: 46
               end_line: 34
               file: 2
               start_column: 25
@@ -582,7 +590,7 @@ body {
           }
         }
         src {
-          end_column: 64
+          end_column: 70
           end_line: 34
           file: 2
           start_column: 25
@@ -613,7 +621,7 @@ body {
                 }
               }
               src {
-                end_column: 65
+                end_column: 71
                 end_line: 34
                 file: 2
                 start_column: 14
@@ -631,7 +639,7 @@ body {
           }
         }
         src {
-          end_column: 65
+          end_column: 71
           end_line: 34
           file: 2
           start_column: 14
@@ -669,20 +677,20 @@ body {
               pos_args {
                 string_val {
                   src {
-                    end_column: 83
+                    end_column: 89
                     end_line: 34
                     file: 2
-                    start_column: 71
+                    start_column: 77
                     start_line: 34
                   }
                   v: "primo"
                 }
               }
               src {
-                end_column: 83
+                end_column: 89
                 end_line: 34
                 file: 2
-                start_column: 71
+                start_column: 77
                 start_line: 34
               }
             }
@@ -697,7 +705,7 @@ body {
           }
         }
         src {
-          end_column: 84
+          end_column: 90
           end_line: 34
           file: 2
           start_column: 14
@@ -1967,6 +1975,326 @@ body {
     uid: 22
     var_id {
       bitfield1: 22
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "explode"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              dataframe_col {
+                col_name: "lists"
+                df {
+                  dataframe_ref {
+                    id {
+                      bitfield1: 1
+                    }
+                  }
+                }
+                src {
+                  end_column: 51
+                  end_line: 64
+                  file: 2
+                  start_column: 42
+                  start_line: 64
+                }
+              }
+            }
+            src {
+              end_column: 52
+              end_line: 64
+              file: 2
+              start_column: 34
+              start_line: 64
+            }
+          }
+        }
+        order_by {
+          args {
+            string_val {
+              src {
+                end_column: 93
+                end_line: 64
+                file: 2
+                start_column: 34
+                start_line: 64
+              }
+              v: "idx"
+            }
+          }
+          variadic: true
+        }
+        partition_by {
+          args {
+            string_val {
+              src {
+                end_column: 93
+                end_line: 64
+                file: 2
+                start_column: 34
+                start_line: 64
+              }
+              v: "idx"
+            }
+          }
+          variadic: true
+        }
+        src {
+          end_column: 93
+          end_line: 64
+          file: 2
+          start_column: 34
+          start_line: 64
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 23
+    var_id {
+      bitfield1: 23
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            dataframe_col {
+              col_name: "idx"
+              df {
+                dataframe_ref {
+                  id {
+                    bitfield1: 1
+                  }
+                }
+              }
+              src {
+                end_column: 32
+                end_line: 64
+                file: 2
+                start_column: 25
+                start_line: 64
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                indirect_table_fn_id_ref {
+                  id {
+                    bitfield1: 23
+                  }
+                }
+              }
+              src {
+                end_column: 94
+                end_line: 64
+                file: 2
+                start_column: 14
+                start_line: 64
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 94
+          end_line: 64
+          file: 2
+          start_column: 14
+          start_line: 64
+        }
+      }
+    }
+    symbol {
+      value: "df8"
+    }
+    uid: 24
+    var_id {
+      bitfield1: 24
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      table_fn_call_over {
+        lhs {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "explode_outer"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              dataframe_col {
+                col_name: "maps"
+                df {
+                  dataframe_ref {
+                    id {
+                      bitfield1: 1
+                    }
+                  }
+                }
+                src {
+                  end_column: 56
+                  end_line: 66
+                  file: 2
+                  start_column: 48
+                  start_line: 66
+                }
+              }
+            }
+            src {
+              end_column: 57
+              end_line: 66
+              file: 2
+              start_column: 34
+              start_line: 66
+            }
+          }
+        }
+        order_by {
+          args {
+            string_val {
+              src {
+                end_column: 102
+                end_line: 66
+                file: 2
+                start_column: 34
+                start_line: 66
+              }
+              v: "idx"
+            }
+          }
+        }
+        partition_by {
+          args {
+            string_val {
+              src {
+                end_column: 102
+                end_line: 66
+                file: 2
+                start_column: 34
+                start_line: 66
+              }
+              v: "idx"
+            }
+          }
+        }
+        src {
+          end_column: 102
+          end_line: 66
+          file: 2
+          start_column: 34
+          start_line: 66
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 25
+    var_id {
+      bitfield1: 25
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            dataframe_col {
+              col_name: "idx"
+              df {
+                dataframe_ref {
+                  id {
+                    bitfield1: 1
+                  }
+                }
+              }
+              src {
+                end_column: 32
+                end_line: 66
+                file: 2
+                start_column: 25
+                start_line: 66
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                indirect_table_fn_id_ref {
+                  id {
+                    bitfield1: 25
+                  }
+                }
+              }
+              src {
+                end_column: 103
+                end_line: 66
+                file: 2
+                start_column: 14
+                start_line: 66
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 103
+          end_line: 66
+          file: 2
+          start_column: 14
+          start_line: 66
+        }
+      }
+    }
+    symbol {
+      value: "df9"
+    }
+    uid: 26
+    var_id {
+      bitfield1: 26
     }
   }
 }

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -298,6 +298,10 @@ df146 = df.select(to_utc_timestamp("A", lit(1234)), to_utc_timestamp(col("A"), c
 
 df147 = df.select(to_date("A"), to_date("A", col("A")), to_date(col("A"), None))
 
+df148 = df.select(system_reference("table", "table1"))
+
+df149 = df.select(to_boolean("A"), to_boolean(col("A")))
+
 ## EXPECTED UNPARSER OUTPUT
 
 df = session.table("table1")
@@ -388,7 +392,7 @@ df42 = df.select(kurtosis("A"))
 
 df43 = df.select(max("*"), max("A"), max(col("A")))
 
-df44 = df.select(avg("A"))
+df44 = df.select(mean("A"))
 
 df45 = df.select(median("A"))
 
@@ -410,7 +414,7 @@ df53 = df.select(sum_distinct("A"))
 
 df54 = df.select(variance("A"))
 
-df55 = df.select(variance("A"))
+df55 = df.select(var_samp("A"))
 
 df56 = df.select(var_pop("A"))
 
@@ -595,6 +599,10 @@ df145 = df111.select(from_utc_timestamp("A", lit(1234)), from_utc_timestamp(col(
 df146 = df111.select(to_utc_timestamp("A", lit(1234)), to_utc_timestamp(col("A"), col("B")))
 
 df147 = df111.select(to_date("A"), to_date("A", col("A")), to_date(col("A")))
+
+df148 = df111.select(system_reference("table", "table1", "CALL", []))
+
+df149 = df111.select(to_boolean("A"), to_boolean(col("A")))
 
 ## EXPECTED ENCODED AST
 
@@ -5575,7 +5583,7 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "avg"
+                        name: "mean"
                       }
                     }
                   }
@@ -6301,7 +6309,7 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "variance"
+                        name: "var_samp"
                       }
                     }
                   }
@@ -19360,6 +19368,229 @@ body {
     uid: 148
     var_id {
       bitfield1: 148
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "system_reference"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 61
+                    end_line: 323
+                    file: 2
+                    start_column: 26
+                    start_line: 323
+                  }
+                  v: "table"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 61
+                    end_line: 323
+                    file: 2
+                    start_column: 26
+                    start_line: 323
+                  }
+                  v: "table1"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 61
+                    end_line: 323
+                    file: 2
+                    start_column: 26
+                    start_line: 323
+                  }
+                  v: "CALL"
+                }
+              }
+              pos_args {
+                list_val {
+                  src {
+                    end_column: 61
+                    end_line: 323
+                    file: 2
+                    start_column: 26
+                    start_line: 323
+                  }
+                }
+              }
+              src {
+                end_column: 61
+                end_line: 323
+                file: 2
+                start_column: 26
+                start_line: 323
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 112
+            }
+          }
+        }
+        src {
+          end_column: 62
+          end_line: 323
+          file: 2
+          start_column: 16
+          start_line: 323
+        }
+      }
+    }
+    symbol {
+      value: "df148"
+    }
+    uid: 149
+    var_id {
+      bitfield1: 149
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "to_boolean"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 41
+                    end_line: 325
+                    file: 2
+                    start_column: 26
+                    start_line: 325
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 41
+                end_line: 325
+                file: 2
+                start_column: 26
+                start_line: 325
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "to_boolean"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 62
+                        end_line: 325
+                        file: 2
+                        start_column: 54
+                        start_line: 325
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 62
+                    end_line: 325
+                    file: 2
+                    start_column: 54
+                    start_line: 325
+                  }
+                }
+              }
+              src {
+                end_column: 63
+                end_line: 325
+                file: 2
+                start_column: 43
+                start_line: 325
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 112
+            }
+          }
+        }
+        src {
+          end_column: 64
+          end_line: 325
+          file: 2
+          start_column: 16
+          start_line: 325
+        }
+      }
+    }
+    symbol {
+      value: "df149"
+    }
+    uid: 150
+    var_id {
+      bitfield1: 150
     }
   }
 }

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -380,6 +380,70 @@ df343 = df.select(fl_is_image("A"))
 
 df344 = df.select(fl_is_video("A"))
 
+df345 = df.select(arrays_zip("A", lit(1)), arrays_zip("A", "B"), arrays_zip(col("A"), col("B")))
+
+df346 = df.select(window("A", "1 minute"), window(col("A"), window_duration="1 minute", start_time="2 minutes"))
+
+df347 = df.select(from_json(col("B"), StringType()), from_json("A", "array<integer>"))
+
+df348 = df.select(array_remove("A", lit(1)), array_remove("A", "B"), array_remove(col("A"), col("B")))
+
+df349 = df.select(ln("A"))
+
+df350 = df.select(call_builtin("avg", col("B")))
+
+df351 = df.select(builtin("avg")("B"))
+
+df352 = df.select(acosh("A"), acosh(col("B")))
+
+df353 = df.select(asinh("A"), asinh(col("B")))
+
+df354 = df.select(atanh("A"), atanh(col("B")))
+
+df355 = df.select(bit_length("A"), bit_length(col("B")))
+
+df356 = df.select(bitmap_bit_position("A"), bitmap_bit_position(col("B")))
+
+df357 = df.select(bitmap_bucket_number("A"), bitmap_bucket_number(col("B")))
+
+df358 = df.select(bitmap_construct_agg("A"), bitmap_construct_agg(col("B")))
+
+df359 = df.select(cbrt("A"), cbrt(col("B")))
+
+df360 = df.select(ifnull("A", "B"), ifnull(col("A"), col("B")))
+
+df361 = df.select(localtimestamp(), localtimestamp(0), localtimestamp(1), localtimestamp(2))
+
+df362 = df.select(max_by("A", "B"), max_by(col("A"), "B", 3))
+
+df363 = df.select(min_by("A", "B"), min_by(col("A"), "B", 3))
+
+df364 = df.select(octet_length("A"), octet_length(col("B")))
+
+df365 = df.select(position("A", "B"), position(col("A"), "B", 5))
+
+df366 = df.select(regr_avgx("A", "B"), regr_avgx(col("A"), col("B")))
+
+df367 = df.select(regr_avgy("A", "B"), regr_avgy(col("A"), col("B")))
+
+df368 = df.select(regr_count("A", "B"), regr_count(col("A"), col("B")))
+
+df369 = df.select(regr_intercept("A", "B"), regr_intercept(col("A"), col("B")))
+
+df370 = df.select(regr_r2("A", "B"), regr_r2(col("A"), col("B")))
+
+df371 = df.select(regr_slope("A", "B"), regr_slope(col("A"), col("B")))
+
+df372 = df.select(regr_sxx("A", "B"), regr_sxx(col("A"), col("B")))
+
+df373 = df.select(regr_sxy("A", "B"), regr_sxy(col("A"), col("B")))
+
+df374 = df.select(regr_syy("A", "B"), regr_syy(col("A"), col("B")))
+
+df375 = df.select(try_to_binary("A"), try_to_binary("A", "BASE64"), try_to_binary(col("A"), "UTF-8"))
+
+df376 = df.select(build_stage_file_url("@images_stage", "/us/yosemite/half_dome.jpg"))
+
 ## EXPECTED UNPARSER OUTPUT
 
 df = session.table("table1")
@@ -759,6 +823,70 @@ df342 = df.select(fl_is_document("A"))
 df343 = df.select(fl_is_image("A"))
 
 df344 = df.select(fl_is_video("A"))
+
+df345 = df.select(arrays_zip("A", lit(1)), arrays_zip("A", "B"), arrays_zip(col("A"), col("B")))
+
+df346 = df.select(window("A", "1 minute", None, None), window(col("A"), "1 minute", None, "2 minutes"))
+
+df347 = df.select(from_json(col("B"), StringType()), from_json("A", "array<integer>"))
+
+df348 = df.select(array_remove("A", lit(1)), array_remove("A", "B"), array_remove(col("A"), col("B")))
+
+df349 = df.select(ln("A"))
+
+df350 = df.select(avg(col("B")))
+
+df351 = df.select(avg("B"))
+
+df352 = df.select(acosh("A"), acosh(col("B")))
+
+df353 = df.select(asinh("A"), asinh(col("B")))
+
+df354 = df.select(atanh("A"), atanh(col("B")))
+
+df355 = df.select(bit_length("A"), bit_length(col("B")))
+
+df356 = df.select(bitmap_bit_position("A"), bitmap_bit_position(col("B")))
+
+df357 = df.select(bitmap_bucket_number("A"), bitmap_bucket_number(col("B")))
+
+df358 = df.select(bitmap_construct_agg("A"), bitmap_construct_agg(col("B")))
+
+df359 = df.select(cbrt("A"), cbrt(col("B")))
+
+df360 = df.select(ifnull("A", "B"), ifnull(col("A"), col("B")))
+
+df361 = df.select(localtimestamp(9), localtimestamp(0), localtimestamp(1), localtimestamp(2))
+
+df362 = df.select(max_by("A", "B"), max_by(col("A"), "B", 3))
+
+df363 = df.select(min_by("A", "B"), max_by(col("A"), "B", 3))
+
+df364 = df.select(octet_length("A"), octet_length(col("B")))
+
+df365 = df.select(position("A", "B", 1), position(col("A"), "B", 5))
+
+df366 = df.select(regr_avgx("A", "B"), regr_avgx(col("A"), col("B")))
+
+df367 = df.select(regr_avgy("A", "B"), regr_avgy(col("A"), col("B")))
+
+df368 = df.select(regr_count("A", "B"), regr_count(col("A"), col("B")))
+
+df369 = df.select(regr_intercept("A", "B"), regr_intercept(col("A"), col("B")))
+
+df370 = df.select(regr_r2("A", "B"), regr_r2(col("A"), col("B")))
+
+df371 = df.select(regr_slope("A", "B"), regr_slope(col("A"), col("B")))
+
+df372 = df.select(regr_sxx("A", "B"), regr_sxx(col("A"), col("B")))
+
+df373 = df.select(regr_sxy("A", "B"), regr_sxy(col("A"), col("B")))
+
+df374 = df.select(regr_syy("A", "B"), regr_syy(col("A"), col("B")))
+
+df375 = df.select(try_to_binary("A"), try_to_binary("A", "BASE64"), try_to_binary(col("A"), "UTF-8"))
+
+df376 = df.select(build_stage_file_url("@images_stage", "/us/yosemite/half_dome.jpg"))
 
 ## EXPECTED ENCODED AST
 
@@ -25441,6 +25569,4729 @@ body {
     uid: 189
     var_id {
       bitfield1: 189
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "arrays_zip"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 49
+                    end_line: 405
+                    file: 2
+                    start_column: 26
+                    start_line: 405
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "lit"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    int64_val {
+                      src {
+                        end_column: 48
+                        end_line: 405
+                        file: 2
+                        start_column: 42
+                        start_line: 405
+                      }
+                      v: 1
+                    }
+                  }
+                  src {
+                    end_column: 48
+                    end_line: 405
+                    file: 2
+                    start_column: 42
+                    start_line: 405
+                  }
+                }
+              }
+              src {
+                end_column: 49
+                end_line: 405
+                file: 2
+                start_column: 26
+                start_line: 405
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "arrays_zip"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 71
+                    end_line: 405
+                    file: 2
+                    start_column: 51
+                    start_line: 405
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 71
+                    end_line: 405
+                    file: 2
+                    start_column: 51
+                    start_line: 405
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 71
+                end_line: 405
+                file: 2
+                start_column: 51
+                start_line: 405
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "arrays_zip"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 92
+                        end_line: 405
+                        file: 2
+                        start_column: 84
+                        start_line: 405
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 92
+                    end_line: 405
+                    file: 2
+                    start_column: 84
+                    start_line: 405
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 102
+                        end_line: 405
+                        file: 2
+                        start_column: 94
+                        start_line: 405
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 102
+                    end_line: 405
+                    file: 2
+                    start_column: 94
+                    start_line: 405
+                  }
+                }
+              }
+              src {
+                end_column: 103
+                end_line: 405
+                file: 2
+                start_column: 73
+                start_line: 405
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 104
+          end_line: 405
+          file: 2
+          start_column: 16
+          start_line: 405
+        }
+      }
+    }
+    symbol {
+      value: "df345"
+    }
+    uid: 190
+    var_id {
+      bitfield1: 190
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "window"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 49
+                    end_line: 407
+                    file: 2
+                    start_column: 26
+                    start_line: 407
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 49
+                    end_line: 407
+                    file: 2
+                    start_column: 26
+                    start_line: 407
+                  }
+                  v: "1 minute"
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 49
+                    end_line: 407
+                    file: 2
+                    start_column: 26
+                    start_line: 407
+                  }
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 49
+                    end_line: 407
+                    file: 2
+                    start_column: 26
+                    start_line: 407
+                  }
+                }
+              }
+              src {
+                end_column: 49
+                end_line: 407
+                file: 2
+                start_column: 26
+                start_line: 407
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "window"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 66
+                        end_line: 407
+                        file: 2
+                        start_column: 58
+                        start_line: 407
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 66
+                    end_line: 407
+                    file: 2
+                    start_column: 58
+                    start_line: 407
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 119
+                    end_line: 407
+                    file: 2
+                    start_column: 51
+                    start_line: 407
+                  }
+                  v: "1 minute"
+                }
+              }
+              pos_args {
+                null_val {
+                  src {
+                    end_column: 119
+                    end_line: 407
+                    file: 2
+                    start_column: 51
+                    start_line: 407
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 119
+                    end_line: 407
+                    file: 2
+                    start_column: 51
+                    start_line: 407
+                  }
+                  v: "2 minutes"
+                }
+              }
+              src {
+                end_column: 119
+                end_line: 407
+                file: 2
+                start_column: 51
+                start_line: 407
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 120
+          end_line: 407
+          file: 2
+          start_column: 16
+          start_line: 407
+        }
+      }
+    }
+    symbol {
+      value: "df346"
+    }
+    uid: 191
+    var_id {
+      bitfield1: 191
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "from_json"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 44
+                        end_line: 409
+                        file: 2
+                        start_column: 36
+                        start_line: 409
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 44
+                    end_line: 409
+                    file: 2
+                    start_column: 36
+                    start_line: 409
+                  }
+                }
+              }
+              pos_args {
+                datatype_val {
+                  datatype {
+                    string_type {
+                      length {
+                      }
+                    }
+                  }
+                  src {
+                    end_column: 59
+                    end_line: 409
+                    file: 2
+                    start_column: 26
+                    start_line: 409
+                  }
+                }
+              }
+              src {
+                end_column: 59
+                end_line: 409
+                file: 2
+                start_column: 26
+                start_line: 409
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "from_json"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 93
+                    end_line: 409
+                    file: 2
+                    start_column: 61
+                    start_line: 409
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 93
+                    end_line: 409
+                    file: 2
+                    start_column: 61
+                    start_line: 409
+                  }
+                  v: "array<integer>"
+                }
+              }
+              src {
+                end_column: 93
+                end_line: 409
+                file: 2
+                start_column: 61
+                start_line: 409
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 94
+          end_line: 409
+          file: 2
+          start_column: 16
+          start_line: 409
+        }
+      }
+    }
+    symbol {
+      value: "df347"
+    }
+    uid: 192
+    var_id {
+      bitfield1: 192
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "array_remove"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 51
+                    end_line: 411
+                    file: 2
+                    start_column: 26
+                    start_line: 411
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "lit"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    int64_val {
+                      src {
+                        end_column: 50
+                        end_line: 411
+                        file: 2
+                        start_column: 44
+                        start_line: 411
+                      }
+                      v: 1
+                    }
+                  }
+                  src {
+                    end_column: 50
+                    end_line: 411
+                    file: 2
+                    start_column: 44
+                    start_line: 411
+                  }
+                }
+              }
+              src {
+                end_column: 51
+                end_line: 411
+                file: 2
+                start_column: 26
+                start_line: 411
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "array_remove"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 75
+                    end_line: 411
+                    file: 2
+                    start_column: 53
+                    start_line: 411
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 75
+                    end_line: 411
+                    file: 2
+                    start_column: 53
+                    start_line: 411
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 75
+                end_line: 411
+                file: 2
+                start_column: 53
+                start_line: 411
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "array_remove"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 98
+                        end_line: 411
+                        file: 2
+                        start_column: 90
+                        start_line: 411
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 98
+                    end_line: 411
+                    file: 2
+                    start_column: 90
+                    start_line: 411
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 108
+                        end_line: 411
+                        file: 2
+                        start_column: 100
+                        start_line: 411
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 108
+                    end_line: 411
+                    file: 2
+                    start_column: 100
+                    start_line: 411
+                  }
+                }
+              }
+              src {
+                end_column: 109
+                end_line: 411
+                file: 2
+                start_column: 77
+                start_line: 411
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 110
+          end_line: 411
+          file: 2
+          start_column: 16
+          start_line: 411
+        }
+      }
+    }
+    symbol {
+      value: "df348"
+    }
+    uid: 193
+    var_id {
+      bitfield1: 193
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "ln"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 33
+                    end_line: 413
+                    file: 2
+                    start_column: 26
+                    start_line: 413
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 33
+                end_line: 413
+                file: 2
+                start_column: 26
+                start_line: 413
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 34
+          end_line: 413
+          file: 2
+          start_column: 16
+          start_line: 413
+        }
+      }
+    }
+    symbol {
+      value: "df349"
+    }
+    uid: 194
+    var_id {
+      bitfield1: 194
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "avg"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 54
+                        end_line: 415
+                        file: 2
+                        start_column: 46
+                        start_line: 415
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 54
+                    end_line: 415
+                    file: 2
+                    start_column: 46
+                    start_line: 415
+                  }
+                }
+              }
+              src {
+                end_column: 55
+                end_line: 415
+                file: 2
+                start_column: 26
+                start_line: 415
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 56
+          end_line: 415
+          file: 2
+          start_column: 16
+          start_line: 415
+        }
+      }
+    }
+    symbol {
+      value: "df350"
+    }
+    uid: 195
+    var_id {
+      bitfield1: 195
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "avg"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 45
+                    end_line: 417
+                    file: 2
+                    start_column: 26
+                    start_line: 417
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 45
+                end_line: 417
+                file: 2
+                start_column: 26
+                start_line: 417
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 46
+          end_line: 417
+          file: 2
+          start_column: 16
+          start_line: 417
+        }
+      }
+    }
+    symbol {
+      value: "df351"
+    }
+    uid: 196
+    var_id {
+      bitfield1: 196
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "acosh"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 36
+                    end_line: 419
+                    file: 2
+                    start_column: 26
+                    start_line: 419
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 36
+                end_line: 419
+                file: 2
+                start_column: 26
+                start_line: 419
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "acosh"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 52
+                        end_line: 419
+                        file: 2
+                        start_column: 44
+                        start_line: 419
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 52
+                    end_line: 419
+                    file: 2
+                    start_column: 44
+                    start_line: 419
+                  }
+                }
+              }
+              src {
+                end_column: 53
+                end_line: 419
+                file: 2
+                start_column: 38
+                start_line: 419
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 54
+          end_line: 419
+          file: 2
+          start_column: 16
+          start_line: 419
+        }
+      }
+    }
+    symbol {
+      value: "df352"
+    }
+    uid: 197
+    var_id {
+      bitfield1: 197
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "asinh"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 36
+                    end_line: 421
+                    file: 2
+                    start_column: 26
+                    start_line: 421
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 36
+                end_line: 421
+                file: 2
+                start_column: 26
+                start_line: 421
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "asinh"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 52
+                        end_line: 421
+                        file: 2
+                        start_column: 44
+                        start_line: 421
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 52
+                    end_line: 421
+                    file: 2
+                    start_column: 44
+                    start_line: 421
+                  }
+                }
+              }
+              src {
+                end_column: 53
+                end_line: 421
+                file: 2
+                start_column: 38
+                start_line: 421
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 54
+          end_line: 421
+          file: 2
+          start_column: 16
+          start_line: 421
+        }
+      }
+    }
+    symbol {
+      value: "df353"
+    }
+    uid: 198
+    var_id {
+      bitfield1: 198
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "atanh"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 36
+                    end_line: 423
+                    file: 2
+                    start_column: 26
+                    start_line: 423
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 36
+                end_line: 423
+                file: 2
+                start_column: 26
+                start_line: 423
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "atanh"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 52
+                        end_line: 423
+                        file: 2
+                        start_column: 44
+                        start_line: 423
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 52
+                    end_line: 423
+                    file: 2
+                    start_column: 44
+                    start_line: 423
+                  }
+                }
+              }
+              src {
+                end_column: 53
+                end_line: 423
+                file: 2
+                start_column: 38
+                start_line: 423
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 54
+          end_line: 423
+          file: 2
+          start_column: 16
+          start_line: 423
+        }
+      }
+    }
+    symbol {
+      value: "df354"
+    }
+    uid: 199
+    var_id {
+      bitfield1: 199
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bit_length"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 41
+                    end_line: 425
+                    file: 2
+                    start_column: 26
+                    start_line: 425
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 41
+                end_line: 425
+                file: 2
+                start_column: 26
+                start_line: 425
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bit_length"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 62
+                        end_line: 425
+                        file: 2
+                        start_column: 54
+                        start_line: 425
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 62
+                    end_line: 425
+                    file: 2
+                    start_column: 54
+                    start_line: 425
+                  }
+                }
+              }
+              src {
+                end_column: 63
+                end_line: 425
+                file: 2
+                start_column: 43
+                start_line: 425
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 64
+          end_line: 425
+          file: 2
+          start_column: 16
+          start_line: 425
+        }
+      }
+    }
+    symbol {
+      value: "df355"
+    }
+    uid: 200
+    var_id {
+      bitfield1: 200
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bitmap_bit_position"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 50
+                    end_line: 427
+                    file: 2
+                    start_column: 26
+                    start_line: 427
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 50
+                end_line: 427
+                file: 2
+                start_column: 26
+                start_line: 427
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bitmap_bit_position"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 80
+                        end_line: 427
+                        file: 2
+                        start_column: 72
+                        start_line: 427
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 80
+                    end_line: 427
+                    file: 2
+                    start_column: 72
+                    start_line: 427
+                  }
+                }
+              }
+              src {
+                end_column: 81
+                end_line: 427
+                file: 2
+                start_column: 52
+                start_line: 427
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 82
+          end_line: 427
+          file: 2
+          start_column: 16
+          start_line: 427
+        }
+      }
+    }
+    symbol {
+      value: "df356"
+    }
+    uid: 201
+    var_id {
+      bitfield1: 201
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bitmap_bucket_number"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 51
+                    end_line: 429
+                    file: 2
+                    start_column: 26
+                    start_line: 429
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 51
+                end_line: 429
+                file: 2
+                start_column: 26
+                start_line: 429
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bitmap_bucket_number"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 82
+                        end_line: 429
+                        file: 2
+                        start_column: 74
+                        start_line: 429
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 82
+                    end_line: 429
+                    file: 2
+                    start_column: 74
+                    start_line: 429
+                  }
+                }
+              }
+              src {
+                end_column: 83
+                end_line: 429
+                file: 2
+                start_column: 53
+                start_line: 429
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 84
+          end_line: 429
+          file: 2
+          start_column: 16
+          start_line: 429
+        }
+      }
+    }
+    symbol {
+      value: "df357"
+    }
+    uid: 202
+    var_id {
+      bitfield1: 202
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bitmap_construct_agg"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 51
+                    end_line: 431
+                    file: 2
+                    start_column: 26
+                    start_line: 431
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 51
+                end_line: 431
+                file: 2
+                start_column: 26
+                start_line: 431
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "bitmap_construct_agg"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 82
+                        end_line: 431
+                        file: 2
+                        start_column: 74
+                        start_line: 431
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 82
+                    end_line: 431
+                    file: 2
+                    start_column: 74
+                    start_line: 431
+                  }
+                }
+              }
+              src {
+                end_column: 83
+                end_line: 431
+                file: 2
+                start_column: 53
+                start_line: 431
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 84
+          end_line: 431
+          file: 2
+          start_column: 16
+          start_line: 431
+        }
+      }
+    }
+    symbol {
+      value: "df358"
+    }
+    uid: 203
+    var_id {
+      bitfield1: 203
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "cbrt"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 35
+                    end_line: 433
+                    file: 2
+                    start_column: 26
+                    start_line: 433
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 35
+                end_line: 433
+                file: 2
+                start_column: 26
+                start_line: 433
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "cbrt"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 50
+                        end_line: 433
+                        file: 2
+                        start_column: 42
+                        start_line: 433
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 50
+                    end_line: 433
+                    file: 2
+                    start_column: 42
+                    start_line: 433
+                  }
+                }
+              }
+              src {
+                end_column: 51
+                end_line: 433
+                file: 2
+                start_column: 37
+                start_line: 433
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 52
+          end_line: 433
+          file: 2
+          start_column: 16
+          start_line: 433
+        }
+      }
+    }
+    symbol {
+      value: "df359"
+    }
+    uid: 204
+    var_id {
+      bitfield1: 204
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "ifnull"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 42
+                    end_line: 435
+                    file: 2
+                    start_column: 26
+                    start_line: 435
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 42
+                    end_line: 435
+                    file: 2
+                    start_column: 26
+                    start_line: 435
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 42
+                end_line: 435
+                file: 2
+                start_column: 26
+                start_line: 435
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "ifnull"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 59
+                        end_line: 435
+                        file: 2
+                        start_column: 51
+                        start_line: 435
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 59
+                    end_line: 435
+                    file: 2
+                    start_column: 51
+                    start_line: 435
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 69
+                        end_line: 435
+                        file: 2
+                        start_column: 61
+                        start_line: 435
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 69
+                    end_line: 435
+                    file: 2
+                    start_column: 61
+                    start_line: 435
+                  }
+                }
+              }
+              src {
+                end_column: 70
+                end_line: 435
+                file: 2
+                start_column: 44
+                start_line: 435
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 71
+          end_line: 435
+          file: 2
+          start_column: 16
+          start_line: 435
+        }
+      }
+    }
+    symbol {
+      value: "df360"
+    }
+    uid: 205
+    var_id {
+      bitfield1: 205
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "localtimestamp"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 42
+                    end_line: 437
+                    file: 2
+                    start_column: 26
+                    start_line: 437
+                  }
+                  v: 9
+                }
+              }
+              src {
+                end_column: 42
+                end_line: 437
+                file: 2
+                start_column: 26
+                start_line: 437
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "localtimestamp"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 61
+                    end_line: 437
+                    file: 2
+                    start_column: 44
+                    start_line: 437
+                  }
+                }
+              }
+              src {
+                end_column: 61
+                end_line: 437
+                file: 2
+                start_column: 44
+                start_line: 437
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "localtimestamp"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 80
+                    end_line: 437
+                    file: 2
+                    start_column: 63
+                    start_line: 437
+                  }
+                  v: 1
+                }
+              }
+              src {
+                end_column: 80
+                end_line: 437
+                file: 2
+                start_column: 63
+                start_line: 437
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "localtimestamp"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 99
+                    end_line: 437
+                    file: 2
+                    start_column: 82
+                    start_line: 437
+                  }
+                  v: 2
+                }
+              }
+              src {
+                end_column: 99
+                end_line: 437
+                file: 2
+                start_column: 82
+                start_line: 437
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 100
+          end_line: 437
+          file: 2
+          start_column: 16
+          start_line: 437
+        }
+      }
+    }
+    symbol {
+      value: "df361"
+    }
+    uid: 206
+    var_id {
+      bitfield1: 206
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "max_by"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 42
+                    end_line: 439
+                    file: 2
+                    start_column: 26
+                    start_line: 439
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 42
+                    end_line: 439
+                    file: 2
+                    start_column: 26
+                    start_line: 439
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 42
+                end_line: 439
+                file: 2
+                start_column: 26
+                start_line: 439
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "max_by"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 59
+                        end_line: 439
+                        file: 2
+                        start_column: 51
+                        start_line: 439
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 59
+                    end_line: 439
+                    file: 2
+                    start_column: 51
+                    start_line: 439
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 68
+                    end_line: 439
+                    file: 2
+                    start_column: 44
+                    start_line: 439
+                  }
+                  v: "B"
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 68
+                    end_line: 439
+                    file: 2
+                    start_column: 44
+                    start_line: 439
+                  }
+                  v: 3
+                }
+              }
+              src {
+                end_column: 68
+                end_line: 439
+                file: 2
+                start_column: 44
+                start_line: 439
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 69
+          end_line: 439
+          file: 2
+          start_column: 16
+          start_line: 439
+        }
+      }
+    }
+    symbol {
+      value: "df362"
+    }
+    uid: 207
+    var_id {
+      bitfield1: 207
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "min_by"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 42
+                    end_line: 441
+                    file: 2
+                    start_column: 26
+                    start_line: 441
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 42
+                    end_line: 441
+                    file: 2
+                    start_column: 26
+                    start_line: 441
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 42
+                end_line: 441
+                file: 2
+                start_column: 26
+                start_line: 441
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "max_by"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 59
+                        end_line: 441
+                        file: 2
+                        start_column: 51
+                        start_line: 441
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 59
+                    end_line: 441
+                    file: 2
+                    start_column: 51
+                    start_line: 441
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 68
+                    end_line: 441
+                    file: 2
+                    start_column: 44
+                    start_line: 441
+                  }
+                  v: "B"
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 68
+                    end_line: 441
+                    file: 2
+                    start_column: 44
+                    start_line: 441
+                  }
+                  v: 3
+                }
+              }
+              src {
+                end_column: 68
+                end_line: 441
+                file: 2
+                start_column: 44
+                start_line: 441
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 69
+          end_line: 441
+          file: 2
+          start_column: 16
+          start_line: 441
+        }
+      }
+    }
+    symbol {
+      value: "df363"
+    }
+    uid: 208
+    var_id {
+      bitfield1: 208
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "octet_length"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 43
+                    end_line: 443
+                    file: 2
+                    start_column: 26
+                    start_line: 443
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 43
+                end_line: 443
+                file: 2
+                start_column: 26
+                start_line: 443
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "octet_length"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 66
+                        end_line: 443
+                        file: 2
+                        start_column: 58
+                        start_line: 443
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 66
+                    end_line: 443
+                    file: 2
+                    start_column: 58
+                    start_line: 443
+                  }
+                }
+              }
+              src {
+                end_column: 67
+                end_line: 443
+                file: 2
+                start_column: 45
+                start_line: 443
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 68
+          end_line: 443
+          file: 2
+          start_column: 16
+          start_line: 443
+        }
+      }
+    }
+    symbol {
+      value: "df364"
+    }
+    uid: 209
+    var_id {
+      bitfield1: 209
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "position"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 445
+                    file: 2
+                    start_column: 26
+                    start_line: 445
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 445
+                    file: 2
+                    start_column: 26
+                    start_line: 445
+                  }
+                  v: "B"
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 44
+                    end_line: 445
+                    file: 2
+                    start_column: 26
+                    start_line: 445
+                  }
+                  v: 1
+                }
+              }
+              src {
+                end_column: 44
+                end_line: 445
+                file: 2
+                start_column: 26
+                start_line: 445
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "position"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 63
+                        end_line: 445
+                        file: 2
+                        start_column: 55
+                        start_line: 445
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 63
+                    end_line: 445
+                    file: 2
+                    start_column: 55
+                    start_line: 445
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 72
+                    end_line: 445
+                    file: 2
+                    start_column: 46
+                    start_line: 445
+                  }
+                  v: "B"
+                }
+              }
+              pos_args {
+                int64_val {
+                  src {
+                    end_column: 72
+                    end_line: 445
+                    file: 2
+                    start_column: 46
+                    start_line: 445
+                  }
+                  v: 5
+                }
+              }
+              src {
+                end_column: 72
+                end_line: 445
+                file: 2
+                start_column: 46
+                start_line: 445
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 73
+          end_line: 445
+          file: 2
+          start_column: 16
+          start_line: 445
+        }
+      }
+    }
+    symbol {
+      value: "df365"
+    }
+    uid: 210
+    var_id {
+      bitfield1: 210
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_avgx"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 45
+                    end_line: 447
+                    file: 2
+                    start_column: 26
+                    start_line: 447
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 45
+                    end_line: 447
+                    file: 2
+                    start_column: 26
+                    start_line: 447
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 45
+                end_line: 447
+                file: 2
+                start_column: 26
+                start_line: 447
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_avgx"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 65
+                        end_line: 447
+                        file: 2
+                        start_column: 57
+                        start_line: 447
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 65
+                    end_line: 447
+                    file: 2
+                    start_column: 57
+                    start_line: 447
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 75
+                        end_line: 447
+                        file: 2
+                        start_column: 67
+                        start_line: 447
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 75
+                    end_line: 447
+                    file: 2
+                    start_column: 67
+                    start_line: 447
+                  }
+                }
+              }
+              src {
+                end_column: 76
+                end_line: 447
+                file: 2
+                start_column: 47
+                start_line: 447
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 77
+          end_line: 447
+          file: 2
+          start_column: 16
+          start_line: 447
+        }
+      }
+    }
+    symbol {
+      value: "df366"
+    }
+    uid: 211
+    var_id {
+      bitfield1: 211
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_avgy"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 45
+                    end_line: 449
+                    file: 2
+                    start_column: 26
+                    start_line: 449
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 45
+                    end_line: 449
+                    file: 2
+                    start_column: 26
+                    start_line: 449
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 45
+                end_line: 449
+                file: 2
+                start_column: 26
+                start_line: 449
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_avgy"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 65
+                        end_line: 449
+                        file: 2
+                        start_column: 57
+                        start_line: 449
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 65
+                    end_line: 449
+                    file: 2
+                    start_column: 57
+                    start_line: 449
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 75
+                        end_line: 449
+                        file: 2
+                        start_column: 67
+                        start_line: 449
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 75
+                    end_line: 449
+                    file: 2
+                    start_column: 67
+                    start_line: 449
+                  }
+                }
+              }
+              src {
+                end_column: 76
+                end_line: 449
+                file: 2
+                start_column: 47
+                start_line: 449
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 77
+          end_line: 449
+          file: 2
+          start_column: 16
+          start_line: 449
+        }
+      }
+    }
+    symbol {
+      value: "df367"
+    }
+    uid: 212
+    var_id {
+      bitfield1: 212
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_count"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 451
+                    file: 2
+                    start_column: 26
+                    start_line: 451
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 451
+                    file: 2
+                    start_column: 26
+                    start_line: 451
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 46
+                end_line: 451
+                file: 2
+                start_column: 26
+                start_line: 451
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_count"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 67
+                        end_line: 451
+                        file: 2
+                        start_column: 59
+                        start_line: 451
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 67
+                    end_line: 451
+                    file: 2
+                    start_column: 59
+                    start_line: 451
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 77
+                        end_line: 451
+                        file: 2
+                        start_column: 69
+                        start_line: 451
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 77
+                    end_line: 451
+                    file: 2
+                    start_column: 69
+                    start_line: 451
+                  }
+                }
+              }
+              src {
+                end_column: 78
+                end_line: 451
+                file: 2
+                start_column: 48
+                start_line: 451
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 79
+          end_line: 451
+          file: 2
+          start_column: 16
+          start_line: 451
+        }
+      }
+    }
+    symbol {
+      value: "df368"
+    }
+    uid: 213
+    var_id {
+      bitfield1: 213
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_intercept"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 50
+                    end_line: 453
+                    file: 2
+                    start_column: 26
+                    start_line: 453
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 50
+                    end_line: 453
+                    file: 2
+                    start_column: 26
+                    start_line: 453
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 50
+                end_line: 453
+                file: 2
+                start_column: 26
+                start_line: 453
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_intercept"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 75
+                        end_line: 453
+                        file: 2
+                        start_column: 67
+                        start_line: 453
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 75
+                    end_line: 453
+                    file: 2
+                    start_column: 67
+                    start_line: 453
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 85
+                        end_line: 453
+                        file: 2
+                        start_column: 77
+                        start_line: 453
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 85
+                    end_line: 453
+                    file: 2
+                    start_column: 77
+                    start_line: 453
+                  }
+                }
+              }
+              src {
+                end_column: 86
+                end_line: 453
+                file: 2
+                start_column: 52
+                start_line: 453
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 87
+          end_line: 453
+          file: 2
+          start_column: 16
+          start_line: 453
+        }
+      }
+    }
+    symbol {
+      value: "df369"
+    }
+    uid: 214
+    var_id {
+      bitfield1: 214
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_r2"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 43
+                    end_line: 455
+                    file: 2
+                    start_column: 26
+                    start_line: 455
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 43
+                    end_line: 455
+                    file: 2
+                    start_column: 26
+                    start_line: 455
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 43
+                end_line: 455
+                file: 2
+                start_column: 26
+                start_line: 455
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_r2"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 61
+                        end_line: 455
+                        file: 2
+                        start_column: 53
+                        start_line: 455
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 61
+                    end_line: 455
+                    file: 2
+                    start_column: 53
+                    start_line: 455
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 71
+                        end_line: 455
+                        file: 2
+                        start_column: 63
+                        start_line: 455
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 71
+                    end_line: 455
+                    file: 2
+                    start_column: 63
+                    start_line: 455
+                  }
+                }
+              }
+              src {
+                end_column: 72
+                end_line: 455
+                file: 2
+                start_column: 45
+                start_line: 455
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 73
+          end_line: 455
+          file: 2
+          start_column: 16
+          start_line: 455
+        }
+      }
+    }
+    symbol {
+      value: "df370"
+    }
+    uid: 215
+    var_id {
+      bitfield1: 215
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_slope"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 457
+                    file: 2
+                    start_column: 26
+                    start_line: 457
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 457
+                    file: 2
+                    start_column: 26
+                    start_line: 457
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 46
+                end_line: 457
+                file: 2
+                start_column: 26
+                start_line: 457
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_slope"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 67
+                        end_line: 457
+                        file: 2
+                        start_column: 59
+                        start_line: 457
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 67
+                    end_line: 457
+                    file: 2
+                    start_column: 59
+                    start_line: 457
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 77
+                        end_line: 457
+                        file: 2
+                        start_column: 69
+                        start_line: 457
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 77
+                    end_line: 457
+                    file: 2
+                    start_column: 69
+                    start_line: 457
+                  }
+                }
+              }
+              src {
+                end_column: 78
+                end_line: 457
+                file: 2
+                start_column: 48
+                start_line: 457
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 79
+          end_line: 457
+          file: 2
+          start_column: 16
+          start_line: 457
+        }
+      }
+    }
+    symbol {
+      value: "df371"
+    }
+    uid: 216
+    var_id {
+      bitfield1: 216
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_sxx"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 459
+                    file: 2
+                    start_column: 26
+                    start_line: 459
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 459
+                    file: 2
+                    start_column: 26
+                    start_line: 459
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 44
+                end_line: 459
+                file: 2
+                start_column: 26
+                start_line: 459
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_sxx"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 63
+                        end_line: 459
+                        file: 2
+                        start_column: 55
+                        start_line: 459
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 63
+                    end_line: 459
+                    file: 2
+                    start_column: 55
+                    start_line: 459
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 73
+                        end_line: 459
+                        file: 2
+                        start_column: 65
+                        start_line: 459
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 73
+                    end_line: 459
+                    file: 2
+                    start_column: 65
+                    start_line: 459
+                  }
+                }
+              }
+              src {
+                end_column: 74
+                end_line: 459
+                file: 2
+                start_column: 46
+                start_line: 459
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 75
+          end_line: 459
+          file: 2
+          start_column: 16
+          start_line: 459
+        }
+      }
+    }
+    symbol {
+      value: "df372"
+    }
+    uid: 217
+    var_id {
+      bitfield1: 217
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_sxy"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 461
+                    file: 2
+                    start_column: 26
+                    start_line: 461
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 461
+                    file: 2
+                    start_column: 26
+                    start_line: 461
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 44
+                end_line: 461
+                file: 2
+                start_column: 26
+                start_line: 461
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_sxy"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 63
+                        end_line: 461
+                        file: 2
+                        start_column: 55
+                        start_line: 461
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 63
+                    end_line: 461
+                    file: 2
+                    start_column: 55
+                    start_line: 461
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 73
+                        end_line: 461
+                        file: 2
+                        start_column: 65
+                        start_line: 461
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 73
+                    end_line: 461
+                    file: 2
+                    start_column: 65
+                    start_line: 461
+                  }
+                }
+              }
+              src {
+                end_column: 74
+                end_line: 461
+                file: 2
+                start_column: 46
+                start_line: 461
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 75
+          end_line: 461
+          file: 2
+          start_column: 16
+          start_line: 461
+        }
+      }
+    }
+    symbol {
+      value: "df373"
+    }
+    uid: 218
+    var_id {
+      bitfield1: 218
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_syy"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 463
+                    file: 2
+                    start_column: 26
+                    start_line: 463
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 463
+                    file: 2
+                    start_column: 26
+                    start_line: 463
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 44
+                end_line: 463
+                file: 2
+                start_column: 26
+                start_line: 463
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "regr_syy"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 63
+                        end_line: 463
+                        file: 2
+                        start_column: 55
+                        start_line: 463
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 63
+                    end_line: 463
+                    file: 2
+                    start_column: 55
+                    start_line: 463
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 73
+                        end_line: 463
+                        file: 2
+                        start_column: 65
+                        start_line: 463
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 73
+                    end_line: 463
+                    file: 2
+                    start_column: 65
+                    start_line: 463
+                  }
+                }
+              }
+              src {
+                end_column: 74
+                end_line: 463
+                file: 2
+                start_column: 46
+                start_line: 463
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 75
+          end_line: 463
+          file: 2
+          start_column: 16
+          start_line: 463
+        }
+      }
+    }
+    symbol {
+      value: "df374"
+    }
+    uid: 219
+    var_id {
+      bitfield1: 219
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "try_to_binary"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 44
+                    end_line: 465
+                    file: 2
+                    start_column: 26
+                    start_line: 465
+                  }
+                  v: "A"
+                }
+              }
+              src {
+                end_column: 44
+                end_line: 465
+                file: 2
+                start_column: 26
+                start_line: 465
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "try_to_binary"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 74
+                    end_line: 465
+                    file: 2
+                    start_column: 46
+                    start_line: 465
+                  }
+                  v: "A"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 74
+                    end_line: 465
+                    file: 2
+                    start_column: 46
+                    start_line: 465
+                  }
+                  v: "BASE64"
+                }
+              }
+              src {
+                end_column: 74
+                end_line: 465
+                file: 2
+                start_column: 46
+                start_line: 465
+              }
+            }
+          }
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "try_to_binary"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 98
+                        end_line: 465
+                        file: 2
+                        start_column: 90
+                        start_line: 465
+                      }
+                      v: "A"
+                    }
+                  }
+                  src {
+                    end_column: 98
+                    end_line: 465
+                    file: 2
+                    start_column: 90
+                    start_line: 465
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 108
+                    end_line: 465
+                    file: 2
+                    start_column: 76
+                    start_line: 465
+                  }
+                  v: "UTF-8"
+                }
+              }
+              src {
+                end_column: 108
+                end_line: 465
+                file: 2
+                start_column: 76
+                start_line: 465
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 109
+          end_line: 465
+          file: 2
+          start_column: 16
+          start_line: 465
+        }
+      }
+    }
+    symbol {
+      value: "df375"
+    }
+    uid: 220
+    var_id {
+      bitfield1: 220
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "build_stage_file_url"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 93
+                    end_line: 467
+                    file: 2
+                    start_column: 26
+                    start_line: 467
+                  }
+                  v: "@images_stage"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 93
+                    end_line: 467
+                    file: 2
+                    start_column: 26
+                    start_line: 467
+                  }
+                  v: "/us/yosemite/half_dome.jpg"
+                }
+              }
+              src {
+                end_column: 93
+                end_line: 467
+                file: 2
+                start_column: 26
+                start_line: 467
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
+        }
+        src {
+          end_column: 94
+          end_line: 467
+          file: 2
+          start_column: 16
+          start_line: 467
+        }
+      }
+    }
+    symbol {
+      value: "df376"
+    }
+    uid: 221
+    var_id {
+      bitfield1: 221
     }
   }
 }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -112,6 +112,21 @@ def select_sp(session_: snowflake.snowpark.Session, x: int, y: int) -> DataFrame
     return session_.sql(f"SELECT {x} as A, {y} as B")
 select_sp(1, 2).show()
 
+# Example 9: Registering a stored procedure from a file
+mod5_sp = session.sproc.register_from_file(
+    test_files.test_sp_py_file,
+    "mod5",
+    return_type=IntegerType(),
+    input_types=[IntegerType()],
+)
+mod5_sp(3)
+
+# Example 10: Registering a stored procedure from a file with type hints
+range5_sproc = session.sproc.register_from_file(
+    test_files.test_table_sp_py_file,
+    "range5_sproc",
+)
+range5_sproc()
 
 ## EXPECTED UNPARSER OUTPUT
 
@@ -180,6 +195,18 @@ session.sql("SELECT 1 as A, 2 as B").show()
 res41 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
+
+mod5_sp = sproc("mod5", return_type=IntegerType(), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+
+session.create_dataframe([[3]], schema=["a"]).select(col("a") % 5).collect()
+
+mod5_sp(3)
+
+range5_sproc = sproc("range5_sproc", return_type=StructType(structured=False), _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+
+res48 = range5_sproc()
+
+res49 = session.range(5, None, 1)
 
 ## EXPECTED ENCODED AST
 
@@ -2186,6 +2213,364 @@ body {
     uid: 73
     var_id {
       bitfield1: 72
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      stored_procedure {
+        execute_as: "owner"
+        func {
+          id: 9
+          name: "mod5"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\""
+              }
+            }
+          }
+        }
+        input_types {
+          integer_type: true
+        }
+        parallel: 4
+        return_type {
+          integer_type: true
+        }
+        source_code_display: true
+        src {
+          end_column: 9
+          end_line: 143
+          file: 2
+          start_column: 18
+          start_line: 138
+        }
+      }
+    }
+    symbol {
+      value: "mod5_sp"
+    }
+    uid: 74
+    var_id {
+      bitfield1: 74
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          fn_ref {
+            id {
+              bitfield1: 74
+            }
+          }
+        }
+        pos_args {
+          int64_val {
+            src {
+              end_column: 18
+              end_line: 144
+              file: 2
+              start_column: 8
+              start_line: 144
+            }
+            v: 3
+          }
+        }
+        src {
+          end_column: 18
+          end_line: 144
+          file: 2
+          start_column: 8
+          start_line: 144
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 75
+    var_id {
+      bitfield1: 75
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      create_dataframe {
+        data {
+          dataframe_data__list {
+            vs {
+              list_val {
+                src {
+                  end_column: 53
+                  end_line: 7
+                  file: 2
+                  start_column: 8
+                  start_line: 7
+                }
+                vs {
+                  int64_val {
+                    src {
+                      end_column: 53
+                      end_line: 7
+                      file: 2
+                      start_column: 8
+                      start_line: 7
+                    }
+                    v: 3
+                  }
+                }
+              }
+            }
+          }
+        }
+        schema {
+          dataframe_schema__list {
+            vs: "a"
+          }
+        }
+        src {
+          end_column: 53
+          end_line: 7
+          file: 2
+          start_column: 8
+          start_line: 7
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 76
+    var_id {
+      bitfield1: 76
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            mod {
+              lhs {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 24
+                        end_line: 8
+                        file: 2
+                        start_column: 16
+                        start_line: 8
+                      }
+                      v: "a"
+                    }
+                  }
+                  src {
+                    end_column: 24
+                    end_line: 8
+                    file: 2
+                    start_column: 16
+                    start_line: 8
+                  }
+                }
+              }
+              rhs {
+                int64_val {
+                  src {
+                    end_column: 28
+                    end_line: 8
+                    file: 2
+                    start_column: 16
+                    start_line: 8
+                  }
+                  v: 5
+                }
+              }
+              src {
+                end_column: 28
+                end_line: 8
+                file: 2
+                start_column: 16
+                start_line: 8
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 76
+            }
+          }
+        }
+        src {
+          end_column: 29
+          end_line: 8
+          file: 2
+          start_column: 9
+          start_line: 8
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 77
+    var_id {
+      bitfield1: 77
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_collect {
+        block: true
+        case_sensitive: true
+        id {
+          bitfield1: 77
+        }
+        src {
+          end_column: 18
+          end_line: 9
+          file: 2
+          start_column: 9
+          start_line: 9
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 78
+    var_id {
+      bitfield1: 78
+    }
+  }
+}
+body {
+  eval {
+    uid: 79
+    var_id {
+      bitfield1: 78
+    }
+  }
+}
+body {
+  eval {
+    uid: 80
+    var_id {
+      bitfield1: 75
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      stored_procedure {
+        execute_as: "owner"
+        func {
+          id: 10
+          name: "range5_sproc"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\""
+              }
+            }
+          }
+        }
+        parallel: 4
+        return_type {
+          struct_type {
+          }
+        }
+        source_code_display: true
+        src {
+          end_column: 9
+          end_line: 150
+          file: 2
+          start_column: 23
+          start_line: 147
+        }
+      }
+    }
+    symbol {
+      value: "range5_sproc"
+    }
+    uid: 81
+    var_id {
+      bitfield1: 81
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          fn_ref {
+            id {
+              bitfield1: 81
+            }
+          }
+        }
+        src {
+          end_column: 22
+          end_line: 151
+          file: 2
+          start_column: 8
+          start_line: 151
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 82
+    var_id {
+      bitfield1: 82
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      range {
+        src {
+          end_column: 27
+          end_line: 6
+          file: 2
+          start_column: 11
+          start_line: 6
+        }
+        start: 5
+        step {
+          value: 1
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 83
+    var_id {
+      bitfield1: 83
     }
   }
 }

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -87,6 +87,23 @@ u2 = udaf(PythonTopK, return_type=IntegerType(), input_types=[IntegerType()], na
 
 df.agg(u2("a"))
 
+# Test registering UDAF from file without type hints
+sum_udaf = session.udaf.register_from_file(
+    test_files.test_udaf_py_file,
+    "MyUDAFWithoutTypeHints",
+    return_type=IntegerType(),
+    input_types=[IntegerType()],
+    immutable=True,
+)
+df.agg(sum_udaf("a"))
+
+# Test registering UDAF from file with type hints
+sum_udaf = session.udaf.register_from_file(
+    test_files.test_udaf_py_file,
+    "MyUDAFWithTypeHints",
+)
+df.agg(sum_udaf("a"))
+
 ## EXPECTED UNPARSER OUTPUT
 
 sum_udaf = udaf("PythonSumUDAF", return_type=IntegerType(), input_types=[IntegerType()], name="sum_int", replace=True, copy_grants=False, _registered_object_name="sum_int")
@@ -100,6 +117,14 @@ df.agg(sum_udaf("a")).collect()
 u2 = udaf("PythonTopK", return_type=IntegerType(), input_types=[IntegerType()], name="top_k", is_permanent=True, stage_location="@", imports=["numpy"], packages=["numpy"], replace=True, parallel=8, statement_params={"a": "b", "d": "e"}, external_access_integrations=["s3"], secrets={"a": "c", "e": "f"}, immutable=True, comment="test udaf", copy_grants=False, force_inline_code=True, _registered_object_name="top_k")
 
 res3 = df.agg(u2("a"))
+
+sum_udaf = udaf("MyUDAFWithoutTypeHints", return_type=IntegerType(), input_types=[IntegerType()], immutable=True, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
+
+res4 = df.agg(sum_udaf("a"))
+
+sum_udaf = udaf("MyUDAFWithTypeHints", return_type=LongType(), input_types=[LongType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
+
+res5 = df.agg(sum_udaf("a"))
 
 ## EXPECTED ENCODED AST
 
@@ -658,6 +683,237 @@ body {
     uid: 8
     var_id {
       bitfield1: 8
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udaf {
+        handler {
+          id: 2
+          name: "MyUDAFWithoutTypeHints"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        immutable: true
+        input_types {
+          integer_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 119
+                file: 2
+                start_column: 19
+                start_line: 113
+              }
+            }
+          }
+        }
+        parallel: 4
+        return_type {
+          integer_type: true
+        }
+        src {
+          end_column: 9
+          end_line: 119
+          file: 2
+          start_column: 19
+          start_line: 113
+        }
+      }
+    }
+    symbol {
+      value: "sum_udaf"
+    }
+    uid: 9
+    var_id {
+      bitfield1: 9
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_agg {
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
+        }
+        exprs {
+          args {
+            apply_expr {
+              fn {
+                fn_ref {
+                  id {
+                    bitfield1: 9
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 28
+                    end_line: 120
+                    file: 2
+                    start_column: 15
+                    start_line: 120
+                  }
+                  v: "a"
+                }
+              }
+              src {
+                end_column: 28
+                end_line: 120
+                file: 2
+                start_column: 15
+                start_line: 120
+              }
+            }
+          }
+          variadic: true
+        }
+        src {
+          end_column: 29
+          end_line: 120
+          file: 2
+          start_column: 8
+          start_line: 120
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 10
+    var_id {
+      bitfield1: 10
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udaf {
+        handler {
+          id: 3
+          name: "MyUDAFWithTypeHints"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 126
+                file: 2
+                start_column: 19
+                start_line: 123
+              }
+            }
+          }
+        }
+        parallel: 4
+        return_type {
+          long_type: true
+        }
+        src {
+          end_column: 9
+          end_line: 126
+          file: 2
+          start_column: 19
+          start_line: 123
+        }
+      }
+    }
+    symbol {
+      value: "sum_udaf"
+    }
+    uid: 11
+    var_id {
+      bitfield1: 11
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      dataframe_agg {
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
+        }
+        exprs {
+          args {
+            apply_expr {
+              fn {
+                fn_ref {
+                  id {
+                    bitfield1: 11
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 28
+                    end_line: 127
+                    file: 2
+                    start_column: 15
+                    start_line: 127
+                  }
+                  v: "a"
+                }
+              }
+              src {
+                end_column: 28
+                end_line: 127
+                file: 2
+                start_column: 15
+                start_line: 127
+              }
+            }
+          }
+          variadic: true
+        }
+        src {
+          end_column: 29
+          end_line: 127
+          file: 2
+          start_column: 8
+          start_line: 127
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 12
+    var_id {
+      bitfield1: 12
     }
   }
 }

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -1,5 +1,7 @@
 ## TEST CASE
 
+import decimal
+
 from snowflake.snowpark.functions import col, udtf
 
 from snowflake.snowpark.types import IntegerType, StructField, StructType
@@ -99,6 +101,64 @@ df.select(df.a, twoxsix_udtf(df.a)).collect()
 
 df.select("a", twoxsix_udtf("a").alias("double", "six_x"), "c").collect()
 
+# Test registering UDTF from file without type hints
+schema = StructType(
+    [
+        StructField("int_", IntegerType()),
+        StructField("float_", FloatType()),
+        StructField("bool_", BooleanType()),
+        StructField("decimal_", DecimalType(10, 2)),
+        StructField("str_", StringType()),
+        StructField("bytes_", BinaryType()),
+        StructField("bytearray_", BinaryType()),
+    ]
+)
+my_udtf = session.udtf.register_from_file(
+    test_files.test_udtf_py_file,
+    "MyUDTFWithoutTypeHints",
+    output_schema=schema,
+    input_types=[
+        IntegerType(),
+        FloatType(),
+        BooleanType(),
+        DecimalType(10, 2),
+        StringType(),
+        BinaryType(),
+        BinaryType(),
+    ],
+    immutable=True,
+)
+df = session.table_function(
+      my_udtf(
+          lit(1),
+          lit(2.2),
+          lit(True),
+          lit(decimal.Decimal("3.33")).cast("number(10, 2)"),
+          lit("python"),
+          lit(b"bytes"),
+          lit(bytearray("bytearray", "utf-8")),
+      )
+)
+
+# Test registering UDTF from file with type hints
+schema = ["int_", "float_", "bool_", "decimal_", "str_", "bytes_", "bytearray_"]
+my_udtf = session.udtf.register_from_file(
+    test_files.test_udtf_py_file,
+    "MyUDTFWithTypeHints",
+    output_schema=schema,
+)
+df = session.table_function(
+    my_udtf(
+        lit(1),
+        lit(2.2),
+        lit(True),
+        lit(decimal.Decimal("3.33")),
+        lit("python"),
+        lit(b"bytes"),
+        lit(bytearray("bytearray", "utf-8")),
+    )
+)
+
 ## EXPECTED UNPARSER OUTPUT
 
 prime_udtf = udtf("PrimeSieve", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
@@ -128,6 +188,14 @@ twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType(fields=[StructField
 df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 
 df.select("a", (twoxsix_udtf("a").alias("double", "six_x")), "c").collect()
+
+my_udtf = udtf("MyUDTFWithoutTypeHints", output_schema=StructType(fields=[StructField("int_", IntegerType(), nullable=True), StructField("float_", FloatType(), nullable=True), StructField("bool_", BooleanType(), nullable=True), StructField("decimal_", DecimalType(10, 2), nullable=True), StructField("str_", StringType(), nullable=True), StructField("bytes_", BinaryType(), nullable=True), StructField("bytearray_", BinaryType(), nullable=True)], structured=False), input_types=[IntegerType(), FloatType(), BooleanType(), DecimalType(10, 2), StringType(), BinaryType(), BinaryType()], immutable=True, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df = session.table_function(my_udtf(lit(1), lit(2.2), lit(True), lit(Decimal("3.33")).cast(DecimalType(10, 2)), lit("python"), lit(bytes("bytes", "utf-8")), lit(bytes("bytearray", "utf-8"))))
+
+my_udtf = udtf("MyUDTFWithTypeHints", output_schema=StructType(fields=[StructField("int_", LongType(), nullable=True), StructField("float_", FloatType(), nullable=True), StructField("bool_", BooleanType(), nullable=True), StructField("decimal_", DecimalType(38, 18), nullable=True), StructField("str_", StringType(), nullable=True), StructField("bytes_", BinaryType(), nullable=True), StructField("bytearray_", BinaryType(), nullable=True)], structured=False), input_types=[LongType(), FloatType(), BooleanType(), DecimalType(38, 18), StringType(), BinaryType(), BinaryType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+
+df = session.table_function(my_udtf(lit(1), lit(2.2), lit(True), lit(Decimal("3.33")), lit("python"), lit(bytes("bytes", "utf-8")), lit(bytes("bytearray", "utf-8"))))
 
 ## EXPECTED ENCODED AST
 
@@ -163,10 +231,10 @@ body {
             bool_val {
               src {
                 end_column: 132
-                end_line: 46
+                end_line: 48
                 file: 2
                 start_column: 21
-                start_line: 46
+                start_line: 48
               }
             }
           }
@@ -193,10 +261,10 @@ body {
         parallel: 4
         src {
           end_column: 132
-          end_line: 46
+          end_line: 48
           file: 2
           start_column: 21
-          start_line: 46
+          start_line: 48
         }
       }
     }
@@ -237,29 +305,29 @@ body {
               int64_val {
                 src {
                   end_column: 49
-                  end_line: 48
+                  end_line: 50
                   file: 2
                   start_column: 42
-                  start_line: 48
+                  start_line: 50
                 }
                 v: 20
               }
             }
             src {
               end_column: 49
-              end_line: 48
+              end_line: 50
               file: 2
               start_column: 42
-              start_line: 48
+              start_line: 50
             }
           }
         }
         src {
           end_column: 50
-          end_line: 48
+          end_line: 50
           file: 2
           start_column: 31
-          start_line: 48
+          start_line: 50
         }
       }
     }
@@ -286,19 +354,19 @@ body {
             }
             src {
               end_column: 51
-              end_line: 48
+              end_line: 50
               file: 2
               start_column: 8
-              start_line: 48
+              start_line: 50
             }
           }
         }
         src {
           end_column: 51
-          end_line: 48
+          end_line: 50
           file: 2
           start_column: 8
-          start_line: 48
+          start_line: 50
         }
       }
     }
@@ -321,10 +389,10 @@ body {
         }
         src {
           end_column: 61
-          end_line: 48
+          end_line: 50
           file: 2
           start_column: 8
-          start_line: 48
+          start_line: 50
         }
       }
     }
@@ -371,10 +439,10 @@ body {
             bool_val {
               src {
                 end_column: 39
-                end_line: 50
+                end_line: 52
                 file: 2
                 start_column: 9
-                start_line: 50
+                start_line: 52
               }
             }
           }
@@ -401,10 +469,10 @@ body {
         parallel: 4
         src {
           end_column: 39
-          end_line: 50
+          end_line: 52
           file: 2
           start_column: 9
-          start_line: 50
+          start_line: 52
         }
       }
     }
@@ -426,19 +494,19 @@ body {
               list_val {
                 src {
                   end_column: 74
-                  end_line: 55
+                  end_line: 57
                   file: 2
                   start_column: 13
-                  start_line: 55
+                  start_line: 57
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 74
-                      end_line: 55
+                      end_line: 57
                       file: 2
                       start_column: 13
-                      start_line: 55
+                      start_line: 57
                     }
                     v: 1
                   }
@@ -447,10 +515,10 @@ body {
                   int64_val {
                     src {
                       end_column: 74
-                      end_line: 55
+                      end_line: 57
                       file: 2
                       start_column: 13
-                      start_line: 55
+                      start_line: 57
                     }
                     v: 2
                   }
@@ -461,19 +529,19 @@ body {
               list_val {
                 src {
                   end_column: 74
-                  end_line: 55
+                  end_line: 57
                   file: 2
                   start_column: 13
-                  start_line: 55
+                  start_line: 57
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 74
-                      end_line: 55
+                      end_line: 57
                       file: 2
                       start_column: 13
-                      start_line: 55
+                      start_line: 57
                     }
                     v: 3
                   }
@@ -482,10 +550,10 @@ body {
                   int64_val {
                     src {
                       end_column: 74
-                      end_line: 55
+                      end_line: 57
                       file: 2
                       start_column: 13
-                      start_line: 55
+                      start_line: 57
                     }
                     v: 4
                   }
@@ -502,10 +570,10 @@ body {
         }
         src {
           end_column: 74
-          end_line: 55
+          end_line: 57
           file: 2
           start_column: 13
-          start_line: 55
+          start_line: 57
         }
       }
     }
@@ -543,10 +611,10 @@ body {
                 }
                 src {
                   end_column: 45
-                  end_line: 56
+                  end_line: 58
                   file: 2
                   start_column: 41
-                  start_line: 56
+                  start_line: 58
                 }
               }
             }
@@ -562,19 +630,19 @@ body {
                 }
                 src {
                   end_column: 51
-                  end_line: 56
+                  end_line: 58
                   file: 2
                   start_column: 47
-                  start_line: 56
+                  start_line: 58
                 }
               }
             }
             src {
               end_column: 52
-              end_line: 56
+              end_line: 58
               file: 2
               start_column: 32
-              start_line: 56
+              start_line: 58
             }
           }
         }
@@ -588,10 +656,10 @@ body {
         }
         src {
           end_column: 53
-          end_line: 56
+          end_line: 58
           file: 2
           start_column: 8
-          start_line: 56
+          start_line: 58
         }
       }
     }
@@ -620,10 +688,10 @@ body {
               }
               src {
                 end_column: 63
-                end_line: 56
+                end_line: 58
                 file: 2
                 start_column: 59
-                start_line: 56
+                start_line: 58
               }
             }
           }
@@ -638,10 +706,10 @@ body {
         }
         src {
           end_column: 64
-          end_line: 56
+          end_line: 58
           file: 2
           start_column: 8
-          start_line: 56
+          start_line: 58
         }
       }
     }
@@ -703,10 +771,10 @@ body {
             bool_val {
               src {
                 end_column: 139
-                end_line: 63
+                end_line: 65
                 file: 2
                 start_column: 25
-                start_line: 63
+                start_line: 65
               }
             }
           }
@@ -733,10 +801,10 @@ body {
         parallel: 4
         src {
           end_column: 139
-          end_line: 63
+          end_line: 65
           file: 2
           start_column: 25
-          start_line: 63
+          start_line: 65
         }
       }
     }
@@ -777,29 +845,29 @@ body {
               int64_val {
                 src {
                   end_column: 52
-                  end_line: 65
+                  end_line: 67
                   file: 2
                   start_column: 46
-                  start_line: 65
+                  start_line: 67
                 }
                 v: 3
               }
             }
             src {
               end_column: 52
-              end_line: 65
+              end_line: 67
               file: 2
               start_column: 46
-              start_line: 65
+              start_line: 67
             }
           }
         }
         src {
           end_column: 53
-          end_line: 65
+          end_line: 67
           file: 2
           start_column: 31
-          start_line: 65
+          start_line: 67
         }
       }
     }
@@ -826,19 +894,19 @@ body {
             }
             src {
               end_column: 54
-              end_line: 65
+              end_line: 67
               file: 2
               start_column: 8
-              start_line: 65
+              start_line: 67
             }
           }
         }
         src {
           end_column: 54
-          end_line: 65
+          end_line: 67
           file: 2
           start_column: 8
-          start_line: 65
+          start_line: 67
         }
       }
     }
@@ -861,10 +929,10 @@ body {
         }
         src {
           end_column: 64
-          end_line: 65
+          end_line: 67
           file: 2
           start_column: 8
-          start_line: 65
+          start_line: 67
         }
       }
     }
@@ -932,10 +1000,10 @@ body {
             bool_val {
               src {
                 end_column: 40
-                end_line: 89
+                end_line: 91
                 file: 2
                 start_column: 14
-                start_line: 72
+                start_line: 74
               }
             }
           }
@@ -946,10 +1014,10 @@ body {
             bool_val {
               src {
                 end_column: 40
-                end_line: 89
+                end_line: 91
                 file: 2
                 start_column: 14
-                start_line: 72
+                start_line: 74
               }
               v: true
             }
@@ -1002,10 +1070,10 @@ body {
         secure: true
         src {
           end_column: 40
-          end_line: 89
+          end_line: 91
           file: 2
           start_column: 14
-          start_line: 72
+          start_line: 74
         }
         stage_location: "@"
         statement_params {
@@ -1034,19 +1102,19 @@ body {
               tuple_val {
                 src {
                   end_column: 9
-                  end_line: 93
+                  end_line: 95
                   file: 2
                   start_column: 13
-                  start_line: 91
+                  start_line: 93
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: 1
                   }
@@ -1055,10 +1123,10 @@ body {
                   string_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: "one o one"
                   }
@@ -1067,10 +1135,10 @@ body {
                   int64_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: 10
                   }
@@ -1081,19 +1149,19 @@ body {
               tuple_val {
                 src {
                   end_column: 9
-                  end_line: 93
+                  end_line: 95
                   file: 2
                   start_column: 13
-                  start_line: 91
+                  start_line: 93
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: 2
                   }
@@ -1102,10 +1170,10 @@ body {
                   string_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: "twenty two"
                   }
@@ -1114,10 +1182,10 @@ body {
                   int64_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: 20
                   }
@@ -1128,19 +1196,19 @@ body {
               tuple_val {
                 src {
                   end_column: 9
-                  end_line: 93
+                  end_line: 95
                   file: 2
                   start_column: 13
-                  start_line: 91
+                  start_line: 93
                 }
                 vs {
                   int64_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: 3
                   }
@@ -1149,10 +1217,10 @@ body {
                   string_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: "thirty three"
                   }
@@ -1161,10 +1229,10 @@ body {
                   int64_val {
                     src {
                       end_column: 9
-                      end_line: 93
+                      end_line: 95
                       file: 2
                       start_column: 13
-                      start_line: 91
+                      start_line: 93
                     }
                     v: 30
                   }
@@ -1175,10 +1243,10 @@ body {
         }
         src {
           end_column: 9
-          end_line: 93
+          end_line: 95
           file: 2
           start_column: 13
-          start_line: 91
+          start_line: 93
         }
       }
     }
@@ -1200,10 +1268,10 @@ body {
             string_val {
               src {
                 end_column: 38
-                end_line: 94
+                end_line: 96
                 file: 2
                 start_column: 13
-                start_line: 94
+                start_line: 96
               }
               v: "a"
             }
@@ -1212,10 +1280,10 @@ body {
             string_val {
               src {
                 end_column: 38
-                end_line: 94
+                end_line: 96
                 file: 2
                 start_column: 13
-                start_line: 94
+                start_line: 96
               }
               v: "b"
             }
@@ -1224,10 +1292,10 @@ body {
             string_val {
               src {
                 end_column: 38
-                end_line: 94
+                end_line: 96
                 file: 2
                 start_column: 13
-                start_line: 94
+                start_line: 96
               }
               v: "c"
             }
@@ -1242,10 +1310,10 @@ body {
         }
         src {
           end_column: 38
-          end_line: 94
+          end_line: 96
           file: 2
           start_column: 13
-          start_line: 94
+          start_line: 96
         }
       }
     }
@@ -1282,10 +1350,10 @@ body {
             bool_val {
               src {
                 end_column: 9
-                end_line: 104
+                end_line: 106
                 file: 2
                 start_column: 20
-                start_line: 100
+                start_line: 102
               }
             }
           }
@@ -1312,10 +1380,10 @@ body {
         parallel: 4
         src {
           end_column: 9
-          end_line: 104
+          end_line: 106
           file: 2
           start_column: 20
-          start_line: 100
+          start_line: 102
         }
       }
     }
@@ -1343,20 +1411,20 @@ body {
           string_val {
             src {
               end_column: 32
-              end_line: 106
+              end_line: 108
               file: 2
               start_column: 18
-              start_line: 106
+              start_line: 108
             }
             v: "a"
           }
         }
         src {
           end_column: 32
-          end_line: 106
+          end_line: 108
           file: 2
           start_column: 18
-          start_line: 106
+          start_line: 108
         }
       }
     }
@@ -1384,10 +1452,10 @@ body {
               }
               src {
                 end_column: 33
-                end_line: 106
+                end_line: 108
                 file: 2
                 start_column: 8
-                start_line: 106
+                start_line: 108
               }
             }
           }
@@ -1402,10 +1470,10 @@ body {
         }
         src {
           end_column: 33
-          end_line: 106
+          end_line: 108
           file: 2
           start_column: 8
-          start_line: 106
+          start_line: 108
         }
       }
     }
@@ -1428,10 +1496,10 @@ body {
         }
         src {
           end_column: 43
-          end_line: 106
+          end_line: 108
           file: 2
           start_column: 8
-          start_line: 106
+          start_line: 108
         }
       }
     }
@@ -1475,10 +1543,10 @@ body {
             bool_val {
               src {
                 end_column: 9
-                end_line: 118
+                end_line: 120
                 file: 2
                 start_column: 23
-                start_line: 112
+                start_line: 114
               }
             }
           }
@@ -1516,10 +1584,10 @@ body {
         parallel: 4
         src {
           end_column: 9
-          end_line: 118
+          end_line: 120
           file: 2
           start_column: 23
-          start_line: 112
+          start_line: 114
         }
       }
     }
@@ -1555,19 +1623,19 @@ body {
             }
             src {
               end_column: 41
-              end_line: 120
+              end_line: 122
               file: 2
               start_column: 37
-              start_line: 120
+              start_line: 122
             }
           }
         }
         src {
           end_column: 42
-          end_line: 120
+          end_line: 122
           file: 2
           start_column: 24
-          start_line: 120
+          start_line: 122
         }
       }
     }
@@ -1596,10 +1664,10 @@ body {
               }
               src {
                 end_column: 22
-                end_line: 120
+                end_line: 122
                 file: 2
                 start_column: 18
-                start_line: 120
+                start_line: 122
               }
             }
           }
@@ -1614,10 +1682,10 @@ body {
               }
               src {
                 end_column: 43
-                end_line: 120
+                end_line: 122
                 file: 2
                 start_column: 8
-                start_line: 120
+                start_line: 122
               }
             }
           }
@@ -1632,10 +1700,10 @@ body {
         }
         src {
           end_column: 43
-          end_line: 120
+          end_line: 122
           file: 2
           start_column: 8
-          start_line: 120
+          start_line: 122
         }
       }
     }
@@ -1658,10 +1726,10 @@ body {
         }
         src {
           end_column: 53
-          end_line: 120
+          end_line: 122
           file: 2
           start_column: 8
-          start_line: 120
+          start_line: 122
         }
       }
     }
@@ -1690,10 +1758,10 @@ body {
             string_val {
               src {
                 end_column: 65
-                end_line: 122
+                end_line: 124
                 file: 2
                 start_column: 23
-                start_line: 122
+                start_line: 124
               }
               v: "double"
             }
@@ -1702,10 +1770,10 @@ body {
             string_val {
               src {
                 end_column: 65
-                end_line: 122
+                end_line: 124
                 file: 2
                 start_column: 23
-                start_line: 122
+                start_line: 124
               }
               v: "six_x"
             }
@@ -1725,29 +1793,29 @@ body {
               string_val {
                 src {
                   end_column: 40
-                  end_line: 122
+                  end_line: 124
                   file: 2
                   start_column: 23
-                  start_line: 122
+                  start_line: 124
                 }
                 v: "a"
               }
             }
             src {
               end_column: 40
-              end_line: 122
+              end_line: 124
               file: 2
               start_column: 23
-              start_line: 122
+              start_line: 124
             }
           }
         }
         src {
           end_column: 65
-          end_line: 122
+          end_line: 124
           file: 2
           start_column: 23
-          start_line: 122
+          start_line: 124
         }
       }
     }
@@ -1768,10 +1836,10 @@ body {
             string_val {
               src {
                 end_column: 71
-                end_line: 122
+                end_line: 124
                 file: 2
                 start_column: 8
-                start_line: 122
+                start_line: 124
               }
               v: "a"
             }
@@ -1787,10 +1855,10 @@ body {
               }
               src {
                 end_column: 71
-                end_line: 122
+                end_line: 124
                 file: 2
                 start_column: 8
-                start_line: 122
+                start_line: 124
               }
             }
           }
@@ -1798,10 +1866,10 @@ body {
             string_val {
               src {
                 end_column: 71
-                end_line: 122
+                end_line: 124
                 file: 2
                 start_column: 8
-                start_line: 122
+                start_line: 124
               }
               v: "c"
             }
@@ -1817,10 +1885,10 @@ body {
         }
         src {
           end_column: 71
-          end_line: 122
+          end_line: 124
           file: 2
           start_column: 8
-          start_line: 122
+          start_line: 124
         }
       }
     }
@@ -1843,10 +1911,10 @@ body {
         }
         src {
           end_column: 81
-          end_line: 122
+          end_line: 124
           file: 2
           start_column: 8
-          start_line: 122
+          start_line: 124
         }
       }
     }
@@ -1863,6 +1931,970 @@ body {
     uid: 33
     var_id {
       bitfield1: 32
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 6
+          name: "MyUDTFWithoutTypeHints"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        immutable: true
+        input_types {
+          integer_type: true
+        }
+        input_types {
+          float_type: true
+        }
+        input_types {
+          boolean_type: true
+        }
+        input_types {
+          decimal_type {
+            precision: 10
+            scale: 2
+          }
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          binary_type: true
+        }
+        input_types {
+          binary_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 152
+                file: 2
+                start_column: 18
+                start_line: 138
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              struct_type {
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "int_"
+                    }
+                  }
+                  data_type {
+                    integer_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "float_"
+                    }
+                  }
+                  data_type {
+                    float_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "bool_"
+                    }
+                  }
+                  data_type {
+                    boolean_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "decimal_"
+                    }
+                  }
+                  data_type {
+                    decimal_type {
+                      precision: 10
+                      scale: 2
+                    }
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "str_"
+                    }
+                  }
+                  data_type {
+                    string_type {
+                      length {
+                      }
+                    }
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "bytes_"
+                    }
+                  }
+                  data_type {
+                    binary_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "bytearray_"
+                    }
+                  }
+                  data_type {
+                    binary_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        parallel: 4
+        src {
+          end_column: 9
+          end_line: 152
+          file: 2
+          start_column: 18
+          start_line: 138
+        }
+      }
+    }
+    symbol {
+      value: "my_udtf"
+    }
+    uid: 34
+    var_id {
+      bitfield1: 34
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          fn_ref {
+            id {
+              bitfield1: 34
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              int64_val {
+                src {
+                  end_column: 24
+                  end_line: 155
+                  file: 2
+                  start_column: 18
+                  start_line: 155
+                }
+                v: 1
+              }
+            }
+            src {
+              end_column: 24
+              end_line: 155
+              file: 2
+              start_column: 18
+              start_line: 155
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              float64_val {
+                src {
+                  end_column: 26
+                  end_line: 156
+                  file: 2
+                  start_column: 18
+                  start_line: 156
+                }
+                v: 2.2
+              }
+            }
+            src {
+              end_column: 26
+              end_line: 156
+              file: 2
+              start_column: 18
+              start_line: 156
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              bool_val {
+                src {
+                  end_column: 27
+                  end_line: 157
+                  file: 2
+                  start_column: 18
+                  start_line: 157
+                }
+                v: true
+              }
+            }
+            src {
+              end_column: 27
+              end_line: 157
+              file: 2
+              start_column: 18
+              start_line: 157
+            }
+          }
+        }
+        pos_args {
+          column_cast {
+            col {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "lit"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  big_decimal_val {
+                    scale: -2
+                    src {
+                      end_column: 46
+                      end_line: 158
+                      file: 2
+                      start_column: 18
+                      start_line: 158
+                    }
+                    unscaled_value: "\001M"
+                  }
+                }
+                src {
+                  end_column: 46
+                  end_line: 158
+                  file: 2
+                  start_column: 18
+                  start_line: 158
+                }
+              }
+            }
+            src {
+              end_column: 68
+              end_line: 158
+              file: 2
+              start_column: 18
+              start_line: 158
+            }
+            to {
+              decimal_type {
+                precision: 10
+                scale: 2
+              }
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 31
+                  end_line: 159
+                  file: 2
+                  start_column: 18
+                  start_line: 159
+                }
+                v: "python"
+              }
+            }
+            src {
+              end_column: 31
+              end_line: 159
+              file: 2
+              start_column: 18
+              start_line: 159
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              binary_val {
+                src {
+                  end_column: 31
+                  end_line: 160
+                  file: 2
+                  start_column: 18
+                  start_line: 160
+                }
+                v: "bytes"
+              }
+            }
+            src {
+              end_column: 31
+              end_line: 160
+              file: 2
+              start_column: 18
+              start_line: 160
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              binary_val {
+                src {
+                  end_column: 54
+                  end_line: 161
+                  file: 2
+                  start_column: 18
+                  start_line: 161
+                }
+                v: "bytearray"
+              }
+            }
+            src {
+              end_column: 54
+              end_line: 161
+              file: 2
+              start_column: 18
+              start_line: 161
+            }
+          }
+        }
+        src {
+          end_column: 15
+          end_line: 162
+          file: 2
+          start_column: 14
+          start_line: 154
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 35
+    var_id {
+      bitfield1: 35
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      session_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 35
+                }
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 163
+              file: 2
+              start_column: 13
+              start_line: 153
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 163
+          file: 2
+          start_column: 13
+          start_line: 153
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 36
+    var_id {
+      bitfield1: 36
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      udtf {
+        handler {
+          id: 7
+          name: "MyUDTFWithTypeHints"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          long_type: true
+        }
+        input_types {
+          float_type: true
+        }
+        input_types {
+          boolean_type: true
+        }
+        input_types {
+          decimal_type {
+            precision: 38
+            scale: 18
+          }
+        }
+        input_types {
+          string_type {
+            length {
+            }
+          }
+        }
+        input_types {
+          binary_type: true
+        }
+        input_types {
+          binary_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 171
+                file: 2
+                start_column: 18
+                start_line: 167
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              struct_type {
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "int_"
+                    }
+                  }
+                  data_type {
+                    long_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "float_"
+                    }
+                  }
+                  data_type {
+                    float_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "bool_"
+                    }
+                  }
+                  data_type {
+                    boolean_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "decimal_"
+                    }
+                  }
+                  data_type {
+                    decimal_type {
+                      precision: 38
+                      scale: 18
+                    }
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "str_"
+                    }
+                  }
+                  data_type {
+                    string_type {
+                      length {
+                      }
+                    }
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "bytes_"
+                    }
+                  }
+                  data_type {
+                    binary_type: true
+                  }
+                  nullable: true
+                }
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "bytearray_"
+                    }
+                  }
+                  data_type {
+                    binary_type: true
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        parallel: 4
+        src {
+          end_column: 9
+          end_line: 171
+          file: 2
+          start_column: 18
+          start_line: 167
+        }
+      }
+    }
+    symbol {
+      value: "my_udtf"
+    }
+    uid: 37
+    var_id {
+      bitfield1: 37
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      apply_expr {
+        fn {
+          fn_ref {
+            id {
+              bitfield1: 37
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              int64_val {
+                src {
+                  end_column: 22
+                  end_line: 174
+                  file: 2
+                  start_column: 16
+                  start_line: 174
+                }
+                v: 1
+              }
+            }
+            src {
+              end_column: 22
+              end_line: 174
+              file: 2
+              start_column: 16
+              start_line: 174
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              float64_val {
+                src {
+                  end_column: 24
+                  end_line: 175
+                  file: 2
+                  start_column: 16
+                  start_line: 175
+                }
+                v: 2.2
+              }
+            }
+            src {
+              end_column: 24
+              end_line: 175
+              file: 2
+              start_column: 16
+              start_line: 175
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              bool_val {
+                src {
+                  end_column: 25
+                  end_line: 176
+                  file: 2
+                  start_column: 16
+                  start_line: 176
+                }
+                v: true
+              }
+            }
+            src {
+              end_column: 25
+              end_line: 176
+              file: 2
+              start_column: 16
+              start_line: 176
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              big_decimal_val {
+                scale: -2
+                src {
+                  end_column: 44
+                  end_line: 177
+                  file: 2
+                  start_column: 16
+                  start_line: 177
+                }
+                unscaled_value: "\001M"
+              }
+            }
+            src {
+              end_column: 44
+              end_line: 177
+              file: 2
+              start_column: 16
+              start_line: 177
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              string_val {
+                src {
+                  end_column: 29
+                  end_line: 178
+                  file: 2
+                  start_column: 16
+                  start_line: 178
+                }
+                v: "python"
+              }
+            }
+            src {
+              end_column: 29
+              end_line: 178
+              file: 2
+              start_column: 16
+              start_line: 178
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              binary_val {
+                src {
+                  end_column: 29
+                  end_line: 179
+                  file: 2
+                  start_column: 16
+                  start_line: 179
+                }
+                v: "bytes"
+              }
+            }
+            src {
+              end_column: 29
+              end_line: 179
+              file: 2
+              start_column: 16
+              start_line: 179
+            }
+          }
+        }
+        pos_args {
+          apply_expr {
+            fn {
+              builtin_fn {
+                name {
+                  name {
+                    name_flat {
+                      name: "lit"
+                    }
+                  }
+                }
+              }
+            }
+            pos_args {
+              binary_val {
+                src {
+                  end_column: 52
+                  end_line: 180
+                  file: 2
+                  start_column: 16
+                  start_line: 180
+                }
+                v: "bytearray"
+              }
+            }
+            src {
+              end_column: 52
+              end_line: 180
+              file: 2
+              start_column: 16
+              start_line: 180
+            }
+          }
+        }
+        src {
+          end_column: 13
+          end_line: 181
+          file: 2
+          start_column: 12
+          start_line: 173
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 38
+    var_id {
+      bitfield1: 38
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      session_table_function {
+        fn {
+          apply_expr {
+            fn {
+              indirect_table_fn_id_ref {
+                id {
+                  bitfield1: 38
+                }
+              }
+            }
+            src {
+              end_column: 9
+              end_line: 182
+              file: 2
+              start_column: 13
+              start_line: 172
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 182
+          file: 2
+          start_column: 13
+          start_line: 172
+        }
+      }
+    }
+    symbol {
+      value: "df"
+    }
+    uid: 39
+    var_id {
+      bitfield1: 39
     }
   }
 }

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -190,7 +190,7 @@ def test_resolve_package_current_database(has_current_database):
     def mock_get_current_parameter(param: str, quoted: bool = True) -> Optional[str]:
         return "db" if has_current_database else None
 
-    def mock_get_information_schema_packages(table_name: str):
+    def mock_get_information_schema_packages(table_name: str, _emit_ast: bool = True):
         if has_current_database:
             assert table_name == "information_schema.packages"
         else:
@@ -218,7 +218,7 @@ def test_resolve_package_current_database(has_current_database):
 def test_resolve_package_terms_not_accepted(mock_server_connection):
     session = Session(mock_server_connection)
 
-    def get_information_schema_packages(table_name: str):
+    def get_information_schema_packages(table_name: str, _emit_ast: bool = True):
         if table_name == "information_schema.packages":
             result = MagicMock()
             result.filter().group_by().agg()._internal_collect_with_tag.return_value = (
@@ -249,7 +249,7 @@ def test_resolve_package_terms_not_accepted(mock_server_connection):
 def test_resolve_packages_side_effect(mock_server_connection):
     """Python stored procedure depends on this behavior to add packages to the session."""
 
-    def mock_get_information_schema_packages(table_name: str):
+    def mock_get_information_schema_packages(table_name: str, _emit_ast: bool = True):
         result = MagicMock()
         result.filter().group_by().agg()._internal_collect_with_tag.return_value = [
             ("random_package_name", json.dumps(["1.0.0"]))


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-1916224](https://snowflakecomputing.atlassian.net/browse/SNOW-1916224)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

    Updates `dataframe.na.{replace,fill}` to add the new `include_decimal` parameter to the AST.

    Adds the `@publicapi` decorator to APIs missing it
    - `DataframeWriter.{partition_by, option, options}`
    - `functions.fl_is_{video, document, compressed, image}`
    - Overload of `Table.merge`
    - `GroupingSets.__init__` in `relational_grouped_dataframe.py`

    Fixes for issues in the following APIs and expectation tests for them:
    - `map` in `dataframe.py`
    - `Functions.`
      - `system_reference`
      - `mean`
      - `var_samp`
      - `explode_outer`
      - `to_boolean`
      - `arrays_zip`
      - `window`
      - `from_json`
      - `array_remove`
      - `ln`
      - `call_builtin`
      - `builtin`
      - `acosh`
      - `asinh`
      - `atanh`
      - `bit_length`
      - `bitmap_bit_position`
      - `bitmap_bucket_number`
      - `bitmap_construct_agg`
      - `cbrt`
      - `ifnull`
      - `localtimestamp`
      - `max_by`
      - `min_by`
      - `octet_length`
      - `position`
      - `regr_avgx`
      - `regr_avgy`
      - `regr_count`
      - `regr_intercept`
      - `regr_r2`
      - `regr_slope`
      - `regr_sxx`
      - `regr_sxy`
      - `regr_syy`
      - `try_to_binary`
      - `build_stage_file_url`
    - `RelationalGroupedDataframe.{min, max}
    - `TableFunctionCall.over`
       - Also includes changes to build `order_by` and `partition_by` parameters as `ExprArgList` type fields in the AST
    - `Session.sproc.register_from_file`
    - `Session.udaf.register_from_file`
    - `Session.udf.register_from_file`
    - `Session.udtf.register_from_file`

This PR is accompanied by a [server-side PR](https://github.com/snowflakedb/snowflake/pull/269207).


[SNOW-1916224]: https://snowflakecomputing.atlassian.net/browse/SNOW-1916224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ