### PR TITLE
SNOW-2004982: Fix test_read_snowflake_call_sproc_relaxed_ordering_neg when sql simplifier is disabled

### DIFF
--- a/tests/integ/modin/io/test_read_snowflake_query_call.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_call.py
@@ -79,7 +79,11 @@ def filter_by_role(session, table_name, role):
     return df.filter(col('role') == role)
                 $$"""
     ).collect()
+    sql_simplifier_enabled_original = session.sql_simplifier_enabled
+
     try:
+        # Error is raised only when SQL simplifier is enabled.
+        session.sql_simplifier_enabled = True
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.sql(
             f"""CREATE OR REPLACE TEMPORARY TABLE {table_name}(id NUMBER, name VARCHAR, role VARCHAR) AS SELECT * FROM VALUES(1, 'Alice', 'op'), (2, 'Bob', 'dev')"""
@@ -93,6 +97,7 @@ def filter_by_role(session, table_name, role):
                 relaxed_ordering=True,
             ).head()
     finally:
+        session.sql_simplifier_enabled = sql_simplifier_enabled_original
         session.sql("DROP PROCEDURE filter_by_role(VARCHAR, VARCHAR)").collect()
 
 


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2004982

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Fix test_read_snowflake_call_sproc_relaxed_ordering_neg when sql simplifier is disabled.
