### PR TITLE
SNOW-1708509: Add support for resource_constraint when registering udxf

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -104,6 +104,7 @@ REGISTER_KWARGS_ALLOWLIST = {
     "_registered_object_name",  # object name within Snowflake (post registration)
     "artifact_repository",
     "artifact_repository_packages",
+    "resource_constraint",
 }
 
 
@@ -532,6 +533,23 @@ def check_python_runtime_version(runtime_version_from_requirement: Optional[str]
             f"Your system version is {system_version} while your requirements have specified version "
             f"{runtime_version_from_requirement}!"
         )
+
+
+def check_resource_constraint(constraint: Optional[Dict[str, str]]):
+    if constraint is None:
+        return
+
+    allowed_values = {"architecture": {"x86"}}
+    errors = []
+    for key, value in constraint.items():
+        if key not in allowed_values:
+            errors.append(ValueError(f"Unknown resource constraint key '{key}'"))
+            continue
+        if value not in allowed_values[key]:
+            errors.append(ValueError(f"Unknown value '{value}' for key '{key}'"))
+
+    if errors:
+        raise Exception(errors)
 
 
 def process_file_path(file_path: str) -> str:
@@ -1261,8 +1279,10 @@ def create_python_udf_or_sp(
     runtime_version: Optional[str] = None,
     artifact_repository: Optional[str] = None,
     artifact_repository_packages: Optional[List[str]] = None,
+    resource_constraint: Optional[Dict[str, str]] = None,
 ) -> None:
     runtime_version = runtime_version or f"{sys.version_info[0]}.{sys.version_info[1]}"
+    check_resource_constraint(resource_constraint)
 
     if replace and if_not_exists:
         raise ValueError("options replace and if_not_exists are incompatible")
@@ -1296,6 +1316,17 @@ def create_python_udf_or_sp(
     artifact_repository_packages_in_sql = (
         f"ARTIFACT_REPOSITORY_PACKAGES=('{artifact_repository_packages_str}')"
         if artifact_repository_packages
+        else ""
+    )
+
+    resource_constraint_fmt = (
+        ""
+        if resource_constraint is None
+        else ",".join(f"{k}='{v}'" for k, v in resource_constraint.items())
+    )
+    resource_constraint_sql = (
+        f"RESOURCE_CONSTRAINT=({resource_constraint_fmt})"
+        if resource_constraint_fmt
         else ""
     )
     if artifact_repository_in_sql or artifact_repository_packages_in_sql:
@@ -1383,6 +1414,7 @@ RUNTIME_VERSION={runtime_version}
 {artifact_repository_in_sql}
 {artifact_repository_packages_in_sql}
 {external_access_integrations_in_sql}
+{resource_constraint_sql}
 {secrets_in_sql}
 HANDLER='{handler}'{execute_as_sql}
 {inline_python_code_in_sql}

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -990,6 +990,7 @@ class StoredProcedureRegistration:
                     artifact_repository_packages=kwargs.get(
                         "artifact_repository_packages"
                     ),
+                    resource_constraint=kwargs.get("resource_constraint"),
                 )
             # an exception might happen during registering a stored procedure
             # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -813,6 +813,7 @@ class UDAFRegistration:
                 runtime_version=runtime_version_from_requirement,
                 artifact_repository=kwargs.get("artifact_repository"),
                 artifact_repository_packages=kwargs.get("artifact_repository_packages"),
+                resource_constraint=kwargs.get("resource_constraint"),
             )
         # an exception might happen during registering a udaf
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -1011,6 +1011,7 @@ class UDFRegistration:
                 runtime_version=runtime_version_from_requirement,
                 artifact_repository=kwargs.get("artifact_repository"),
                 artifact_repository_packages=kwargs.get("artifact_repository_packages"),
+                resource_constraint=kwargs.get("resource_constraint"),
             )
         # an exception might happen during registering a udf
         # (e.g., a dependency might not be found on the stage),

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -1073,6 +1073,7 @@ class UDTFRegistration:
                 runtime_version=runtime_version_from_requirement,
                 artifact_repository=kwargs.get("artifact_repository"),
                 artifact_repository_packages=kwargs.get("artifact_repository_packages"),
+                resource_constraint=kwargs.get("resource_constraint"),
             )
         # an exception might happen during registering a udtf
         # (e.g., a dependency might not be found on the stage),

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1954,6 +1954,19 @@ def test_sproc_artifact_repository(session):
     )
     assert artifact_repo_sproc(session=session) == "test"
 
+    with pytest.raises(
+        SnowparkSQLException,
+        match="Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse.",
+    ):
+        artifact_repo_sproc = sproc(
+            artifact_repo_test,
+            session=session,
+            return_type=StringType(),
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3", "requests"],
+            resource_constraint={"architecture": "x86"},
+        )
+
 
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -630,3 +630,16 @@ def test_udaf_artifact_repository(session):
     )
     df = session.create_dataframe([(1,)], schema=["a"])
     Utils.check_answer(df.agg(ar_udaf("a")), [Row("test")])
+
+    with pytest.raises(
+        SnowparkSQLException,
+        match="Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse.",
+    ):
+        ar_udaf = udaf(
+            ArtifactRepositoryHandler,
+            return_type=StringType(),
+            input_types=[IntegerType()],
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3", "requests"],
+            resource_constraint={"architecture": "x86"},
+        )

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2873,3 +2873,35 @@ def test_register_artifact_repository_negative(session):
             artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
             artifact_repository_packages=["urllib3==2.1.0", "requests"],
         )
+
+    with pytest.raises(
+        SnowparkSQLException,
+        match="Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse.",
+    ):
+        udf(
+            func=test_nop,
+            name=temp_func_name,
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3", "requests"],
+            resource_constraint={"architecture": "x86"},
+        )
+
+    with pytest.raises(Exception, match="Unknown resource constraint key"):
+        udf(
+            func=test_nop,
+            name=temp_func_name,
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3", "requests"],
+            resource_constraint={"cpu": "x86"},
+        )
+
+    with pytest.raises(
+        Exception, match="Unknown value 'risc-v' for key 'architecture'"
+    ):
+        udf(
+            func=test_nop,
+            name=temp_func_name,
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3", "requests"],
+            resource_constraint={"architecture": "risc-v"},
+        )

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -1311,7 +1311,7 @@ def test_udtf_external_access_integration(session, db_parameters):
     "config.getoption('local_testing_mode', default=False)",
     reason="artifact repository not supported in local testing",
 )
-@pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+# @pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="artifact repository requires Python 3.9+"
 )
@@ -1337,3 +1337,15 @@ def test_udtf_artifact_repository(session, resources_path):
             )
         ],
     )
+
+    with pytest.raises(
+        SnowparkSQLException,
+        match="Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse.",
+    ):
+        ar_udtf = session.udtf.register(
+            ArtifactRepositoryUDTF,
+            output_schema=StructType([StructField("a", StringType())]),
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+            artifact_repository_packages=["urllib3", "requests"],
+            resource_constraint={"architecture": "x86"},
+        )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1708509

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   This change adds support for resource_constraint statements when registering UDxFs. This is required for the artifact repository PrPr. Since this feature is not generally available yet I have added it via kwargs and omitted docstrings for now. There is a follow-up jira for adding that later.