### PR TITLE
SNOW-1995618 Store ref to temp table created in cache_result in AST

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -223,7 +223,7 @@ message FlattenMode {
   }
 }
 
-// dataframe.ir:230
+// dataframe.ir:232
 message JoinType {
   oneof variant {
     bool join_type__asof = 1;
@@ -741,14 +741,14 @@ message CreateDataframe {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:163
+// dataframe.ir:165
 message DataframeAgg {
   Expr df = 1;
   ExprArgList exprs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:168
+// dataframe.ir:170
 message DataframeAlias {
   Expr df = 1;
   string name = 2;
@@ -811,11 +811,12 @@ message DataframeAnalyticsTimeSeriesAgg {
   repeated string windows = 8;
 }
 
-// dataframe-io.ir:183
+// dataframe.ir:348
 message DataframeCacheResult {
   Expr df = 1;
-  SrcPosition src = 2;
-  repeated Tuple_String_String statement_params = 3;
+  NameRef object_name = 2;
+  SrcPosition src = 3;
+  repeated Tuple_String_String statement_params = 4;
 }
 
 // column.ir:1
@@ -888,7 +889,7 @@ message DataframeCreateOrReplaceView {
   repeated Tuple_String_String statement_params = 6;
 }
 
-// dataframe.ir:173
+// dataframe.ir:175
 message DataframeCrossJoin {
   Expr lhs = 1;
   google.protobuf.StringValue lsuffix = 2;
@@ -904,48 +905,48 @@ message DataframeCube {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:180
+// dataframe.ir:182
 message DataframeDescribe {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:185
+// dataframe.ir:187
 message DataframeDistinct {
   Expr df = 1;
   SrcPosition src = 2;
 }
 
-// dataframe.ir:189
+// dataframe.ir:191
 message DataframeDrop {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:194
+// dataframe.ir:196
 message DataframeDropDuplicates {
   ExprArgList cols = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:199
+// dataframe.ir:201
 message DataframeExcept {
   Expr df = 1;
   Expr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:204
+// dataframe.ir:206
 message DataframeFilter {
   Expr condition = 1;
   Expr df = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:218
+// dataframe.ir:220
 message DataframeFirst {
   bool block = 1;
   Expr df = 2;
@@ -954,7 +955,7 @@ message DataframeFirst {
   repeated Tuple_String_String statement_params = 5;
 }
 
-// dataframe.ir:209
+// dataframe.ir:211
 message DataframeFlatten {
   Expr df = 1;
   Expr input = 2;
@@ -979,14 +980,14 @@ message DataframeGroupByGroupingSets {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:225
+// dataframe.ir:227
 message DataframeIntersect {
   Expr df = 1;
   Expr other = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:241
+// dataframe.ir:243
 message DataframeJoin {
   Expr join_expr = 1;
   JoinType join_type = 2;
@@ -998,14 +999,14 @@ message DataframeJoin {
   SrcPosition src = 8;
 }
 
-// dataframe.ir:251
+// dataframe.ir:253
 message DataframeJoinTableFunction {
   Expr fn = 1;
   Expr lhs = 2;
   SrcPosition src = 3;
 }
 
-// dataframe.ir:256
+// dataframe.ir:258
 message DataframeLimit {
   Expr df = 1;
   int64 n = 2;
@@ -1033,25 +1034,27 @@ message DataframeNaDrop_Scala {
 // dataframe.ir:142
 message DataframeNaFill {
   Expr df = 1;
-  SrcPosition src = 2;
-  ExprArgList subset = 3;
-  Expr value = 4;
-  repeated Tuple_String_Expr value_map = 5;
-}
-
-// dataframe.ir:149
-message DataframeNaReplace {
-  Expr df = 1;
-  repeated Tuple_Expr_Expr replacement_map = 2;
+  bool include_decimal = 2;
   SrcPosition src = 3;
   ExprArgList subset = 4;
-  repeated Expr to_replace_list = 5;
-  Expr to_replace_value = 6;
-  Expr value = 7;
-  repeated Expr values = 8;
+  Expr value = 5;
+  repeated Tuple_String_Expr value_map = 6;
 }
 
-// dataframe.ir:262
+// dataframe.ir:150
+message DataframeNaReplace {
+  Expr df = 1;
+  bool include_decimal = 2;
+  repeated Tuple_Expr_Expr replacement_map = 3;
+  SrcPosition src = 4;
+  ExprArgList subset = 5;
+  repeated Expr to_replace_list = 6;
+  Expr to_replace_value = 7;
+  Expr value = 8;
+  repeated Expr values = 9;
+}
+
+// dataframe.ir:264
 message DataframeNaturalJoin {
   JoinType join_type = 1;
   Expr lhs = 2;
@@ -1068,7 +1071,7 @@ message DataframePivot {
   PivotValue values = 5;
 }
 
-// dataframe.ir:276
+// dataframe.ir:278
 message DataframeRandomSplit {
   Expr df = 1;
   google.protobuf.Int64Value seed = 2;
@@ -1117,7 +1120,7 @@ message DataframeRef {
   SrcPosition src = 2;
 }
 
-// dataframe.ir:283
+// dataframe.ir:285
 message DataframeRename {
   Expr col_or_mapper = 1;
   Expr df = 2;
@@ -1132,7 +1135,7 @@ message DataframeRollup {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:289
+// dataframe.ir:291
 message DataframeSample {
   Expr df = 1;
   google.protobuf.Int64Value num = 2;
@@ -1141,7 +1144,7 @@ message DataframeSample {
   SrcPosition src = 5;
 }
 
-// dataframe.ir:296
+// dataframe.ir:298
 message DataframeSelect {
   ExprArgList cols = 1;
   Expr df = 2;
@@ -1156,7 +1159,7 @@ message DataframeShow {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:303
+// dataframe.ir:305
 message DataframeSort {
   Expr ascending = 1;
   ExprArgList cols = 2;
@@ -1240,7 +1243,7 @@ message DataframeToPandasBatches {
   repeated Tuple_String_String statement_params = 4;
 }
 
-// dataframe.ir:309
+// dataframe.ir:311
 message DataframeUnion {
   bool all = 1;
   bool allow_missing_columns = 2;
@@ -1250,7 +1253,7 @@ message DataframeUnion {
   SrcPosition src = 6;
 }
 
-// dataframe.ir:268
+// dataframe.ir:270
 message DataframeUnpivot {
   repeated Expr column_list = 1;
   Expr df = 2;
@@ -1260,7 +1263,7 @@ message DataframeUnpivot {
   string value_column = 6;
 }
 
-// dataframe.ir:317
+// dataframe.ir:319
 message DataframeWithColumn {
   Expr col = 1;
   string col_name = 2;
@@ -1268,7 +1271,7 @@ message DataframeWithColumn {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:323
+// dataframe.ir:325
 message DataframeWithColumnRenamed {
   Expr col = 1;
   Expr df = 2;
@@ -1276,7 +1279,7 @@ message DataframeWithColumnRenamed {
   SrcPosition src = 4;
 }
 
-// dataframe.ir:329
+// dataframe.ir:331
 message DataframeWithColumns {
   repeated string col_names = 1;
   Expr df = 2;
@@ -1629,7 +1632,7 @@ message Geq {
   SrcPosition src = 3;
 }
 
-// dataframe.ir:335
+// dataframe.ir:337
 message GroupingSets {
   ExprArgList sets = 1;
   SrcPosition src = 2;
@@ -2246,8 +2249,8 @@ message TableFnCallAlias {
 // fn.ir:151
 message TableFnCallOver {
   Expr lhs = 1;
-  repeated Expr order_by = 2;
-  repeated Expr partition_by = 3;
+  ExprArgList order_by = 2;
+  ExprArgList partition_by = 3;
   SrcPosition src = 4;
 }
 
@@ -2283,7 +2286,7 @@ message TableUpdate {
   repeated Tuple_String_String statement_params = 7;
 }
 
-// dataframe.ir:339
+// dataframe.ir:341
 message ToSnowparkPandas {
   repeated string columns = 1;
   Expr df = 2;

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -28,6 +28,7 @@ from typing import (
 import snowflake.snowpark
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 from snowflake.connector.options import installed_pandas, pandas, pyarrow
+
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,
     Cross,
@@ -116,6 +117,7 @@ from snowflake.snowpark._internal.ast.utils import (
     DATAFRAME_AST_PARAMETER,
     build_view_name,
     build_table_name,
+    build_name,
 )
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.open_telemetry import open_telemetry_context_manager
@@ -5816,6 +5818,10 @@ class DataFrame:
         with open_telemetry_context_manager(self.cache_result, self):
             from snowflake.snowpark.mock._connection import MockServerConnection
 
+        temp_table_name = self._session.get_fully_qualified_name_if_possible(
+            f'"{random_name_for_temp_object(TempObjectType.TABLE)}"'
+        )
+
         # AST.
         stmt = None
         if _emit_ast:
@@ -5825,11 +5831,12 @@ class DataFrame:
             if statement_params is not None:
                 build_expr_from_dict_str_str(expr.statement_params, statement_params)
 
-        temp_table_name = self._session.get_fully_qualified_name_if_possible(
-            f'"{random_name_for_temp_object(TempObjectType.TABLE)}"'
-        )
-
-        # TODO: Clarify whether cache_result() is an Eval or not. Currently, treat as Assign.
+            # We do not treat cache_result() (alias: cache()) as eval. Instead, in AST given it returns a
+            # Dataframe we follow a similar model to other APIs. However, this API will materialize the data before in
+            # a temporary table. We store a reference to this entity as part of the AST.
+            build_name(
+                temp_table_name, stmt.expr.dataframe_cache_result.object_name.name
+            )
 
         if isinstance(self._session._conn, MockServerConnection):
             ast_id = self._ast_id

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -461,6 +461,13 @@ body {
             }
           }
         }
+        object_name {
+          name {
+            name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_TABLE_xxx\""
+            }
+          }
+        }
         src {
           end_column: 31
           end_line: 51
@@ -487,6 +494,13 @@ body {
           dataframe_ref {
             id {
               bitfield1: 1
+            }
+          }
+        }
+        object_name {
+          name {
+            name_flat {
+              name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_TABLE_xxx\""
             }
           }
         }

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -52,23 +52,23 @@ drop6 = df.na.drop("any", 42, ["NUM"])
 
 drop7 = df.na.drop("any", [])
 
-fill1 = df.na.fill(42)
+fill1 = df.na.fill(42, include_decimal=False)
 
-fill2 = df.na.fill({"NUM": 42, "STR": "abc"})
+fill2 = df.na.fill({"NUM": 42, "STR": "abc"}, include_decimal=False)
 
-fill3 = df.na.fill(42, "NUM")
+fill3 = df.na.fill(42, "NUM", include_decimal=False)
 
-fill4 = df.na.fill("def", ["STR"])
+fill4 = df.na.fill("def", ["STR"], include_decimal=False)
 
-fill5 = df.na.fill(42, [])
+fill5 = df.na.fill(42, [], include_decimal=False)
 
-replace1 = df.na.replace({1: 10, "three": "trzy"}, None)
+replace1 = df.na.replace({1: 10, "three": "trzy"}, None, include_decimal=False)
 
-replace2 = df.na.replace([1, 2], [10, 20])
+replace2 = df.na.replace([1, 2], [10, 20], include_decimal=False)
 
-replace3 = df.na.replace(1, 10, ["NUM"])
+replace3 = df.na.replace(1, 10, ["NUM"], include_decimal=False)
 
-replace4 = df.na.replace(1, 10, [])
+replace4 = df.na.replace(1, 10, [], include_decimal=False)
 
 ## EXPECTED ENCODED AST
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1995618

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   To enable server-side execution, cache_result presents a duality as it effectively is a crossover of eval/assign. We resolve the existing TODO by treating cache_result as an expr together with an assign. Client-side optionally a temp table is created, and then stored within the expr. This will allow server-side to skip any nodes that formed lineage to the cache_result expr. Decoder changes done in monorepo/followup once decoder is refreshed to 1.29.