### PR TITLE
SNOW-1969300: support multiple session init statements in dbapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Snowpark Python API Updates
 
+#### New Features
+
+- `DataFrameReader.dbapi` (PrPr) now accepts a list of strings for the session_init_statement parameter, allowing multiple SQL statements to be executed during session initialization.
+
 #### Improvements
 
 - Improved query generation for `Dataframe.stat.sample_by` to generate a single flat query that scales well with large `fractions` dictionary compared to older method of creating a UNION ALL subquery for each key in `fractions`. To enable this feature, set `session.conf.set("use_simplified_query_generation", True)`.

--- a/src/snowflake/snowpark/_internal/data_source/datasource_partitioner.py
+++ b/src/snowflake/snowpark/_internal/data_source/datasource_partitioner.py
@@ -44,7 +44,7 @@ class DataSourcePartitioner:
         fetch_size: Optional[int] = 0,
         custom_schema: Optional[Union[str, StructType]] = None,
         predicates: Optional[List[str]] = None,
-        session_init_statement: Optional[str] = None,
+        session_init_statement: Optional[List[str]] = None,
     ) -> None:
         self.create_connection = create_connection
         self.table_or_query = table_or_query

--- a/src/snowflake/snowpark/_internal/data_source/utils.py
+++ b/src/snowflake/snowpark/_internal/data_source/utils.py
@@ -183,6 +183,9 @@ def _retry_run(func: Callable, *args, **kwargs) -> Any:
         try:
             return func(*args, **kwargs)
         except Exception as e:
+            # SnowparkDataframeReaderException is a non-retryable exception
+            if isinstance(e, SnowparkDataframeReaderException):
+                raise e
             last_error = e
             error_trace = traceback.format_exc()
             retry_count += 1

--- a/src/snowflake/snowpark/_internal/data_source/utils.py
+++ b/src/snowflake/snowpark/_internal/data_source/utils.py
@@ -182,10 +182,10 @@ def _retry_run(func: Callable, *args, **kwargs) -> Any:
     while retry_count < _MAX_RETRY_TIME:
         try:
             return func(*args, **kwargs)
-        except Exception as e:
+        except SnowparkDataframeReaderException:
             # SnowparkDataframeReaderException is a non-retryable exception
-            if isinstance(e, SnowparkDataframeReaderException):
-                raise e
+            raise
+        except Exception as e:
             last_error = e
             error_trace = traceback.format_exc()
             retry_count += 1

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1089,7 +1089,7 @@ class DataFrameReader:
         fetch_size: Optional[int] = 0,
         custom_schema: Optional[Union[str, StructType]] = None,
         predicates: Optional[List[str]] = None,
-        session_init_statement: Optional[str] = None,
+        session_init_statement: Optional[Union[str, List[str]]] = None,
         _emit_ast: bool = True,
     ) -> DataFrame:
         """
@@ -1137,7 +1137,8 @@ class DataFrameReader:
             predicates: A list of expressions suitable for inclusion in WHERE clauses, where each expression defines a partition.
                 Partitions will be retrieved in parallel.
                 If both `column` and `predicates` are specified, `column` takes precedence.
-            session_init_statement: A SQL statement executed before fetching data from the external data source.
+            session_init_statement: One or more SQL statements executed before fetching data from
+                the external data source.
                 This can be used for session initialization tasks such as setting configurations.
                 For example, `"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"` can be used in SQL Server
                 to avoid row locks and improve read performance.
@@ -1160,7 +1161,8 @@ class DataFrameReader:
         table_or_query = table or query
         statements_params_for_telemetry = {STATEMENT_PARAMS_DATA_SOURCE: "1"}
         start_time = time.perf_counter()
-
+        if session_init_statement and isinstance(session_init_statement, str):
+            session_init_statement = [session_init_statement]
         partitioner = DataSourcePartitioner(
             create_connection,
             table_or_query,

--- a/tests/integ/test_data_source_api.py
+++ b/tests/integ/test_data_source_api.py
@@ -473,18 +473,33 @@ def test_predicates():
 def test_session_init_statement(session):
     with tempfile.TemporaryDirectory() as temp_dir:
         dbpath = os.path.join(temp_dir, "testsqlite3.db")
-        table_name, _, _, assert_data = sqlite3_db(dbpath)
+        table_name, columns, _, assert_data = sqlite3_db(dbpath)
+
+        new_data1 = (5, 100) + (None,) * (len(columns) - 2)
+        new_data2 = (6, 101) + (None,) * (len(columns) - 2)
 
         df = session.read.dbapi(
             functools.partial(create_connection_to_sqlite3_db, dbpath),
             table=table_name,
             custom_schema="id INTEGER, int_col INTEGER, real_col FLOAT, text_col STRING, blob_col BINARY, null_col STRING, ts_col TIMESTAMP, date_col DATE, time_col TIME, short_col SHORT, long_col LONG, double_col DOUBLE, decimal_col DECIMAL, map_col MAP, array_col ARRAY, var_col VARIANT",
-            session_init_statement="SELECT 1;",
+            session_init_statement=f"insert into {table_name} (int_col) values (100);",
         )
-        assert df.collect() == assert_data
+        assert df.collect() == assert_data + [new_data1]
+
+        df = session.read.dbapi(
+            functools.partial(create_connection_to_sqlite3_db, dbpath),
+            table=table_name,
+            custom_schema="id INTEGER, int_col INTEGER, real_col FLOAT, text_col STRING, blob_col BINARY, null_col STRING, ts_col TIMESTAMP, date_col DATE, time_col TIME, short_col SHORT, long_col LONG, double_col DOUBLE, decimal_col DECIMAL, map_col MAP, array_col ARRAY, var_col VARIANT",
+            session_init_statement=[
+                f"insert into {table_name} (int_col) values (100);",
+                f"insert into {table_name} (int_col) values (101);",
+            ],
+        )
+        assert df.collect() == assert_data + [new_data1, new_data2]
 
         with pytest.raises(
-            SnowparkDataframeReaderException, match='near "FROM": syntax error'
+            SnowparkDataframeReaderException,
+            match=r'Failed to execute session init statement: \'SELECT FROM NOTHING;\' due to exception \'OperationalError\(\'near "FROM": syntax error\'\)\'',
         ):
             session.read.dbapi(
                 functools.partial(create_connection_to_sqlite3_db, dbpath),

--- a/tests/integ/test_data_source_api.py
+++ b/tests/integ/test_data_source_api.py
@@ -473,16 +473,16 @@ def test_predicates():
 def test_session_init_statement(session):
     with tempfile.TemporaryDirectory() as temp_dir:
         dbpath = os.path.join(temp_dir, "testsqlite3.db")
-        table_name, columns, _, assert_data = sqlite3_db(dbpath)
+        table_name, columns, example_data, assert_data = sqlite3_db(dbpath)
 
-        new_data1 = (5, 100) + (None,) * (len(columns) - 2)
-        new_data2 = (6, 101) + (None,) * (len(columns) - 2)
+        new_data1 = (5, 100) + (None,) * (len(columns) - 3) + ('"123"',)
+        new_data2 = (6, 101) + (None,) * (len(columns) - 3) + ('"456"',)
 
         df = session.read.dbapi(
             functools.partial(create_connection_to_sqlite3_db, dbpath),
             table=table_name,
             custom_schema="id INTEGER, int_col INTEGER, real_col FLOAT, text_col STRING, blob_col BINARY, null_col STRING, ts_col TIMESTAMP, date_col DATE, time_col TIME, short_col SHORT, long_col LONG, double_col DOUBLE, decimal_col DECIMAL, map_col MAP, array_col ARRAY, var_col VARIANT",
-            session_init_statement=f"insert into {table_name} (int_col) values (100);",
+            session_init_statement=f"insert into {table_name} (int_col, var_col) values (100, '123');",
         )
         assert df.collect() == assert_data + [new_data1]
 
@@ -491,8 +491,8 @@ def test_session_init_statement(session):
             table=table_name,
             custom_schema="id INTEGER, int_col INTEGER, real_col FLOAT, text_col STRING, blob_col BINARY, null_col STRING, ts_col TIMESTAMP, date_col DATE, time_col TIME, short_col SHORT, long_col LONG, double_col DOUBLE, decimal_col DECIMAL, map_col MAP, array_col ARRAY, var_col VARIANT",
             session_init_statement=[
-                f"insert into {table_name} (int_col) values (100);",
-                f"insert into {table_name} (int_col) values (101);",
+                f"insert into {table_name} (int_col, var_col) values (100, '123');",
+                f"insert into {table_name} (int_col, var_col) values (101, '456');",
             ],
         )
         assert df.collect() == assert_data + [new_data1, new_data2]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

 support multiple session init statements in dbapi
python dbapi only allows one statement to be executed in one statement, we take a list and execute them in sequence
