### PR TITLE
SNOW-1974954: Support relaxed pandas in to_snowpark_pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Snowpark Python API Updates
 
+#### New Features
+
+- Added Support for relaxed consistency and ordering guarantees in `Dataframe.to_snowpark_pandas` by introducing the new parameter `relaxed_ordering`.
+
 #### Improvements
 
 - Improved query generation for `Dataframe.stat.sample_by` to generate a single flat query that scales well with large `fractions` dictionary compared to older method of creating a UNION ALL subquery for each key in `fractions`. To enable this feature, set `session.conf.set("use_simplified_query_generation", True)`.
@@ -33,11 +37,11 @@
 
 - Added support for list values in `Series.str.__getitem__` (`Series.str[...]`).
 - Added support for `pd.Grouper` objects in group by operations. When `freq` is specified, the default values of the `sort`, `closed`, `label`, and `convention` arguments are supported; `origin` is supported when it is `start` or `start_day`.
+- Added support for relaxed consistency and ordering guarantees in `pd.read_snowflake` for both named data sources (e.g., tables and views) and query data sources by introducing the new parameter `relaxed_ordering`.
 
 #### Improvements
 
 - Raise a warning whenever `QUOTED_IDENTIFIERS_IGNORE_CASE` is found to be set, ask user to unset it.
-- Support relaxed consistency and ordering guarantees in `pd.read_snowflake` for both named data sources (e.g., tables and views) and query data sources.
 - Improved how a missing `index_label` in `DataFrame.to_snowflake` and `Series.to_snowflake` is handled when `index=True`. Instead of raising a `ValueError`, system-defined labels are used for the index columns.
 
 ## 1.29.1 (2025-03-12)

--- a/tests/integ/modin/test_df_to_snowpark_pandas.py
+++ b/tests/integ/modin/test_df_to_snowpark_pandas.py
@@ -10,6 +10,13 @@ import pytest
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.exceptions import SnowparkSQLException
+from snowflake.snowpark.types import (
+    DoubleType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import Utils, multithreaded_run
 
@@ -39,14 +46,22 @@ def tmp_table_basic(session):
         ["FOOT_SIZE", "SHOE_MODEL", "SHOE_MODEL"],
     ],
 )
-def test_to_snowpark_pandas_basic(session, tmp_table_basic, index_col, columns) -> None:
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
+def test_to_snowpark_pandas_basic(
+    session, tmp_table_basic, index_col, columns, relaxed_ordering
+) -> None:
+    expected_query_count = 3 if not relaxed_ordering else 1
     # One less query when we don't have a multi-index
     with SqlCounter(
-        query_count=3 if isinstance(index_col, list) and len(index_col) > 1 else 2
+        query_count=expected_query_count
+        if isinstance(index_col, list) and len(index_col) > 1
+        else expected_query_count - 1
     ):
         snowpark_df = session.table(tmp_table_basic)
 
-        snowpark_pandas_df = snowpark_df.to_snowpark_pandas(index_col, columns)
+        snowpark_pandas_df = snowpark_df.to_snowpark_pandas(
+            index_col, columns, relaxed_ordering=relaxed_ordering
+        )
 
         # verify index columns
         snowpandas_index = snowpark_pandas_df.index
@@ -74,45 +89,58 @@ def test_to_snowpark_pandas_basic(session, tmp_table_basic, index_col, columns) 
 
 
 @multithreaded_run()
-@sql_count_checker(query_count=3)
-def test_to_snowpark_pandas_from_views(session, tmp_table_basic) -> None:
-    snowpark_df = session.sql(
-        f"SELECT ID, SHOE_MODEL FROM {tmp_table_basic} WHERE ID > 1"
-    )
-    snowpark_pandas_df = snowpark_df.to_snowpark_pandas()
-
-    # verify all columns are data columns
-    assert snowpark_pandas_df.columns.tolist() == ["ID", "SHOE_MODEL"]
-    # verify a default row_position column is created
-    snowpandas_index = snowpark_pandas_df.index
-    assert snowpandas_index.dtype == np.dtype("int64")
-    assert sorted(snowpandas_index.values.tolist()) == [0, 1]
-
-
-@sql_count_checker(query_count=3)
-def test_to_snowpark_pandas_with_operations(session, tmp_table_basic) -> None:
-    snowpark_df = session.table(tmp_table_basic)
-    snowpark_df = (
-        snowpark_df.select(
-            Column("ID"),
-            Column("FOOT_SIZE").as_('"size"'),
-            Column("SHOE_MODEL").as_('"model"'),
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
+def test_to_snowpark_pandas_from_views(
+    session, tmp_table_basic, relaxed_ordering
+) -> None:
+    with SqlCounter(query_count=3 if not relaxed_ordering else 1):
+        snowpark_df = session.sql(
+            f"SELECT ID, SHOE_MODEL FROM {tmp_table_basic} WHERE ID > 1"
         )
-        .where(Column("ID") > 2)
-        .select(Column('"size"'), Column('"model"'))
-    )
+        snowpark_pandas_df = snowpark_df.to_snowpark_pandas(
+            relaxed_ordering=relaxed_ordering
+        )
 
-    snowpark_pandas_df = snowpark_df.to_snowpark_pandas()
-    # verify all columns are data columns
-    assert snowpark_pandas_df.columns.tolist() == ["size", "model"]
-    # verify a default row_position column is created
-    snowpandas_index = snowpark_pandas_df.index
-    assert snowpandas_index.dtype == np.dtype("int64")
-    assert sorted(snowpandas_index.values.tolist()) == [0]
+        # verify all columns are data columns
+        assert snowpark_pandas_df.columns.tolist() == ["ID", "SHOE_MODEL"]
+        # verify a default row_position column is created
+        snowpandas_index = snowpark_pandas_df.index
+        assert snowpandas_index.dtype == np.dtype("int64")
+        assert sorted(snowpandas_index.values.tolist()) == [0, 1]
 
 
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
+def test_to_snowpark_pandas_with_operations(
+    session, tmp_table_basic, relaxed_ordering
+) -> None:
+    with SqlCounter(query_count=3 if not relaxed_ordering else 1):
+        snowpark_df = session.table(tmp_table_basic)
+        snowpark_df = (
+            snowpark_df.select(
+                Column("ID"),
+                Column("FOOT_SIZE").as_('"size"'),
+                Column("SHOE_MODEL").as_('"model"'),
+            )
+            .where(Column("ID") > 2)
+            .select(Column('"size"'), Column('"model"'))
+        )
+
+        snowpark_pandas_df = snowpark_df.to_snowpark_pandas(
+            relaxed_ordering=relaxed_ordering
+        )
+        # verify all columns are data columns
+        assert snowpark_pandas_df.columns.tolist() == ["size", "model"]
+        # verify a default row_position column is created
+        snowpandas_index = snowpark_pandas_df.index
+        assert snowpandas_index.dtype == np.dtype("int64")
+        assert sorted(snowpandas_index.values.tolist()) == [0]
+
+
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
 @sql_count_checker(query_count=0)
-def test_to_snowpark_pandas_duplicated_columns_raises(session, tmp_table_basic) -> None:
+def test_to_snowpark_pandas_duplicated_columns_raises(
+    session, tmp_table_basic, relaxed_ordering
+) -> None:
     snowpark_df = session.table(tmp_table_basic)
     snowpark_df = snowpark_df.select(
         Column("ID"),
@@ -120,13 +148,45 @@ def test_to_snowpark_pandas_duplicated_columns_raises(session, tmp_table_basic) 
         Column("SHOE_MODEL").as_('"shoe"'),
     )
 
-    with pytest.raises(SnowparkSQLException, match="duplicate column name 'shoe'"):
-        snowpark_df.to_snowpark_pandas()
+    pattern = (
+        "duplicate column name 'shoe'"
+        if not relaxed_ordering
+        else "ambiguous column name 'shoe'"
+    )
+
+    with pytest.raises(SnowparkSQLException, match=pattern):
+        snowpark_df.to_snowpark_pandas(relaxed_ordering=relaxed_ordering).head()
 
 
-@sql_count_checker(query_count=1)
-def test_to_snowpark_pandas_columns_not_list_raises(session, tmp_table_basic) -> None:
-    snowpark_df = session.table(tmp_table_basic)
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
+def test_to_snowpark_pandas_columns_not_list_raises(
+    session, tmp_table_basic, relaxed_ordering
+) -> None:
+    with SqlCounter(query_count=1 if not relaxed_ordering else 0):
+        snowpark_df = session.table(tmp_table_basic)
 
-    with pytest.raises(ValueError, match="columns must be provided as list"):
-        snowpark_df.to_snowpark_pandas(columns="FOOT_SIZE")
+        with pytest.raises(ValueError, match="columns must be provided as list"):
+            snowpark_df.to_snowpark_pandas(
+                columns="FOOT_SIZE", relaxed_ordering=relaxed_ordering
+            )
+
+
+@sql_count_checker(query_count=0)
+def test_to_snowpark_pandas_with_multiple_queries_and_relaxed_ordering_raises(session):
+    tmp_stage_name = Utils.random_stage_name()
+    test_file_on_stage = f"@{tmp_stage_name}/testCSV.csv"
+    user_schema = StructType(
+        [
+            StructField("a", IntegerType()),
+            StructField("b", StringType()),
+            StructField("c", DoubleType()),
+        ]
+    )
+    snowpark_df = (
+        session.read.option("purge", False).schema(user_schema).csv(test_file_on_stage)
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="dataframe includes DDL or DML operations",
+    ):
+        snowpark_df.to_snowpark_pandas(relaxed_ordering=True)

--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -37,7 +37,8 @@ def tmp_table_basic(session):
         Utils.drop_table(session, table_name)
 
 
-def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
+def test_to_snowpark_pandas_no_modin(session, tmp_table_basic, relaxed_ordering):
     snowpark_df = session.table(tmp_table_basic)
     # Check if modin is installed (if so, we're running in Snowpark pandas; if not, we're just in Snowpark Python)
     try:
@@ -56,6 +57,8 @@ def test_to_snowpark_pandas_no_modin(session, tmp_table_basic):
                 match="Modin is not installed.",
             )
         with ctx:
-            snowpark_df.to_snowpark_pandas()
+            snowpark_df.to_snowpark_pandas(relaxed_ordering=relaxed_ordering)
     else:
-        snowpark_df.to_snowpark_pandas()  # should have no errors
+        snowpark_df.to_snowpark_pandas(
+            relaxed_ordering=relaxed_ordering
+        )  # should have no errors


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1974954

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Support relaxed pandas in to_snowpark_pandas.
