### PR TITLE
SNOW-2006135 : Remove preview warning for lineage.trace API

### DIFF
--- a/src/snowflake/snowpark/lineage.py
+++ b/src/snowflake/snowpark/lineage.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import snowflake.snowpark
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
-from snowflake.snowpark._internal.utils import private_preview
 from snowflake.snowpark.types import (
     IntegerType,
     StringType,
@@ -569,7 +568,6 @@ class Lineage:
             if not re.match(r'^"[^"]*"$|\w+', part):
                 raise ValueError(f"Invalid object name: {object_name}")
 
-    @private_preview(version="1.16.0")
     def trace(
         self,
         object_name: str,


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

Remove preview warning for lineage.trace API since its GA. 

   Fixes SNOW-2006135

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
