### PR TITLE
SNOW-1882075,SNOW-1990301,SNOW-1990302,SNOW-1821290: AST finalizations for stateless batches, and DataframeWriter,DataframeReader new APIs

### DIFF
--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -334,10 +334,7 @@ def build_expr_from_python_val(
             build_expr_from_python_val(ast.vs.add(), v)  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "vs"
     elif isinstance(obj, snowflake.snowpark.dataframe.DataFrame):
         ast = with_src_position(expr_builder.dataframe_ref)  # type: ignore[arg-type] # TODO(SNOW-1491199) # Argument 1 to "with_src_position" has incompatible type "DataframeRef"; expected "Expr"
-        assert (
-            obj._ast_id is not None
-        ), "Dataframe object to encode as part of AST does not have an id assigned. Missing AST for object or previous operation?"
-        ast.id.bitfield1 = obj._ast_id  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "id"
+        obj._set_ast_ref(expr_builder)
     elif isinstance(obj, snowflake.snowpark.table_function.TableFunctionCall):
         raise NotImplementedError(
             "TODO SNOW-1629946: Implement TableFunctionCall with args."
@@ -1090,21 +1087,6 @@ def fill_write_file(
             t = expr.copy_options.add()  # type: ignore[attr-defined] # TODO(SNOW-1491199) # "Expr" has no attribute "copy_options"
             t._1 = k
             build_expr_from_python_val(t._2, v)
-
-
-# TODO(SNOW-1491199) - This method is not covered by tests until the end of phase 0. Drop the pragma when it is covered.
-def build_proto_from_pivot_values(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function is missing a return type annotation
-    expr_builder: proto.PivotValue,
-    values: Optional[Union[Iterable["LiteralType"], "DataFrame"]],  # type: ignore[name-defined] # noqa: F821 # TODO(SNOW-1491199) # Name "LiteralType" is not defined, Name "DataFrame" is not defined
-):  # pragma: no cover
-    """Helper function to encode Snowpark pivot values that are used in various pivot operations to AST."""
-    if not values:
-        return
-
-    if isinstance(values, snowflake.snowpark.dataframe.DataFrame):
-        expr_builder.pivot_value__dataframe.v.id.bitfield1 = values._ast_id
-    else:
-        build_expr_from_python_val(expr_builder.pivot_value__expr.v, values)
 
 
 # TODO(SNOW-1491199) - This method is not covered by tests until the end of phase 0. Drop the pragma when it is covered.

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -288,31 +288,13 @@ message NullOrder {
   }
 }
 
-// dataframe-grouped.ir:64
-message PivotValue {
-  oneof sealed_value {
-    PivotValue_Dataframe pivot_value__dataframe = 1;
-    PivotValue_Expr pivot_value__expr = 2;
-  }
-}
-
-// dataframe-grouped.ir:65
-message PivotValue_Expr {
-  Expr v = 1;
-}
-
-// dataframe-grouped.ir:66
-message PivotValue_Dataframe {
-  DataframeRef v = 1;
-}
-
 // const.ir:84
 message PythonTimeZone {
   google.protobuf.StringValue name = 1;
   int64 offset_seconds = 2;
 }
 
-// dataframe-io.ir:71
+// dataframe-io.ir:49
 message SaveMode {
   oneof variant {
     bool save_mode_append = 1;
@@ -830,14 +812,14 @@ message DataframeCol {
 message DataframeCollect {
   bool block = 1;
   bool case_sensitive = 2;
-  VarId id = 3;
+  Expr df = 3;
   bool log_on_exception = 4;
   bool no_wait = 5;
   SrcPosition src = 6;
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe-io.ir:165
+// dataframe-io.ir:148
 message DataframeCopyIntoTable {
   repeated Tuple_String_Expr copy_options = 1;
   Expr df = 2;
@@ -856,12 +838,12 @@ message DataframeCopyIntoTable {
 // dataframe.ir:13
 message DataframeCount {
   bool block = 1;
-  VarId id = 2;
+  Expr df = 2;
   SrcPosition src = 3;
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe-io.ir:149
+// dataframe-io.ir:132
 message DataframeCreateOrReplaceDynamicTable {
   repeated Expr clustering_keys = 1;
   google.protobuf.StringValue comment = 2;
@@ -879,7 +861,7 @@ message DataframeCreateOrReplaceDynamicTable {
   string warehouse = 14;
 }
 
-// dataframe-io.ir:141
+// dataframe-io.ir:124
 message DataframeCreateOrReplaceView {
   google.protobuf.StringValue comment = 1;
   Expr df = 2;
@@ -1068,7 +1050,7 @@ message DataframePivot {
   Expr df = 2;
   Expr pivot_col = 3;
   SrcPosition src = 4;
-  PivotValue values = 5;
+  Expr values = 5;
 }
 
 // dataframe.ir:278
@@ -1080,38 +1062,13 @@ message DataframeRandomSplit {
   repeated double weights = 5;
 }
 
-// dataframe-io.ir:8
-message DataframeReaderInit {
-  SrcPosition src = 1;
-}
-
-// dataframe-io.ir:10
-message DataframeReaderOption {
-  string key = 1;
-  Expr reader = 2;
-  SrcPosition src = 3;
-  Expr value = 4;
-}
-
-// dataframe-io.ir:16
-message DataframeReaderOptions {
-  repeated Tuple_String_Expr configs = 1;
-  Expr reader = 2;
-  SrcPosition src = 3;
-}
-
-// dataframe-io.ir:21
-message DataframeReaderSchema {
-  Expr reader = 1;
-  StructType schema = 2;
-  SrcPosition src = 3;
-}
-
-// dataframe-io.ir:26
-message DataframeReaderWithMetadata {
-  ExprArgList metadata_columns = 1;
-  Expr reader = 2;
-  SrcPosition src = 3;
+// dataframe-io.ir:13
+message DataframeReader {
+  google.protobuf.StringValue format = 1;
+  ExprArgList metadata_columns = 2;
+  repeated Tuple_String_Expr options = 3;
+  StructType schema = 4;
+  SrcPosition src = 5;
 }
 
 // dataframe.ir:4
@@ -1154,7 +1111,7 @@ message DataframeSelect {
 
 // dataframe.ir:8
 message DataframeShow {
-  VarId id = 1;
+  Expr df = 1;
   int64 n = 2;
   SrcPosition src = 3;
 }
@@ -1170,7 +1127,7 @@ message DataframeSort {
 // dataframe-stat.ir:1
 message DataframeStatApproxQuantile {
   ExprArgList cols = 1;
-  VarId id = 2;
+  Expr df = 2;
   repeated double percentile = 3;
   SrcPosition src = 4;
   repeated Tuple_String_String statement_params = 5;
@@ -1180,7 +1137,7 @@ message DataframeStatApproxQuantile {
 message DataframeStatCorr {
   Expr col1 = 1;
   Expr col2 = 2;
-  VarId id = 3;
+  Expr df = 3;
   SrcPosition src = 4;
   repeated Tuple_String_String statement_params = 5;
 }
@@ -1189,7 +1146,7 @@ message DataframeStatCorr {
 message DataframeStatCov {
   Expr col1 = 1;
   Expr col2 = 2;
-  VarId id = 3;
+  Expr df = 3;
   SrcPosition src = 4;
   repeated Tuple_String_String statement_params = 5;
 }
@@ -1198,7 +1155,7 @@ message DataframeStatCov {
 message DataframeStatCrossTab {
   Expr col1 = 1;
   Expr col2 = 2;
-  VarId id = 3;
+  Expr df = 3;
   SrcPosition src = 4;
   repeated Tuple_String_String statement_params = 5;
 }
@@ -1222,7 +1179,7 @@ message DataframeToDf {
 message DataframeToLocalIterator {
   bool block = 1;
   bool case_sensitive = 2;
-  VarId id = 3;
+  Expr df = 3;
   SrcPosition src = 4;
   repeated Tuple_String_String statement_params = 5;
 }
@@ -1230,7 +1187,7 @@ message DataframeToLocalIterator {
 // dataframe.ir:108
 message DataframeToPandas {
   bool block = 1;
-  VarId id = 2;
+  Expr df = 2;
   SrcPosition src = 3;
   repeated Tuple_String_String statement_params = 4;
 }
@@ -1238,7 +1195,7 @@ message DataframeToPandas {
 // dataframe.ir:114
 message DataframeToPandasBatches {
   bool block = 1;
-  VarId id = 2;
+  Expr df = 2;
   SrcPosition src = 3;
   repeated Tuple_String_String statement_params = 4;
 }
@@ -1287,13 +1244,14 @@ message DataframeWithColumns {
   repeated Expr values = 4;
 }
 
-// dataframe-io.ir:80
-message DataframeWrite {
+// dataframe-io.ir:62
+message DataframeWriter {
   Expr df = 1;
-  repeated Tuple_String_Expr options = 2;
-  Expr partition_by = 3;
-  SaveMode save_mode = 4;
-  SrcPosition src = 5;
+  google.protobuf.StringValue format = 2;
+  repeated Tuple_String_Expr options = 3;
+  Expr partition_by = 4;
+  SaveMode save_mode = 5;
+  SrcPosition src = 6;
 }
 
 // const.ir:49
@@ -1366,180 +1324,180 @@ message Expr {
     ExtensionExpr trait_extension_expr = 4;
     FnIdRefExpr trait_fn_id_ref_expr = 5;
     FnNameRefExpr trait_fn_name_ref_expr = 6;
-    TruncatedExpr trait_truncated_expr = 7;
-    UnaryOp trait_unary_op = 8;
-    WriteFile trait_write_file = 9;
-    Add add = 10;
-    And and = 11;
-    ApplyExpr apply_expr = 12;
-    BigDecimalVal big_decimal_val = 13;
-    BigIntVal big_int_val = 14;
-    BinaryVal binary_val = 15;
-    BitAnd bit_and = 16;
-    BitOr bit_or = 17;
-    BitXor bit_xor = 18;
-    BoolVal bool_val = 19;
-    BuiltinFn builtin_fn = 20;
-    CallTableFunctionExpr call_table_function_expr = 21;
-    ColumnAlias column_alias = 22;
-    ColumnApply_Int column_apply__int = 23;
-    ColumnApply_String column_apply__string = 24;
-    ColumnAsc column_asc = 25;
-    ColumnBetween column_between = 26;
-    ColumnCaseExpr column_case_expr = 27;
-    ColumnCast column_cast = 28;
-    ColumnDesc column_desc = 29;
-    ColumnEqualNan column_equal_nan = 30;
-    ColumnEqualNull column_equal_null = 31;
-    ColumnIn column_in = 32;
-    ColumnIsNotNull column_is_not_null = 33;
-    ColumnIsNull column_is_null = 34;
-    ColumnOver column_over = 35;
-    ColumnRegexp column_regexp = 36;
-    ColumnStringCollate column_string_collate = 37;
-    ColumnStringContains column_string_contains = 38;
-    ColumnStringEndsWith column_string_ends_with = 39;
-    ColumnStringLike column_string_like = 40;
-    ColumnStringStartsWith column_string_starts_with = 41;
-    ColumnStringSubstr column_string_substr = 42;
-    ColumnTryCast column_try_cast = 43;
-    ColumnWithinGroup column_within_group = 44;
-    CreateDataframe create_dataframe = 45;
-    DataframeAgg dataframe_agg = 46;
-    DataframeAlias dataframe_alias = 47;
-    DataframeAnalyticsComputeLag dataframe_analytics_compute_lag = 48;
-    DataframeAnalyticsComputeLead dataframe_analytics_compute_lead = 49;
-    DataframeAnalyticsCumulativeAgg dataframe_analytics_cumulative_agg = 50;
-    DataframeAnalyticsMovingAgg dataframe_analytics_moving_agg = 51;
-    DataframeAnalyticsTimeSeriesAgg dataframe_analytics_time_series_agg = 52;
-    DataframeCacheResult dataframe_cache_result = 53;
-    DataframeCol dataframe_col = 54;
-    DataframeCollect dataframe_collect = 55;
-    DataframeCopyIntoTable dataframe_copy_into_table = 56;
-    DataframeCount dataframe_count = 57;
-    DataframeCreateOrReplaceDynamicTable dataframe_create_or_replace_dynamic_table = 58;
-    DataframeCreateOrReplaceView dataframe_create_or_replace_view = 59;
-    DataframeCrossJoin dataframe_cross_join = 60;
-    DataframeCube dataframe_cube = 61;
-    DataframeDescribe dataframe_describe = 62;
-    DataframeDistinct dataframe_distinct = 63;
-    DataframeDrop dataframe_drop = 64;
-    DataframeDropDuplicates dataframe_drop_duplicates = 65;
-    DataframeExcept dataframe_except = 66;
-    DataframeFilter dataframe_filter = 67;
-    DataframeFirst dataframe_first = 68;
-    DataframeFlatten dataframe_flatten = 69;
-    DataframeGroupBy dataframe_group_by = 70;
-    DataframeGroupByGroupingSets dataframe_group_by_grouping_sets = 71;
-    DataframeIntersect dataframe_intersect = 72;
-    DataframeJoin dataframe_join = 73;
-    DataframeJoinTableFunction dataframe_join_table_function = 74;
-    DataframeLimit dataframe_limit = 75;
-    DataframeNaDrop_Python dataframe_na_drop__python = 76;
-    DataframeNaDrop_Scala dataframe_na_drop__scala = 77;
-    DataframeNaFill dataframe_na_fill = 78;
-    DataframeNaReplace dataframe_na_replace = 79;
-    DataframeNaturalJoin dataframe_natural_join = 80;
-    DataframePivot dataframe_pivot = 81;
-    DataframeRandomSplit dataframe_random_split = 82;
-    DataframeReaderInit dataframe_reader_init = 83;
-    DataframeReaderOption dataframe_reader_option = 84;
-    DataframeReaderOptions dataframe_reader_options = 85;
-    DataframeReaderSchema dataframe_reader_schema = 86;
-    DataframeReaderWithMetadata dataframe_reader_with_metadata = 87;
-    DataframeRef dataframe_ref = 88;
-    DataframeRename dataframe_rename = 89;
-    DataframeRollup dataframe_rollup = 90;
-    DataframeSample dataframe_sample = 91;
-    DataframeSelect dataframe_select = 92;
-    DataframeShow dataframe_show = 93;
-    DataframeSort dataframe_sort = 94;
-    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 95;
-    DataframeStatCorr dataframe_stat_corr = 96;
-    DataframeStatCov dataframe_stat_cov = 97;
-    DataframeStatCrossTab dataframe_stat_cross_tab = 98;
-    DataframeStatSampleBy dataframe_stat_sample_by = 99;
-    DataframeToDf dataframe_to_df = 100;
-    DataframeToLocalIterator dataframe_to_local_iterator = 101;
-    DataframeToPandas dataframe_to_pandas = 102;
-    DataframeToPandasBatches dataframe_to_pandas_batches = 103;
-    DataframeUnion dataframe_union = 104;
-    DataframeUnpivot dataframe_unpivot = 105;
-    DataframeWithColumn dataframe_with_column = 106;
-    DataframeWithColumnRenamed dataframe_with_column_renamed = 107;
-    DataframeWithColumns dataframe_with_columns = 108;
-    DataframeWrite dataframe_write = 109;
-    DatatypeVal datatype_val = 110;
-    Div div = 111;
-    Eq eq = 112;
-    Flatten flatten = 113;
-    Float64Val float64_val = 114;
-    FnRef fn_ref = 115;
-    Generator generator = 116;
-    Geq geq = 117;
-    GroupingSets grouping_sets = 118;
-    Gt gt = 119;
-    IndirectTableFnIdRef indirect_table_fn_id_ref = 120;
-    IndirectTableFnNameRef indirect_table_fn_name_ref = 121;
-    Int64Val int64_val = 122;
-    Leq leq = 123;
-    ListVal list_val = 124;
-    Lt lt = 125;
-    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 126;
-    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 127;
-    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 128;
-    Mod mod = 129;
-    Mul mul = 130;
-    Neg neg = 131;
-    Neq neq = 132;
-    Not not = 133;
-    NullVal null_val = 134;
-    ObjectGetItem object_get_item = 135;
-    Or or = 136;
-    Pow pow = 137;
-    PythonDateVal python_date_val = 138;
-    PythonTimeVal python_time_val = 139;
-    PythonTimestampVal python_timestamp_val = 140;
-    Range range = 141;
-    ReadAvro read_avro = 142;
-    ReadCsv read_csv = 143;
-    ReadJson read_json = 144;
-    ReadOrc read_orc = 145;
-    ReadParquet read_parquet = 146;
-    ReadTable read_table = 147;
-    ReadXml read_xml = 148;
-    RedactedConst redacted_const = 149;
-    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 150;
-    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 151;
-    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 152;
-    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 153;
-    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 154;
-    Row row = 155;
-    SeqMapVal seq_map_val = 156;
-    SessionTableFunction session_table_function = 157;
-    Sql sql = 158;
-    SqlExpr sql_expr = 159;
-    StoredProcedure stored_procedure = 160;
-    StringVal string_val = 161;
-    Sub sub = 162;
-    Table table = 163;
-    TableDelete table_delete = 164;
-    TableDropTable table_drop_table = 165;
-    TableFnCallAlias table_fn_call_alias = 166;
-    TableFnCallOver table_fn_call_over = 167;
-    TableMerge table_merge = 168;
-    TableSample table_sample = 169;
-    TableUpdate table_update = 170;
-    ToSnowparkPandas to_snowpark_pandas = 171;
-    TupleVal tuple_val = 172;
-    Udaf udaf = 173;
-    Udf udf = 174;
-    Udtf udtf = 175;
-    WriteCopyIntoLocation write_copy_into_location = 176;
-    WriteCsv write_csv = 177;
-    WriteJson write_json = 178;
-    WritePandas write_pandas = 179;
-    WriteParquet write_parquet = 180;
+    ReadFile trait_read_file = 7;
+    TruncatedExpr trait_truncated_expr = 8;
+    UnaryOp trait_unary_op = 9;
+    WriteFile trait_write_file = 10;
+    Add add = 11;
+    And and = 12;
+    ApplyExpr apply_expr = 13;
+    BigDecimalVal big_decimal_val = 14;
+    BigIntVal big_int_val = 15;
+    BinaryVal binary_val = 16;
+    BitAnd bit_and = 17;
+    BitOr bit_or = 18;
+    BitXor bit_xor = 19;
+    BoolVal bool_val = 20;
+    BuiltinFn builtin_fn = 21;
+    CallTableFunctionExpr call_table_function_expr = 22;
+    ColumnAlias column_alias = 23;
+    ColumnApply_Int column_apply__int = 24;
+    ColumnApply_String column_apply__string = 25;
+    ColumnAsc column_asc = 26;
+    ColumnBetween column_between = 27;
+    ColumnCaseExpr column_case_expr = 28;
+    ColumnCast column_cast = 29;
+    ColumnDesc column_desc = 30;
+    ColumnEqualNan column_equal_nan = 31;
+    ColumnEqualNull column_equal_null = 32;
+    ColumnIn column_in = 33;
+    ColumnIsNotNull column_is_not_null = 34;
+    ColumnIsNull column_is_null = 35;
+    ColumnOver column_over = 36;
+    ColumnRegexp column_regexp = 37;
+    ColumnStringCollate column_string_collate = 38;
+    ColumnStringContains column_string_contains = 39;
+    ColumnStringEndsWith column_string_ends_with = 40;
+    ColumnStringLike column_string_like = 41;
+    ColumnStringStartsWith column_string_starts_with = 42;
+    ColumnStringSubstr column_string_substr = 43;
+    ColumnTryCast column_try_cast = 44;
+    ColumnWithinGroup column_within_group = 45;
+    CreateDataframe create_dataframe = 46;
+    DataframeAgg dataframe_agg = 47;
+    DataframeAlias dataframe_alias = 48;
+    DataframeAnalyticsComputeLag dataframe_analytics_compute_lag = 49;
+    DataframeAnalyticsComputeLead dataframe_analytics_compute_lead = 50;
+    DataframeAnalyticsCumulativeAgg dataframe_analytics_cumulative_agg = 51;
+    DataframeAnalyticsMovingAgg dataframe_analytics_moving_agg = 52;
+    DataframeAnalyticsTimeSeriesAgg dataframe_analytics_time_series_agg = 53;
+    DataframeCacheResult dataframe_cache_result = 54;
+    DataframeCol dataframe_col = 55;
+    DataframeCollect dataframe_collect = 56;
+    DataframeCopyIntoTable dataframe_copy_into_table = 57;
+    DataframeCount dataframe_count = 58;
+    DataframeCreateOrReplaceDynamicTable dataframe_create_or_replace_dynamic_table = 59;
+    DataframeCreateOrReplaceView dataframe_create_or_replace_view = 60;
+    DataframeCrossJoin dataframe_cross_join = 61;
+    DataframeCube dataframe_cube = 62;
+    DataframeDescribe dataframe_describe = 63;
+    DataframeDistinct dataframe_distinct = 64;
+    DataframeDrop dataframe_drop = 65;
+    DataframeDropDuplicates dataframe_drop_duplicates = 66;
+    DataframeExcept dataframe_except = 67;
+    DataframeFilter dataframe_filter = 68;
+    DataframeFirst dataframe_first = 69;
+    DataframeFlatten dataframe_flatten = 70;
+    DataframeGroupBy dataframe_group_by = 71;
+    DataframeGroupByGroupingSets dataframe_group_by_grouping_sets = 72;
+    DataframeIntersect dataframe_intersect = 73;
+    DataframeJoin dataframe_join = 74;
+    DataframeJoinTableFunction dataframe_join_table_function = 75;
+    DataframeLimit dataframe_limit = 76;
+    DataframeNaDrop_Python dataframe_na_drop__python = 77;
+    DataframeNaDrop_Scala dataframe_na_drop__scala = 78;
+    DataframeNaFill dataframe_na_fill = 79;
+    DataframeNaReplace dataframe_na_replace = 80;
+    DataframeNaturalJoin dataframe_natural_join = 81;
+    DataframePivot dataframe_pivot = 82;
+    DataframeRandomSplit dataframe_random_split = 83;
+    DataframeReader dataframe_reader = 84;
+    DataframeRef dataframe_ref = 85;
+    DataframeRename dataframe_rename = 86;
+    DataframeRollup dataframe_rollup = 87;
+    DataframeSample dataframe_sample = 88;
+    DataframeSelect dataframe_select = 89;
+    DataframeShow dataframe_show = 90;
+    DataframeSort dataframe_sort = 91;
+    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 92;
+    DataframeStatCorr dataframe_stat_corr = 93;
+    DataframeStatCov dataframe_stat_cov = 94;
+    DataframeStatCrossTab dataframe_stat_cross_tab = 95;
+    DataframeStatSampleBy dataframe_stat_sample_by = 96;
+    DataframeToDf dataframe_to_df = 97;
+    DataframeToLocalIterator dataframe_to_local_iterator = 98;
+    DataframeToPandas dataframe_to_pandas = 99;
+    DataframeToPandasBatches dataframe_to_pandas_batches = 100;
+    DataframeUnion dataframe_union = 101;
+    DataframeUnpivot dataframe_unpivot = 102;
+    DataframeWithColumn dataframe_with_column = 103;
+    DataframeWithColumnRenamed dataframe_with_column_renamed = 104;
+    DataframeWithColumns dataframe_with_columns = 105;
+    DataframeWriter dataframe_writer = 106;
+    DatatypeVal datatype_val = 107;
+    Div div = 108;
+    Eq eq = 109;
+    Flatten flatten = 110;
+    Float64Val float64_val = 111;
+    FnRef fn_ref = 112;
+    Generator generator = 113;
+    Geq geq = 114;
+    GroupingSets grouping_sets = 115;
+    Gt gt = 116;
+    IndirectTableFnIdRef indirect_table_fn_id_ref = 117;
+    IndirectTableFnNameRef indirect_table_fn_name_ref = 118;
+    Int64Val int64_val = 119;
+    Leq leq = 120;
+    ListVal list_val = 121;
+    Lt lt = 122;
+    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 123;
+    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 124;
+    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 125;
+    Mod mod = 126;
+    Mul mul = 127;
+    Neg neg = 128;
+    Neq neq = 129;
+    Not not = 130;
+    NullVal null_val = 131;
+    ObjectGetItem object_get_item = 132;
+    Or or = 133;
+    Pow pow = 134;
+    PythonDateVal python_date_val = 135;
+    PythonTimeVal python_time_val = 136;
+    PythonTimestampVal python_timestamp_val = 137;
+    Range range = 138;
+    ReadAvro read_avro = 139;
+    ReadCsv read_csv = 140;
+    ReadJson read_json = 141;
+    ReadLoad read_load = 142;
+    ReadOrc read_orc = 143;
+    ReadParquet read_parquet = 144;
+    ReadTable read_table = 145;
+    ReadXml read_xml = 146;
+    RedactedConst redacted_const = 147;
+    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 148;
+    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 149;
+    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 150;
+    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 151;
+    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 152;
+    Row row = 153;
+    SeqMapVal seq_map_val = 154;
+    SessionTableFunction session_table_function = 155;
+    Sql sql = 156;
+    SqlExpr sql_expr = 157;
+    StoredProcedure stored_procedure = 158;
+    StringVal string_val = 159;
+    Sub sub = 160;
+    Table table = 161;
+    TableDelete table_delete = 162;
+    TableDropTable table_drop_table = 163;
+    TableFnCallAlias table_fn_call_alias = 164;
+    TableFnCallOver table_fn_call_over = 165;
+    TableMerge table_merge = 166;
+    TableSample table_sample = 167;
+    TableUpdate table_update = 168;
+    ToSnowparkPandas to_snowpark_pandas = 169;
+    TupleVal tuple_val = 170;
+    Udaf udaf = 171;
+    Udf udf = 172;
+    Udtf udtf = 173;
+    WriteCopyIntoLocation write_copy_into_location = 174;
+    WriteCsv write_csv = 175;
+    WriteInsertInto write_insert_into = 176;
+    WriteJson write_json = 177;
+    WritePandas write_pandas = 178;
+    WriteParquet write_parquet = 179;
+    WriteSave write_save = 180;
     WriteTable write_table = 181;
   }
 }
@@ -1654,188 +1612,188 @@ message HasSrcPosition {
     ExtensionExpr trait_extension_expr = 5;
     FnIdRefExpr trait_fn_id_ref_expr = 6;
     FnNameRefExpr trait_fn_name_ref_expr = 7;
-    TruncatedExpr trait_truncated_expr = 8;
-    UnaryOp trait_unary_op = 9;
-    WindowSpecExpr trait_window_spec_expr = 10;
-    WriteFile trait_write_file = 11;
-    Add add = 12;
-    And and = 13;
-    ApplyExpr apply_expr = 14;
-    BigDecimalVal big_decimal_val = 15;
-    BigIntVal big_int_val = 16;
-    BinaryVal binary_val = 17;
-    BitAnd bit_and = 18;
-    BitOr bit_or = 19;
-    BitXor bit_xor = 20;
-    BoolVal bool_val = 21;
-    BuiltinFn builtin_fn = 22;
-    CallTableFunctionExpr call_table_function_expr = 23;
-    ColumnAlias column_alias = 24;
-    ColumnApply_Int column_apply__int = 25;
-    ColumnApply_String column_apply__string = 26;
-    ColumnAsc column_asc = 27;
-    ColumnBetween column_between = 28;
-    ColumnCaseExpr column_case_expr = 29;
-    ColumnCaseExprClause column_case_expr_clause = 30;
-    ColumnCast column_cast = 31;
-    ColumnDesc column_desc = 32;
-    ColumnEqualNan column_equal_nan = 33;
-    ColumnEqualNull column_equal_null = 34;
-    ColumnIn column_in = 35;
-    ColumnIsNotNull column_is_not_null = 36;
-    ColumnIsNull column_is_null = 37;
-    ColumnOver column_over = 38;
-    ColumnRegexp column_regexp = 39;
-    ColumnStringCollate column_string_collate = 40;
-    ColumnStringContains column_string_contains = 41;
-    ColumnStringEndsWith column_string_ends_with = 42;
-    ColumnStringLike column_string_like = 43;
-    ColumnStringStartsWith column_string_starts_with = 44;
-    ColumnStringSubstr column_string_substr = 45;
-    ColumnTryCast column_try_cast = 46;
-    ColumnWithinGroup column_within_group = 47;
-    CreateDataframe create_dataframe = 48;
-    DataframeAgg dataframe_agg = 49;
-    DataframeAlias dataframe_alias = 50;
-    DataframeAnalyticsComputeLag dataframe_analytics_compute_lag = 51;
-    DataframeAnalyticsComputeLead dataframe_analytics_compute_lead = 52;
-    DataframeAnalyticsCumulativeAgg dataframe_analytics_cumulative_agg = 53;
-    DataframeAnalyticsMovingAgg dataframe_analytics_moving_agg = 54;
-    DataframeAnalyticsTimeSeriesAgg dataframe_analytics_time_series_agg = 55;
-    DataframeCacheResult dataframe_cache_result = 56;
-    DataframeCol dataframe_col = 57;
-    DataframeCollect dataframe_collect = 58;
-    DataframeCopyIntoTable dataframe_copy_into_table = 59;
-    DataframeCount dataframe_count = 60;
-    DataframeCreateOrReplaceDynamicTable dataframe_create_or_replace_dynamic_table = 61;
-    DataframeCreateOrReplaceView dataframe_create_or_replace_view = 62;
-    DataframeCrossJoin dataframe_cross_join = 63;
-    DataframeCube dataframe_cube = 64;
-    DataframeDescribe dataframe_describe = 65;
-    DataframeDistinct dataframe_distinct = 66;
-    DataframeDrop dataframe_drop = 67;
-    DataframeDropDuplicates dataframe_drop_duplicates = 68;
-    DataframeExcept dataframe_except = 69;
-    DataframeFilter dataframe_filter = 70;
-    DataframeFirst dataframe_first = 71;
-    DataframeFlatten dataframe_flatten = 72;
-    DataframeGroupBy dataframe_group_by = 73;
-    DataframeGroupByGroupingSets dataframe_group_by_grouping_sets = 74;
-    DataframeIntersect dataframe_intersect = 75;
-    DataframeJoin dataframe_join = 76;
-    DataframeJoinTableFunction dataframe_join_table_function = 77;
-    DataframeLimit dataframe_limit = 78;
-    DataframeNaDrop_Python dataframe_na_drop__python = 79;
-    DataframeNaDrop_Scala dataframe_na_drop__scala = 80;
-    DataframeNaFill dataframe_na_fill = 81;
-    DataframeNaReplace dataframe_na_replace = 82;
-    DataframeNaturalJoin dataframe_natural_join = 83;
-    DataframePivot dataframe_pivot = 84;
-    DataframeRandomSplit dataframe_random_split = 85;
-    DataframeReaderInit dataframe_reader_init = 86;
-    DataframeReaderOption dataframe_reader_option = 87;
-    DataframeReaderOptions dataframe_reader_options = 88;
-    DataframeReaderSchema dataframe_reader_schema = 89;
-    DataframeReaderWithMetadata dataframe_reader_with_metadata = 90;
-    DataframeRef dataframe_ref = 91;
-    DataframeRename dataframe_rename = 92;
-    DataframeRollup dataframe_rollup = 93;
-    DataframeSample dataframe_sample = 94;
-    DataframeSelect dataframe_select = 95;
-    DataframeShow dataframe_show = 96;
-    DataframeSort dataframe_sort = 97;
-    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 98;
-    DataframeStatCorr dataframe_stat_corr = 99;
-    DataframeStatCov dataframe_stat_cov = 100;
-    DataframeStatCrossTab dataframe_stat_cross_tab = 101;
-    DataframeStatSampleBy dataframe_stat_sample_by = 102;
-    DataframeToDf dataframe_to_df = 103;
-    DataframeToLocalIterator dataframe_to_local_iterator = 104;
-    DataframeToPandas dataframe_to_pandas = 105;
-    DataframeToPandasBatches dataframe_to_pandas_batches = 106;
-    DataframeUnion dataframe_union = 107;
-    DataframeUnpivot dataframe_unpivot = 108;
-    DataframeWithColumn dataframe_with_column = 109;
-    DataframeWithColumnRenamed dataframe_with_column_renamed = 110;
-    DataframeWithColumns dataframe_with_columns = 111;
-    DataframeWrite dataframe_write = 112;
-    DatatypeVal datatype_val = 113;
-    Div div = 114;
-    Eq eq = 115;
-    Flatten flatten = 116;
-    Float64Val float64_val = 117;
-    FnRef fn_ref = 118;
-    Generator generator = 119;
-    Geq geq = 120;
-    GroupingSets grouping_sets = 121;
-    Gt gt = 122;
-    IndirectTableFnIdRef indirect_table_fn_id_ref = 123;
-    IndirectTableFnNameRef indirect_table_fn_name_ref = 124;
-    Int64Val int64_val = 125;
-    Leq leq = 126;
-    ListVal list_val = 127;
-    Lt lt = 128;
-    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 129;
-    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 130;
-    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 131;
-    Mod mod = 132;
-    Mul mul = 133;
-    NameRef name_ref = 134;
-    Neg neg = 135;
-    Neq neq = 136;
-    Not not = 137;
-    NullVal null_val = 138;
-    ObjectGetItem object_get_item = 139;
-    Or or = 140;
-    Pow pow = 141;
-    PythonDateVal python_date_val = 142;
-    PythonTimeVal python_time_val = 143;
-    PythonTimestampVal python_timestamp_val = 144;
-    Range range = 145;
-    ReadAvro read_avro = 146;
-    ReadCsv read_csv = 147;
-    ReadJson read_json = 148;
-    ReadOrc read_orc = 149;
-    ReadParquet read_parquet = 150;
-    ReadTable read_table = 151;
-    ReadXml read_xml = 152;
-    RedactedConst redacted_const = 153;
-    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 154;
-    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 155;
-    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 156;
-    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 157;
-    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 158;
-    Row row = 159;
-    SeqMapVal seq_map_val = 160;
-    SessionTableFunction session_table_function = 161;
-    Sql sql = 162;
-    SqlExpr sql_expr = 163;
-    StoredProcedure stored_procedure = 164;
-    StringVal string_val = 165;
-    Sub sub = 166;
-    Table table = 167;
-    TableDelete table_delete = 168;
-    TableDropTable table_drop_table = 169;
-    TableFnCallAlias table_fn_call_alias = 170;
-    TableFnCallOver table_fn_call_over = 171;
-    TableMerge table_merge = 172;
-    TableSample table_sample = 173;
-    TableUpdate table_update = 174;
-    ToSnowparkPandas to_snowpark_pandas = 175;
-    TupleVal tuple_val = 176;
-    Udaf udaf = 177;
-    Udf udf = 178;
-    Udtf udtf = 179;
-    WindowSpecEmpty window_spec_empty = 180;
-    WindowSpecOrderBy window_spec_order_by = 181;
-    WindowSpecPartitionBy window_spec_partition_by = 182;
-    WindowSpecRangeBetween window_spec_range_between = 183;
-    WindowSpecRowsBetween window_spec_rows_between = 184;
-    WriteCopyIntoLocation write_copy_into_location = 185;
-    WriteCsv write_csv = 186;
-    WriteJson write_json = 187;
-    WritePandas write_pandas = 188;
-    WriteParquet write_parquet = 189;
+    ReadFile trait_read_file = 8;
+    TruncatedExpr trait_truncated_expr = 9;
+    UnaryOp trait_unary_op = 10;
+    WindowSpecExpr trait_window_spec_expr = 11;
+    WriteFile trait_write_file = 12;
+    Add add = 13;
+    And and = 14;
+    ApplyExpr apply_expr = 15;
+    BigDecimalVal big_decimal_val = 16;
+    BigIntVal big_int_val = 17;
+    BinaryVal binary_val = 18;
+    BitAnd bit_and = 19;
+    BitOr bit_or = 20;
+    BitXor bit_xor = 21;
+    BoolVal bool_val = 22;
+    BuiltinFn builtin_fn = 23;
+    CallTableFunctionExpr call_table_function_expr = 24;
+    ColumnAlias column_alias = 25;
+    ColumnApply_Int column_apply__int = 26;
+    ColumnApply_String column_apply__string = 27;
+    ColumnAsc column_asc = 28;
+    ColumnBetween column_between = 29;
+    ColumnCaseExpr column_case_expr = 30;
+    ColumnCaseExprClause column_case_expr_clause = 31;
+    ColumnCast column_cast = 32;
+    ColumnDesc column_desc = 33;
+    ColumnEqualNan column_equal_nan = 34;
+    ColumnEqualNull column_equal_null = 35;
+    ColumnIn column_in = 36;
+    ColumnIsNotNull column_is_not_null = 37;
+    ColumnIsNull column_is_null = 38;
+    ColumnOver column_over = 39;
+    ColumnRegexp column_regexp = 40;
+    ColumnStringCollate column_string_collate = 41;
+    ColumnStringContains column_string_contains = 42;
+    ColumnStringEndsWith column_string_ends_with = 43;
+    ColumnStringLike column_string_like = 44;
+    ColumnStringStartsWith column_string_starts_with = 45;
+    ColumnStringSubstr column_string_substr = 46;
+    ColumnTryCast column_try_cast = 47;
+    ColumnWithinGroup column_within_group = 48;
+    CreateDataframe create_dataframe = 49;
+    DataframeAgg dataframe_agg = 50;
+    DataframeAlias dataframe_alias = 51;
+    DataframeAnalyticsComputeLag dataframe_analytics_compute_lag = 52;
+    DataframeAnalyticsComputeLead dataframe_analytics_compute_lead = 53;
+    DataframeAnalyticsCumulativeAgg dataframe_analytics_cumulative_agg = 54;
+    DataframeAnalyticsMovingAgg dataframe_analytics_moving_agg = 55;
+    DataframeAnalyticsTimeSeriesAgg dataframe_analytics_time_series_agg = 56;
+    DataframeCacheResult dataframe_cache_result = 57;
+    DataframeCol dataframe_col = 58;
+    DataframeCollect dataframe_collect = 59;
+    DataframeCopyIntoTable dataframe_copy_into_table = 60;
+    DataframeCount dataframe_count = 61;
+    DataframeCreateOrReplaceDynamicTable dataframe_create_or_replace_dynamic_table = 62;
+    DataframeCreateOrReplaceView dataframe_create_or_replace_view = 63;
+    DataframeCrossJoin dataframe_cross_join = 64;
+    DataframeCube dataframe_cube = 65;
+    DataframeDescribe dataframe_describe = 66;
+    DataframeDistinct dataframe_distinct = 67;
+    DataframeDrop dataframe_drop = 68;
+    DataframeDropDuplicates dataframe_drop_duplicates = 69;
+    DataframeExcept dataframe_except = 70;
+    DataframeFilter dataframe_filter = 71;
+    DataframeFirst dataframe_first = 72;
+    DataframeFlatten dataframe_flatten = 73;
+    DataframeGroupBy dataframe_group_by = 74;
+    DataframeGroupByGroupingSets dataframe_group_by_grouping_sets = 75;
+    DataframeIntersect dataframe_intersect = 76;
+    DataframeJoin dataframe_join = 77;
+    DataframeJoinTableFunction dataframe_join_table_function = 78;
+    DataframeLimit dataframe_limit = 79;
+    DataframeNaDrop_Python dataframe_na_drop__python = 80;
+    DataframeNaDrop_Scala dataframe_na_drop__scala = 81;
+    DataframeNaFill dataframe_na_fill = 82;
+    DataframeNaReplace dataframe_na_replace = 83;
+    DataframeNaturalJoin dataframe_natural_join = 84;
+    DataframePivot dataframe_pivot = 85;
+    DataframeRandomSplit dataframe_random_split = 86;
+    DataframeReader dataframe_reader = 87;
+    DataframeRef dataframe_ref = 88;
+    DataframeRename dataframe_rename = 89;
+    DataframeRollup dataframe_rollup = 90;
+    DataframeSample dataframe_sample = 91;
+    DataframeSelect dataframe_select = 92;
+    DataframeShow dataframe_show = 93;
+    DataframeSort dataframe_sort = 94;
+    DataframeStatApproxQuantile dataframe_stat_approx_quantile = 95;
+    DataframeStatCorr dataframe_stat_corr = 96;
+    DataframeStatCov dataframe_stat_cov = 97;
+    DataframeStatCrossTab dataframe_stat_cross_tab = 98;
+    DataframeStatSampleBy dataframe_stat_sample_by = 99;
+    DataframeToDf dataframe_to_df = 100;
+    DataframeToLocalIterator dataframe_to_local_iterator = 101;
+    DataframeToPandas dataframe_to_pandas = 102;
+    DataframeToPandasBatches dataframe_to_pandas_batches = 103;
+    DataframeUnion dataframe_union = 104;
+    DataframeUnpivot dataframe_unpivot = 105;
+    DataframeWithColumn dataframe_with_column = 106;
+    DataframeWithColumnRenamed dataframe_with_column_renamed = 107;
+    DataframeWithColumns dataframe_with_columns = 108;
+    DataframeWriter dataframe_writer = 109;
+    DatatypeVal datatype_val = 110;
+    Div div = 111;
+    Eq eq = 112;
+    Flatten flatten = 113;
+    Float64Val float64_val = 114;
+    FnRef fn_ref = 115;
+    Generator generator = 116;
+    Geq geq = 117;
+    GroupingSets grouping_sets = 118;
+    Gt gt = 119;
+    IndirectTableFnIdRef indirect_table_fn_id_ref = 120;
+    IndirectTableFnNameRef indirect_table_fn_name_ref = 121;
+    Int64Val int64_val = 122;
+    Leq leq = 123;
+    ListVal list_val = 124;
+    Lt lt = 125;
+    MergeDeleteWhenMatchedClause merge_delete_when_matched_clause = 126;
+    MergeInsertWhenNotMatchedClause merge_insert_when_not_matched_clause = 127;
+    MergeUpdateWhenMatchedClause merge_update_when_matched_clause = 128;
+    Mod mod = 129;
+    Mul mul = 130;
+    NameRef name_ref = 131;
+    Neg neg = 132;
+    Neq neq = 133;
+    Not not = 134;
+    NullVal null_val = 135;
+    ObjectGetItem object_get_item = 136;
+    Or or = 137;
+    Pow pow = 138;
+    PythonDateVal python_date_val = 139;
+    PythonTimeVal python_time_val = 140;
+    PythonTimestampVal python_timestamp_val = 141;
+    Range range = 142;
+    ReadAvro read_avro = 143;
+    ReadCsv read_csv = 144;
+    ReadJson read_json = 145;
+    ReadLoad read_load = 146;
+    ReadOrc read_orc = 147;
+    ReadParquet read_parquet = 148;
+    ReadTable read_table = 149;
+    ReadXml read_xml = 150;
+    RedactedConst redacted_const = 151;
+    RelationalGroupedDataframeAgg relational_grouped_dataframe_agg = 152;
+    RelationalGroupedDataframeApplyInPandas relational_grouped_dataframe_apply_in_pandas = 153;
+    RelationalGroupedDataframeBuiltin relational_grouped_dataframe_builtin = 154;
+    RelationalGroupedDataframePivot relational_grouped_dataframe_pivot = 155;
+    RelationalGroupedDataframeRef relational_grouped_dataframe_ref = 156;
+    Row row = 157;
+    SeqMapVal seq_map_val = 158;
+    SessionTableFunction session_table_function = 159;
+    Sql sql = 160;
+    SqlExpr sql_expr = 161;
+    StoredProcedure stored_procedure = 162;
+    StringVal string_val = 163;
+    Sub sub = 164;
+    Table table = 165;
+    TableDelete table_delete = 166;
+    TableDropTable table_drop_table = 167;
+    TableFnCallAlias table_fn_call_alias = 168;
+    TableFnCallOver table_fn_call_over = 169;
+    TableMerge table_merge = 170;
+    TableSample table_sample = 171;
+    TableUpdate table_update = 172;
+    ToSnowparkPandas to_snowpark_pandas = 173;
+    TupleVal tuple_val = 174;
+    Udaf udaf = 175;
+    Udf udf = 176;
+    Udtf udtf = 177;
+    WindowSpecEmpty window_spec_empty = 178;
+    WindowSpecOrderBy window_spec_order_by = 179;
+    WindowSpecPartitionBy window_spec_partition_by = 180;
+    WindowSpecRangeBetween window_spec_range_between = 181;
+    WindowSpecRowsBetween window_spec_rows_between = 182;
+    WriteCopyIntoLocation write_copy_into_location = 183;
+    WriteCsv write_csv = 184;
+    WriteInsertInto write_insert_into = 185;
+    WriteJson write_json = 186;
+    WritePandas write_pandas = 187;
+    WriteParquet write_parquet = 188;
+    WriteSave write_save = 189;
     WriteTable write_table = 190;
   }
 }
@@ -2003,49 +1961,68 @@ message Range {
   google.protobuf.Int64Value step = 4;
 }
 
-// dataframe-io.ir:47
+// dataframe-io.ir:37
 message ReadAvro {
   string path = 1;
   Expr reader = 2;
   SrcPosition src = 3;
 }
 
-// dataframe-io.ir:36
+// dataframe-io.ir:33
 message ReadCsv {
   string path = 1;
   Expr reader = 2;
   SrcPosition src = 3;
 }
 
-// dataframe-io.ir:42
+message ReadFile {
+  oneof variant {
+    ReadAvro read_avro = 1;
+    ReadCsv read_csv = 2;
+    ReadJson read_json = 3;
+    ReadLoad read_load = 4;
+    ReadOrc read_orc = 5;
+    ReadParquet read_parquet = 6;
+    ReadXml read_xml = 7;
+  }
+}
+
+// dataframe-io.ir:35
 message ReadJson {
   string path = 1;
   Expr reader = 2;
   SrcPosition src = 3;
 }
 
-// dataframe-io.ir:52
+// dataframe-io.ir:31
+message ReadLoad {
+  string path = 1;
+  Expr reader = 2;
+  SrcPosition src = 3;
+}
+
+// dataframe-io.ir:39
 message ReadOrc {
   string path = 1;
   Expr reader = 2;
   SrcPosition src = 3;
 }
 
-// dataframe-io.ir:57
+// dataframe-io.ir:41
 message ReadParquet {
   string path = 1;
   Expr reader = 2;
   SrcPosition src = 3;
 }
 
-// dataframe-io.ir:31
+// dataframe-io.ir:20
 message ReadTable {
   NameRef name = 1;
   Expr reader = 2;
   SrcPosition src = 3;
 }
 
-// dataframe-io.ir:62
+// dataframe-io.ir:43
 message ReadXml {
   string path = 1;
   Expr reader = 2;
@@ -2088,7 +2065,7 @@ message RelationalGroupedDataframePivot {
   Expr grouped_df = 2;
   Expr pivot_col = 3;
   SrcPosition src = 4;
-  PivotValue values = 5;
+  Expr values = 5;
 }
 
 // dataframe-grouped.ir:2
@@ -2227,7 +2204,7 @@ message Table {
 message TableDelete {
   bool block = 1;
   Expr condition = 2;
-  VarId id = 3;
+  Expr df = 3;
   Expr source = 4;
   SrcPosition src = 5;
   repeated Tuple_String_String statement_params = 6;
@@ -2235,7 +2212,7 @@ message TableDelete {
 
 // table.ir:9
 message TableDropTable {
-  VarId id = 1;
+  Expr df = 1;
   SrcPosition src = 2;
 }
 
@@ -2258,7 +2235,7 @@ message TableFnCallOver {
 message TableMerge {
   bool block = 1;
   repeated Expr clauses = 2;
-  VarId id = 3;
+  Expr df = 3;
   Expr join_expr = 4;
   Expr source = 5;
   SrcPosition src = 6;
@@ -2280,7 +2257,7 @@ message TableUpdate {
   repeated Tuple_String_Expr assignments = 1;
   bool block = 2;
   Expr condition = 3;
-  VarId id = 4;
+  Expr df = 4;
   Expr source = 5;
   SrcPosition src = 6;
   repeated Tuple_String_String statement_params = 7;
@@ -2431,7 +2408,7 @@ message WindowSpecRowsBetween {
   WindowSpecExpr wnd = 4;
 }
 
-// dataframe-io.ir:131
+// dataframe-io.ir:101
 message WriteCopyIntoLocation {
   bool block = 1;
   repeated Tuple_String_Expr copy_options = 2;
@@ -2439,24 +2416,24 @@ message WriteCopyIntoLocation {
   google.protobuf.StringValue file_format_type = 4;
   repeated Tuple_String_String format_type_options = 5;
   bool header = 6;
-  VarId id = 7;
-  string location = 8;
-  Expr partition_by = 9;
-  SrcPosition src = 10;
-  repeated Tuple_String_String statement_params = 11;
+  string location = 7;
+  Expr partition_by = 8;
+  SrcPosition src = 9;
+  repeated Tuple_String_String statement_params = 10;
+  Expr writer = 11;
 }
 
-// dataframe-io.ir:98
+// dataframe-io.ir:108
 message WriteCsv {
   bool block = 1;
   repeated Tuple_String_Expr copy_options = 2;
   repeated Tuple_String_String format_type_options = 3;
   bool header = 4;
-  VarId id = 5;
-  string location = 6;
-  Expr partition_by = 7;
-  SrcPosition src = 8;
-  repeated Tuple_String_String statement_params = 9;
+  string location = 5;
+  Expr partition_by = 6;
+  SrcPosition src = 7;
+  repeated Tuple_String_String statement_params = 8;
+  Expr writer = 9;
 }
 
 message WriteFile {
@@ -2465,20 +2442,29 @@ message WriteFile {
     WriteCsv write_csv = 2;
     WriteJson write_json = 3;
     WriteParquet write_parquet = 4;
+    WriteSave write_save = 5;
   }
 }
 
-// dataframe-io.ir:102
+// dataframe-io.ir:114
+message WriteInsertInto {
+  bool overwrite = 1;
+  SrcPosition src = 2;
+  NameRef table_name = 3;
+  Expr writer = 4;
+}
+
+// dataframe-io.ir:110
 message WriteJson {
   bool block = 1;
   repeated Tuple_String_Expr copy_options = 2;
   repeated Tuple_String_String format_type_options = 3;
   bool header = 4;
-  VarId id = 5;
-  string location = 6;
-  Expr partition_by = 7;
-  SrcPosition src = 8;
-  repeated Tuple_String_String statement_params = 9;
+  string location = 5;
+  Expr partition_by = 6;
+  SrcPosition src = 7;
+  repeated Tuple_String_String statement_params = 8;
+  Expr writer = 9;
 }
 
 // dataframe.ir:44
@@ -2498,20 +2484,33 @@ message WritePandas {
   string table_type = 13;
 }
 
-// dataframe-io.ir:106
+// dataframe-io.ir:112
 message WriteParquet {
   bool block = 1;
   repeated Tuple_String_Expr copy_options = 2;
   repeated Tuple_String_String format_type_options = 3;
   bool header = 4;
-  VarId id = 5;
-  string location = 6;
-  Expr partition_by = 7;
-  SrcPosition src = 8;
-  repeated Tuple_String_String statement_params = 9;
+  string location = 5;
+  Expr partition_by = 6;
+  SrcPosition src = 7;
+  repeated Tuple_String_String statement_params = 8;
+  Expr writer = 9;
 }
 
-// dataframe-io.ir:110
+// dataframe-io.ir:106
+message WriteSave {
+  bool block = 1;
+  repeated Tuple_String_Expr copy_options = 2;
+  repeated Tuple_String_String format_type_options = 3;
+  bool header = 4;
+  string location = 5;
+  Expr partition_by = 6;
+  SrcPosition src = 7;
+  repeated Tuple_String_String statement_params = 8;
+  Expr writer = 9;
+}
+
+// dataframe-io.ir:70
 message WriteTable {
   bool block = 1;
   google.protobuf.BoolValue change_tracking = 2;
@@ -2523,11 +2522,11 @@ message WriteTable {
   google.protobuf.Int64Value data_retention_time = 8;
   google.protobuf.BoolValue enable_schema_evolution = 9;
   repeated Tuple_String_String iceberg_config = 10;
-  VarId id = 11;
-  google.protobuf.Int64Value max_data_extension_time = 12;
-  SaveMode mode = 13;
-  SrcPosition src = 14;
-  repeated Tuple_String_String statement_params = 15;
-  NameRef table_name = 16;
-  string table_type = 17;
+  google.protobuf.Int64Value max_data_extension_time = 11;
+  SaveMode mode = 12;
+  SrcPosition src = 13;
+  repeated Tuple_String_String statement_params = 14;
+  NameRef table_name = 15;
+  string table_type = 16;
+  Expr writer = 17;
 }

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -250,6 +250,7 @@ class Column:
     #       For example, running: df.filter(col("A").isin(1, 2, 3) & col("B")) would fail since the boolean operator
     #       '&' would try to construct an AST using that of the new col("A").isin(1, 2, 3) column (which we currently
     #       don't fill if the only argument provided in the Column constructor is 'expr1' of type Expression)
+    @publicapi
     def __init__(
         self,
         expr1: Union[str, Expression],
@@ -1523,6 +1524,7 @@ class CaseExpr(Column):
         [Row(CASE_WHEN_COLUMN=1), Row(CASE_WHEN_COLUMN=2), Row(CASE_WHEN_COLUMN=3)]
     """
 
+    @publicapi
     def __init__(
         self,
         expr: CaseWhen,

--- a/src/snowflake/snowpark/dataframe_stat_functions.py
+++ b/src/snowflake/snowpark/dataframe_stat_functions.py
@@ -98,9 +98,9 @@ class DataFrameStatFunctions:
 
         if _emit_ast:
             # Add an assign node that applies DataframeStatsApproxQuantile() to the input, followed by its Eval.
-            repr = self._dataframe._session._ast_batch.assign()
-            expr = with_src_position(repr.expr.dataframe_stat_approx_quantile, repr)
-            expr.id.bitfield1 = self._dataframe._ast_id
+            stmt = self._dataframe._session._ast_batch.assign()
+            expr = with_src_position(stmt.expr.dataframe_stat_approx_quantile, stmt)
+            self._dataframe._set_ast_ref(expr.df)
 
             if isinstance(col, Iterable) and not isinstance(col, str):
                 expr.cols.variadic = False
@@ -124,7 +124,7 @@ class DataFrameStatFunctions:
                     t._1 = k
                     t._2 = v
 
-            self._dataframe._session._ast_batch.eval(repr)
+            self._dataframe._session._ast_batch.eval(stmt)
 
             # Flush the AST and encode it as part of the query.
             (
@@ -208,9 +208,9 @@ class DataFrameStatFunctions:
 
         if _emit_ast:
             # Add an assign node that applies DataframeStatsCorr() to the input, followed by its Eval.
-            repr = self._dataframe._session._ast_batch.assign()
-            expr = with_src_position(repr.expr.dataframe_stat_corr, repr)
-            expr.id.bitfield1 = self._dataframe._ast_id
+            stmt = self._dataframe._session._ast_batch.assign()
+            expr = with_src_position(stmt.expr.dataframe_stat_corr, stmt)
+            self._dataframe._set_ast_ref(expr.df)
 
             build_expr_from_snowpark_column_or_col_name(expr.col1, col1)
             build_expr_from_snowpark_column_or_col_name(expr.col2, col2)
@@ -221,7 +221,7 @@ class DataFrameStatFunctions:
                     t._1 = k
                     t._2 = v
 
-            self._dataframe._session._ast_batch.eval(repr)
+            self._dataframe._session._ast_batch.eval(stmt)
 
             # Flush the AST and encode it as part of the query.
             (
@@ -265,9 +265,9 @@ class DataFrameStatFunctions:
 
         if _emit_ast:
             # Add an assign node that applies DataframeStatsCov() to the input, followed by its Eval.
-            repr = self._dataframe._session._ast_batch.assign()
-            expr = with_src_position(repr.expr.dataframe_stat_cov, repr)
-            expr.id.bitfield1 = self._dataframe._ast_id
+            stmt = self._dataframe._session._ast_batch.assign()
+            expr = with_src_position(stmt.expr.dataframe_stat_cov, stmt)
+            self._dataframe._set_ast_ref(expr.df)
 
             build_expr_from_snowpark_column_or_col_name(expr.col1, col1)
             build_expr_from_snowpark_column_or_col_name(expr.col2, col2)
@@ -278,7 +278,7 @@ class DataFrameStatFunctions:
                     t._1 = k
                     t._2 = v
 
-            self._dataframe._session._ast_batch.eval(repr)
+            self._dataframe._session._ast_batch.eval(stmt)
 
             # Flush the AST and encode it as part of the query.
             (
@@ -337,7 +337,7 @@ class DataFrameStatFunctions:
             # Add an assign node that applies DataframeStatsCrossTab() to the input, followed by its Eval.
             stmt = self._dataframe._session._ast_batch.assign()
             expr = with_src_position(stmt.expr.dataframe_stat_cross_tab, stmt)
-            expr.id.bitfield1 = self._dataframe._ast_id
+            self._dataframe._set_ast_ref(expr.df)
 
             build_expr_from_snowpark_column_or_col_name(expr.col1, col1)
             build_expr_from_snowpark_column_or_col_name(expr.col2, col2)

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -8721,13 +8721,6 @@ def in_(
 
         values_args = []
         for val in vals:
-            # Skip if for other value AST generation was disabled.
-            if (
-                isinstance(val, snowflake.snowpark.dataframe.DataFrame)
-                and val._ast_id is None
-            ):
-                continue
-
             val_ast = proto.Expr()
             if isinstance(val, snowflake.snowpark.dataframe.DataFrame):
                 val._set_ast_ref(val_ast)

--- a/src/snowflake/snowpark/mock/_pandas_util.py
+++ b/src/snowflake/snowpark/mock/_pandas_util.py
@@ -241,15 +241,15 @@ def _extract_schema_and_data_from_pandas_df(
 
 
 def _convert_dataframe_to_table(
-    data: "DataFrame", table_name: str, session: "Session", _emit_ast: bool = False
+    data: "DataFrame", table_name: str, session: "Session"
 ) -> Table:
     """
     used by create_dataframe from a pandas dataframe to convert a mocking dataframe into a table
     """
     df_select_statement, df_plan = data._select_statement, data._plan
-    table = Table(table_name, session, _emit_ast=_emit_ast)
+    table = Table(table_name, session, _emit_ast=False)
     # the original _select_statement & plan of Table is query table name
     # replace the table._select_statement & plan with the df mocking one
     table._select_statement, table._plan = df_select_statement, df_plan
-    table.write.save_as_table(table_name, _emit_ast=_emit_ast)
+    table.write.save_as_table(table_name, _emit_ast=False)
     return table

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -33,7 +33,6 @@ from snowflake.snowpark._internal.ast.utils import (
     build_expr_from_python_val,
     build_expr_from_snowpark_column_or_col_name,
     build_proto_from_callable,
-    build_proto_from_pivot_values,
     build_proto_from_struct_type,
     debug_check_missing_ast,
     with_src_position,
@@ -591,7 +590,7 @@ class RelationalGroupedDataFrame:
             if default_on_null is not None:
                 build_expr_from_python_val(ast.default_on_null, default_on_null)
             build_expr_from_snowpark_column_or_col_name(ast.pivot_col, pivot_col)
-            build_proto_from_pivot_values(ast.values, values)
+            build_expr_from_python_val(ast.values, values)
             self._set_ast_ref(ast.grouped_df)
 
             # Update self's id.
@@ -707,6 +706,5 @@ class RelationalGroupedDataFrame:
         """
         Given a field builder expression of the AST type Expr, points the builder to reference this RelationalGroupedDataFrame.
         """
-        # TODO: remove the None guard below once we generate the correct AST.
         debug_check_missing_ast(self._ast_id, self._dataframe._session, self._dataframe)
         expr_builder.relational_grouped_dataframe_ref.id.bitfield1 = self._ast_id

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2497,17 +2497,17 @@ class Session:
                     from_=SelectTableFunction(func_expr, analyzer=self._analyzer),
                     analyzer=self._analyzer,
                 ),
+                _ast_stmt=stmt,
+                _emit_ast=_emit_ast,
             )
         else:
             d = DataFrame(
                 self,
                 TableFunctionRelation(func_expr),
+                _ast_stmt=stmt,
+                _emit_ast=_emit_ast,
             )
         set_api_call_source(d, "Session.table_function")
-
-        if _emit_ast:
-            d._ast_id = stmt.var_id.bitfield1
-
         return d
 
     @publicapi
@@ -2701,6 +2701,7 @@ class Session:
                     analyzer=self._analyzer,
                 ),
                 _ast_stmt=stmt,
+                _emit_ast=_emit_ast,
             )
         else:
             d = DataFrame(
@@ -2709,6 +2710,7 @@ class Session:
                     query, source_plan=None, params=params
                 ),
                 _ast_stmt=stmt,
+                _emit_ast=_emit_ast,
             )
         set_api_call_source(d, "Session.sql")
         return d
@@ -3617,9 +3619,7 @@ class Session:
             and isinstance(self._conn, MockServerConnection)
         ):
             # MockServerConnection internally creates a table, and returns Table object (which inherits from Dataframe).
-            table = _convert_dataframe_to_table(
-                df, temp_table_name, self, _emit_ast=False
-            )
+            table = _convert_dataframe_to_table(df, temp_table_name, self)
 
             # AST.
             if _emit_ast:
@@ -3719,14 +3719,12 @@ class Session:
                     ),
                     analyzer=self._analyzer,
                 ),
+                _ast_stmt=stmt,
+                _emit_ast=_emit_ast,
             )
         else:
-            df = DataFrame(self, range_plan)
+            df = DataFrame(self, range_plan, _ast_stmt=stmt, _emit_ast=_emit_ast)
         set_api_call_source(df, "Session.range")
-
-        if _emit_ast:
-            df._ast_id = stmt.var_id.bitfield1
-
         return df
 
     def create_async_job(self, query_id: str) -> AsyncJob:
@@ -4240,6 +4238,7 @@ class Session:
                 FlattenFunction(input._expression, path, outer, recursive, mode)
             ),
             _ast_stmt=stmt,
+            _emit_ast=_emit_ast,
         )
         set_api_call_source(df, "Session.flatten")
         return df

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -24,7 +24,6 @@ from snowflake.snowpark._internal.ast.utils import (
     build_expr_from_dict_str_str,
     build_expr_from_snowpark_column,
     build_expr_from_snowpark_column_or_python_val,
-    debug_check_missing_ast,
     with_src_position,
     DATAFRAME_AST_PARAMETER,
     build_table_name,
@@ -527,8 +526,7 @@ class Table(DataFrame):
         if _emit_ast:
             stmt = self._session._ast_batch.assign()
             ast = with_src_position(stmt.expr.table_update, stmt)
-            debug_check_missing_ast(self._ast_id, self._session, self)
-            ast.id.bitfield1 = self._ast_id
+            self._set_ast_ref(ast.df)
             if assignments is not None:
                 for k, v in assignments.items():
                     t = ast.assignments.add()
@@ -659,8 +657,7 @@ class Table(DataFrame):
         if _emit_ast:
             stmt = self._session._ast_batch.assign()
             ast = with_src_position(stmt.expr.table_delete, stmt)
-            debug_check_missing_ast(self._ast_id, self._session, self)
-            ast.id.bitfield1 = self._ast_id
+            self._set_ast_ref(ast.df)
             if condition is not None:
                 build_expr_from_snowpark_column(ast.condition, condition)
             if source is not None:
@@ -791,8 +788,7 @@ class Table(DataFrame):
         if _emit_ast:
             stmt = self._session._ast_batch.assign()
             ast = with_src_position(stmt.expr.table_merge, stmt)
-            debug_check_missing_ast(self._ast_id, self._session, self)
-            ast.id.bitfield1 = self._ast_id
+            self._set_ast_ref(ast.df)
             source._set_ast_ref(ast.source)
             build_expr_from_snowpark_column_or_python_val(ast.join_expr, join_expr)
 
@@ -911,8 +907,7 @@ class Table(DataFrame):
         if _emit_ast:
             stmt = self._session._ast_batch.assign()
             ast = with_src_position(stmt.expr.table_drop_table, stmt)
-            debug_check_missing_ast(self._ast_id, self._session, self)
-            ast.id.bitfield1 = self._ast_id
+            self._set_ast_ref(ast.df)
             self._session._ast_batch.eval(stmt)
 
             # Flush AST and encode it as part of the query.

--- a/src/snowflake/snowpark/table_function.py
+++ b/src/snowflake/snowpark/table_function.py
@@ -109,7 +109,7 @@ class TableFunctionCall:
         # End code for check.
 
         ast = None
-        if _emit_ast and self._ast:
+        if _emit_ast and self._ast is not None:
             ast = proto.Expr()
             expr = with_src_position(ast.table_fn_call_over)
             expr.lhs.CopyFrom(self._ast)

--- a/tests/ast/data/DataFrame.collect.test
+++ b/tests/ast/data/DataFrame.collect.test
@@ -83,8 +83,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 20
@@ -116,8 +120,12 @@ body {
     expr {
       dataframe_collect {
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 31
@@ -150,8 +158,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 67
@@ -186,8 +198,12 @@ body {
   assign {
     expr {
       dataframe_collect {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         log_on_exception: true
         src {
@@ -224,8 +240,12 @@ body {
     expr {
       dataframe_collect {
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         no_wait: true
         src {
@@ -258,8 +278,12 @@ body {
     expr {
       dataframe_collect {
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         no_wait: true
         src {
@@ -295,8 +319,12 @@ body {
   assign {
     expr {
       dataframe_collect {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         log_on_exception: true
         no_wait: true

--- a/tests/ast/data/DataFrame.count.test
+++ b/tests/ast/data/DataFrame.count.test
@@ -66,8 +66,12 @@ body {
     expr {
       dataframe_count {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 18
@@ -98,8 +102,12 @@ body {
   assign {
     expr {
       dataframe_count {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 29
@@ -130,8 +138,12 @@ body {
   assign {
     expr {
       dataframe_count {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 78

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -97,8 +97,12 @@ body {
     expr {
       dataframe_count {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 18
@@ -129,8 +133,12 @@ body {
   assign {
     expr {
       dataframe_count {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 29
@@ -161,8 +169,12 @@ body {
   assign {
     expr {
       dataframe_count {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 78

--- a/tests/ast/data/DataFrame.pivot.test
+++ b/tests/ast/data/DataFrame.pivot.test
@@ -448,9 +448,16 @@ body {
           start_line: 38
         }
         values {
-          pivot_value__expr {
-            v {
-              list_val {
+          list_val {
+            src {
+              end_column: 44
+              end_line: 38
+              file: 2
+              start_column: 14
+              start_line: 38
+            }
+            vs {
+              string_val {
                 src {
                   end_column: 44
                   end_line: 38
@@ -458,30 +465,19 @@ body {
                   start_column: 14
                   start_line: 38
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 44
-                      end_line: 38
-                      file: 2
-                      start_column: 14
-                      start_line: 38
-                    }
-                    v: "JAN"
-                  }
+                v: "JAN"
+              }
+            }
+            vs {
+              string_val {
+                src {
+                  end_column: 44
+                  end_line: 38
+                  file: 2
+                  start_column: 14
+                  start_line: 38
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 44
-                      end_line: 38
-                      file: 2
-                      start_column: 14
-                      start_line: 38
-                    }
-                    v: "FEB"
-                  }
-                }
+                v: "FEB"
               }
             }
           }
@@ -629,9 +625,16 @@ body {
           start_line: 40
         }
         values {
-          pivot_value__expr {
-            v {
-              list_val {
+          list_val {
+            src {
+              end_column: 78
+              end_line: 40
+              file: 2
+              start_column: 14
+              start_line: 40
+            }
+            vs {
+              string_val {
                 src {
                   end_column: 78
                   end_line: 40
@@ -639,30 +642,19 @@ body {
                   start_column: 14
                   start_line: 40
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 78
-                      end_line: 40
-                      file: 2
-                      start_column: 14
-                      start_line: 40
-                    }
-                    v: "JAN"
-                  }
+                v: "JAN"
+              }
+            }
+            vs {
+              string_val {
+                src {
+                  end_column: 78
+                  end_line: 40
+                  file: 2
+                  start_column: 14
+                  start_line: 40
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 78
-                      end_line: 40
-                      file: 2
-                      start_column: 14
-                      start_line: 40
-                    }
-                    v: "FEB"
-                  }
-                }
+                v: "FEB"
               }
             }
           }

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -130,8 +130,12 @@ body {
           }
           variadic: true
         }
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         percentile: 0.5
         src {
@@ -190,8 +194,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         percentile: 0.0
         percentile: 0.2
@@ -391,8 +399,12 @@ body {
             v: "b"
           }
         }
-        id {
-          bitfield1: 6
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
         }
         src {
           end_column: 35
@@ -448,8 +460,12 @@ body {
             v: "b"
           }
         }
-        id {
-          bitfield1: 6
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
         }
         src {
           end_column: 63
@@ -509,8 +525,12 @@ body {
             v: "b"
           }
         }
-        id {
-          bitfield1: 6
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
         }
         src {
           end_column: 36
@@ -566,8 +586,12 @@ body {
             v: "b"
           }
         }
-        id {
-          bitfield1: 6
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
         }
         src {
           end_column: 64
@@ -904,8 +928,12 @@ body {
             v: "value"
           }
         }
-        id {
-          bitfield1: 15
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 15
+            }
+          }
         }
         src {
           end_column: 45
@@ -953,8 +981,12 @@ body {
             v: "value"
           }
         }
-        id {
-          bitfield1: 15
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 15
+            }
+          }
         }
         src {
           end_column: 74

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -80,8 +80,12 @@ body {
       dataframe_to_local_iterator {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 53
@@ -113,8 +117,12 @@ body {
     expr {
       dataframe_to_local_iterator {
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 64
@@ -190,8 +198,12 @@ body {
       dataframe_to_local_iterator {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 6
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
         }
         src {
           end_column: 65
@@ -224,8 +236,12 @@ body {
       dataframe_to_local_iterator {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 100
@@ -331,8 +347,12 @@ body {
     expr {
       dataframe_to_local_iterator {
         case_sensitive: true
-        id {
-          bitfield1: 11
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 11
+            }
+          }
         }
         src {
           end_column: 86
@@ -364,8 +384,12 @@ body {
     expr {
       dataframe_to_local_iterator {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 122

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -70,8 +70,12 @@ body {
     expr {
       dataframe_to_pandas {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 22
@@ -102,8 +106,12 @@ body {
   assign {
     expr {
       dataframe_to_pandas {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 33
@@ -135,8 +143,12 @@ body {
     expr {
       dataframe_to_pandas {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 69
@@ -171,8 +183,12 @@ body {
   assign {
     expr {
       dataframe_to_pandas {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 82

--- a/tests/ast/data/DataFrame.to_pandas_batch.test
+++ b/tests/ast/data/DataFrame.to_pandas_batch.test
@@ -70,8 +70,12 @@ body {
     expr {
       dataframe_to_pandas_batches {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 30
@@ -102,8 +106,12 @@ body {
   assign {
     expr {
       dataframe_to_pandas_batches {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 41
@@ -135,8 +143,12 @@ body {
     expr {
       dataframe_to_pandas_batches {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 77
@@ -171,8 +183,12 @@ body {
   assign {
     expr {
       dataframe_to_pandas_batches {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 90

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -36,13 +36,23 @@ remote_file_path = "@test_stage/test.csv"
 
 df.write.csv(remote_file_path, header=True, format_type_options={"compression":"bzip2"}, overwrite=True, single=True)
 
+df.write.format("csv").option("header", True).mode("overwrite").save(remote_file_path, format_type_options={"compression":"bzip2"})
+
 remote_file_path = "@test_stage/test.json"
 
 df.write.json(remote_file_path, overwrite=True, single=True, format_type_options={"compression":"bzip2"},)
 
+df.write.format("json").mode("overwrite").save(remote_file_path, format_type_options={"compression":"bzip2"})
+
 remote_file_path = "@test_stage/test.parquet"
 
 df.write.parquet(remote_file_path, format_type_options={"compression":"bzip2"}, header=False, overwrite=True, single=True)
+
+df.write.format("parquet").mode("overwrite").save(remote_file_path, format_type_options={"compression":"bzip2"})
+
+df.write.insert_into("saved_table", overwrite=True)
+
+df.write.insert_into("saved_table", overwrite=False)
 
 ## EXPECTED UNPARSER OUTPUT
 
@@ -62,25 +72,35 @@ df.write.mode("overwrite").partition_by(col("value")).save_as_table("saved_table
 
 df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd"}).save_as_table("saved_table", table_type="temporary")
 
-df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).save_as_table("saved_table", table_type="temporary")
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).save_as_table("saved_table", table_type="temporary")
 
 stage_created_result = session.sql("create temp stage if not exists test_stage")
 
 stage_created_result.collect()
 
-df.write.copy_into_location("@test_stage/copied_from_dataframe")
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).copy_into_location("@test_stage/copied_from_dataframe")
 
-df.write.copy_into_location("@test_stage/copied_from_dataframe", file_format_type="parquet", header=True, overwrite=True, single=True)
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).copy_into_location("@test_stage/copied_from_dataframe", file_format_type="parquet", header=True, overwrite=True, single=True)
 
-df.write.copy_into_location("@test_stage/copied_from_dataframe", file_format_name="csv", format_type_options={"compression": "bzip2"}, block=False, INCLUDE_QUERY_ID=True, DETAILED_OUTPUT=False)
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).copy_into_location("@test_stage/copied_from_dataframe", file_format_name="csv", format_type_options={"compression": "bzip2"}, block=False, INCLUDE_QUERY_ID=True, DETAILED_OUTPUT=False)
 
-df.write.copy_into_location("@test_stage/copied_from_dataframe", file_format_name="csv", format_type_options={"compression": "bzip2", "binary_format": "base64"}, block=False, INCLUDE_QUERY_ID=True, DETAILED_OUTPUT=False)
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).copy_into_location("@test_stage/copied_from_dataframe", file_format_name="csv", format_type_options={"compression": "bzip2", "binary_format": "base64"}, block=False, INCLUDE_QUERY_ID=True, DETAILED_OUTPUT=False)
 
-df.write.csv("@test_stage/test.csv", format_type_options={"compression": "bzip2"}, header=True, overwrite=True, single=True)
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append"}).csv("@test_stage/test.csv", format_type_options={"compression": "bzip2"}, header=True, overwrite=True, single=True)
 
-df.write.json("@test_stage/test.json", format_type_options={"compression": "bzip2"}, overwrite=True, single=True)
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("csv").save("@test_stage/test.csv", format_type_options={"compression": "bzip2"})
 
-df.write.parquet("@test_stage/test.parquet", format_type_options={"compression": "bzip2"}, overwrite=True, single=True)
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("csv").json("@test_stage/test.json", format_type_options={"compression": "bzip2"}, overwrite=True, single=True)
+
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("json").save("@test_stage/test.json", format_type_options={"compression": "bzip2"})
+
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("json").parquet("@test_stage/test.parquet", format_type_options={"compression": "bzip2"}, overwrite=True, single=True)
+
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("parquet").save("@test_stage/test.parquet", format_type_options={"compression": "bzip2"})
+
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("parquet").insert_into("saved_table", overwrite=True)
+
+df.write.mode("overwrite").partition_by(col("value")).options({"COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "abcd", "COPY_INTO_LOCATION": "pqrs", "OVERWRITE": True, "MODE": "append", "HEADER": True}).format("parquet").insert_into("saved_table", overwrite=False)
 
 ## EXPECTED ENCODED AST
 
@@ -128,40 +148,9 @@ body {
 body {
   assign {
     expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 16
-          end_line: 29
-          file: 2
-          start_column: 8
-          start_line: 29
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 2
-    var_id {
-      bitfield1: 2
-    }
-  }
-}
-body {
-  assign {
-    expr {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 2
-        }
         src {
           end_column: 45
           end_line: 29
@@ -176,52 +165,39 @@ body {
             }
           }
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 3
+    uid: 2
     var_id {
-      bitfield1: 3
+      bitfield1: 2
     }
   }
 }
 body {
   eval {
-    uid: 4
+    uid: 3
     var_id {
-      bitfield1: 3
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        save_mode {
-          save_mode_overwrite: true
-        }
-        src {
-          end_column: 16
-          end_line: 31
-          file: 2
-          start_column: 8
-          start_line: 31
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 5
-    var_id {
-      bitfield1: 5
+      bitfield1: 2
     }
   }
 }
@@ -231,9 +207,6 @@ body {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 5
-        }
         src {
           end_column: 87
           end_line: 31
@@ -249,52 +222,42 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 6
+    uid: 4
     var_id {
-      bitfield1: 6
+      bitfield1: 4
     }
   }
 }
 body {
   eval {
-    uid: 7
+    uid: 5
     var_id {
-      bitfield1: 6
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        save_mode {
-          save_mode_overwrite: true
-        }
-        src {
-          end_column: 16
-          end_line: 33
-          file: 2
-          start_column: 8
-          start_line: 33
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 8
-    var_id {
-      bitfield1: 8
+      bitfield1: 4
     }
   }
 }
@@ -304,9 +267,6 @@ body {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 8
-        }
         mode {
           save_mode_ignore: true
         }
@@ -325,52 +285,42 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 9
+    uid: 6
     var_id {
-      bitfield1: 9
+      bitfield1: 6
     }
   }
 }
 body {
   eval {
-    uid: 10
+    uid: 7
     var_id {
-      bitfield1: 9
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        save_mode {
-          save_mode_truncate: true
-        }
-        src {
-          end_column: 16
-          end_line: 35
-          file: 2
-          start_column: 8
-          start_line: 35
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 11
-    var_id {
-      bitfield1: 11
+      bitfield1: 6
     }
   }
 }
@@ -429,9 +379,6 @@ body {
         comment {
           value: "test"
         }
-        id {
-          bitfield1: 11
-        }
         src {
           end_column: 231
           end_line: 35
@@ -451,6 +398,193 @@ body {
           }
         }
         table_type: "transient"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            save_mode {
+              save_mode_truncate: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 8
+    var_id {
+      bitfield1: 8
+    }
+  }
+}
+body {
+  eval {
+    uid: 9
+    var_id {
+      bitfield1: 8
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      write_table {
+        block: true
+        column_order: "index"
+        src {
+          end_column: 109
+          end_line: 37
+          file: 2
+          start_column: 8
+          start_line: 37
+        }
+        table_name {
+          name {
+            name_flat {
+              name: "saved_table"
+            }
+          }
+        }
+        table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            partition_by {
+              sql_expr {
+                sql: "value"
+                src {
+                  end_column: 38
+                  end_line: 37
+                  file: 2
+                  start_column: 8
+                  start_line: 37
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 10
+    var_id {
+      bitfield1: 10
+    }
+  }
+}
+body {
+  eval {
+    uid: 11
+    var_id {
+      bitfield1: 10
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      write_table {
+        block: true
+        column_order: "index"
+        src {
+          end_column: 114
+          end_line: 39
+          file: 2
+          start_column: 8
+          start_line: 39
+        }
+        table_name {
+          name {
+            name_flat {
+              name: "saved_table"
+            }
+          }
+        }
+        table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 42
+                      end_line: 39
+                      file: 2
+                      start_column: 30
+                      start_line: 39
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 42
+                  end_line: 39
+                  file: 2
+                  start_column: 30
+                  start_line: 39
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
@@ -472,284 +606,9 @@ body {
 body {
   assign {
     expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        partition_by {
-          sql_expr {
-            sql: "value"
-            src {
-              end_column: 38
-              end_line: 37
-              file: 2
-              start_column: 8
-              start_line: 37
-            }
-          }
-        }
-        save_mode {
-          save_mode_overwrite: true
-        }
-        src {
-          end_column: 16
-          end_line: 37
-          file: 2
-          start_column: 8
-          start_line: 37
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 14
-    var_id {
-      bitfield1: 14
-    }
-  }
-}
-body {
-  assign {
-    expr {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 14
-        }
-        src {
-          end_column: 109
-          end_line: 37
-          file: 2
-          start_column: 8
-          start_line: 37
-        }
-        table_name {
-          name {
-            name_flat {
-              name: "saved_table"
-            }
-          }
-        }
-        table_type: "temporary"
-      }
-    }
-    symbol {
-    }
-    uid: 15
-    var_id {
-      bitfield1: 15
-    }
-  }
-}
-body {
-  eval {
-    uid: 16
-    var_id {
-      bitfield1: 15
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        partition_by {
-          apply_expr {
-            fn {
-              builtin_fn {
-                name {
-                  name {
-                    name_flat {
-                      name: "col"
-                    }
-                  }
-                }
-              }
-            }
-            pos_args {
-              string_val {
-                src {
-                  end_column: 42
-                  end_line: 39
-                  file: 2
-                  start_column: 30
-                  start_line: 39
-                }
-                v: "value"
-              }
-            }
-            src {
-              end_column: 42
-              end_line: 39
-              file: 2
-              start_column: 30
-              start_line: 39
-            }
-          }
-        }
-        save_mode {
-          save_mode_overwrite: true
-        }
-        src {
-          end_column: 16
-          end_line: 39
-          file: 2
-          start_column: 8
-          start_line: 39
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 17
-    var_id {
-      bitfield1: 17
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      write_table {
-        block: true
-        column_order: "index"
-        id {
-          bitfield1: 17
-        }
-        src {
-          end_column: 114
-          end_line: 39
-          file: 2
-          start_column: 8
-          start_line: 39
-        }
-        table_name {
-          name {
-            name_flat {
-              name: "saved_table"
-            }
-          }
-        }
-        table_type: "temporary"
-      }
-    }
-    symbol {
-    }
-    uid: 18
-    var_id {
-      bitfield1: 18
-    }
-  }
-}
-body {
-  eval {
-    uid: 19
-    var_id {
-      bitfield1: 18
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        options {
-          _1: "COPY_INTO_LOCATION"
-          _2 {
-            string_val {
-              src {
-                end_column: 53
-                end_line: 41
-                file: 2
-                start_column: 8
-                start_line: 41
-              }
-              v: "abcd"
-            }
-          }
-        }
-        partition_by {
-          apply_expr {
-            fn {
-              builtin_fn {
-                name {
-                  name {
-                    name_flat {
-                      name: "col"
-                    }
-                  }
-                }
-              }
-            }
-            pos_args {
-              string_val {
-                src {
-                  end_column: 79
-                  end_line: 41
-                  file: 2
-                  start_column: 67
-                  start_line: 41
-                }
-                v: "value"
-              }
-            }
-            src {
-              end_column: 79
-              end_line: 41
-              file: 2
-              start_column: 67
-              start_line: 41
-            }
-          }
-        }
-        save_mode {
-          save_mode_overwrite: true
-        }
-        src {
-          end_column: 16
-          end_line: 41
-          file: 2
-          start_column: 8
-          start_line: 41
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 20
-    var_id {
-      bitfield1: 20
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      write_table {
-        block: true
-        column_order: "index"
-        id {
-          bitfield1: 20
-        }
         src {
           end_column: 151
           end_line: 41
@@ -765,146 +624,91 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 79
+                      end_line: 41
+                      file: 2
+                      start_column: 67
+                      start_line: 41
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 79
+                  end_line: 41
+                  file: 2
+                  start_column: 67
+                  start_line: 41
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 21
+    uid: 14
     var_id {
-      bitfield1: 21
+      bitfield1: 14
     }
   }
 }
 body {
   eval {
-    uid: 22
+    uid: 15
     var_id {
-      bitfield1: 21
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        options {
-          _1: "COPY_INTO_LOCATION"
-          _2 {
-            string_val {
-              src {
-                end_column: 53
-                end_line: 43
-                file: 2
-                start_column: 8
-                start_line: 43
-              }
-              v: "abcd"
-            }
-          }
-        }
-        options {
-          _1: "COPY_INTO_LOCATION"
-          _2 {
-            string_val {
-              src {
-                end_column: 90
-                end_line: 43
-                file: 2
-                start_column: 8
-                start_line: 43
-              }
-              v: "pqrs"
-            }
-          }
-        }
-        options {
-          _1: "OVERWRITE"
-          _2 {
-            bool_val {
-              src {
-                end_column: 116
-                end_line: 43
-                file: 2
-                start_column: 8
-                start_line: 43
-              }
-              v: true
-            }
-          }
-        }
-        options {
-          _1: "MODE"
-          _2 {
-            string_val {
-              src {
-                end_column: 141
-                end_line: 43
-                file: 2
-                start_column: 8
-                start_line: 43
-              }
-              v: "append"
-            }
-          }
-        }
-        partition_by {
-          apply_expr {
-            fn {
-              builtin_fn {
-                name {
-                  name {
-                    name_flat {
-                      name: "col"
-                    }
-                  }
-                }
-              }
-            }
-            pos_args {
-              string_val {
-                src {
-                  end_column: 167
-                  end_line: 43
-                  file: 2
-                  start_column: 155
-                  start_line: 43
-                }
-                v: "value"
-              }
-            }
-            src {
-              end_column: 167
-              end_line: 43
-              file: 2
-              start_column: 155
-              start_line: 43
-            }
-          }
-        }
-        save_mode {
-          save_mode_overwrite: true
-        }
-        src {
-          end_column: 16
-          end_line: 43
-          file: 2
-          start_column: 8
-          start_line: 43
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 23
-    var_id {
-      bitfield1: 23
+      bitfield1: 14
     }
   }
 }
@@ -914,9 +718,6 @@ body {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 23
-        }
         src {
           end_column: 239
           end_line: 43
@@ -932,21 +733,151 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 24
+    uid: 16
     var_id {
-      bitfield1: 24
+      bitfield1: 16
     }
   }
 }
 body {
   eval {
-    uid: 25
+    uid: 17
     var_id {
-      bitfield1: 24
+      bitfield1: 16
     }
   }
 }
@@ -967,9 +898,9 @@ body {
     symbol {
       value: "stage_created_result"
     }
-    uid: 26
+    uid: 18
     var_id {
-      bitfield1: 26
+      bitfield1: 18
     }
   }
 }
@@ -979,8 +910,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 26
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 18
+            }
+          }
         }
         src {
           end_column: 98
@@ -993,45 +928,17 @@ body {
     }
     symbol {
     }
-    uid: 27
+    uid: 19
     var_id {
-      bitfield1: 27
+      bitfield1: 19
     }
   }
 }
 body {
   eval {
-    uid: 28
+    uid: 20
     var_id {
-      bitfield1: 27
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 16
-          end_line: 47
-          file: 2
-          start_column: 8
-          start_line: 47
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 29
-    var_id {
-      bitfield1: 29
+      bitfield1: 19
     }
   }
 }
@@ -1040,9 +947,6 @@ body {
     expr {
       write_copy_into_location {
         block: true
-        id {
-          bitfield1: 29
-        }
         location: "@test_stage/copied_from_dataframe"
         src {
           end_column: 72
@@ -1051,49 +955,151 @@ body {
           start_column: 8
           start_line: 47
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 30
+    uid: 21
     var_id {
-      bitfield1: 30
+      bitfield1: 21
     }
   }
 }
 body {
   eval {
-    uid: 31
+    uid: 22
     var_id {
-      bitfield1: 30
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 16
-          end_line: 51
-          file: 2
-          start_column: 8
-          start_line: 51
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 32
-    var_id {
-      bitfield1: 32
+      bitfield1: 21
     }
   }
 }
@@ -1136,9 +1142,6 @@ body {
           value: "parquet"
         }
         header: true
-        id {
-          bitfield1: 32
-        }
         location: "@test_stage/copied_from_dataframe"
         src {
           end_column: 123
@@ -1147,49 +1150,151 @@ body {
           start_column: 8
           start_line: 51
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 33
+    uid: 23
     var_id {
-      bitfield1: 33
+      bitfield1: 23
     }
   }
 }
 body {
   eval {
-    uid: 34
+    uid: 24
     var_id {
-      bitfield1: 33
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 16
-          end_line: 53
-          file: 2
-          start_column: 8
-          start_line: 53
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 35
-    var_id {
-      bitfield1: 35
+      bitfield1: 23
     }
   }
 }
@@ -1233,9 +1338,6 @@ body {
           _1: "compression"
           _2: "bzip2"
         }
-        id {
-          bitfield1: 35
-        }
         location: "@test_stage/copied_from_dataframe"
         src {
           end_column: 181
@@ -1244,49 +1346,151 @@ body {
           start_column: 8
           start_line: 53
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 36
+    uid: 25
     var_id {
-      bitfield1: 36
+      bitfield1: 25
     }
   }
 }
 body {
   eval {
-    uid: 37
+    uid: 26
     var_id {
-      bitfield1: 36
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 16
-          end_line: 55
-          file: 2
-          start_column: 8
-          start_line: 55
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 38
-    var_id {
-      bitfield1: 38
+      bitfield1: 25
     }
   }
 }
@@ -1334,9 +1538,6 @@ body {
           _1: "binary_format"
           _2: "base64"
         }
-        id {
-          bitfield1: 38
-        }
         location: "@test_stage/copied_from_dataframe"
         src {
           end_column: 207
@@ -1345,49 +1546,151 @@ body {
           start_column: 8
           start_line: 55
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 39
+    uid: 27
     var_id {
-      bitfield1: 39
+      bitfield1: 27
     }
   }
 }
 body {
   eval {
-    uid: 40
+    uid: 28
     var_id {
-      bitfield1: 39
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
-        }
-        src {
-          end_column: 16
-          end_line: 59
-          file: 2
-          start_column: 8
-          start_line: 59
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 41
-    var_id {
-      bitfield1: 41
+      bitfield1: 27
     }
   }
 }
@@ -1431,9 +1734,6 @@ body {
           _2: "bzip2"
         }
         header: true
-        id {
-          bitfield1: 41
-        }
         location: "@test_stage/test.csv"
         src {
           end_column: 125
@@ -1442,49 +1742,334 @@ body {
           start_column: 8
           start_line: 59
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 42
+    uid: 29
     var_id {
-      bitfield1: 42
+      bitfield1: 29
     }
   }
 }
 body {
   eval {
-    uid: 43
+    uid: 30
     var_id {
-      bitfield1: 42
+      bitfield1: 29
     }
   }
 }
 body {
   assign {
     expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
+      write_save {
+        block: true
+        format_type_options {
+          _1: "compression"
+          _2: "bzip2"
         }
+        location: "@test_stage/test.csv"
         src {
-          end_column: 16
-          end_line: 63
+          end_column: 139
+          end_line: 61
           file: 2
           start_column: 8
-          start_line: 63
+          start_line: 61
+        }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "csv"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
         }
       }
     }
     symbol {
     }
-    uid: 44
+    uid: 31
     var_id {
-      bitfield1: 44
+      bitfield1: 31
+    }
+  }
+}
+body {
+  eval {
+    uid: 32
+    var_id {
+      bitfield1: 31
     }
   }
 }
@@ -1499,10 +2084,10 @@ body {
             bool_val {
               src {
                 end_column: 114
-                end_line: 63
+                end_line: 65
                 file: 2
                 start_column: 8
-                start_line: 63
+                start_line: 65
               }
               v: true
             }
@@ -1514,10 +2099,10 @@ body {
             bool_val {
               src {
                 end_column: 114
-                end_line: 63
+                end_line: 65
                 file: 2
                 start_column: 8
-                start_line: 63
+                start_line: 65
               }
               v: true
             }
@@ -1527,60 +2112,360 @@ body {
           _1: "compression"
           _2: "bzip2"
         }
-        id {
-          bitfield1: 44
-        }
         location: "@test_stage/test.json"
         src {
           end_column: 114
-          end_line: 63
+          end_line: 65
           file: 2
           start_column: 8
-          start_line: 63
+          start_line: 65
+        }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "csv"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
         }
       }
     }
     symbol {
     }
-    uid: 45
+    uid: 33
     var_id {
-      bitfield1: 45
+      bitfield1: 33
     }
   }
 }
 body {
   eval {
-    uid: 46
+    uid: 34
     var_id {
-      bitfield1: 45
+      bitfield1: 33
     }
   }
 }
 body {
   assign {
     expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 1
-            }
-          }
+      write_save {
+        block: true
+        format_type_options {
+          _1: "compression"
+          _2: "bzip2"
         }
+        location: "@test_stage/test.json"
         src {
-          end_column: 16
+          end_column: 117
           end_line: 67
           file: 2
           start_column: 8
           start_line: 67
         }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "json"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 47
+    uid: 35
     var_id {
-      bitfield1: 47
+      bitfield1: 35
+    }
+  }
+}
+body {
+  eval {
+    uid: 36
+    var_id {
+      bitfield1: 35
     }
   }
 }
@@ -1595,10 +2480,10 @@ body {
             bool_val {
               src {
                 end_column: 130
-                end_line: 67
+                end_line: 71
                 file: 2
                 start_column: 8
-                start_line: 67
+                start_line: 71
               }
               v: true
             }
@@ -1610,10 +2495,10 @@ body {
             bool_val {
               src {
                 end_column: 130
-                end_line: 67
+                end_line: 71
                 file: 2
                 start_column: 8
-                start_line: 67
+                start_line: 71
               }
               v: true
             }
@@ -1623,32 +2508,729 @@ body {
           _1: "compression"
           _2: "bzip2"
         }
-        id {
-          bitfield1: 47
-        }
         location: "@test_stage/test.parquet"
         src {
           end_column: 130
-          end_line: 67
+          end_line: 71
           file: 2
           start_column: 8
-          start_line: 67
+          start_line: 71
+        }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "json"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
         }
       }
     }
     symbol {
     }
-    uid: 48
+    uid: 37
     var_id {
-      bitfield1: 48
+      bitfield1: 37
     }
   }
 }
 body {
   eval {
-    uid: 49
+    uid: 38
     var_id {
-      bitfield1: 48
+      bitfield1: 37
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      write_save {
+        block: true
+        format_type_options {
+          _1: "compression"
+          _2: "bzip2"
+        }
+        location: "@test_stage/test.parquet"
+        src {
+          end_column: 120
+          end_line: 73
+          file: 2
+          start_column: 8
+          start_line: 73
+        }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "parquet"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 39
+    var_id {
+      bitfield1: 39
+    }
+  }
+}
+body {
+  eval {
+    uid: 40
+    var_id {
+      bitfield1: 39
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      write_insert_into {
+        overwrite: true
+        src {
+          end_column: 59
+          end_line: 75
+          file: 2
+          start_column: 8
+          start_line: 75
+        }
+        table_name {
+          name {
+            name_flat {
+              name: "saved_table"
+            }
+          }
+        }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "parquet"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 41
+    var_id {
+      bitfield1: 41
+    }
+  }
+}
+body {
+  eval {
+    uid: 42
+    var_id {
+      bitfield1: 41
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      write_insert_into {
+        src {
+          end_column: 60
+          end_line: 77
+          file: 2
+          start_column: 8
+          start_line: 77
+        }
+        table_name {
+          name {
+            name_flat {
+              name: "saved_table"
+            }
+          }
+        }
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 1
+                }
+              }
+            }
+            format {
+              value: "parquet"
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 41
+                    file: 2
+                    start_column: 8
+                    start_line: 41
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 53
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "abcd"
+                }
+              }
+            }
+            options {
+              _1: "COPY_INTO_LOCATION"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 90
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "pqrs"
+                }
+              }
+            }
+            options {
+              _1: "OVERWRITE"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 116
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: true
+                }
+              }
+            }
+            options {
+              _1: "MODE"
+              _2 {
+                string_val {
+                  src {
+                    end_column: 141
+                    end_line: 43
+                    file: 2
+                    start_column: 8
+                    start_line: 43
+                  }
+                  v: "append"
+                }
+              }
+            }
+            options {
+              _1: "HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 53
+                    end_line: 61
+                    file: 2
+                    start_column: 8
+                    start_line: 61
+                  }
+                  v: true
+                }
+              }
+            }
+            partition_by {
+              apply_expr {
+                fn {
+                  builtin_fn {
+                    name {
+                      name {
+                        name_flat {
+                          name: "col"
+                        }
+                      }
+                    }
+                  }
+                }
+                pos_args {
+                  string_val {
+                    src {
+                      end_column: 167
+                      end_line: 43
+                      file: 2
+                      start_column: 155
+                      start_line: 43
+                    }
+                    v: "value"
+                  }
+                }
+                src {
+                  end_column: 167
+                  end_line: 43
+                  file: 2
+                  start_column: 155
+                  start_line: 43
+                }
+              }
+            }
+            save_mode {
+              save_mode_overwrite: true
+            }
+            src {
+              end_column: 16
+              end_line: 29
+              file: 2
+              start_column: 8
+              start_line: 29
+            }
+          }
+        }
+      }
+    }
+    symbol {
+    }
+    uid: 43
+    var_id {
+      bitfield1: 43
+    }
+  }
+}
+body {
+  eval {
+    uid: 44
+    var_id {
+      bitfield1: 43
     }
   }
 }

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -132,8 +132,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 2
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
         }
         src {
           end_column: 46
@@ -220,8 +224,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 5
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 5
+            }
+          }
         }
         src {
           end_column: 36

--- a/tests/ast/data/Dataframe.join.asof.test
+++ b/tests/ast/data/Dataframe.join.asof.test
@@ -717,8 +717,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 4
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 4
+            }
+          }
         }
         src {
           end_column: 52

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -796,8 +796,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 6
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 6
+            }
+          }
         }
         src {
           end_column: 21

--- a/tests/ast/data/Dataframe.show.test
+++ b/tests/ast/data/Dataframe.show.test
@@ -279,10 +279,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 23
+          end_line: 27
+          file: 2
+          start_column: 14
+          start_line: 27
+        }
       }
     }
     symbol {
@@ -305,10 +316,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         n: 1
+        src {
+          end_column: 24
+          end_line: 29
+          file: 2
+          start_column: 14
+          start_line: 29
+        }
       }
     }
     symbol {
@@ -331,10 +353,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 25
+          end_line: 31
+          file: 2
+          start_column: 14
+          start_line: 31
+        }
       }
     }
     symbol {
@@ -357,10 +390,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         n: -2
+        src {
+          end_column: 25
+          end_line: 33
+          file: 2
+          start_column: 14
+          start_line: 33
+        }
       }
     }
     symbol {

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -62,7 +62,7 @@ df.group_by("empid").pivot("month", values=["JAN", "FEB"]).sum("amount").sort(df
 
 df.group_by("empid").pivot("month", values=["JAN", "FEB"]).sum("amount").show()
 
-df.group_by(["empid", "team"]).pivot("month").sum("amount").sort("empid", "team").show()
+df.group_by(["empid", "team"]).pivot("month", values=None).sum("amount").sort("empid", "team").show()
 
 ## EXPECTED ENCODED AST
 
@@ -410,8 +410,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 3
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
         }
         src {
           end_column: 43
@@ -531,8 +535,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 7
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 7
+            }
+          }
         }
         src {
           end_column: 43
@@ -652,8 +660,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 11
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 11
+            }
+          }
         }
         src {
           end_column: 46
@@ -773,8 +785,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 15
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 15
+            }
+          }
         }
         src {
           end_column: 55
@@ -1403,8 +1419,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 24
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 24
+            }
+          }
         }
         src {
           end_column: 104
@@ -1716,9 +1736,16 @@ body {
           start_line: 55
         }
         values {
-          pivot_value__expr {
-            v {
-              list_val {
+          list_val {
+            src {
+              end_column: 59
+              end_line: 55
+              file: 2
+              start_column: 8
+              start_line: 55
+            }
+            vs {
+              string_val {
                 src {
                   end_column: 59
                   end_line: 55
@@ -1726,30 +1753,19 @@ body {
                   start_column: 8
                   start_line: 55
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 59
-                      end_line: 55
-                      file: 2
-                      start_column: 8
-                      start_line: 55
-                    }
-                    v: "JAN"
-                  }
+                v: "JAN"
+              }
+            }
+            vs {
+              string_val {
+                src {
+                  end_column: 59
+                  end_line: 55
+                  file: 2
+                  start_column: 8
+                  start_line: 55
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 59
-                      end_line: 55
-                      file: 2
-                      start_column: 8
-                      start_line: 55
-                    }
-                    v: "FEB"
-                  }
-                }
+                v: "FEB"
               }
             }
           }
@@ -1862,10 +1878,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 31
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 31
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 98
+          end_line: 55
+          file: 2
+          start_column: 8
+          start_line: 55
+        }
       }
     }
     symbol {
@@ -1958,9 +1985,16 @@ body {
           start_line: 57
         }
         values {
-          pivot_value__expr {
-            v {
-              list_val {
+          list_val {
+            src {
+              end_column: 59
+              end_line: 57
+              file: 2
+              start_column: 8
+              start_line: 57
+            }
+            vs {
+              string_val {
                 src {
                   end_column: 59
                   end_line: 57
@@ -1968,30 +2002,19 @@ body {
                   start_column: 8
                   start_line: 57
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 59
-                      end_line: 57
-                      file: 2
-                      start_column: 8
-                      start_line: 57
-                    }
-                    v: "JAN"
-                  }
+                v: "JAN"
+              }
+            }
+            vs {
+              string_val {
+                src {
+                  end_column: 59
+                  end_line: 57
+                  file: 2
+                  start_column: 8
+                  start_line: 57
                 }
-                vs {
-                  string_val {
-                    src {
-                      end_column: 59
-                      end_line: 57
-                      file: 2
-                      start_column: 8
-                      start_line: 57
-                    }
-                    v: "FEB"
-                  }
-                }
+                v: "FEB"
               }
             }
           }
@@ -2054,10 +2077,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 36
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 36
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 80
+          end_line: 57
+          file: 2
+          start_column: 8
+          start_line: 57
+        }
       }
     }
     symbol {
@@ -2159,6 +2193,17 @@ body {
           file: 2
           start_column: 8
           start_line: 59
+        }
+        values {
+          null_val {
+            src {
+              end_column: 53
+              end_line: 59
+              file: 2
+              start_column: 8
+              start_line: 59
+            }
+          }
         }
       }
     }
@@ -2273,10 +2318,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 42
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 42
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 96
+          end_line: 59
+          file: 2
+          start_column: 8
+          start_line: 59
+        }
       }
     }
     symbol {

--- a/tests/ast/data/Table.delete.test
+++ b/tests/ast/data/Table.delete.test
@@ -94,8 +94,12 @@ body {
     expr {
       table_delete {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 19
@@ -158,8 +162,12 @@ body {
   assign {
     expr {
       table_delete {
-        id {
-          bitfield1: 4
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 4
+            }
+          }
         }
         src {
           end_column: 30
@@ -222,8 +230,12 @@ body {
   assign {
     expr {
       table_delete {
-        id {
-          bitfield1: 7
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 7
+            }
+          }
         }
         src {
           end_column: 79
@@ -333,8 +345,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 10
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 10
+            }
+          }
         }
         src {
           end_column: 33
@@ -530,8 +546,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 13
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 13
+            }
+          }
         }
         source {
           dataframe_ref {

--- a/tests/ast/data/Table.drop_table.test
+++ b/tests/ast/data/Table.drop_table.test
@@ -57,8 +57,12 @@ body {
   assign {
     expr {
       table_drop_table {
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 23

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -313,8 +313,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 2
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
         }
         join_expr {
           and {
@@ -589,8 +593,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 5
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 5
+            }
+          }
         }
         join_expr {
           neq {
@@ -731,8 +739,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 8
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 8
+            }
+          }
         }
         join_expr {
           and {
@@ -1005,8 +1017,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 11
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 11
+            }
+          }
         }
         join_expr {
           neq {
@@ -1123,8 +1139,12 @@ body {
           merge_delete_when_matched_clause {
           }
         }
-        id {
-          bitfield1: 14
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 14
+            }
+          }
         }
         join_expr {
           eq {
@@ -1289,8 +1309,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 17
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 17
+            }
+          }
         }
         join_expr {
           and {
@@ -1462,8 +1486,12 @@ body {
   assign {
     expr {
       table_merge {
-        id {
-          bitfield1: 20
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 20
+            }
+          }
         }
         join_expr {
           eq {

--- a/tests/ast/data/Table.update.test
+++ b/tests/ast/data/Table.update.test
@@ -86,8 +86,12 @@ body {
     expr {
       table_update {
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 21
@@ -133,8 +137,12 @@ body {
           }
         }
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 27
@@ -203,8 +211,12 @@ body {
           }
         }
         block: true
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 40
@@ -293,8 +305,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         src {
           end_column: 43
@@ -469,8 +485,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         source {
           dataframe_ref {
@@ -572,8 +592,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         source {
           dataframe_ref {
@@ -675,8 +699,12 @@ body {
             }
           }
         }
-        id {
-          bitfield1: 1
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 1
+            }
+          }
         }
         source {
           dataframe_ref {

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -298,8 +298,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 3
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
         }
         src {
           end_column: 57
@@ -495,8 +499,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 7
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 7
+            }
+          }
         }
         src {
           end_column: 71
@@ -969,8 +977,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 14
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 14
+            }
+          }
         }
         src {
           end_column: 57
@@ -1137,8 +1149,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 18
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 18
+            }
+          }
         }
         src {
           end_column: 71

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -525,8 +525,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 11
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 11
+            }
+          }
         }
         src {
           end_column: 50
@@ -701,8 +705,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 15
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 15
+            }
+          }
         }
         src {
           end_column: 22

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -22,6 +22,18 @@ df9 = session.read.with_metadata(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE
 
 df10 = session.read.table(tables.table1)
 
+df11 = session.read.format("csv").load("@resources/iris.csv")
+
+df12 = session.read.format("json").load("@resources/testJson.json")
+
+df13 = session.read.format("avro").load("@resources/test.avro")
+
+df14 = session.read.format("parquet").load("@resources/test.parquet")
+
+df15 = session.read.format("xml").load("@resources/test.xml")
+
+df16 = session.read.format("orc").load("@resources/test.orc")
+
 ## EXPECTED UNPARSER OUTPUT
 
 df1 = session.read.csv("@resources/iris.csv")
@@ -36,13 +48,25 @@ df5 = session.read.xml("@resources/test.xml")
 
 df6 = session.read.orc("@resources/test.orc")
 
-df7 = session.read.option("INFER_SCHEMA", True).option("PARSE_HEADER", True).csv("@testCSVheader.csv")
+df7 = session.read.options({"INFER_SCHEMA": True, "PARSE_HEADER": True}).csv("@testCSVheader.csv")
 
 df8 = session.read.options({"INFER_SCHEMA": True, "PARSE_HEADER": True}).csv("@testCSVheader.csv")
 
-df9 = session.read.with_metadata(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE_LAST_MODIFIED").schema(StructType(fields=[StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True), StructField("c", FloatType(), nullable=True)], structured=False)).csv("@testCSVheader.csv")
+df9 = session.read.schema(StructType(fields=[StructField("a", IntegerType(), nullable=True), StructField("b", StringType(), nullable=True), StructField("c", FloatType(), nullable=True)], structured=False)).metadata_columns(col("METADATA$FILE_ROW_NUMBER"), "METADATA$FILE_LAST_MODIFIED").csv("@testCSVheader.csv")
 
 df10 = session.read.table("table1")
+
+df11 = session.read.format("csv").load("@resources/iris.csv")
+
+df12 = session.read.format("json").load("@resources/testJson.json")
+
+df13 = session.read.format("avro").load("@resources/test.avro")
+
+df14 = session.read.format("parquet").load("@resources/test.parquet")
+
+df15 = session.read.format("xml").load("@resources/test.xml")
+
+df16 = session.read.format("orc").load("@resources/test.orc")
 
 ## EXPECTED ENCODED AST
 
@@ -61,7 +85,7 @@ body {
       read_csv {
         path: "@resources/iris.csv"
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 26
               end_line: 25
@@ -95,7 +119,7 @@ body {
       read_json {
         path: "@resources/testJson.json"
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 26
               end_line: 27
@@ -129,7 +153,7 @@ body {
       read_avro {
         path: "@resources/test.avro"
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 26
               end_line: 29
@@ -163,7 +187,7 @@ body {
       read_parquet {
         path: "@resources/test.parquet"
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 26
               end_line: 31
@@ -197,7 +221,7 @@ body {
       read_xml {
         path: "@resources/test.xml"
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 26
               end_line: 33
@@ -231,7 +255,7 @@ body {
       read_orc {
         path: "@resources/test.orc"
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 26
               end_line: 35
@@ -265,61 +289,43 @@ body {
       read_csv {
         path: "@testCSVheader.csv"
         reader {
-          dataframe_reader_option {
-            key: "PARSE_HEADER"
-            reader {
-              dataframe_reader_option {
-                key: "INFER_SCHEMA"
-                reader {
-                  dataframe_reader_init {
-                    src {
-                      end_column: 26
-                      end_line: 37
-                      file: 2
-                      start_column: 14
-                      start_line: 37
-                    }
+          dataframe_reader {
+            options {
+              _1: "INFER_SCHEMA"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 55
+                    end_line: 37
+                    file: 2
+                    start_column: 14
+                    start_line: 37
                   }
+                  v: true
                 }
-                src {
-                  end_column: 55
-                  end_line: 37
-                  file: 2
-                  start_column: 14
-                  start_line: 37
-                }
-                value {
-                  bool_val {
-                    src {
-                      end_column: 55
-                      end_line: 37
-                      file: 2
-                      start_column: 14
-                      start_line: 37
-                    }
-                    v: true
+              }
+            }
+            options {
+              _1: "PARSE_HEADER"
+              _2 {
+                bool_val {
+                  src {
+                    end_column: 84
+                    end_line: 37
+                    file: 2
+                    start_column: 14
+                    start_line: 37
                   }
+                  v: true
                 }
               }
             }
             src {
-              end_column: 84
+              end_column: 26
               end_line: 37
               file: 2
               start_column: 14
               start_line: 37
-            }
-            value {
-              bool_val {
-                src {
-                  end_column: 84
-                  end_line: 37
-                  file: 2
-                  start_column: 14
-                  start_line: 37
-                }
-                v: true
-              }
             }
           }
         }
@@ -347,8 +353,8 @@ body {
       read_csv {
         path: "@testCSVheader.csv"
         reader {
-          dataframe_reader_options {
-            configs {
+          dataframe_reader {
+            options {
               _1: "INFER_SCHEMA"
               _2 {
                 bool_val {
@@ -363,7 +369,7 @@ body {
                 }
               }
             }
-            configs {
+            options {
               _1: "PARSE_HEADER"
               _2 {
                 bool_val {
@@ -378,19 +384,8 @@ body {
                 }
               }
             }
-            reader {
-              dataframe_reader_init {
-                src {
-                  end_column: 26
-                  end_line: 39
-                  file: 2
-                  start_column: 14
-                  start_line: 39
-                }
-              }
-            }
             src {
-              end_column: 80
+              end_column: 26
               end_line: 39
               file: 2
               start_column: 14
@@ -422,35 +417,23 @@ body {
       read_csv {
         path: "@testCSVheader.csv"
         reader {
-          dataframe_reader_schema {
-            reader {
-              dataframe_reader_with_metadata {
-                metadata_columns {
-                  args {
-                    apply_expr {
-                      fn {
-                        builtin_fn {
-                          name {
-                            name {
-                              name_flat {
-                                name: "col"
-                              }
-                            }
+          dataframe_reader {
+            metadata_columns {
+              args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
                           }
                         }
                       }
-                      pos_args {
-                        string_val {
-                          src {
-                            end_column: 72
-                            end_line: 43
-                            file: 2
-                            start_column: 41
-                            start_line: 43
-                          }
-                          v: "METADATA$FILE_ROW_NUMBER"
-                        }
-                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
                       src {
                         end_column: 72
                         end_line: 43
@@ -458,41 +441,31 @@ body {
                         start_column: 41
                         start_line: 43
                       }
+                      v: "METADATA$FILE_ROW_NUMBER"
                     }
                   }
-                  args {
-                    string_val {
-                      src {
-                        end_column: 104
-                        end_line: 43
-                        file: 2
-                        start_column: 14
-                        start_line: 43
-                      }
-                      v: "METADATA$FILE_LAST_MODIFIED"
-                    }
+                  src {
+                    end_column: 72
+                    end_line: 43
+                    file: 2
+                    start_column: 41
+                    start_line: 43
                   }
-                  variadic: true
-                }
-                reader {
-                  dataframe_reader_init {
-                    src {
-                      end_column: 26
-                      end_line: 43
-                      file: 2
-                      start_column: 14
-                      start_line: 43
-                    }
-                  }
-                }
-                src {
-                  end_column: 104
-                  end_line: 43
-                  file: 2
-                  start_column: 14
-                  start_line: 43
                 }
               }
+              args {
+                string_val {
+                  src {
+                    end_column: 104
+                    end_line: 43
+                    file: 2
+                    start_column: 14
+                    start_line: 43
+                  }
+                  v: "METADATA$FILE_LAST_MODIFIED"
+                }
+              }
+              variadic: true
             }
             schema {
               fields {
@@ -533,7 +506,7 @@ body {
               }
             }
             src {
-              end_column: 124
+              end_column: 26
               end_line: 43
               file: 2
               start_column: 14
@@ -571,7 +544,7 @@ body {
           }
         }
         reader {
-          dataframe_reader_init {
+          dataframe_reader {
             src {
               end_column: 27
               end_line: 45
@@ -596,6 +569,228 @@ body {
     uid: 10
     var_id {
       bitfield1: 10
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_load {
+        path: "@resources/iris.csv"
+        reader {
+          dataframe_reader {
+            format {
+              value: "csv"
+            }
+            src {
+              end_column: 27
+              end_line: 47
+              file: 2
+              start_column: 15
+              start_line: 47
+            }
+          }
+        }
+        src {
+          end_column: 69
+          end_line: 47
+          file: 2
+          start_column: 15
+          start_line: 47
+        }
+      }
+    }
+    symbol {
+      value: "df11"
+    }
+    uid: 11
+    var_id {
+      bitfield1: 11
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_load {
+        path: "@resources/testJson.json"
+        reader {
+          dataframe_reader {
+            format {
+              value: "json"
+            }
+            src {
+              end_column: 27
+              end_line: 49
+              file: 2
+              start_column: 15
+              start_line: 49
+            }
+          }
+        }
+        src {
+          end_column: 75
+          end_line: 49
+          file: 2
+          start_column: 15
+          start_line: 49
+        }
+      }
+    }
+    symbol {
+      value: "df12"
+    }
+    uid: 12
+    var_id {
+      bitfield1: 12
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_load {
+        path: "@resources/test.avro"
+        reader {
+          dataframe_reader {
+            format {
+              value: "avro"
+            }
+            src {
+              end_column: 27
+              end_line: 51
+              file: 2
+              start_column: 15
+              start_line: 51
+            }
+          }
+        }
+        src {
+          end_column: 71
+          end_line: 51
+          file: 2
+          start_column: 15
+          start_line: 51
+        }
+      }
+    }
+    symbol {
+      value: "df13"
+    }
+    uid: 13
+    var_id {
+      bitfield1: 13
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_load {
+        path: "@resources/test.parquet"
+        reader {
+          dataframe_reader {
+            format {
+              value: "parquet"
+            }
+            src {
+              end_column: 27
+              end_line: 53
+              file: 2
+              start_column: 15
+              start_line: 53
+            }
+          }
+        }
+        src {
+          end_column: 77
+          end_line: 53
+          file: 2
+          start_column: 15
+          start_line: 53
+        }
+      }
+    }
+    symbol {
+      value: "df14"
+    }
+    uid: 14
+    var_id {
+      bitfield1: 14
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_load {
+        path: "@resources/test.xml"
+        reader {
+          dataframe_reader {
+            format {
+              value: "xml"
+            }
+            src {
+              end_column: 27
+              end_line: 55
+              file: 2
+              start_column: 15
+              start_line: 55
+            }
+          }
+        }
+        src {
+          end_column: 69
+          end_line: 55
+          file: 2
+          start_column: 15
+          start_line: 55
+        }
+      }
+    }
+    symbol {
+      value: "df15"
+    }
+    uid: 15
+    var_id {
+      bitfield1: 15
+    }
+  }
+}
+body {
+  assign {
+    expr {
+      read_load {
+        path: "@resources/test.orc"
+        reader {
+          dataframe_reader {
+            format {
+              value: "orc"
+            }
+            src {
+              end_column: 27
+              end_line: 57
+              file: 2
+              start_column: 15
+              start_line: 57
+            }
+          }
+        }
+        src {
+          end_column: 69
+          end_line: 57
+          file: 2
+          start_column: 15
+          start_line: 57
+        }
+      }
+    }
+    symbol {
+      value: "df16"
+    }
+    uid: 16
+    var_id {
+      bitfield1: 16
     }
   }
 }

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -184,15 +184,15 @@ session.sql("call mul_sp(5, 6)").collect()
 
 sproc("sin_sp", return_type=FloatType(), input_types=[FloatType()], packages=["snowflake-snowpark-python", "numpy"], statement_params={"SF_PARTNER": "FAKE_PARTNER"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1.5707963267948966)
 
-res33 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res30 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res37 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res34 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res41 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res38 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
@@ -204,9 +204,9 @@ mod5_sp(3)
 
 range5_sproc = sproc("range5_sproc", return_type=StructType(structured=False), _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
 
-res48 = range5_sproc()
+res45 = range5_sproc()
 
-res49 = session.range(5, None, 1)
+res46 = session.range(5, None, 1)
 
 ## EXPECTED ENCODED AST
 
@@ -315,8 +315,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 2
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 2
+            }
+          }
         }
         src {
           end_column: 165
@@ -413,40 +417,9 @@ body {
 body {
   assign {
     expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 5
-            }
-          }
-        }
-        src {
-          end_column: 21
-          end_line: 47
-          file: 2
-          start_column: 8
-          start_line: 47
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 6
-    var_id {
-      bitfield1: 6
-    }
-  }
-}
-body {
-  assign {
-    expr {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 6
-        }
         mode {
           save_mode_overwrite: true
         }
@@ -465,21 +438,39 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 5
+                }
+              }
+            }
+            src {
+              end_column: 21
+              end_line: 47
+              file: 2
+              start_column: 8
+              start_line: 47
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 7
+    uid: 6
     var_id {
-      bitfield1: 7
+      bitfield1: 6
     }
   }
 }
 body {
   eval {
-    uid: 8
+    uid: 7
     var_id {
-      bitfield1: 7
+      bitfield1: 6
     }
   }
 }
@@ -532,37 +523,9 @@ body {
     symbol {
       value: "to_df"
     }
-    uid: 9
+    uid: 8
     var_id {
-      bitfield1: 9
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 9
-            }
-          }
-        }
-        src {
-          end_column: 19
-          end_line: 49
-          file: 2
-          start_column: 8
-          start_line: 49
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 10
-    var_id {
-      bitfield1: 10
+      bitfield1: 8
     }
   }
 }
@@ -572,9 +535,6 @@ body {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 10
-        }
         mode {
           save_mode_overwrite: true
         }
@@ -593,21 +553,39 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 8
+                }
+              }
+            }
+            src {
+              end_column: 19
+              end_line: 49
+              file: 2
+              start_column: 8
+              start_line: 49
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 11
+    uid: 9
     var_id {
-      bitfield1: 11
+      bitfield1: 9
     }
   }
 }
 body {
   eval {
-    uid: 12
+    uid: 10
     var_id {
-      bitfield1: 11
+      bitfield1: 9
     }
   }
 }
@@ -627,9 +605,9 @@ body {
     }
     symbol {
     }
-    uid: 13
+    uid: 11
     var_id {
-      bitfield1: 13
+      bitfield1: 11
     }
   }
 }
@@ -639,8 +617,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 13
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 11
+            }
+          }
         }
         src {
           end_column: 76
@@ -653,17 +635,17 @@ body {
     }
     symbol {
     }
-    uid: 14
+    uid: 12
     var_id {
-      bitfield1: 14
+      bitfield1: 12
     }
   }
 }
 body {
   eval {
-    uid: 15
+    uid: 13
     var_id {
-      bitfield1: 14
+      bitfield1: 12
     }
   }
 }
@@ -692,9 +674,9 @@ body {
     }
     symbol {
     }
-    uid: 16
+    uid: 14
     var_id {
-      bitfield1: 16
+      bitfield1: 14
     }
   }
 }
@@ -703,8 +685,12 @@ body {
     expr {
       dataframe_count {
         block: true
-        id {
-          bitfield1: 16
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 14
+            }
+          }
         }
         src {
           end_column: 40
@@ -717,17 +703,17 @@ body {
     }
     symbol {
     }
-    uid: 17
+    uid: 15
     var_id {
-      bitfield1: 17
+      bitfield1: 15
     }
   }
 }
 body {
   eval {
-    uid: 18
+    uid: 16
     var_id {
-      bitfield1: 17
+      bitfield1: 15
     }
   }
 }
@@ -748,9 +734,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 19
+    uid: 17
     var_id {
-      bitfield1: 19
+      bitfield1: 17
     }
   }
 }
@@ -760,8 +746,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 19
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 17
+            }
+          }
         }
         src {
           end_column: 65
@@ -774,17 +764,17 @@ body {
     }
     symbol {
     }
-    uid: 20
+    uid: 18
     var_id {
-      bitfield1: 20
+      bitfield1: 18
     }
   }
 }
 body {
   eval {
-    uid: 21
+    uid: 19
     var_id {
-      bitfield1: 20
+      bitfield1: 18
     }
   }
 }
@@ -852,17 +842,17 @@ body {
     }
     symbol {
     }
-    uid: 22
+    uid: 20
     var_id {
-      bitfield1: 22
+      bitfield1: 20
     }
   }
 }
 body {
   eval {
-    uid: 23
+    uid: 21
     var_id {
-      bitfield1: 22
+      bitfield1: 20
     }
   }
 }
@@ -891,9 +881,9 @@ body {
     }
     symbol {
     }
-    uid: 24
+    uid: 22
     var_id {
-      bitfield1: 24
+      bitfield1: 22
     }
   }
 }
@@ -904,7 +894,7 @@ body {
         df {
           dataframe_ref {
             id {
-              bitfield1: 24
+              bitfield1: 22
             }
           }
         }
@@ -920,37 +910,9 @@ body {
     }
     symbol {
     }
-    uid: 25
+    uid: 23
     var_id {
-      bitfield1: 25
-    }
-  }
-}
-body {
-  assign {
-    expr {
-      dataframe_write {
-        df {
-          dataframe_ref {
-            id {
-              bitfield1: 25
-            }
-          }
-        }
-        src {
-          end_column: 56
-          end_line: 39
-          file: 2
-          start_column: 12
-          start_line: 39
-        }
-      }
-    }
-    symbol {
-    }
-    uid: 26
-    var_id {
-      bitfield1: 26
+      bitfield1: 23
     }
   }
 }
@@ -960,9 +922,6 @@ body {
       write_table {
         block: true
         column_order: "index"
-        id {
-          bitfield1: 26
-        }
         mode {
           save_mode_overwrite: true
         }
@@ -981,21 +940,39 @@ body {
           }
         }
         table_type: "temporary"
+        writer {
+          dataframe_writer {
+            df {
+              dataframe_ref {
+                id {
+                  bitfield1: 23
+                }
+              }
+            }
+            src {
+              end_column: 56
+              end_line: 39
+              file: 2
+              start_column: 12
+              start_line: 39
+            }
+          }
+        }
       }
     }
     symbol {
     }
-    uid: 27
+    uid: 24
     var_id {
-      bitfield1: 27
+      bitfield1: 24
     }
   }
 }
 body {
   eval {
-    uid: 28
+    uid: 25
     var_id {
-      bitfield1: 27
+      bitfield1: 24
     }
   }
 }
@@ -1024,9 +1001,9 @@ body {
     }
     symbol {
     }
-    uid: 29
+    uid: 26
     var_id {
-      bitfield1: 29
+      bitfield1: 26
     }
   }
 }
@@ -1035,8 +1012,12 @@ body {
     expr {
       dataframe_count {
         block: true
-        id {
-          bitfield1: 29
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 26
+            }
+          }
         }
         src {
           end_column: 40
@@ -1049,17 +1030,17 @@ body {
     }
     symbol {
     }
-    uid: 30
+    uid: 27
     var_id {
-      bitfield1: 30
+      bitfield1: 27
     }
   }
 }
 body {
   eval {
-    uid: 31
+    uid: 28
     var_id {
-      bitfield1: 30
+      bitfield1: 27
     }
   }
 }
@@ -1099,9 +1080,9 @@ body {
     symbol {
       value: "add_one_sp"
     }
-    uid: 32
+    uid: 29
     var_id {
-      bitfield1: 32
+      bitfield1: 29
     }
   }
 }
@@ -1112,7 +1093,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 32
+              bitfield1: 29
             }
           }
         }
@@ -1139,9 +1120,9 @@ body {
     }
     symbol {
     }
-    uid: 33
+    uid: 30
     var_id {
-      bitfield1: 33
+      bitfield1: 30
     }
   }
 }
@@ -1161,9 +1142,9 @@ body {
     }
     symbol {
     }
-    uid: 34
+    uid: 31
     var_id {
-      bitfield1: 34
+      bitfield1: 31
     }
   }
 }
@@ -1173,8 +1154,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 34
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 31
+            }
+          }
         }
         src {
           end_column: 73
@@ -1187,25 +1172,25 @@ body {
     }
     symbol {
     }
-    uid: 35
+    uid: 32
     var_id {
-      bitfield1: 35
+      bitfield1: 32
     }
   }
 }
 body {
   eval {
-    uid: 36
+    uid: 33
     var_id {
-      bitfield1: 35
+      bitfield1: 32
     }
   }
 }
 body {
   eval {
-    uid: 37
+    uid: 34
     var_id {
-      bitfield1: 33
+      bitfield1: 30
     }
   }
 }
@@ -1225,9 +1210,9 @@ body {
     }
     symbol {
     }
-    uid: 38
+    uid: 35
     var_id {
-      bitfield1: 38
+      bitfield1: 35
     }
   }
 }
@@ -1237,8 +1222,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 38
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 35
+            }
+          }
         }
         src {
           end_column: 62
@@ -1251,17 +1240,17 @@ body {
     }
     symbol {
     }
-    uid: 39
+    uid: 36
     var_id {
-      bitfield1: 39
+      bitfield1: 36
     }
   }
 }
 body {
   eval {
-    uid: 40
+    uid: 37
     var_id {
-      bitfield1: 39
+      bitfield1: 36
     }
   }
 }
@@ -1282,9 +1271,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 41
+    uid: 38
     var_id {
-      bitfield1: 41
+      bitfield1: 38
     }
   }
 }
@@ -1294,8 +1283,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 41
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 38
+            }
+          }
         }
         src {
           end_column: 73
@@ -1308,17 +1301,17 @@ body {
     }
     symbol {
     }
-    uid: 42
+    uid: 39
     var_id {
-      bitfield1: 42
+      bitfield1: 39
     }
   }
 }
 body {
   eval {
-    uid: 43
+    uid: 40
     var_id {
-      bitfield1: 42
+      bitfield1: 39
     }
   }
 }
@@ -1371,9 +1364,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 44
+    uid: 41
     var_id {
-      bitfield1: 44
+      bitfield1: 41
     }
   }
 }
@@ -1393,9 +1386,9 @@ body {
     }
     symbol {
     }
-    uid: 45
+    uid: 42
     var_id {
-      bitfield1: 45
+      bitfield1: 42
     }
   }
 }
@@ -1405,8 +1398,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 45
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 42
+            }
+          }
         }
         src {
           end_column: 50
@@ -1419,17 +1416,17 @@ body {
     }
     symbol {
     }
-    uid: 46
+    uid: 43
     var_id {
-      bitfield1: 46
+      bitfield1: 43
     }
   }
 }
 body {
   eval {
-    uid: 47
+    uid: 44
     var_id {
-      bitfield1: 46
+      bitfield1: 43
     }
   }
 }
@@ -1482,9 +1479,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 48
+    uid: 45
     var_id {
-      bitfield1: 48
+      bitfield1: 45
     }
   }
 }
@@ -1504,9 +1501,9 @@ body {
     }
     symbol {
     }
-    uid: 49
+    uid: 46
     var_id {
-      bitfield1: 49
+      bitfield1: 46
     }
   }
 }
@@ -1516,8 +1513,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 49
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 46
+            }
+          }
         }
         src {
           end_column: 50
@@ -1530,17 +1531,17 @@ body {
     }
     symbol {
     }
-    uid: 50
+    uid: 47
     var_id {
-      bitfield1: 50
+      bitfield1: 47
     }
   }
 }
 body {
   eval {
-    uid: 51
+    uid: 48
     var_id {
-      bitfield1: 50
+      bitfield1: 47
     }
   }
 }
@@ -1603,9 +1604,9 @@ body {
     symbol {
       value: "_"
     }
-    uid: 52
+    uid: 49
     var_id {
-      bitfield1: 52
+      bitfield1: 49
     }
   }
 }
@@ -1625,9 +1626,9 @@ body {
     }
     symbol {
     }
-    uid: 53
+    uid: 50
     var_id {
-      bitfield1: 53
+      bitfield1: 50
     }
   }
 }
@@ -1637,8 +1638,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 53
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 50
+            }
+          }
         }
         src {
           end_column: 50
@@ -1651,17 +1656,17 @@ body {
     }
     symbol {
     }
-    uid: 54
+    uid: 51
     var_id {
-      bitfield1: 54
+      bitfield1: 51
     }
   }
 }
 body {
   eval {
-    uid: 55
+    uid: 52
     var_id {
-      bitfield1: 54
+      bitfield1: 51
     }
   }
 }
@@ -1706,9 +1711,9 @@ body {
     }
     symbol {
     }
-    uid: 56
+    uid: 53
     var_id {
-      bitfield1: 56
+      bitfield1: 53
     }
   }
 }
@@ -1719,7 +1724,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 56
+              bitfield1: 53
             }
           }
         }
@@ -1746,17 +1751,17 @@ body {
     }
     symbol {
     }
-    uid: 57
+    uid: 54
     var_id {
-      bitfield1: 57
+      bitfield1: 54
     }
   }
 }
 body {
   eval {
-    uid: 58
+    uid: 55
     var_id {
-      bitfield1: 57
+      bitfield1: 54
     }
   }
 }
@@ -1821,9 +1826,9 @@ body {
     }
     symbol {
     }
-    uid: 59
+    uid: 56
     var_id {
-      bitfield1: 59
+      bitfield1: 56
     }
   }
 }
@@ -1834,7 +1839,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 59
+              bitfield1: 56
             }
           }
         }
@@ -1873,9 +1878,9 @@ body {
     }
     symbol {
     }
-    uid: 60
+    uid: 57
     var_id {
-      bitfield1: 60
+      bitfield1: 57
     }
   }
 }
@@ -1895,9 +1900,9 @@ body {
     }
     symbol {
     }
-    uid: 61
+    uid: 58
     var_id {
-      bitfield1: 61
+      bitfield1: 58
     }
   }
 }
@@ -1905,25 +1910,36 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 61
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 58
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 30
+          end_line: 123
+          file: 2
+          start_column: 8
+          start_line: 123
+        }
       }
     }
     symbol {
     }
-    uid: 62
+    uid: 59
     var_id {
-      bitfield1: 62
+      bitfield1: 59
     }
   }
 }
 body {
   eval {
-    uid: 63
+    uid: 60
     var_id {
-      bitfield1: 62
+      bitfield1: 59
     }
   }
 }
@@ -1965,9 +1981,9 @@ body {
     }
     symbol {
     }
-    uid: 64
+    uid: 61
     var_id {
-      bitfield1: 64
+      bitfield1: 61
     }
   }
 }
@@ -1978,7 +1994,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 64
+              bitfield1: 61
             }
           }
         }
@@ -2017,9 +2033,9 @@ body {
     }
     symbol {
     }
-    uid: 65
+    uid: 62
     var_id {
-      bitfield1: 65
+      bitfield1: 62
     }
   }
 }
@@ -2039,9 +2055,9 @@ body {
     }
     symbol {
     }
-    uid: 66
+    uid: 63
     var_id {
-      bitfield1: 66
+      bitfield1: 63
     }
   }
 }
@@ -2049,25 +2065,36 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 66
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 63
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 30
+          end_line: 129
+          file: 2
+          start_column: 8
+          start_line: 129
+        }
       }
     }
     symbol {
     }
-    uid: 67
+    uid: 64
     var_id {
-      bitfield1: 67
+      bitfield1: 64
     }
   }
 }
 body {
   eval {
-    uid: 68
+    uid: 65
     var_id {
-      bitfield1: 67
+      bitfield1: 64
     }
   }
 }
@@ -2110,9 +2137,9 @@ body {
     }
     symbol {
     }
-    uid: 69
+    uid: 66
     var_id {
-      bitfield1: 69
+      bitfield1: 66
     }
   }
 }
@@ -2123,7 +2150,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 69
+              bitfield1: 66
             }
           }
         }
@@ -2162,9 +2189,9 @@ body {
     }
     symbol {
     }
-    uid: 70
+    uid: 67
     var_id {
-      bitfield1: 70
+      bitfield1: 67
     }
   }
 }
@@ -2184,9 +2211,9 @@ body {
     }
     symbol {
     }
-    uid: 71
+    uid: 68
     var_id {
-      bitfield1: 71
+      bitfield1: 68
     }
   }
 }
@@ -2194,25 +2221,36 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 71
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 68
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 30
+          end_line: 135
+          file: 2
+          start_column: 8
+          start_line: 135
+        }
       }
     }
     symbol {
     }
-    uid: 72
+    uid: 69
     var_id {
-      bitfield1: 72
+      bitfield1: 69
     }
   }
 }
 body {
   eval {
-    uid: 73
+    uid: 70
     var_id {
-      bitfield1: 72
+      bitfield1: 69
     }
   }
 }
@@ -2252,9 +2290,9 @@ body {
     symbol {
       value: "mod5_sp"
     }
-    uid: 74
+    uid: 71
     var_id {
-      bitfield1: 74
+      bitfield1: 71
     }
   }
 }
@@ -2265,7 +2303,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 74
+              bitfield1: 71
             }
           }
         }
@@ -2292,9 +2330,9 @@ body {
     }
     symbol {
     }
-    uid: 75
+    uid: 72
     var_id {
-      bitfield1: 75
+      bitfield1: 72
     }
   }
 }
@@ -2345,9 +2383,9 @@ body {
     }
     symbol {
     }
-    uid: 76
+    uid: 73
     var_id {
-      bitfield1: 76
+      bitfield1: 73
     }
   }
 }
@@ -2418,7 +2456,7 @@ body {
         df {
           dataframe_ref {
             id {
-              bitfield1: 76
+              bitfield1: 73
             }
           }
         }
@@ -2433,9 +2471,9 @@ body {
     }
     symbol {
     }
-    uid: 77
+    uid: 74
     var_id {
-      bitfield1: 77
+      bitfield1: 74
     }
   }
 }
@@ -2445,8 +2483,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 77
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 74
+            }
+          }
         }
         src {
           end_column: 18
@@ -2459,25 +2501,25 @@ body {
     }
     symbol {
     }
-    uid: 78
-    var_id {
-      bitfield1: 78
-    }
-  }
-}
-body {
-  eval {
-    uid: 79
-    var_id {
-      bitfield1: 78
-    }
-  }
-}
-body {
-  eval {
-    uid: 80
+    uid: 75
     var_id {
       bitfield1: 75
+    }
+  }
+}
+body {
+  eval {
+    uid: 76
+    var_id {
+      bitfield1: 75
+    }
+  }
+}
+body {
+  eval {
+    uid: 77
+    var_id {
+      bitfield1: 72
     }
   }
 }
@@ -2515,9 +2557,9 @@ body {
     symbol {
       value: "range5_sproc"
     }
-    uid: 81
+    uid: 78
     var_id {
-      bitfield1: 81
+      bitfield1: 78
     }
   }
 }
@@ -2528,7 +2570,7 @@ body {
         fn {
           fn_ref {
             id {
-              bitfield1: 81
+              bitfield1: 78
             }
           }
         }
@@ -2543,9 +2585,9 @@ body {
     }
     symbol {
     }
-    uid: 82
+    uid: 79
     var_id {
-      bitfield1: 82
+      bitfield1: 79
     }
   }
 }
@@ -2568,9 +2610,9 @@ body {
     }
     symbol {
     }
-    uid: 83
+    uid: 80
     var_id {
-      bitfield1: 83
+      bitfield1: 80
     }
   }
 }

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -487,8 +487,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 4
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 4
+            }
+          }
         }
         src {
           end_column: 39

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -384,8 +384,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 3
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 3
+            }
+          }
         }
         src {
           end_column: 61
@@ -725,10 +729,21 @@ body {
   assign {
     expr {
       dataframe_show {
-        id {
-          bitfield1: 9
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 9
+            }
+          }
         }
         n: 10
+        src {
+          end_column: 71
+          end_line: 58
+          file: 2
+          start_column: 8
+          start_line: 58
+        }
       }
     }
     symbol {
@@ -924,8 +939,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 14
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 14
+            }
+          }
         }
         src {
           end_column: 64
@@ -1491,8 +1510,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 22
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 22
+            }
+          }
         }
         src {
           end_column: 43
@@ -1721,8 +1744,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 27
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 27
+            }
+          }
         }
         src {
           end_column: 53
@@ -1906,8 +1933,12 @@ body {
       dataframe_collect {
         block: true
         case_sensitive: true
-        id {
-          bitfield1: 31
+        df {
+          dataframe_ref {
+            id {
+              bitfield1: 31
+            }
+          }
         }
         src {
           end_column: 81


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   This PR includes all changes required to complete the following tickets.

   - [SNOW-1882075](https://snowflakecomputing.atlassian.net/browse/SNOW-1882075): AST for DataFrameWriter.insertInto/insert_into
   - [SNOW-1990301](https://snowflakecomputing.atlassian.net/browse/SNOW-1990301): AST for DataframerWriter.{format,save}
   - [SNOW-1990302](https://snowflakecomputing.atlassian.net/browse/SNOW-1990302): AST for DataframeReader.{format,load}
   - [SNOW-1821290](https://snowflakecomputing.atlassian.net/browse/SNOW-1821290): Finalize the AST schema v1

   It also includes changes in support of [SNOW-1997136](https://snowflakecomputing.atlassian.net/browse/SNOW-1997136): Ensure AST batch is stateless.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.

3. Please describe how your code solves the related issue.

   AST generation for `DataframeReader` APIs which return the same `DataframeReader` instance have been updated to follow the same pattern as `DataframeWriter`. Since all such methods are setters, it is only necessary to have the last set attributes in the AST sent to the serveer. This is in support of the new `format` API in both Snowpark classes.

    AST generation was added for the new APIs `DataframeReader.{format,load}`, and `DataframeWriter.{format,read,insert_into}` along with expectation test updates.

    Changes were also made in support of AST batch statelessness in the IR, by changing fields typed `VarId` to be `Expr` typed. This allows more consistent usage of `_set_ast_ref` as a helper method across all Snowpark APIs.

    This PR is accompanied by a [server-side PR](https://github.com/snowflakedb/snowflake/pull/270350).

[SNOW-1882075]: https://snowflakecomputing.atlassian.net/browse/SNOW-1882075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-1990301]: https://snowflakecomputing.atlassian.net/browse/SNOW-1990301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-1990302]: https://snowflakecomputing.atlassian.net/browse/SNOW-1990302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-1821290]: https://snowflakecomputing.atlassian.net/browse/SNOW-1821290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNOW-1997136]: https://snowflakecomputing.atlassian.net/browse/SNOW-1997136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ