### PR TITLE
SNOW-2005126: Skip telemetry call count tests if sql simplifier disabled

### DIFF
--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -563,6 +563,10 @@ def test_telemetry_repr():
     ]
 
 
+@pytest.mark.skipif(
+    "config.getoption('disable_sql_simplifier', default=False)",
+    reason="SNOW-1893699: Test failing on github with sql simplifier disabled.",
+)
 @sql_count_checker(query_count=6, join_count=4)
 def test_telemetry_interchange_call_count():
     s = pd.DataFrame([1, 2, 3, 4])
@@ -604,11 +608,11 @@ def test_telemetry_interchange_call_count():
     assert telemetry_data[5]["call_count"] == 2
 
 
+@pytest.mark.skipif(
+    "config.getoption('disable_sql_simplifier', default=False)",
+    reason="SNOW-1893699: Test failing on github with sql simplifier disabled.",
+)
 def test_telemetry_func_call_count(session):
-    # TODO (SNOW-1893699): test failing on github with sql simplifier disabled.
-    #   Turn this back on once fixed.
-    if session.sql_simplifier_enabled is False:
-        return
 
     with SqlCounter(query_count=4):
         s = pd.DataFrame([1, 2, np.nan, 4])
@@ -643,6 +647,10 @@ def test_telemetry_func_call_count(session):
         assert telemetry_data[-1]["call_count"] == 1
 
 
+@pytest.mark.skipif(
+    "config.getoption('disable_sql_simplifier', default=False)",
+    reason="SNOW-1893699: Test failing on github with sql simplifier disabled.",
+)
 @sql_count_checker(query_count=3)
 def test_telemetry_multiple_func_call_count():
     s = pd.DataFrame([1, 2, np.nan, 4])
@@ -672,6 +680,8 @@ def test_telemetry_multiple_func_call_count():
         and _get_data(call)["func_name"] == "DataFrame.__dataframe__"
     ]
 
+    assert len(repr_telemetry_data) == 2
+    assert len(dataframe_telemetry_data) == 1
     # last call from telemetry data
     # s called __repr__() 2 times.
     assert repr_telemetry_data[-1]["call_count"] == 2


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2005126

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

Skips telemetry call count tests if sql simplifier is disabled. This is for fixing the preprod/QA jenkins tests.
