### PR TITLE
SNOW-2014383: Add pandas tag to eager queries to account for their credit usage

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -1758,7 +1758,7 @@ def groupby_apply_sort_method(
         sp_func.builtin("boolor_agg")(
             SnowparkColumn(original_row_position_quoted_identifier) == -1
         ).as_("is_transform")
-    ).collect()[0][0]
+    ).collect(statement_params=get_default_snowpark_pandas_statement_params())[0][0]
     return (
         GroupbyApplySortMethod.ORIGINAL_ROW_ORDER
         if is_transform

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -47,6 +47,7 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     extract_pandas_label_from_snowflake_quoted_identifier,
     fill_missing_levels_for_pandas_label,
     from_pandas_label,
+    get_default_snowpark_pandas_statement_params,
     get_distinct_rows,
     is_valid_snowflake_quoted_identifier,
     snowpark_to_pandas_helper,
@@ -761,7 +762,13 @@ class InternalFrame:
                 return self.ordered_dataframe._dataframe_ref.snowpark_dataframe.select(
                     (count_distinct(index_col) + iff(max_(index_col.is_null()), 1, 0))
                     == count("*")
-                ).collect()[0][0]
+                ).collect(
+                    statement_params=get_default_snowpark_pandas_statement_params()
+                )[
+                    0
+                ][
+                    0
+                ]
             else:
                 # Note: We can't use 'count_distinct' directly on columns because it
                 # ignores null values. As a workaround we first create an ARRAY and
@@ -771,7 +778,13 @@ class InternalFrame:
                         array_construct(*self.index_column_snowflake_quoted_identifiers)
                     )
                     == count("*"),
-                ).collect()[0][0]
+                ).collect(
+                    statement_params=get_default_snowpark_pandas_statement_params()
+                )[
+                    0
+                ][
+                    0
+                ]
 
     def validate_no_duplicated_data_columns_mapped_for_labels(
         self,

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -57,6 +57,7 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     ROW_COUNT_COLUMN_LABEL,
     ROW_POSITION_COLUMN_LABEL,
     append_columns,
+    get_default_snowpark_pandas_statement_params,
     pandas_lit,
     rindex,
 )
@@ -134,7 +135,9 @@ def get_valid_index_values(
     # Since first_valid_index and last_valid_index return a Scalar, we are always going to eagerly compute
     if first_or_last is ValidIndex.FIRST:
         valid_index_values = (
-            ordered_dataframe.select(index_quoted_identifier).limit(1).collect()
+            ordered_dataframe.select(index_quoted_identifier)
+            .limit(1)
+            .collect(statement_params=get_default_snowpark_pandas_statement_params())
         )
     else:
         assert first_or_last is ValidIndex.LAST, "first_or_last is not ValidIndex.LAST"
@@ -144,7 +147,7 @@ def get_valid_index_values(
             )
             .select(index_quoted_identifier)
             .limit(1)
-            .collect()
+            .collect(statement_params=get_default_snowpark_pandas_statement_params())
         )
 
     # If no valid indices, return None

--- a/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/resample_utils.py
@@ -30,7 +30,10 @@ from snowflake.snowpark.modin.plugin._internal.join_utils import (
     MatchComparator,
     join,
 )
-from snowflake.snowpark.modin.plugin._internal.utils import pandas_lit
+from snowflake.snowpark.modin.plugin._internal.utils import (
+    get_default_snowpark_pandas_statement_params,
+    pandas_lit,
+)
 from snowflake.snowpark.modin.plugin.utils.error_message import ErrorMessage
 from snowflake.snowpark.types import DateType, TimestampType
 
@@ -396,7 +399,7 @@ def compute_resample_start_and_end_date(
             date_trunc(slice_unit, max_(datetime_index_col_identifier)).as_(
                 min_max_index_column_quoted_identifier[1]
             ),
-        ).collect()[0]
+        ).collect(statement_params=get_default_snowpark_pandas_statement_params())[0]
         if origin_is_start_day:
             # If this resample was called with origin=start_day, then manually compute the correct
             # bins that are an integer multiple of the slice width starting from midnight of the
@@ -449,7 +452,7 @@ def compute_resample_start_and_end_date(
                 ),
                 slice_unit,
             ).as_(min_max_index_column_quoted_identifier[1]),
-        ).collect()[0]
+        ).collect(statement_params=get_default_snowpark_pandas_statement_params())[0]
     return start_date, end_date
 
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/session.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/session.py
@@ -11,6 +11,9 @@ import warnings
 # that we can mock get_active_session
 import snowflake.snowpark.context
 from snowflake.snowpark.exceptions import SnowparkSessionException
+from snowflake.snowpark.modin.plugin._internal.utils import (
+    get_default_snowpark_pandas_statement_params,
+)
 from snowflake.snowpark.session import Session, _active_sessions
 
 
@@ -50,7 +53,10 @@ class SnowpandasSessionHolder(ModuleType):
                     "SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE' IN SESSION",
                     _emit_ast=False,
                 )
-                .collect(_emit_ast=False)[0]
+                .collect(
+                    statement_params=get_default_snowpark_pandas_statement_params(),
+                    _emit_ast=False,
+                )[0]
                 .value
             )
             if quoted_identifiers_ignore_case.lower() == "true":

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -7409,7 +7409,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                         .filter(col("count") > 1)
                         .limit(limit)
                         .select(snowflake_ids)
-                        .collect()
+                        .collect(
+                            statement_params=get_default_snowpark_pandas_statement_params()
+                        )
                     )
                     overlap = []
                     for row in rows:
@@ -17128,7 +17130,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 max_(
                     col(split_counts_frame.data_column_snowflake_quoted_identifiers[-1])
                 ).as_("max_count")
-            ).collect()
+            ).collect(statement_params=get_default_snowpark_pandas_statement_params())
 
             return max_count_rows[0][0]
 
@@ -17513,7 +17515,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         first_two_rows = (
             frame.ordered_dataframe.select(quantile_column_snowlake_identifier)
             .limit(2)
-            .collect()
+            .collect(statement_params=get_default_snowpark_pandas_statement_params())
         )
         # Array is returned as serialied json. Create list from serialized string.
         quantiles = json.loads(first_two_rows[0][0])
@@ -18838,7 +18840,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         }
 
         try:
-            rows = join_result.result_frame.ordered_dataframe.agg(agg_exprs).collect()
+            rows = join_result.result_frame.ordered_dataframe.agg(agg_exprs).collect(
+                statement_params=get_default_snowpark_pandas_statement_params()
+            )
         except SnowparkSQLException:
             return False
         # In case of empty table/dataframe booland_agg returns None. Add special case
@@ -20026,7 +20030,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         [min_val, max_val] = self._modin_frame.ordered_dataframe.agg(
             min_(hist_col).as_("min_value"),
             max_(hist_col).as_("max_value"),
-        ).collect()[0]
+        ).collect(statement_params=get_default_snowpark_pandas_statement_params())[0]
 
         bin_size = (max_val - min_val) / bins
 


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2014383

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add pandas tag to eager queries to account for their credit usage.
