### PR TITLE
SNOW-1988858: Use docstrings folder for TimedeltaIndex methods and properties

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/docstrings/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/__init__.py
@@ -20,6 +20,7 @@ from snowflake.snowpark.modin.plugin.docstrings.series_utils import (
     CombinedDatetimelikeProperties,
     StringMethods,
 )
+from snowflake.snowpark.modin.plugin.docstrings.timedelta_index import TimedeltaIndex
 from snowflake.snowpark.modin.plugin.docstrings.window import Expanding, Rolling
 
 __all__ = [
@@ -35,4 +36,5 @@ __all__ = [
     "StringMethods",
     "Index",
     "DatetimeIndex",
+    "TimedeltaIndex",
 ]

--- a/src/snowflake/snowpark/modin/plugin/docstrings/timedelta_index.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/timedelta_index.py
@@ -1,0 +1,359 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+# Code in this file may constitute partial or total reimplementation, or modification of
+# existing code originally distributed by the Modin project, under the Apache License,
+# Version 2.0.
+
+"""This module contains TimedeltaIndex docstrings that override modin's docstrings."""
+
+from __future__ import annotations
+
+from snowflake.snowpark.modin.plugin.extensions.index import Index
+
+
+class TimedeltaIndex(Index):
+    def __new__():
+        """
+        Create new instance of TimedeltaIndex. This overrides behavior of Index.__new__.
+
+        Parameters
+        ----------
+        data : array-like (1-dimensional), optional
+            Optional timedelta-like data to construct index with.
+        unit : {'D', 'h', 'm', 's', 'ms', 'us', 'ns'}, optional
+            The unit of ``data``.
+
+            .. deprecated:: 2.2.0
+             Use ``pd.to_timedelta`` instead.
+
+        freq : str or pandas offset object, optional
+            One of pandas date offset strings or corresponding objects. The string
+            ``'infer'`` can be passed in order to set the frequency of the index as
+            the inferred frequency upon creation.
+        dtype : numpy.dtype or str, default None
+            Valid ``numpy`` dtypes are ``timedelta64[ns]``, ``timedelta64[us]``,
+            ``timedelta64[ms]``, and ``timedelta64[s]``.
+        copy : bool
+            Make a copy of input array.
+        name : object
+            Name to be stored in the index.
+
+        Returns:
+            New instance of TimedeltaIndex.
+        """
+
+    def __init__() -> None:
+        """
+        Immutable Index of timedelta64 data.
+
+        Represented internally as int64, and scalars returned Timedelta objects.
+
+        Parameters
+        ----------
+        data : array-like (1-dimensional), optional
+            Optional timedelta-like data to construct index with.
+        unit : {'D', 'h', 'm', 's', 'ms', 'us', 'ns'}, optional
+            The unit of ``data``.
+
+            .. deprecated:: 2.2.0
+             Use ``pd.to_timedelta`` instead.
+
+        freq : str or pandas offset object, optional
+            One of pandas date offset strings or corresponding objects. The string
+            ``'infer'`` can be passed in order to set the frequency of the index as
+            the inferred frequency upon creation.
+        dtype : numpy.dtype or str, default None
+            Valid ``numpy`` dtypes are ``timedelta64[ns]``, ``timedelta64[us]``,
+            ``timedelta64[ms]``, and ``timedelta64[s]``.
+        copy : bool
+            Make a copy of input array.
+        name : object
+            Name to be stored in the index.
+
+        Examples
+        --------
+        >>> pd.TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'])
+        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
+
+        We can also let pandas infer the frequency when possible.
+
+        >>> pd.TimedeltaIndex(np.arange(5) * 24 * 3600 * 1e9, freq='infer')
+        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
+        """
+
+    @property
+    def days():
+        """
+        Number of days for each element.
+
+        Returns
+        -------
+        An Index with the days component of the timedelta.
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta(["0 days", "10 days", "20 days"])
+        >>> idx
+        TimedeltaIndex(['0 days', '10 days', '20 days'], dtype='timedelta64[ns]', freq=None)
+        >>> idx.days
+        Index([0, 10, 20], dtype='int64')
+        """
+
+    @property
+    def seconds():
+        """
+        Number of seconds (>= 0 and less than 1 day) for each element.
+
+        Returns
+        -------
+        An Index with seconds component of the timedelta.
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta([1, 2, 3], unit='s')
+        >>> idx
+        TimedeltaIndex(['0 days 00:00:01', '0 days 00:00:02', '0 days 00:00:03'], dtype='timedelta64[ns]', freq=None)
+        >>> idx.seconds
+        Index([1, 2, 3], dtype='int64')
+        """
+
+    @property
+    def microseconds():
+        """
+        Number of microseconds (>= 0 and less than 1 second) for each element.
+
+        Returns
+        -------
+        An Index with microseconds component of the timedelta.
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta([1, 2, 3], unit='us')
+        >>> idx
+        TimedeltaIndex(['0 days 00:00:00.000001', '0 days 00:00:00.000002',
+                        '0 days 00:00:00.000003'],
+                       dtype='timedelta64[ns]', freq=None)
+        >>> idx.microseconds
+        Index([1, 2, 3], dtype='int64')
+        """
+
+    @property
+    def nanoseconds():
+        """
+        Number of nonoseconds (>= 0 and less than 1 microsecond) for each element.
+
+        Returns
+        -------
+        An Index with nanoseconds compnent of the timedelta.
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta([1, 2, 3], unit='ns')
+        >>> idx
+        TimedeltaIndex(['0 days 00:00:00.000000001', '0 days 00:00:00.000000002',
+                        '0 days 00:00:00.000000003'],
+                       dtype='timedelta64[ns]', freq=None)
+        >>> idx.nanoseconds
+        Index([1, 2, 3], dtype='int64')
+        """
+
+    @property
+    def components():
+        """
+        Return a DataFrame of the individual resolution components of the Timedeltas.
+
+        The components (days, hours, minutes seconds, milliseconds, microseconds,
+        nanoseconds) are returned as columns in a DataFrame.
+
+        Returns
+        -------
+        A DataFrame
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta(['1 day 3 min 2 us 42 ns'])  # doctest: +SKIP
+        >>> idx  # doctest: +SKIP
+        TimedeltaIndex(['1 days 00:03:00.000002042'],
+                       dtype='timedelta64[ns]', freq=None)
+        >>> idx.components  # doctest: +SKIP
+           days  hours  minutes  seconds  milliseconds  microseconds  nanoseconds
+        0     1      0        3        0             0             2           42
+        """
+
+    @property
+    def inferred_freq():
+        """
+        Tries to return a string representing a frequency generated by infer_freq.
+
+        Returns None if it can't autodetect the frequency.
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta(["0 days", "10 days", "20 days"])  # doctest: +SKIP
+        >>> idx  # doctest: +SKIP
+        TimedeltaIndex(['0 days', '10 days', '20 days'],
+                       dtype='timedelta64[ns]', freq=None)
+        >>> idx.inferred_freq  # doctest: +SKIP
+        '10D'
+        """
+
+    def round():
+        """
+        Perform round operation on the data to the specified `freq`.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to round the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end). See
+            frequency aliases for a list of possible `freq` values.
+
+        Returns
+        -------
+        TimedeltaIndex with round values.
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+        """
+
+    def floor():
+        """
+        Perform floor operation on the data to the specified `freq`.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to floor the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end). See
+            frequency aliases for a list of possible `freq` values.
+
+        Returns
+        -------
+        TimedeltaIndex with floor values.
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+        """
+
+    def ceil():
+        """
+        Perform ceil operation on the data to the specified `freq`.
+
+        Parameters
+        ----------
+        freq : str or Offset
+            The frequency level to ceil the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end). See
+            frequency aliases for a list of possible `freq` values.
+
+        Returns
+        -------
+        TimedeltaIndex with ceil values.
+
+        Raises
+        ------
+        ValueError if the `freq` cannot be converted.
+        """
+
+    def to_pytimedelta():
+        """
+        Return an ndarray of datetime.timedelta objects.
+
+        Returns
+        -------
+        numpy.ndarray
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta([1, 2, 3], unit='D')  # doctest: +SKIP
+        >>> idx  # doctest: +SKIP
+        TimedeltaIndex(['1 days', '2 days', '3 days'],
+                        dtype='timedelta64[ns]', freq=None)
+        >>> idx.to_pytimedelta()  # doctest: +SKIP
+        array([datetime.timedelta(days=1), datetime.timedelta(days=2),
+               datetime.timedelta(days=3)], dtype=object)
+        """
+
+    def mean():
+        """
+        Return the mean value of the Timedelta values.
+
+        Parameters
+        ----------
+        skipna : bool, default True
+            Whether to ignore any NaT elements.
+        axis : int, optional, default 0
+
+        Returns
+        -------
+            scalar Timedelta
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta([1, 2, 3, 1], unit='D')
+        >>> idx
+        TimedeltaIndex(['1 days', '2 days', '3 days', '1 days'], dtype='timedelta64[ns]', freq=None)
+        >>> idx.mean()
+        Timedelta('1 days 18:00:00')
+
+        See Also
+        --------
+        numpy.ndarray.mean : Returns the average of array elements along a given axis.
+        Series.mean : Return the mean value in a Series.
+        """
+
+    def as_unit():
+        """
+        Convert to a dtype with the given unit resolution.
+
+        Parameters
+        ----------
+        unit : {'s', 'ms', 'us', 'ns'}
+
+        Returns
+        -------
+        DatetimeIndex
+
+        Examples
+        --------
+        >>> idx = pd.to_timedelta(['1 day 3 min 2 us 42 ns'])  # doctest: +SKIP
+        >>> idx  # doctest: +SKIP
+        TimedeltaIndex(['1 days 00:03:00.000002042'],
+                        dtype='timedelta64[ns]', freq=None)
+        >>> idx.as_unit('s')  # doctest: +SKIP
+        TimedeltaIndex(['1 days 00:03:00'], dtype='timedelta64[s]', freq=None)
+        """
+
+    def total_seconds():
+        """
+        Return total duration of each element expressed in seconds.
+
+        Returns
+        -------
+        An Index with float type.
+
+        Examples:
+        --------
+        >>> idx = pd.to_timedelta(np.arange(5), unit='d')
+        >>> idx
+        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
+        >>> idx.total_seconds()
+        Index([0.0, 86400.0, 172800.0, 259200.0, 345600.0], dtype='float64')
+        """

--- a/src/snowflake/snowpark/modin/plugin/extensions/timedelta_index.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/timedelta_index.py
@@ -40,6 +40,10 @@ from snowflake.snowpark.modin.plugin.extensions.index import Index
 from snowflake.snowpark.modin.plugin.utils.error_message import (
     timedelta_index_not_implemented,
 )
+from snowflake.snowpark.modin.utils import (
+    _inherit_docstrings,
+    doc_replace_dataframe_with_link,
+)
 
 _CONSTRUCTOR_DEFAULTS = {
     "unit": lib.no_default,
@@ -50,6 +54,9 @@ _CONSTRUCTOR_DEFAULTS = {
 }
 
 
+@_inherit_docstrings(
+    native_pd.TimedeltaIndex, modify_doc=doc_replace_dataframe_with_link
+)
 class TimedeltaIndex(Index):
 
     # Equivalent index type in native pandas
@@ -65,34 +72,6 @@ class TimedeltaIndex(Index):
         name: Hashable | None = _CONSTRUCTOR_DEFAULTS["name"],
         query_compiler: SnowflakeQueryCompiler = None,
     ) -> TimedeltaIndex:
-        """
-        Create new instance of TimedeltaIndex. This overrides behavior of Index.__new__.
-
-        Parameters
-        ----------
-        data : array-like (1-dimensional), optional
-            Optional timedelta-like data to construct index with.
-        unit : {'D', 'h', 'm', 's', 'ms', 'us', 'ns'}, optional
-            The unit of ``data``.
-
-            .. deprecated:: 2.2.0
-             Use ``pd.to_timedelta`` instead.
-
-        freq : str or pandas offset object, optional
-            One of pandas date offset strings or corresponding objects. The string
-            ``'infer'`` can be passed in order to set the frequency of the index as
-            the inferred frequency upon creation.
-        dtype : numpy.dtype or str, default None
-            Valid ``numpy`` dtypes are ``timedelta64[ns]``, ``timedelta64[us]``,
-            ``timedelta64[ms]``, and ``timedelta64[s]``.
-        copy : bool
-            Make a copy of input array.
-        name : object
-            Name to be stored in the index.
-
-        Returns:
-            New instance of TimedeltaIndex.
-        """
         if query_compiler:
             # Raise error if underlying type is not a Timedelta type.
             current_dtype = query_compiler.index_dtypes[0]
@@ -125,63 +104,12 @@ class TimedeltaIndex(Index):
         name: Hashable | None = _CONSTRUCTOR_DEFAULTS["name"],
         query_compiler: SnowflakeQueryCompiler = None,
     ) -> None:
-        """
-        Immutable Index of timedelta64 data.
-
-        Represented internally as int64, and scalars returned Timedelta objects.
-
-        Parameters
-        ----------
-        data : array-like (1-dimensional), optional
-            Optional timedelta-like data to construct index with.
-        unit : {'D', 'h', 'm', 's', 'ms', 'us', 'ns'}, optional
-            The unit of ``data``.
-
-            .. deprecated:: 2.2.0
-             Use ``pd.to_timedelta`` instead.
-
-        freq : str or pandas offset object, optional
-            One of pandas date offset strings or corresponding objects. The string
-            ``'infer'`` can be passed in order to set the frequency of the index as
-            the inferred frequency upon creation.
-        dtype : numpy.dtype or str, default None
-            Valid ``numpy`` dtypes are ``timedelta64[ns]``, ``timedelta64[us]``,
-            ``timedelta64[ms]``, and ``timedelta64[s]``.
-        copy : bool
-            Make a copy of input array.
-        name : object
-            Name to be stored in the index.
-
-        Examples
-        --------
-        >>> pd.TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'])
-        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
-
-        We can also let pandas infer the frequency when possible.
-
-        >>> pd.TimedeltaIndex(np.arange(5) * 24 * 3600 * 1e9, freq='infer')
-        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
-        """
         # TimedeltaIndex is already initialized in __new__ method. We keep this method
         # only for docstring generation.
+        pass  # pragma: no cover
 
     @property
     def days(self) -> Index:
-        """
-        Number of days for each element.
-
-        Returns
-        -------
-        An Index with the days component of the timedelta.
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta(["0 days", "10 days", "20 days"])
-        >>> idx
-        TimedeltaIndex(['0 days', '10 days', '20 days'], dtype='timedelta64[ns]', freq=None)
-        >>> idx.days
-        Index([0, 10, 20], dtype='int64')
-        """
         return Index(
             query_compiler=self._query_compiler.timedelta_property(
                 "days", include_index=True
@@ -190,21 +118,6 @@ class TimedeltaIndex(Index):
 
     @property
     def seconds(self) -> Index:
-        """
-        Number of seconds (>= 0 and less than 1 day) for each element.
-
-        Returns
-        -------
-        An Index with seconds component of the timedelta.
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta([1, 2, 3], unit='s')
-        >>> idx
-        TimedeltaIndex(['0 days 00:00:01', '0 days 00:00:02', '0 days 00:00:03'], dtype='timedelta64[ns]', freq=None)
-        >>> idx.seconds
-        Index([1, 2, 3], dtype='int64')
-        """
         return Index(
             query_compiler=self._query_compiler.timedelta_property(
                 "seconds", include_index=True
@@ -213,23 +126,6 @@ class TimedeltaIndex(Index):
 
     @property
     def microseconds(self) -> Index:
-        """
-        Number of microseconds (>= 0 and less than 1 second) for each element.
-
-        Returns
-        -------
-        An Index with microseconds component of the timedelta.
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta([1, 2, 3], unit='us')
-        >>> idx
-        TimedeltaIndex(['0 days 00:00:00.000001', '0 days 00:00:00.000002',
-                        '0 days 00:00:00.000003'],
-                       dtype='timedelta64[ns]', freq=None)
-        >>> idx.microseconds
-        Index([1, 2, 3], dtype='int64')
-        """
         return Index(
             query_compiler=self._query_compiler.timedelta_property(
                 "microseconds", include_index=True
@@ -238,23 +134,6 @@ class TimedeltaIndex(Index):
 
     @property
     def nanoseconds(self) -> Index:
-        """
-        Number of nonoseconds (>= 0 and less than 1 microsecond) for each element.
-
-        Returns
-        -------
-        An Index with nanoseconds compnent of the timedelta.
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta([1, 2, 3], unit='ns')
-        >>> idx
-        TimedeltaIndex(['0 days 00:00:00.000000001', '0 days 00:00:00.000000002',
-                        '0 days 00:00:00.000000003'],
-                       dtype='timedelta64[ns]', freq=None)
-        >>> idx.nanoseconds
-        Index([1, 2, 3], dtype='int64')
-        """
         return Index(
             query_compiler=self._query_compiler.timedelta_property(
                 "nanoseconds", include_index=True
@@ -264,163 +143,35 @@ class TimedeltaIndex(Index):
     @timedelta_index_not_implemented()
     @property
     def components(self) -> DataFrame:
-        """
-        Return a DataFrame of the individual resolution components of the Timedeltas.
-
-        The components (days, hours, minutes seconds, milliseconds, microseconds,
-        nanoseconds) are returned as columns in a DataFrame.
-
-        Returns
-        -------
-        A DataFrame
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta(['1 day 3 min 2 us 42 ns'])  # doctest: +SKIP
-        >>> idx  # doctest: +SKIP
-        TimedeltaIndex(['1 days 00:03:00.000002042'],
-                       dtype='timedelta64[ns]', freq=None)
-        >>> idx.components  # doctest: +SKIP
-           days  hours  minutes  seconds  milliseconds  microseconds  nanoseconds
-        0     1      0        3        0             0             2           42
-        """
+        pass  # pragma: no cover
 
     @timedelta_index_not_implemented()
     @property
     def inferred_freq(self) -> str | None:
-        """
-        Tries to return a string representing a frequency generated by infer_freq.
-
-        Returns None if it can't autodetect the frequency.
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta(["0 days", "10 days", "20 days"])  # doctest: +SKIP
-        >>> idx  # doctest: +SKIP
-        TimedeltaIndex(['0 days', '10 days', '20 days'],
-                       dtype='timedelta64[ns]', freq=None)
-        >>> idx.inferred_freq  # doctest: +SKIP
-        '10D'
-        """
+        pass  # pragma: no cover
 
     def round(self, freq: Frequency) -> TimedeltaIndex:
-        """
-        Perform round operation on the data to the specified `freq`.
-
-        Parameters
-        ----------
-        freq : str or Offset
-            The frequency level to round the index to. Must be a fixed
-            frequency like 'S' (second) not 'ME' (month end). See
-            frequency aliases for a list of possible `freq` values.
-
-        Returns
-        -------
-        TimedeltaIndex with round values.
-
-        Raises
-        ------
-        ValueError if the `freq` cannot be converted.
-        """
         return TimedeltaIndex(
             query_compiler=self._query_compiler.dt_round(freq, include_index=True)
         )
 
     def floor(self, freq: Frequency) -> TimedeltaIndex:
-        """
-        Perform floor operation on the data to the specified `freq`.
-
-        Parameters
-        ----------
-        freq : str or Offset
-            The frequency level to floor the index to. Must be a fixed
-            frequency like 'S' (second) not 'ME' (month end). See
-            frequency aliases for a list of possible `freq` values.
-
-        Returns
-        -------
-        TimedeltaIndex with floor values.
-
-        Raises
-        ------
-        ValueError if the `freq` cannot be converted.
-        """
         return TimedeltaIndex(
             query_compiler=self._query_compiler.dt_floor(freq, include_index=True)
         )
 
     def ceil(self, freq: Frequency) -> TimedeltaIndex:
-        """
-        Perform ceil operation on the data to the specified `freq`.
-
-        Parameters
-        ----------
-        freq : str or Offset
-            The frequency level to ceil the index to. Must be a fixed
-            frequency like 'S' (second) not 'ME' (month end). See
-            frequency aliases for a list of possible `freq` values.
-
-        Returns
-        -------
-        TimedeltaIndex with ceil values.
-
-        Raises
-        ------
-        ValueError if the `freq` cannot be converted.
-        """
         return TimedeltaIndex(
             query_compiler=self._query_compiler.dt_ceil(freq, include_index=True)
         )
 
     @timedelta_index_not_implemented()
     def to_pytimedelta(self) -> np.ndarray:
-        """
-        Return an ndarray of datetime.timedelta objects.
-
-        Returns
-        -------
-        numpy.ndarray
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta([1, 2, 3], unit='D')  # doctest: +SKIP
-        >>> idx  # doctest: +SKIP
-        TimedeltaIndex(['1 days', '2 days', '3 days'],
-                        dtype='timedelta64[ns]', freq=None)
-        >>> idx.to_pytimedelta()  # doctest: +SKIP
-        array([datetime.timedelta(days=1), datetime.timedelta(days=2),
-               datetime.timedelta(days=3)], dtype=object)
-        """
+        pass  # pragma: no cover
 
     def mean(
         self, *, skipna: bool = True, axis: AxisInt | None = 0
     ) -> native_pd.Timedelta:
-        """
-        Return the mean value of the Timedelta values.
-
-        Parameters
-        ----------
-        skipna : bool, default True
-            Whether to ignore any NaT elements.
-        axis : int, optional, default 0
-
-        Returns
-        -------
-            scalar Timedelta
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta([1, 2, 3, 1], unit='D')
-        >>> idx
-        TimedeltaIndex(['1 days', '2 days', '3 days', '1 days'], dtype='timedelta64[ns]', freq=None)
-        >>> idx.mean()
-        Timedelta('1 days 18:00:00')
-
-        See Also
-        --------
-        numpy.ndarray.mean : Returns the average of array elements along a given axis.
-        Series.mean : Return the mean value in a Series.
-        """
         if axis:
             # Native pandas raises IndexError: tuple index out of range
             # We raise a different more user-friendly error message.
@@ -449,43 +200,9 @@ class TimedeltaIndex(Index):
 
     @timedelta_index_not_implemented()
     def as_unit(self, unit: str) -> TimedeltaIndex:
-        """
-        Convert to a dtype with the given unit resolution.
-
-        Parameters
-        ----------
-        unit : {'s', 'ms', 'us', 'ns'}
-
-        Returns
-        -------
-        DatetimeIndex
-
-        Examples
-        --------
-        >>> idx = pd.to_timedelta(['1 day 3 min 2 us 42 ns'])  # doctest: +SKIP
-        >>> idx  # doctest: +SKIP
-        TimedeltaIndex(['1 days 00:03:00.000002042'],
-                        dtype='timedelta64[ns]', freq=None)
-        >>> idx.as_unit('s')  # doctest: +SKIP
-        TimedeltaIndex(['1 days 00:03:00'], dtype='timedelta64[s]', freq=None)
-        """
+        pass  # pragma: no cover
 
     def total_seconds(self) -> Index:
-        """
-        Return total duration of each element expressed in seconds.
-
-        Returns
-        -------
-        An Index with float type.
-
-        Examples:
-        --------
-        >>> idx = pd.to_timedelta(np.arange(5), unit='d')
-        >>> idx
-        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
-        >>> idx.total_seconds()
-        Index([0.0, 86400.0, 172800.0, 259200.0, 345600.0], dtype='float64')
-        """
         return Index(
             query_compiler=self._query_compiler.dt_total_seconds(include_index=True)
         )


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1988858

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Use docstrings folder for TimedeltaIndex methods and properties.
