### PR TITLE
SNOW-1979918 snowpark python client ast mode and min ast version

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -873,6 +873,15 @@ def create_rlock(
 
 
 @unique
+class AstMode(IntEnum):
+    """
+    Describes the ast modes that instruct the client to send sql and/or dataframe AST to snowflake server.
+    """
+    SQL_ONLY = 0
+    SQL_AND_AST = 1
+    AST_ONLY = 2
+
+@unique
 class AstFlagSource(IntEnum):
     """
     Describes the source of the AST feature flag value. This is not just an annotation!

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -877,9 +877,11 @@ class AstMode(IntEnum):
     """
     Describes the ast modes that instruct the client to send sql and/or dataframe AST to snowflake server.
     """
+
     SQL_ONLY = 0
     SQL_AND_AST = 1
     AST_ONLY = 2
+
 
 @unique
 class AstFlagSource(IntEnum):

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -218,7 +218,6 @@ from snowflake.snowpark.types import (
 from snowflake.snowpark.udaf import UDAFRegistration
 from snowflake.snowpark.udf import UDFRegistration
 from snowflake.snowpark.udtf import UDTFRegistration
-from snowflake.snowpark.version import VERSION
 
 if TYPE_CHECKING:
     import modin.pandas  # pragma: no cover
@@ -680,7 +679,7 @@ class Session:
                 )
                 if not ast_supported_version:
                     _logger.warning(
-                        f"Server side dataframe support requires minimum snowpark-python client version."
+                        "Server side dataframe support requires minimum snowpark-python client version."
                     )
                     self._ast_mode = AstMode.SQL_ONLY
                     ast_enabled = False

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -140,6 +140,7 @@ from snowflake.snowpark._internal.utils import (
     set_ast_state,
     is_ast_enabled,
     AstFlagSource,
+    AstMode,
 )
 from snowflake.snowpark.async_job import AsyncJob
 from snowflake.snowpark.column import Column
@@ -217,6 +218,7 @@ from snowflake.snowpark.types import (
 from snowflake.snowpark.udaf import UDAFRegistration
 from snowflake.snowpark.udf import UDFRegistration
 from snowflake.snowpark.udtf import UDTFRegistration
+from snowflake.snowpark.version import VERSION
 
 if TYPE_CHECKING:
     import modin.pandas  # pragma: no cover
@@ -281,6 +283,13 @@ _PYTHON_SNOWPARK_ENABLE_SCOPED_TEMP_READ_ONLY_TABLE = (
 _PYTHON_SNOWPARK_DATAFRAME_JOIN_ALIAS_FIX_VERSION = (
     "PYTHON_SNOWPARK_DATAFRAME_JOIN_ALIAS_FIX_VERSION"
 )
+_PYTHON_SNOWPARK_CLIENT_AST_MODE = (
+    "PYTHON_SNOWPARK_CLIENT_AST_MODE"
+)
+_PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST = (
+    "PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST"
+)
+
 # AST encoding.
 _PYTHON_SNOWPARK_USE_AST = "PYTHON_SNOWPARK_USE_AST"
 # TODO SNOW-1677514: Add server-side flag and initialize value with it. Add telemetry support for flag.
@@ -641,9 +650,36 @@ class Session:
         self._large_query_breakdown_enabled: bool = self.is_feature_enabled_for_version(
             _PYTHON_SNOWPARK_USE_LARGE_QUERY_BREAKDOWN_OPTIMIZATION_VERSION
         )
-        ast_enabled: bool = self._conn._get_client_side_session_parameter(
-            _PYTHON_SNOWPARK_USE_AST, _PYTHON_SNOWPARK_USE_AST_DEFAULT_VALUE
+        ast_mode_value: int = self._conn._get_client_side_session_parameter(
+            _PYTHON_SNOWPARK_CLIENT_AST_MODE, None
         )
+        self._ast_mode = AstMode(ast_mode_value) if ast_mode_value is not None else None
+
+        # If PYTHON_SNOWPARK_AST_MODE is available, it has precedence over PYTHON_SNOWPARK_USE_AST.
+        if self._ast_mode is None:
+            ast_enabled: bool = self._conn._get_client_side_session_parameter(
+                _PYTHON_SNOWPARK_USE_AST, _PYTHON_SNOWPARK_USE_AST_DEFAULT_VALUE
+            )
+            self._ast_mode = AstMode.SQL_AND_AST if ast_enabled else AstMode.SQL_ONLY
+        else:
+            if self._ast_mode == AstMode.AST_ONLY:
+                _logger.warning("Snowpark python client does not support dataframe requests, reverting to SQL_AND_AST.")
+                self._ast_mode = AstMode.SQL_AND_AST
+
+            ast_enabled = (
+                self._ast_mode == AstMode.SQL_AND_AST
+            )
+
+        sp_min_version_for_ast: int = self._conn._get_client_side_session_parameter(
+            _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST, None
+        )
+        if sp_min_version_for_ast is not None and self._ast_mode != AstMode.SQL_ONLY:
+            sp_min_version = tuple(int(v) for v in sp_min_version_for_ast.split('.'))
+            if VERSION < sp_min_version:
+                _logger.warning(f"Server side dataframe support requires minimum snowpark-python client version {sp_min_version_for_ast}.")
+                self._ast_mode = AstMode.SQL_ONLY
+                ast_enabled = False
+
         set_ast_state(AstFlagSource.SERVER, ast_enabled)
         # The complexity score lower bound is set to match COMPILATION_MEMORY_LIMIT
         # in Snowflake. This is the limit where we start seeing compilation errors.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -669,9 +669,12 @@ class Session:
             ast_enabled = self._ast_mode == AstMode.SQL_AND_AST
 
         if self._ast_mode != AstMode.SQL_ONLY:
-            if self._conn._get_client_side_session_parameter(
-                _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST, None
-            ) is not None:
+            if (
+                self._conn._get_client_side_session_parameter(
+                    _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST, None
+                )
+                is not None
+            ):
                 ast_supported_version: bool = self.is_feature_enabled_for_version(
                     _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST
                 )

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -283,9 +283,7 @@ _PYTHON_SNOWPARK_ENABLE_SCOPED_TEMP_READ_ONLY_TABLE = (
 _PYTHON_SNOWPARK_DATAFRAME_JOIN_ALIAS_FIX_VERSION = (
     "PYTHON_SNOWPARK_DATAFRAME_JOIN_ALIAS_FIX_VERSION"
 )
-_PYTHON_SNOWPARK_CLIENT_AST_MODE = (
-    "PYTHON_SNOWPARK_CLIENT_AST_MODE"
-)
+_PYTHON_SNOWPARK_CLIENT_AST_MODE = "PYTHON_SNOWPARK_CLIENT_AST_MODE"
 _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST = (
     "PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST"
 )
@@ -663,20 +661,22 @@ class Session:
             self._ast_mode = AstMode.SQL_AND_AST if ast_enabled else AstMode.SQL_ONLY
         else:
             if self._ast_mode == AstMode.AST_ONLY:
-                _logger.warning("Snowpark python client does not support dataframe requests, reverting to SQL_AND_AST.")
+                _logger.warning(
+                    "Snowpark python client does not support dataframe requests, downgrading to SQL_AND_AST."
+                )
                 self._ast_mode = AstMode.SQL_AND_AST
 
-            ast_enabled = (
-                self._ast_mode == AstMode.SQL_AND_AST
-            )
+            ast_enabled = self._ast_mode == AstMode.SQL_AND_AST
 
         sp_min_version_for_ast: int = self._conn._get_client_side_session_parameter(
             _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST, None
         )
         if sp_min_version_for_ast is not None and self._ast_mode != AstMode.SQL_ONLY:
-            sp_min_version = tuple(int(v) for v in sp_min_version_for_ast.split('.'))
+            sp_min_version = tuple(int(v) for v in sp_min_version_for_ast.split("."))
             if VERSION < sp_min_version:
-                _logger.warning(f"Server side dataframe support requires minimum snowpark-python client version {sp_min_version_for_ast}.")
+                _logger.warning(
+                    f"Server side dataframe support requires minimum snowpark-python client version {sp_min_version_for_ast}."
+                )
                 self._ast_mode = AstMode.SQL_ONLY
                 ast_enabled = False
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -650,7 +650,10 @@ class Session:
         ast_mode_value: int = self._conn._get_client_side_session_parameter(
             _PYTHON_SNOWPARK_CLIENT_AST_MODE, None
         )
-        self._ast_mode = AstMode(ast_mode_value) if ast_mode_value is not None else None
+        if ast_mode_value is not None and isinstance(ast_mode_value, int):
+            self._ast_mode = AstMode(ast_mode_value)
+        else:
+            self._ast_mode = None
 
         # If PYTHON_SNOWPARK_AST_MODE is available, it has precedence over PYTHON_SNOWPARK_USE_AST.
         if self._ast_mode is None:

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
-import os
 import pytest
 
 from snowflake.snowpark.session import (

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -88,7 +88,7 @@ def test_snowpark_python_ast_mode_and_version(
     )
     assert (
         any(
-            "Server side dataframe support requires minimum snowpark-python client version "
+            "Server side dataframe support requires minimum snowpark-python client version."
             in m
             for m in caplog.messages
         )

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -4,26 +4,23 @@
 
 import os
 import pytest
-from typing import Generator
 
 from snowflake.snowpark.session import (
     AstMode,
     Session,
     _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST,
     _PYTHON_SNOWPARK_CLIENT_AST_MODE,
-    _PYTHON_SNOWPARK_USE_AST
+    _PYTHON_SNOWPARK_USE_AST,
 )
-from snowflake.snowpark._internal.server_connection import ServerConnection
 from snowflake.snowpark.version import VERSION
-from _pytest.logging import LogCaptureFixture
-from snowflake.connector import Connect, SnowflakeConnection
+from snowflake.connector import SnowflakeConnection
 
 
 @pytest.fixture(scope="module")
 def snowflake_connection() -> SnowflakeConnection:
     curr_path = os.path.abspath(__file__)
-    curr_path_parts = curr_path.split('/')
-    tests_path = '/'.join(curr_path_parts[0:(curr_path_parts.index('tests')+1)])
+    curr_path_parts = curr_path.split("/")
+    tests_path = "/".join(curr_path_parts[0 : (curr_path_parts.index("tests") + 1)])
 
     with open(f"{tests_path}/parameters.py", encoding="utf-8") as f:
         exec(f.read(), globals())
@@ -31,36 +28,69 @@ def snowflake_connection() -> SnowflakeConnection:
     return SnowflakeConnection(None, None, **globals()["CONNECTION_PARAMETERS"])
 
 
-@pytest.mark.parametrize("use_ast,ast_mode,min_ver,expected_ast_mode,expect_downgrade_log,expect_min_ver_log", [
-    # Test: None of the new client ast / version parameters are set, but PYTHON_SNOWPARK_USE_AST=false
-    (False, None, None, AstMode.SQL_ONLY, False, False),
-    # Test: None of the new client ast / version parameters are set, but PYTHON_SNOWPARK_USE_AST=true
-    (True, None, None, AstMode.SQL_AND_AST, False, False),
-    # Test: The new client ast mode parameters takes precedence over PYTHON_SNOWPARK_USE_AST value
-    (True, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
-    # Test: The new client ast mode parameters takes precedence over PYTHON_SNOWPARK_USE_AST value
-    (False, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
-    # Test: The new client ast mode SQL_ONLY is applied
-    (None, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
-    # Test: The new client ast mode SQL_AND_AST is applied
-    (None, AstMode.SQL_AND_AST, VERSION, AstMode.SQL_AND_AST, False, False),
-    # Test: AST_ONLY is downgraded to SQL_AND_AST since no support yet.
-    (None, AstMode.AST_ONLY, VERSION, AstMode.SQL_AND_AST, True, False),
-    # Test: The client ast mode SQL_ONLY is applied and ignores the min version check.
-    (None, AstMode.SQL_ONLY, (99, 0, 0), AstMode.SQL_ONLY, False, False),
-    # Test: AST_ONLY is downgraded to SQL_ONLY because not supported by client.
-    (None, AstMode.AST_ONLY, (99, 0, 0), AstMode.SQL_ONLY, True, True),
-    # Test: SQL_AND_AST is downgraded to SQL_ONLY because client version is too low.
-    (None, AstMode.SQL_AND_AST, (99, 0, 0), AstMode.SQL_ONLY, False, True),
-])
-def test_snowpark_python_ast_mode_and_version(snowflake_connection, caplog, use_ast, ast_mode, min_ver, expected_ast_mode, expect_downgrade_log, expect_min_ver_log) -> None:
-    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_USE_AST] = use_ast if use_ast is not None else None
-    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_CLIENT_AST_MODE] = int(ast_mode) if ast_mode is not None else None
-    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST] = '.'.join(str(v) for v in min_ver) if min_ver is not None else None
+@pytest.mark.parametrize(
+    "use_ast,ast_mode,min_ver,expected_ast_mode,expect_downgrade_log,expect_min_ver_log",
+    [
+        # Test: None of the new client ast / version parameters are set, but PYTHON_SNOWPARK_USE_AST=false
+        (False, None, None, AstMode.SQL_ONLY, False, False),
+        # Test: None of the new client ast / version parameters are set, but PYTHON_SNOWPARK_USE_AST=true
+        (True, None, None, AstMode.SQL_AND_AST, False, False),
+        # Test: The new client ast mode parameters takes precedence over PYTHON_SNOWPARK_USE_AST value
+        (True, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
+        # Test: The new client ast mode parameters takes precedence over PYTHON_SNOWPARK_USE_AST value
+        (False, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
+        # Test: The new client ast mode SQL_ONLY is applied
+        (None, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
+        # Test: The new client ast mode SQL_AND_AST is applied
+        (None, AstMode.SQL_AND_AST, VERSION, AstMode.SQL_AND_AST, False, False),
+        # Test: AST_ONLY is downgraded to SQL_AND_AST since no support yet.
+        (None, AstMode.AST_ONLY, VERSION, AstMode.SQL_AND_AST, True, False),
+        # Test: The client ast mode SQL_ONLY is applied and ignores the min version check.
+        (None, AstMode.SQL_ONLY, (99, 0, 0), AstMode.SQL_ONLY, False, False),
+        # Test: AST_ONLY is downgraded to SQL_ONLY because not supported by client.
+        (None, AstMode.AST_ONLY, (99, 0, 0), AstMode.SQL_ONLY, True, True),
+        # Test: SQL_AND_AST is downgraded to SQL_ONLY because client version is too low.
+        (None, AstMode.SQL_AND_AST, (99, 0, 0), AstMode.SQL_ONLY, False, True),
+    ],
+)
+def test_snowpark_python_ast_mode_and_version(
+    snowflake_connection,
+    caplog,
+    use_ast,
+    ast_mode,
+    min_ver,
+    expected_ast_mode,
+    expect_downgrade_log,
+    expect_min_ver_log,
+) -> None:
+    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_USE_AST] = (
+        use_ast if use_ast is not None else None
+    )
+    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_CLIENT_AST_MODE] = (
+        int(ast_mode) if ast_mode is not None else None
+    )
+    snowflake_connection._session_parameters[
+        _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST
+    ] = (".".join(str(v) for v in min_ver) if min_ver is not None else None)
 
-    sess = Session.SessionBuilder().configs({"connection":snowflake_connection}).create()
+    sess = (
+        Session.SessionBuilder().configs({"connection": snowflake_connection}).create()
+    )
 
     assert sess._ast_mode == expected_ast_mode
-    assert any("Snowpark python client does not support dataframe requests, reverting to SQL_AND_AST." in m for m in caplog.messages) == expect_downgrade_log
-    assert any("Server side dataframe support requires minimum snowpark-python client version " in m for m in caplog.messages) == expect_min_ver_log
-
+    assert (
+        any(
+            "Snowpark python client does not support dataframe requests, downgrading to SQL_AND_AST."
+            in m
+            for m in caplog.messages
+        )
+        == expect_downgrade_log
+    )
+    assert (
+        any(
+            "Server side dataframe support requires minimum snowpark-python client version "
+            in m
+            for m in caplog.messages
+        )
+        == expect_min_ver_log
+    )

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -20,7 +20,7 @@ from snowflake.connector import SnowflakeConnection
 def snowflake_connection() -> SnowflakeConnection:
     curr_path = os.path.abspath(__file__)
     curr_path_parts = curr_path.split("/")
-    tests_path = "/".join(curr_path_parts[0 : -2])
+    tests_path = "/".join(curr_path_parts[0:-2])
 
     with open(f"{tests_path}/parameters.py", encoding="utf-8") as f:
         exec(f.read(), globals())

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -14,18 +14,11 @@ from snowflake.snowpark.session import (
 )
 from snowflake.snowpark.version import VERSION
 from snowflake.connector import SnowflakeConnection
-
+from tests.parameters import CONNECTION_PARAMETERS
 
 @pytest.fixture(autouse=True, scope="module")
 def snowflake_connection() -> SnowflakeConnection:
-    curr_path = os.path.abspath(__file__)
-    curr_path_parts = curr_path.split("/")
-    tests_path = "/".join(curr_path_parts[0:-2])
-
-    with open(f"{tests_path}/parameters.py", encoding="utf-8") as f:
-        exec(f.read(), globals())
-
-    conn = SnowflakeConnection(None, None, **globals()["CONNECTION_PARAMETERS"])
+    conn = SnowflakeConnection(None, None, **CONNECTION_PARAMETERS)
     yield conn
     conn.close()
 

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -16,6 +16,7 @@ from snowflake.snowpark.version import VERSION
 from snowflake.connector import SnowflakeConnection
 from tests.parameters import CONNECTION_PARAMETERS
 
+
 @pytest.fixture(autouse=True, scope="module")
 def snowflake_connection() -> SnowflakeConnection:
     conn = SnowflakeConnection(None, None, **CONNECTION_PARAMETERS)

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import os
+import pytest
+from typing import Generator
+
+from snowflake.snowpark.session import (
+    AstMode,
+    Session,
+    _PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST,
+    _PYTHON_SNOWPARK_CLIENT_AST_MODE,
+    _PYTHON_SNOWPARK_USE_AST
+)
+from snowflake.snowpark._internal.server_connection import ServerConnection
+from snowflake.snowpark.version import VERSION
+from _pytest.logging import LogCaptureFixture
+from snowflake.connector import Connect, SnowflakeConnection
+
+
+@pytest.fixture(scope="module")
+def snowflake_connection() -> SnowflakeConnection:
+    curr_path = os.path.abspath(__file__)
+    curr_path_parts = curr_path.split('/')
+    tests_path = '/'.join(curr_path_parts[0:(curr_path_parts.index('tests')+1)])
+
+    with open(f"{tests_path}/parameters.py", encoding="utf-8") as f:
+        exec(f.read(), globals())
+
+    return SnowflakeConnection(None, None, **globals()["CONNECTION_PARAMETERS"])
+
+
+@pytest.mark.parametrize("use_ast,ast_mode,min_ver,expected_ast_mode,expect_downgrade_log,expect_min_ver_log", [
+    # Test: None of the new client ast / version parameters are set, but PYTHON_SNOWPARK_USE_AST=false
+    (False, None, None, AstMode.SQL_ONLY, False, False),
+    # Test: None of the new client ast / version parameters are set, but PYTHON_SNOWPARK_USE_AST=true
+    (True, None, None, AstMode.SQL_AND_AST, False, False),
+    # Test: The new client ast mode parameters takes precedence over PYTHON_SNOWPARK_USE_AST value
+    (True, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
+    # Test: The new client ast mode parameters takes precedence over PYTHON_SNOWPARK_USE_AST value
+    (False, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
+    # Test: The new client ast mode SQL_ONLY is applied
+    (None, AstMode.SQL_ONLY, VERSION, AstMode.SQL_ONLY, False, False),
+    # Test: The new client ast mode SQL_AND_AST is applied
+    (None, AstMode.SQL_AND_AST, VERSION, AstMode.SQL_AND_AST, False, False),
+    # Test: AST_ONLY is downgraded to SQL_AND_AST since no support yet.
+    (None, AstMode.AST_ONLY, VERSION, AstMode.SQL_AND_AST, True, False),
+    # Test: The client ast mode SQL_ONLY is applied and ignores the min version check.
+    (None, AstMode.SQL_ONLY, (99, 0, 0), AstMode.SQL_ONLY, False, False),
+    # Test: AST_ONLY is downgraded to SQL_ONLY because not supported by client.
+    (None, AstMode.AST_ONLY, (99, 0, 0), AstMode.SQL_ONLY, True, True),
+    # Test: SQL_AND_AST is downgraded to SQL_ONLY because client version is too low.
+    (None, AstMode.SQL_AND_AST, (99, 0, 0), AstMode.SQL_ONLY, False, True),
+])
+def test_snowpark_python_ast_mode_and_version(snowflake_connection, caplog, use_ast, ast_mode, min_ver, expected_ast_mode, expect_downgrade_log, expect_min_ver_log) -> None:
+    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_USE_AST] = use_ast if use_ast is not None else None
+    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_CLIENT_AST_MODE] = int(ast_mode) if ast_mode is not None else None
+    snowflake_connection._session_parameters[_PYTHON_SNOWPARK_CLIENT_MIN_VERSION_FOR_AST] = '.'.join(str(v) for v in min_ver) if min_ver is not None else None
+
+    sess = Session.SessionBuilder().configs({"connection":snowflake_connection}).create()
+
+    assert sess._ast_mode == expected_ast_mode
+    assert any("Snowpark python client does not support dataframe requests, reverting to SQL_AND_AST." in m for m in caplog.messages) == expect_downgrade_log
+    assert any("Server side dataframe support requires minimum snowpark-python client version " in m for m in caplog.messages) == expect_min_ver_log
+

--- a/tests/ast/test_ast_mode.py
+++ b/tests/ast/test_ast_mode.py
@@ -16,16 +16,18 @@ from snowflake.snowpark.version import VERSION
 from snowflake.connector import SnowflakeConnection
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(autouse=True, scope="module")
 def snowflake_connection() -> SnowflakeConnection:
     curr_path = os.path.abspath(__file__)
     curr_path_parts = curr_path.split("/")
-    tests_path = "/".join(curr_path_parts[0 : (curr_path_parts.index("tests") + 1)])
+    tests_path = "/".join(curr_path_parts[0 : -2])
 
     with open(f"{tests_path}/parameters.py", encoding="utf-8") as f:
         exec(f.read(), globals())
 
-    return SnowflakeConnection(None, None, **globals()["CONNECTION_PARAMETERS"])
+    conn = SnowflakeConnection(None, None, **globals()["CONNECTION_PARAMETERS"])
+    yield conn
+    conn.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/ast/test_ast_parameter.py
+++ b/tests/ast/test_ast_parameter.py
@@ -18,7 +18,7 @@ def test_parameter(use_local_testing, ast_enabled, n_batches):
     session = (
         Session.builder.configs(CONNECTION_PARAMETERS)
         .config("local_testing", use_local_testing)
-        .getOrCreate()
+        .create()
     )
     session.ast_enabled = ast_enabled
 


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1979918 snowpark python client ast mode and min ast version

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
[x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.

3. Please describe how your code solves the related issue.

There is logic in snowpark session start up that checks for the client parameters and sets internal _ast_mode and ast_enabled states.

See: https://docs.google.com/document/d/1KwWYMxITaPxxKVU9Itsj1BuBeY04KftilcpwDdlC2Jg/edit?usp=sharing