### PR TITLE
SNOW-1989053: [Local Testing] Fix to_timestamp when called on filtered data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### Snowpark Local Testing Updates
 
+#### Bug Fixes
+
+- Fixed a bug that caused `to_timestamp` to fail when casting filtered columns.
+
 #### New Features
 
 ### Snowpark pandas API Updates

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -923,7 +923,11 @@ def _to_timestamp(
 
     import dateutil.parser
 
-    fmt = [fmt] * len(column) if not isinstance(fmt, ColumnEmulator) else fmt
+    fmt = (
+        ColumnEmulator([fmt] * len(column), index=column.index)
+        if not isinstance(fmt, ColumnEmulator)
+        else fmt
+    )
 
     def convert_timestamp(row):
         _fmt = fmt[row.name]

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -1396,6 +1396,19 @@ def test_to_timestamp(session):
         ],
     )
 
+    # Test filtered df works as expected
+    df = session.create_dataframe(
+        [1742423376, 1742423377, 1742423378, 1742423379, 1742423380], ["ts"]
+    )
+    Utils.check_answer(
+        df.filter((df.ts % 2) == 0).select(to_timestamp(df.ts)),
+        [
+            Row(datetime(2025, 3, 19, 22, 29, 36)),
+            Row(datetime(2025, 3, 19, 22, 29, 38)),
+            Row(datetime(2025, 3, 19, 22, 29, 40)),
+        ],
+    )
+
 
 def test_to_time(session, local_testing_mode):
     # basic string expr


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1989053

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   When to_timestamp was called on a filtered column without a fmt defined the generated fmt would not have the correct index causing an indexing issue during conversion. This change applies the input columns index to the generated fmt in order to avoid this issue.