### PR TITLE
SNOW-2009895: fix client regression job not to pin to python 3.8

### DIFF
--- a/scripts/tox_install_cmd.sh
+++ b/scripts/tox_install_cmd.sh
@@ -15,6 +15,7 @@ echo "${pip_options[*]}"
 
 # Default to empty, to ensure snowflake_path variable is defined.
 snowflake_path=${snowflake_path:-""}
+python_version=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
 
 if [[ -z "${snowflake_path}" ]]; then
   echo "Using Python Connector from PyPI"
@@ -23,6 +24,6 @@ else
   echo "Installing locally built Python Connector"
   echo "Python Connector path: ${snowflake_path}"
   ls -al ${snowflake_path}
-  python -m pip install ${snowflake_path}/snowflake_connector_python*cp38*.whl
+  python -m pip install ${snowflake_path}/snowflake_connector_python*${python_version}*.whl
   python -m pip install -U ${pip_options[@]}
 fi


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

the script should be dynamic instead of pinning to 3.8 which will be deprecated soon
