### PR TITLE
SNOW-1926348: Re-implement groupby-apply without pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 - Deprecated support for Python3.8.
 
+### Snowpark pandas API Updates
+
+#### Improvements
+
+- Improve performance of `DataFrame.groupby.apply` and `Series.groupby.apply` by avoiding expensive pivot step.
+
 ## 1.30.0 (2024-03-27)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -2076,10 +2076,10 @@ def create_internal_frame_for_groupby_apply_no_pivot_result(
     min_row_position_id = output_cols[0][1]
     # 2. Original row position or row position within group.
     row_position_id = output_cols[1][1]
-    # 4. index columns (will always include by columns)
+    # 3. index columns (will always include by columns)
     index_cols = output_cols[2 : 2 + num_index_cols]
     by_ids = [output_col[1] for output_col in output_cols[2 : 2 + num_by]]
-    # 5. data columns
+    # 4. data columns
     data_cols = output_cols[2 + num_index_cols :]
 
     # df.groupby(group_keys=False).apply(transform_func) is equivalent to

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -2055,7 +2055,7 @@ def create_internal_frame_for_groupby_apply_no_pivot_result(
     sort: bool,
 ) -> InternalFrame:
     """
-    Create Interframe for groupy apply no pivot output.
+    Create InternalFrame for groupy apply no pivot output.
     Args:
         input_frame: Input internal frame.
         ordered_dataframe: Output ordered dataframe from groupby apply udtf.

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -2061,7 +2061,7 @@ def create_internal_frame_for_groupby_apply_no_pivot_result(
         ordered_dataframe: Output ordered dataframe from groupby apply udtf.
         output_schema: Inferred output schema for groupby apply.
         num_by: Number of by columns.
-        is_transform: Weather this is groupy.transform or not.
+        is_transform: Whether this is groupy.transform or not.
         group_keys: The `group_keys` argument to groupby()
         as_index: The `as_index` argument to groupby()
         sort: The `sort` argument to groupby()

--- a/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/apply_utils.py
@@ -4,6 +4,7 @@
 
 import inspect
 import json
+import logging
 import sys
 from collections import namedtuple
 from collections.abc import Hashable
@@ -38,7 +39,9 @@ from snowflake.snowpark.modin.plugin._internal.ordered_dataframe import (
     OrderingColumn,
 )
 from snowflake.snowpark.modin.plugin._internal.utils import (
+    INDEX_LABEL,
     TempObjectType,
+    append_columns,
     generate_snowflake_quoted_identifiers_helper,
     get_default_snowpark_pandas_statement_params,
     parse_object_construct_snowflake_quoted_identifier_and_extract_pandas_label,
@@ -69,6 +72,8 @@ from snowflake.snowpark.types import (
 from snowflake.snowpark.udf import UserDefinedFunction
 from snowflake.snowpark.udtf import UserDefinedTableFunction
 from snowflake.snowpark.window import Window
+
+_logger = logging.getLogger(__name__)
 
 APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER = '"LABEL"'
 APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER = '"VALUE"'
@@ -143,6 +148,48 @@ class GroupbyApplySortMethod(Enum):
     # result for each group. this is like "sort=false" for groupby
     # aggregations.
     GROUP_KEY_APPEARANCE_ORDER = auto()
+
+
+class GroupbyApplyFuncType(Enum):
+    """
+    The type of function that is being applied to each group in a groupby apply.
+    """
+
+    AGGREGATE = auto()
+    TRANSFORM = auto()
+    OTHER = auto()  # If apply function is neither aggregate nor transform.
+
+
+class GroupbyApplyOutputSchema:
+    """
+    Class to hold the inferred output schema of a groupby apply function.
+    """
+
+    def __init__(self) -> None:
+        # List of pandas labels (includes index columns).
+        self.column_labels: list[Hashable] = []
+        # List of snowflake column types (includes index columns).
+        self.column_types: list[DataType] = []
+        # List of snowflake quoted identifiers (includes index columns).
+        self.column_ids: list[str] = []
+        # Number of index columns.
+        self.num_index_columns = 0
+        # Type of function passed to groupby apply.
+        self.func_type = GroupbyApplyFuncType.OTHER
+        # Column index names.
+        self.column_index_names: list[Hashable] = []
+
+    def add_column(self, label: Hashable, column_type: DataType) -> None:
+        """
+        Add a column to the schema.
+        Args:
+            label: The label of the column.
+            column_type: The Snowflake type of the column.
+        Returns:
+
+        """
+        self.column_labels.append(label)
+        self.column_types.append(column_type)
 
 
 def check_return_variant_and_get_return_type(func: Callable) -> tuple[bool, DataType]:
@@ -324,8 +371,7 @@ def create_udtf_for_apply_axis_1(
 def convert_groupby_apply_dataframe_result_to_standard_schema(
     func_output_df: native_pd.DataFrame,
     input_row_positions: native_pd.Series,
-    include_index_columns: bool,
-    is_transform: bool,
+    func_type: GroupbyApplyFuncType,
 ) -> native_pd.DataFrame:  # pragma: no cover: this function runs inside a UDTF, so coverage tools can't detect that we are testing it.
     """
     Take the result of applying the user-provided function to a dataframe, and convert it to a dataframe with known schema that we can output from a vUDTF.
@@ -336,9 +382,7 @@ def convert_groupby_apply_dataframe_result_to_standard_schema(
         func_output_df: The output of `func`.
         input_row_positions: The original row positions of the rows that
                              func_input_df came from.
-        include_index_columns: Whether to include the result's index columns in
-                               the output.
-        is_transform: Whether the function is a transform or not.
+        func_type: Type of function passed to groupby apply.
 
     Returns:
         A 5-column dataframe that represents the function result per the
@@ -347,8 +391,14 @@ def convert_groupby_apply_dataframe_result_to_standard_schema(
     """
     result_rows = []
     result_index_names = func_output_df.index.names
+    # We don't need to include index columns if func_type is aggregate.
+    include_index_columns = func_type != GroupbyApplyFuncType.AGGREGATE
     for row_number, (index_label, row) in enumerate(func_output_df.iterrows()):
-        output_row_number = input_row_positions.iloc[row_number] if is_transform else -1
+        output_row_number = (
+            input_row_positions.iloc[row_number]
+            if func_type == GroupbyApplyFuncType.TRANSFORM
+            else -1
+        )
         if include_index_columns:
             if isinstance(index_label, tuple):
                 for k, v in enumerate(index_label):
@@ -460,7 +510,7 @@ def apply_groupby_func_to_df(
     args: tuple,
     kwargs: dict,
     force_list_like_to_series: bool = False,
-) -> Tuple[native_pd.Series, native_pd.DataFrame, bool, bool]:  # pragma: no cover
+) -> Tuple[native_pd.DataFrame, native_pd.Series, GroupbyApplyFuncType, Tuple]:
     """
     Restore input dataframe received in udtf to original schema.
     Args:
@@ -476,10 +526,10 @@ def apply_groupby_func_to_df(
 
     Returns:
         A Tuple of
-         1. rows positions
-         2. Result of applying the function to input dataframe.
-         3. Whether final result should include index columns.
-         4. Whether the index of the result is the same as the index of the input.
+         1. Result of applying the function to input dataframe.
+         2. rows positions
+         3. Function type (aggregate, transform, or other).
+         4. The group label.
     """
     # The first column is row position. Save it for later.
     col_offset = 0
@@ -491,22 +541,11 @@ def apply_groupby_func_to_df(
     # group label from the first row.
     group_label = tuple(df.iloc[0, col_offset : col_offset + num_by])
     col_offset = col_offset + num_by
-    if len(group_label) == 1:
-        group_label = group_label[0]
 
     df = df.iloc[:, col_offset:]
-    # Snowflake names the original columns "ARG1", "ARG2", ... "ARGN".
-    # the columns after the by columns are the index columns.
-    df.set_index(
-        [
-            f"ARG{i}"
-            for i in range(
-                1 + col_offset,
-                1 + col_offset + len(index_column_names),
-            )
-        ],
-        inplace=True,
-    )
+    # The columns after the by columns are the index columns. Set index and also rename
+    # them to the original index names.
+    df = df.set_index(df.columns.to_list()[: len(index_column_names)])
     df.index.names = index_column_names
     if series_groupby:
         # For SeriesGroupBy, there should be only one data column.
@@ -514,7 +553,8 @@ def apply_groupby_func_to_df(
         assert (
             num_columns == 1
         ), f"Internal error: SeriesGroupBy func should apply to series, but input data had {num_columns} columns."
-        input_object = df.iloc[:, 0].rename(group_label)
+        series_name = group_label[0] if len(group_label) == 1 else group_label
+        input_object = df.iloc[:, 0].rename(series_name)
     else:
         input_object = df.set_axis(data_column_index, axis="columns")
     # Use infer_objects() because integer columns come as floats
@@ -533,10 +573,13 @@ def apply_groupby_func_to_df(
             func_result = native_pd.Series(func_result)
             if len(func_result) == len(df.index):
                 func_result.index = df.index
+    func_type = GroupbyApplyFuncType.OTHER
     if isinstance(func_result, native_pd.Series):
         if series_groupby:
             func_result_as_frame = func_result.to_frame()
             func_result_as_frame.columns = [MODIN_UNNAMED_SERIES_LABEL]
+            if input_object.index.equals(func_result_as_frame.index):
+                func_type = GroupbyApplyFuncType.TRANSFORM
         else:
             # If function returns series, we have to transpose the series
             # and change its metadata a little bit, but after that we can
@@ -560,41 +603,35 @@ def apply_groupby_func_to_df(
             func_result_as_frame = func_result.to_frame().T
             if func_result_as_frame.columns.nlevels == 1:
                 func_result_as_frame.columns.name = name
-        # For DataFrameGroupBy, we don't need to include any
-        # information about the index of `func_result_as_frame`.
-        # The series only has one index, and that index becomes the
-        # columns of `func_result_as_frame`. For SeriesGroupBy, we
-        # do include the result's index in the result.
-        include_index_columns = series_groupby
-        is_transform = input_object.index.equals(func_result_as_frame.index)
+            # For DataFrameGroupBy, if func returns a series, we should treat it as an
+            # aggregate.
+            func_type = GroupbyApplyFuncType.AGGREGATE
+
     elif isinstance(func_result, native_pd.DataFrame):
-        include_index_columns = True
         func_result_as_frame = func_result
-        is_transform = input_object.index.equals(func_result_as_frame.index)
+        if input_object.index.equals(func_result_as_frame.index):
+            func_type = GroupbyApplyFuncType.TRANSFORM
     else:
         # At this point, we know the function result was not a DataFrame
         # or Series
-        include_index_columns = False
         func_result_as_frame = native_pd.DataFrame(
             {MODIN_UNNAMED_SERIES_LABEL: [func_result]}
         )
-        is_transform = False
-    return row_positions, func_result_as_frame, include_index_columns, is_transform
+        func_type = GroupbyApplyFuncType.AGGREGATE
+    return func_result_as_frame, row_positions, func_type, group_label
 
 
-def create_udtf_for_groupby_transform(
+def create_udtf_for_groupby_no_pivot(
     func: Callable,
     args: tuple,
     kwargs: dict,
     data_column_index: native_pd.Index,
     index_column_names: list,
-    input_data_column_types: list[DataType],
-    input_index_column_types: list[DataType],
+    input_column_types: list[DataType],
     session: Session,
     series_groupby: bool,
-    by_types: list[DataType],
     by_labels: list[Hashable],
-    existing_identifiers: list[str],
+    output_schema: GroupbyApplyOutputSchema,
     force_list_like_to_series: bool = False,
 ) -> UserDefinedTableFunction:
     """
@@ -620,13 +657,11 @@ def create_udtf_for_groupby_transform(
     kwargs: Function's keyword arguments
     data_column_index: Column labels for the input dataframe
     index_column_names: Names of the input dataframe's index
-    input_data_column_types: Types of the input dataframe's data columns
-    input_index_column_types: Types of the input dataframe's index columns
+    input_column_types: List of types for input frame passed to UDTF.
     session: the current session
     series_groupby: Whether we are performing a SeriesGroupBy.apply() instead of DataFrameGroupBy.apply()
-    by_labels: The pandas lables of the by columns.
-    by_types: The snowflake types of the by columns.
-    existing_identifiers: List of existing column identifiers; these are omitted when creating new column identifiers.
+    by_labels: The pandas labels of the by columns.
+    output_schema: Output schema for the UDTF.
     force_list_like_to_series: Force the function result to series if it is list-like
 
     Returns
@@ -634,15 +669,6 @@ def create_udtf_for_groupby_transform(
     A UDTF that will apply the provided function to a group and return a
     dataframe representing all the data and metadata of the result.
     """
-
-    # Get the length of this list outside the vUDTF function because the vUDTF
-    # doesn't have access to the Snowpark module, which defines these types.
-    num_by = len(by_types)
-    from snowflake.snowpark.modin.plugin.extensions.utils import (
-        try_convert_index_to_native,
-    )
-
-    data_column_index = try_convert_index_to_native(data_column_index)
 
     class ApplyFunc:
         def end_partition(self, df: native_pd.DataFrame):  # type: ignore[no-untyped-def] # pragma: no cover: adding type hint causes an error when creating udtf. also, skip coverage for this function because coverage tools can't tell that we're executing this function because we execute it in a UDTF.
@@ -658,9 +684,14 @@ def create_udtf_for_groupby_transform(
             A dataframe representing the result of applying the user-provided
             function to this group.
             """
-            row_positions, func_result, _, _ = apply_groupby_func_to_df(
+            (
+                func_result,
+                row_positions,
+                func_type,
+                group_label,
+            ) = apply_groupby_func_to_df(
                 df,
-                num_by,
+                len(by_labels),
                 index_column_names,
                 series_groupby,
                 data_column_index,
@@ -669,47 +700,37 @@ def create_udtf_for_groupby_transform(
                 kwargs,
                 force_list_like_to_series,
             )
+            # 'min_row_position' is used to sort partitions and 'row_positions' is used
+            # to sort rows within a partition.
+            min_row_position = row_positions.iloc[0]
+            if func_type == GroupbyApplyFuncType.AGGREGATE:
+                row_positions = -1
+            elif func_type == GroupbyApplyFuncType.OTHER:
+                func_result.reset_index(inplace=True, drop=False)
+                row_positions = list(range(0, len(func_result)))
             func_result = func_result.applymap(
                 lambda x: handle_missing_value_in_variant(
                     convert_numpy_int_result_to_int(x)
                 )
             ).astype("object")
-            func_result.reset_index(inplace=True, drop=False)
+            if func_type == GroupbyApplyFuncType.TRANSFORM:
+                func_result.reset_index(inplace=True, drop=False)
+
+            # Add by columns.
+            for i, value in enumerate(group_label):
+                func_result.insert(i, f"group_label_{i}", value, allow_duplicates=True)
+            # Add row position columns.
             func_result.insert(0, "__row_position__", row_positions)
+            func_result.insert(0, "__min_row_position__", min_row_position)
             return func_result
 
-    input_types = [
-        # first input column is the integer row number. the row number integer
-        # becomes a float inside the UDTF due to SNOW-1184587
-        LongType(),
-        # the next columns are the by columns...
-        *by_types,
-        # then the index columns for the input dataframe or series...
-        *input_index_column_types,
-        # ...then the data columns for the input dataframe or series.
-        *input_data_column_types,
-    ]
-
-    output_col_labels = ["__row_position__", *index_column_names] + [
-        col for col in data_column_index if col not in by_labels
-    ]
-
-    output_col_types = [LongType(), *input_index_column_types] + [VariantType()] * (
-        len(data_column_index) - len(by_types)
-    )
-
-    # Generate new column identifiers for all required UDTF columns with the helper
-    # below to prevent collisions in column identifiers.
-    output_col_ids = generate_snowflake_quoted_identifiers_helper(
-        pandas_labels=output_col_labels,
-        excluded=existing_identifiers,
-        wrap_double_underscore=False,
-    )
     try:
         return sp_func.udtf(
             ApplyFunc,
-            output_schema=PandasDataFrameType(output_col_types, output_col_ids),
-            input_types=[PandasDataFrameType(col_types=input_types)],
+            output_schema=PandasDataFrameType(
+                output_schema.column_types, output_schema.column_ids
+            ),
+            input_types=[PandasDataFrameType(col_types=input_column_types)],
             # We have to specify the local pandas package so that the UDF's pandas
             # behavior is consistent with client-side pandas behavior.
             packages=[native_pd] + list(session.get_packages().values()),
@@ -721,6 +742,107 @@ def create_udtf_for_groupby_transform(
         # 'Snowpark pandas does not yet support the method DataFrame.__reduce__' is raised. Instead,
         # catch this exception and return a more user-friendly error message.
         raise ValueError(APPLY_WITH_SNOWPARK_OBJECT_ERROR_MSG)
+
+
+def infer_output_schema_for_apply(
+    func: Callable,
+    args: tuple,
+    kwargs: dict,
+    by_labels: list[Hashable],
+    data_column_index: native_pd.Index,
+    index_column_names: list,
+    input_types: list[DataType],
+    series_groupby: bool,
+    force_list_like_to_series: bool = False,
+) -> Optional[GroupbyApplyOutputSchema]:
+    """
+    Infers the output schema of a groupby apply function. Returns None if the schema
+    cannot be inferred.
+
+    Args:
+        func: The function we need to apply to each group
+        args: Function's positional arguments
+        kwargs: Function's keyword arguments
+        by_labels: List of labels for 'by' columns.
+        data_column_index: Column labels for the input dataframe
+        index_column_names: Names of the input dataframe's index
+        input_types: Types of the input dataframe's columns
+        series_groupby: Whether we are performing a SeriesGroupBy.apply() instead of DataFrameGroupBy.apply()
+        force_list_like_to_series: Force the function result to series if it is list-like.
+
+    Returns:
+        GroupbyApplyOutputSchema or None.
+    """
+    size = 10
+
+    def get_dummy_data(typ: DataType) -> Any:
+        if isinstance(typ, _IntegralType):
+            return np.arange(size)
+        if isinstance(typ, _FractionalType):
+            return np.arange(size) + 0.5
+        if isinstance(typ, StringType):
+            return [f"{chr(97 + i)}" for i in range(size)]
+        if isinstance(typ, BooleanType):
+            return [True, False] * int(size / 2)
+        if isinstance(typ, TimestampType):
+            return native_pd.date_range(start="2025-01-01 03:04:05", periods=size)
+        if isinstance(typ, BinaryType):
+            return [bytes("snow", "utf-8")] * size
+
+    input_data = {}
+    for i, typ in enumerate(input_types):
+        dummy_data = get_dummy_data(typ)
+        if dummy_data is None:
+            # unknown type, fail the schema inference
+            return None
+        input_data[f"ARG{i+1}"] = dummy_data
+
+    input_df = native_pd.DataFrame(input_data)
+    num_by = len(by_labels)
+    try:
+        func_result, _, func_type, _ = apply_groupby_func_to_df(
+            input_df,
+            num_by,
+            index_column_names,
+            series_groupby,
+            data_column_index,
+            func,
+            args,
+            kwargs,
+            force_list_like_to_series,
+        )
+    except Exception as e:
+        _logger.info(f"Failed to infer schema with error={e}")
+        return None
+    schema = GroupbyApplyOutputSchema()
+    schema.num_index_columns = num_by
+    if func_type != GroupbyApplyFuncType.AGGREGATE:
+        schema.num_index_columns += func_result.index.nlevels
+    schema.func_type = func_type
+    schema.column_index_names = func_result.columns.names
+
+    # First two columns are always row position columns.
+    schema.add_column("__min_row_position__", LongType())
+    schema.add_column("__row_position__", LongType())
+
+    # Always include the by columns in the output.
+    for i, by_label in enumerate(by_labels):
+        schema.add_column(by_label, input_types[1 + i])
+
+    # Add index columns to the schema.
+    if func_type != GroupbyApplyFuncType.AGGREGATE:
+        for i, label in enumerate(func_result.index.names):
+            schema.add_column(
+                label,
+                input_types[1 + num_by + i]
+                if func_type == GroupbyApplyFuncType.TRANSFORM
+                else VariantType(),
+            )
+
+    # Add data columns to the schema.
+    for label in func_result.columns:
+        schema.add_column(label, VariantType())
+    return schema
 
 
 def create_udtf_for_groupby_apply(
@@ -736,9 +858,10 @@ def create_udtf_for_groupby_apply(
     by_labels: list[Hashable],
     by_types: list[DataType],
     existing_identifiers: list[str],
-    force_list_like_to_series: bool = False,
-    is_transform: bool = False,
-) -> UserDefinedTableFunction:
+    force_list_like_to_series: bool,
+    is_transform: bool,
+    force_single_group: bool,
+) -> Tuple[Optional[GroupbyApplyOutputSchema], UserDefinedTableFunction]:
     """
     Create a UDTF from the Python function for groupby.apply.
 
@@ -831,39 +954,101 @@ def create_udtf_for_groupby_apply(
     existing_identifiers: List of existing column identifiers; these are omitted when creating new column identifiers.
     force_list_like_to_series: Force the function result to series if it is list-like
     is_transform: Whether the function is a transform or not.
+    force_single_group: Force single group (empty set of group by labels) useful for DataFrame.apply() with axis=0
 
     Returns
     -------
-    A UDTF that will apply the provided function to a group and return a
-    dataframe representing all the data and metadata of the result.
+    A Tuple of:
+        1. Groupby apply output schema. This will be None if the schema cannot be
+           inferred.
+        2. A UDTF that will apply the provided function to a group and return a
+           dataframe representing all the data and metadata of the result.
     """
 
-    if is_transform:
-        return create_udtf_for_groupby_transform(
-            func,
-            args,
-            kwargs,
-            data_column_index,
-            index_column_names,
-            input_data_column_types,
-            input_index_column_types,
-            session,
-            series_groupby,
-            by_types,
-            by_labels,
-            existing_identifiers,
-            force_list_like_to_series,
-        )
+    assert len(index_column_names) == len(
+        input_index_column_types
+    ), "list of index column names and list of index column types must have the same length"
+    assert len(data_column_index) == len(
+        input_data_column_types
+    ), "list of data column names and list of data column types must have the same length"
 
     # Get the length of this list outside the vUDTF function because the vUDTF
     # doesn't have access to the Snowpark module, which defines these types.
     num_by = len(by_types)
+
     from snowflake.snowpark.modin.plugin.extensions.utils import (
         try_convert_index_to_native,
     )
 
     data_column_index = try_convert_index_to_native(data_column_index)
 
+    input_types = [
+        # first input column is the integer row number. the row number integer
+        # becomes a float inside the UDTF due to SNOW-1184587
+        LongType(),
+        # the next columns are the by columns...
+        *by_types,
+        # then the index columns for the input dataframe or series...
+        *input_index_column_types,
+        # ...then the data columns for the input dataframe or series.
+        *input_data_column_types,
+    ]
+    output_schema = None
+    if is_transform:
+        # For transform, the UDTF will return same number of columns as input.
+        output_schema = GroupbyApplyOutputSchema()
+        output_schema.column_labels = [
+            "__min_row_position__",
+            "__row_position__",
+            *by_labels,
+            *index_column_names,
+        ] + [col for col in data_column_index if col not in by_labels]
+        column_types = [LongType(), LongType()] + by_types + input_index_column_types
+        num_data_cols = len(output_schema.column_labels) - len(column_types)
+        output_schema.column_types = column_types + ([VariantType()] * num_data_cols)
+        output_schema.num_index_columns = len(index_column_names) + num_by
+        output_schema.func_type = GroupbyApplyFuncType.TRANSFORM
+        output_schema.column_index_names = data_column_index.names
+    elif force_single_group:
+        # TODO: SNOW-1801328: Enable schema inference for DataFrame.apply and  avoid
+        #  pivot step.
+        output_schema = None
+    else:
+        # Attempt to infer output schema for UDTF
+        output_schema = infer_output_schema_for_apply(
+            func,
+            args,
+            kwargs,
+            by_labels,
+            data_column_index,
+            index_column_names,
+            input_types,
+            series_groupby,
+        )
+
+    if output_schema is not None:
+        # Generate new column identifiers for all required UDTF columns with the helper
+        # below to prevent collisions in column identifiers.
+        output_schema.column_ids = generate_snowflake_quoted_identifiers_helper(
+            pandas_labels=output_schema.column_labels,
+            excluded=existing_identifiers,
+            wrap_double_underscore=False,
+        )
+        return output_schema, create_udtf_for_groupby_no_pivot(
+            func,
+            args,
+            kwargs,
+            data_column_index,
+            index_column_names,
+            input_types,
+            session,
+            series_groupby,
+            by_labels,
+            output_schema,
+            force_list_like_to_series,
+        )
+
+    # Failed to infer schema, fallback to old implementation
     class ApplyFunc:
         def end_partition(self, df: native_pd.DataFrame):  # type: ignore[no-untyped-def] # pragma: no cover: adding type hint causes an error when creating udtf. also, skip coverage for this function because coverage tools can't tell that we're executing this function because we execute it in a UDTF.
             """
@@ -878,12 +1063,7 @@ def create_udtf_for_groupby_apply(
             A dataframe representing the result of applying the user-provided
             function to this group.
             """
-            (
-                row_positions,
-                func_result,
-                include_index_columns,
-                is_transform_func,
-            ) = apply_groupby_func_to_df(
+            func_result, row_positions, func_type, _ = apply_groupby_func_to_df(
                 df,
                 num_by,
                 index_column_names,
@@ -895,20 +1075,8 @@ def create_udtf_for_groupby_apply(
                 force_list_like_to_series,
             )
             return convert_groupby_apply_dataframe_result_to_standard_schema(
-                func_result, row_positions, include_index_columns, is_transform_func
+                func_result, row_positions, func_type
             )
-
-    input_types = [
-        # first input column is the integer row number. the row number integer
-        # becomes a float inside the UDTF due to SNOW-1184587
-        LongType(),
-        # the next columns are the by columns...
-        *by_types,
-        # then the index columns for the input dataframe or series...
-        *input_index_column_types,
-        # ...then the data columns for the input dataframe or series.
-        *input_data_column_types,
-    ]
 
     col_labels = [
         "LABEL",
@@ -925,7 +1093,7 @@ def create_udtf_for_groupby_apply(
         wrap_double_underscore=False,
     )
     try:
-        return sp_func.udtf(
+        return None, sp_func.udtf(
             ApplyFunc,
             output_schema=PandasDataFrameType(
                 [
@@ -1874,3 +2042,112 @@ def make_series_map_snowpark_function(
         return case_expression
 
     return do_map
+
+
+def create_internal_frame_for_groupby_apply_no_pivot_result(
+    input_frame: InternalFrame,
+    ordered_dataframe: OrderedDataFrame,
+    output_schema: GroupbyApplyOutputSchema,
+    num_by: int,
+    is_transform: bool,
+    group_keys: bool,
+    as_index: bool,
+    sort: bool,
+) -> InternalFrame:
+    """
+    Create Interframe for groupy apply no pivot output.
+    Args:
+        input_frame: Input internal frame.
+        ordered_dataframe: Output ordered dataframe from groupby apply udtf.
+        output_schema: Inferred output schema for groupby apply.
+        num_by: Number of by columns.
+        is_transform: Weather this is groupy.transform or not.
+        group_keys: The `group_keys` argument to groupby()
+        as_index: The `as_index` argument to groupby()
+        sort: The `sort` argument to groupby()
+
+    Returns:
+        Final InternalFrame for groupby apply no pivot output.
+    """
+    output_cols = list(zip(output_schema.column_labels, output_schema.column_ids))
+    num_index_cols = output_schema.num_index_columns
+    # Output ordered dataframe has the following columns in order.
+    # 1. min row position. This is used to find order of group when sort=False.
+    min_row_position_id = output_cols[0][1]
+    # 2. Original row position or row position within group.
+    row_position_id = output_cols[1][1]
+    # 4. index columns (will always include by columns)
+    index_cols = output_cols[2 : 2 + num_index_cols]
+    by_ids = [output_col[1] for output_col in output_cols[2 : 2 + num_by]]
+    # 5. data columns
+    data_cols = output_cols[2 + num_index_cols :]
+
+    # df.groupby(group_keys=False).apply(transform_func) is equivalent to
+    # df.groupby().transform(transform_func)
+    if output_schema.func_type == GroupbyApplyFuncType.TRANSFORM and not group_keys:
+        is_transform = True
+
+    # Note: group_keys is ignored for aggregate. Set to default value.
+    if output_schema.func_type == GroupbyApplyFuncType.AGGREGATE:
+        group_keys = True
+
+    # Note: 'sort' and 'as_index' arguments are ignored for transform.
+    # https://pandas.pydata.org/docs/user_guide/groupby.html#transformation
+    if is_transform:
+        as_index = True
+        sort = True
+
+    new_index_order_ids = by_ids if sort else [min_row_position_id]
+    if not as_index:
+        new_index_id = ordered_dataframe.generate_snowflake_quoted_identifiers(
+            pandas_labels=[INDEX_LABEL]
+        )[0]
+        new_index_col = (
+            sp_func.dense_rank().over(
+                Window.order_by(
+                    *(
+                        SnowparkColumn(col_id).asc_nulls_last()
+                        for col_id in new_index_order_ids
+                    )
+                )
+            )
+            - 1
+        )
+        ordered_dataframe = append_columns(
+            ordered_dataframe, new_index_id, new_index_col
+        )
+        # For aggregation if as_index is False 'by' columns should appear
+        # in data columns (excluding 'by' index columns).
+        # https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html#aggregation
+        if output_schema.func_type == GroupbyApplyFuncType.AGGREGATE:
+            cols_to_move = []
+            for index_col in index_cols[:num_by]:
+                if index_col[0] in input_frame.data_column_pandas_labels:
+                    cols_to_move.append(index_col)
+            data_cols = cols_to_move + data_cols
+            index_cols = [(None, new_index_id)]
+            data_cols = [
+                (None if label == MODIN_UNNAMED_SERIES_LABEL else label, sfid)
+                for label, sfid in data_cols
+            ]
+        else:
+            index_cols = [(None, new_index_id)] + index_cols[num_by:]
+
+    if not group_keys and len(index_cols) > num_by:
+        index_cols = index_cols[num_by:]
+
+    sort_ids = (
+        [row_position_id] if is_transform else new_index_order_ids + [row_position_id]
+    )
+    ordered_dataframe = ordered_dataframe.sort(*(OrderingColumn(id) for id in sort_ids))
+
+    return InternalFrame.create(
+        ordered_dataframe=ordered_dataframe,
+        data_column_pandas_labels=[c[0] for c in data_cols],
+        data_column_pandas_index_names=output_schema.column_index_names,
+        data_column_snowflake_quoted_identifiers=[c[1] for c in data_cols],
+        index_column_pandas_labels=[c[0] for c in index_cols],
+        index_column_snowflake_quoted_identifiers=[c[1] for c in index_cols],
+        data_column_types=None,
+        index_column_types=None,
+    )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -185,24 +185,25 @@ from snowflake.snowpark.modin.plugin._internal.align_utils import (
     align_axis_1,
 )
 from snowflake.snowpark.modin.plugin._internal.apply_utils import (
+    ALL_SNOWFLAKE_CORTEX_FUNCTIONS,
     APPLY_LABEL_COLUMN_QUOTED_IDENTIFIER,
     APPLY_VALUE_COLUMN_QUOTED_IDENTIFIER,
     DEFAULT_UDTF_PARTITION_SIZE,
     GroupbyApplySortMethod,
+    SUPPORTED_SNOWFLAKE_CORTEX_FUNCTIONS_IN_APPLY,
     check_return_variant_and_get_return_type,
     create_udf_for_series_apply,
     create_udtf_for_apply_axis_1,
     create_udtf_for_groupby_apply,
+    create_internal_frame_for_groupby_apply_no_pivot_result,
     deduce_return_type_from_function,
     get_metadata_from_groupby_apply_pivot_result_column_names,
     groupby_apply_create_internal_frame_from_final_ordered_dataframe,
     groupby_apply_pivot_result_to_final_ordered_dataframe,
     groupby_apply_sort_method,
     is_supported_snowpark_python_function,
-    sort_apply_udtf_result_columns_by_pandas_positions,
     make_series_map_snowpark_function,
-    SUPPORTED_SNOWFLAKE_CORTEX_FUNCTIONS_IN_APPLY,
-    ALL_SNOWFLAKE_CORTEX_FUNCTIONS,
+    sort_apply_udtf_result_columns_by_pandas_positions,
 )
 from collections import defaultdict
 from snowflake.snowpark.modin.plugin._internal.binary_op_utils import (
@@ -4120,7 +4121,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             input_data_column_positions
         ]
         is_transform = groupby_kwargs.get("apply_op") == "transform"
-        udtf = create_udtf_for_groupby_apply(
+        output_schema, udtf = create_udtf_for_groupby_apply(
             agg_func,
             agg_args,
             agg_kwargs,
@@ -4146,6 +4147,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             existing_identifiers=_modin_frame.ordered_dataframe._dataframe_ref.snowflake_quoted_identifiers,
             force_list_like_to_series=force_list_like_to_series,
             is_transform=is_transform,
+            force_single_group=force_single_group,
         )
 
         new_internal_df = _modin_frame.ensure_row_position_column()
@@ -4200,7 +4202,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         |        1 |        2 | k1                   |                 14 | b                     |                  1 |
         |        0 |        0 | k0                   |                 15 | c                     |                  2 |
         """
-        if is_transform:
+        if output_schema is not None:
             x = udtf(
                 row_position_snowflake_quoted_identifier,
                 *by_snowflake_quoted_identifiers_list,
@@ -4213,30 +4215,18 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 order_by=row_position_snowflake_quoted_identifier,
             )
             ordered_dataframe = ordered_dataframe.select(x)
-            # output frame has the following columns in order
-            # 1. row position column
-            # 2. index columns
-            # 3. data columns (excluding by columns)
-            ids = ordered_dataframe.projected_column_snowflake_quoted_identifiers
-            data_col_labels = [
-                col for col in data_columns_index if col not in by_pandas_labels
-            ]
-            return SnowflakeQueryCompiler(
-                InternalFrame.create(
-                    ordered_dataframe=ordered_dataframe,
-                    data_column_pandas_labels=data_col_labels,
-                    data_column_pandas_index_names=_modin_frame.data_column_pandas_index_names,
-                    data_column_snowflake_quoted_identifiers=ids[
-                        1 + _modin_frame.num_index_levels() :
-                    ],
-                    index_column_pandas_labels=_modin_frame.index_column_pandas_labels,
-                    index_column_snowflake_quoted_identifiers=ids[
-                        1 : 1 + _modin_frame.num_index_levels()
-                    ],
-                    data_column_types=None,
-                    index_column_types=None,
-                )
+            num_by = len(by_snowflake_quoted_identifiers_list)
+            result_frame = create_internal_frame_for_groupby_apply_no_pivot_result(
+                _modin_frame,
+                ordered_dataframe,
+                output_schema,
+                num_by,
+                is_transform,
+                group_keys,
+                as_index,
+                sort,
             )
+            return SnowflakeQueryCompiler(result_frame)
 
         # NOTE we are keeping the cache_result for performance reasons. DO NOT
         # REMOVE the cache_result unless you can prove that doing so will not

--- a/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/groupby.py
@@ -1122,20 +1122,20 @@ class DataFrameGroupBy:
         each group together into a new DataFrame:
 
         >>> g1[['B', 'C']].apply(lambda x: x.select_dtypes('number') / x.select_dtypes('number').sum())
-                    B    C
-        0.0  0.333333  0.4
-        1.0  0.666667  0.6
-        2.0  1.000000  1.0
+                  B    C
+        0  0.333333  0.4
+        1  0.666667  0.6
+        2  1.000000  1.0
 
         In the above, the groups are not part of the index. We can have them included
         by using ``g2`` where ``group_keys=True``:
 
         >>> g2[['B', 'C']].apply(lambda x: x.select_dtypes('number') / x.select_dtypes('number').sum()) # doctest: +NORMALIZE_WHITESPACE
-                      B    C
+                    B    C
         A
-        a 0.0  0.333333  0.4
-          1.0  0.666667  0.6
-        b 2.0  1.000000  1.0
+        a 0  0.333333  0.4
+          1  0.666667  0.6
+        b 2  1.000000  1.0
         """
 
     @property

--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -323,7 +323,7 @@ def test_axis_0_series_basic(apply_func, expected_join_count, expected_union_cou
         )
 
 
-@sql_count_checker(query_count=5, join_count=1, udtf_count=1)
+@sql_count_checker(query_count=4, join_count=1, udtf_count=1)
 def test_groupby_apply_constant_output():
     native_df = native_pd.DataFrame([1, 2])
     native_df["fg"] = 0

--- a/tests/integ/modin/groupby/test_all_any.py
+++ b/tests/integ/modin/groupby/test_all_any.py
@@ -99,7 +99,7 @@ def test_all_any_invalid_types(data, msg):
         pd.DataFrame(data).groupby("by").any().to_pandas()
 
 
-@sql_count_checker(query_count=5, join_count=1, udtf_count=1)
+@sql_count_checker(query_count=4, join_count=1, udtf_count=1)
 def test_all_any_chained():
     data = {
         "by": ["a", "a", "b", "c", "c"],

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -144,7 +144,7 @@ def grouping_dfs_with_multiindexes() -> tuple[pd.DataFrame, native_pd.DataFrame]
     )
 
 
-# For almost all test cases, the query count is either 5 or 6,
+# For almost all test cases, the query count is 4,
 # the join count is 1, and the UDTF count is 1:
 
 # 0. Create temporary stage for UDTF (we filter this out when counting queries)
@@ -155,9 +155,6 @@ def grouping_dfs_with_multiindexes() -> tuple[pd.DataFrame, native_pd.DataFrame]
 # 3. Create the UDTF (increasing UDTF count by 1)
 # 3. Apply the UDTF using a join (increasing join count by 1)
 # 4. convert result to pandas
-
-# For cases where we need to check whether we have a transform, we add an extra
-# query between 4) and 5) to check whether the function acted as a transform.
 
 QUERY_COUNT = 4
 JOIN_COUNT = 1

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -1076,7 +1076,7 @@ class TestFuncReturnsSeries:
         raises=AssertionError,
         strict=True,
         reason="Snowpark pandas return a DataFrame but native pandas returns a"
-        + " Series. This should be very rate in practice.",
+        + " Series. This should be very rare in practice.",
     )
     @sql_count_checker(
         query_count=QUERY_COUNT,

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -154,8 +154,7 @@ def grouping_dfs_with_multiindexes() -> tuple[pd.DataFrame, native_pd.DataFrame]
 # 2. Put a zip file with the UDTF definition in the temporary stage (we filter this out when counting queries)
 # 3. Create the UDTF (increasing UDTF count by 1)
 # 3. Apply the UDTF using a join (increasing join count by 1)
-# 4. Save UDTF result as temp table to work around SNOW-1060191
-# 5. convert result to pandas
+# 4. convert result to pandas
 
 # For cases where we need to check whether we have a transform, we add an extra
 # query between 4) and 5) to check whether the function acted as a transform.
@@ -625,7 +624,9 @@ class TestFuncReturnsDataFrame:
 
     @pytest.mark.xfail(
         raises=AssertionError,
-        reason="If function that returns different labels for different groups, we pick the labels based on dummy input.",
+        reason="If function that returns different labels for different groups, we"
+        + " pick the labels based on dummy input. This should be very rare in"
+        + " practice",
     )
     def test_mismatched_data_column_positions(
         self, grouping_dfs_with_multiindexes, include_groups
@@ -1046,7 +1047,8 @@ class TestFuncReturnsSeries:
     @pytest.mark.xfail(
         raises=AssertionError,
         strict=True,
-        reason="Snowpark pandas uses name returned from first group, while pandas returns None",
+        reason="Snowpark pandas uses name returned from first group, while pandas "
+        + "returns None. This should be very rare in practice",
     )
     @sql_count_checker(
         query_count=QUERY_COUNT,
@@ -1073,7 +1075,8 @@ class TestFuncReturnsSeries:
     @pytest.mark.xfail(
         raises=AssertionError,
         strict=True,
-        reason="Snowpark pandas return a DataFrame but native pandas returns a Series",
+        reason="Snowpark pandas return a DataFrame but native pandas returns a"
+        + " Series. This should be very rate in practice.",
     )
     @sql_count_checker(
         query_count=QUERY_COUNT,
@@ -1252,7 +1255,8 @@ class TestCallableWithMixedReturnTypes:
     @pytest.mark.xfail(
         strict=True,
         raises=SnowparkSQLException,
-        reason="Results in mismatch between udtf schema and the actual result.",
+        reason="Results in mismatch between udtf schema and the actual result."
+        + " This should be rare in practice.",
     )
     def test_scalar_then_dataframe(self):
         eval_snowpark_pandas_result(
@@ -1267,7 +1271,8 @@ class TestCallableWithMixedReturnTypes:
     @pytest.mark.xfail(
         strict=True,
         raises=AssertionError,
-        reason="Results in mismatch between udtf schema and the actual result.",
+        reason="Results in mismatch between udtf schema and the actual result."
+        + " This should be rare in practice.",
     )
     def test_series_then_dataframe(self):
         eval_snowpark_pandas_result(

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -160,8 +160,7 @@ def grouping_dfs_with_multiindexes() -> tuple[pd.DataFrame, native_pd.DataFrame]
 # For cases where we need to check whether we have a transform, we add an extra
 # query between 4) and 5) to check whether the function acted as a transform.
 
-QUERY_COUNT_WITHOUT_TRANSFORM_CHECK = 5
-QUERY_COUNT_WITH_TRANSFORM_CHECK = 6
+QUERY_COUNT = 4
 JOIN_COUNT = 1
 UDTF_COUNT = 1
 
@@ -201,7 +200,7 @@ class TestFuncReturnsDataFrame:
         ],
     )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -216,7 +215,7 @@ class TestFuncReturnsDataFrame:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -231,7 +230,7 @@ class TestFuncReturnsDataFrame:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -245,7 +244,7 @@ class TestFuncReturnsDataFrame:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -268,7 +267,7 @@ class TestFuncReturnsDataFrame:
         ],
     )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -294,7 +293,7 @@ class TestFuncReturnsDataFrame:
         ],
     )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -325,12 +324,12 @@ class TestFuncReturnsDataFrame:
             udtf_count=UDTF_COUNT,
             join_count=JOIN_COUNT,
         ):
+            pandas_result = operation(pandas_df)
             snow_result = operation(snow_df)
-        pandas_result = operation(pandas_df)
-        # results are equal if we ignore index
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
-            snow_result.reset_index(drop=True), pandas_result.reset_index(drop=True)
-        )
+            # results are equal if we ignore index
+            assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+                snow_result.reset_index(drop=True), pandas_result.reset_index(drop=True)
+            )
         # pandas index is not equal to snow index due to https://github.com/pandas-dev/pandas/issues/29111,
         # so hardcode the index for comparison
         assert_values_equal(
@@ -349,7 +348,7 @@ class TestFuncReturnsDataFrame:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         join_count=JOIN_COUNT,
         udtf_count=UDTF_COUNT,
     )
@@ -376,7 +375,7 @@ class TestFuncReturnsDataFrame:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -396,7 +395,7 @@ class TestFuncReturnsDataFrame:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -427,7 +426,7 @@ class TestFuncReturnsDataFrame:
     @sql_count_checker(
         # when group_keys=False, we have to check whether the function was a
         # transform because we only reindex to the original ordering if
-        query_count=QUERY_COUNT_WITH_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -517,13 +516,7 @@ class TestFuncReturnsDataFrame:
 
         pandas_result = operation(pdf)
         with SqlCounter(
-            # group_keys=False requires an extra query to check whether we're
-            # applying a transform.
-            query_count=(
-                QUERY_COUNT_WITHOUT_TRANSFORM_CHECK
-                if group_keys
-                else QUERY_COUNT_WITH_TRANSFORM_CHECK
-            ),
+            query_count=QUERY_COUNT,
             join_count=JOIN_COUNT + 1,
             udtf_count=UDTF_COUNT,
         ):
@@ -583,8 +576,7 @@ class TestFuncReturnsDataFrame:
 
     @pytest.mark.parametrize("set_sql_simplifier", [True, False], indirect=True)
     @sql_count_checker(
-        # we need a transform check because group_keys=False.
-        query_count=QUERY_COUNT_WITH_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         join_count=JOIN_COUNT,
         udtf_count=UDTF_COUNT,
     )
@@ -617,7 +609,7 @@ class TestFuncReturnsDataFrame:
         ],
     )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         join_count=JOIN_COUNT,
         udtf_count=UDTF_COUNT,
     )
@@ -632,9 +624,8 @@ class TestFuncReturnsDataFrame:
         )
 
     @pytest.mark.xfail(
-        strict=True,
-        raises=NotImplementedError,
-        reason="No support for applying a function that returns two dataframes that have different labels for the column at a given position",
+        raises=AssertionError,
+        reason="If function that returns different labels for different groups, we pick the labels based on dummy input.",
     )
     def test_mismatched_data_column_positions(
         self, grouping_dfs_with_multiindexes, include_groups
@@ -649,10 +640,10 @@ class TestFuncReturnsDataFrame:
             ),
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        raises=NotImplementedError,
-        reason="No support for applying a function that returns two dataframes that have different names for a given index level",
+    @sql_count_checker(
+        query_count=QUERY_COUNT,
+        join_count=JOIN_COUNT,
+        udtf_count=UDTF_COUNT,
     )
     def test_mismatched_index_column_positions(
         self, grouping_dfs_with_multiindexes, include_groups
@@ -699,7 +690,7 @@ class TestFuncReturnsDataFrame:
         # 57906.
         with pytest.raises(AssertionError) as ex:
             with SqlCounter(
-                query_count=QUERY_COUNT_WITH_TRANSFORM_CHECK,
+                query_count=QUERY_COUNT,
                 udtf_count=UDTF_COUNT,
                 join_count=JOIN_COUNT,
             ):
@@ -714,7 +705,7 @@ class TestFuncReturnsDataFrame:
         # a deterministic order.
         assert pandas_result.is_unique
         with SqlCounter(
-            query_count=QUERY_COUNT_WITH_TRANSFORM_CHECK,
+            query_count=QUERY_COUNT,
             udtf_count=UDTF_COUNT,
             join_count=JOIN_COUNT + 1,
         ):
@@ -735,7 +726,7 @@ class TestFuncReturnsScalar:
     )
     @pytest.mark.parametrize("dropna", [True, False], ids=lambda v: f"dropna_{v}")
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -777,7 +768,7 @@ class TestFuncReturnsScalar:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -803,7 +794,7 @@ class TestFuncReturnsScalar:
     @pytest.mark.parametrize("sort", [True, False], ids=lambda v: f"sort_{v}")
     @pytest.mark.parametrize("as_index", [True, False], ids=lambda v: f"as_index_{v}")
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -840,7 +831,7 @@ class TestFuncReturnsScalar:
         ],
     )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -872,7 +863,7 @@ class TestFuncReturnsScalar:
             )
 
     @sql_count_checker(
-        query_count=8,
+        query_count=7,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -951,7 +942,7 @@ class TestFuncReturnsSeries:
         "group_keys", [True, False], ids=lambda v: f"group_keys={v}"
     )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -984,7 +975,7 @@ class TestFuncReturnsSeries:
         )
 
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -1011,7 +1002,7 @@ class TestFuncReturnsSeries:
     @pytest.mark.parametrize("dropna", [True, False])
     @sql_count_checker(
         # One extra query to convert index to native pandas in dataframe constructor to create test dataframes
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT + 1,
     )
@@ -1052,9 +1043,13 @@ class TestFuncReturnsSeries:
             ),
         )
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="SNOW-1232201")
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        strict=True,
+        reason="Snowpark pandas uses name returned from first group, while pandas returns None",
+    )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -1075,9 +1070,13 @@ class TestFuncReturnsSeries:
             ),
         )
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="SNOW-1232208")
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        strict=True,
+        reason="Snowpark pandas return a DataFrame but native pandas returns a Series",
+    )
     @sql_count_checker(
-        query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+        query_count=QUERY_COUNT,
         udtf_count=UDTF_COUNT,
         join_count=JOIN_COUNT,
     )
@@ -1123,11 +1122,6 @@ class TestSeriesGroupBy:
         self, by, func, dropna, group_keys, sort, include_groups
     ):
         """Test apply() on a SeriesGroupBy that we get by DataFrameGroupBy.__getitem__"""
-        qc = (
-            QUERY_COUNT_WITH_TRANSFORM_CHECK
-            if group_keys is False and not func == get_scalar_from_numeric_series
-            else QUERY_COUNT_WITHOUT_TRANSFORM_CHECK
-        )
         if (
             func in (get_dataframe_from_numeric_series, get_series_from_numeric_series)
             and not dropna
@@ -1137,7 +1131,7 @@ class TestSeriesGroupBy:
             # (pd.NA, k1) that we cannot serialize.
             pytest.xfail(reason="SNOW-1229760")
         with SqlCounter(
-            query_count=qc,
+            query_count=QUERY_COUNT,
             udtf_count=UDTF_COUNT,
             join_count=JOIN_COUNT + 1,
         ):
@@ -1257,8 +1251,8 @@ class TestCallableWithMixedReturnTypes:
 
     @pytest.mark.xfail(
         strict=True,
-        raises=NotImplementedError,
-        reason="NotImplementedError in Snowpark pandas. see SNOW-1236959",
+        raises=SnowparkSQLException,
+        reason="Results in mismatch between udtf schema and the actual result.",
     )
     def test_scalar_then_dataframe(self):
         eval_snowpark_pandas_result(
@@ -1273,7 +1267,7 @@ class TestCallableWithMixedReturnTypes:
     @pytest.mark.xfail(
         strict=True,
         raises=AssertionError,
-        reason="Snowpark pandas transposes the series, but pandas doesn't. See SNOW-1236959",
+        reason="Results in mismatch between udtf schema and the actual result.",
     )
     def test_series_then_dataframe(self):
         eval_snowpark_pandas_result(
@@ -1319,7 +1313,7 @@ class TestCallableWithMixedReturnTypes:
 
 
 @sql_count_checker(
-    query_count=QUERY_COUNT_WITHOUT_TRANSFORM_CHECK,
+    query_count=QUERY_COUNT,
     join_count=JOIN_COUNT,
     udtf_count=UDTF_COUNT,
 )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1926348

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

 This PR re-implements the `groupby-apply` method without the use of pivot. We infer the output schema and use that to create the UDTF with right number of columns. If we fail to infer to schema we fallback to old implementation.
 
**Performance improvement numbers:**
 microbenchmark dataframe_groupby_apply_transform Before: 64.9 sec After: 21.4 sec
 microbenchmark dataframe_groupby_apply_concat Before: 106.2 sec After: 40.7 sec
 microbenchmark dataframe_groupby_apply_agg Before: 14.0 sec After: 13.4 sec
 
 Customer support ticket [Believe](https://snowflakecomputing.atlassian.net/browse/SNOW-1947974):
 [Before](https://app.snowflake.com/sfengineering/sfctest0_aws_us_west_2/#/compute/history/queries?user=NAMED%3ASNOWPANDAS_TEST&start=1743145200000&columns=sqlText%2CqueryId%2Cstatus%2Cuser%2Cwarehouse%2CtotalDuration%2CstartTime&preset=PRESET_LAST_3_DAYS&type=relative&relative=%7B%22tense%22%3A%22past%22%2C%22value%22%3A3%2C%22unit%22%3A%22day%22%2C%22excludePartial%22%3Afalse%2C%22exclusionSize%22%3A%22day%22%2C%22exclusionSizeParam%22%3A%22%22%7D&startDate=2025-03-30T00%3A00%3A00Z&endDate=2025-03-31T00%3A00%3A00Z&page=history%2Fqueries&session_id=3563545552846631):  6 min 21 secs
 [After](https://app.snowflake.com/sfengineering/sfctest0_aws_us_west_2/#/compute/history/queries?user=NAMED%3ASNOWPANDAS_TEST&start=1743145200000&columns=sqlText%2CqueryId%2Cstatus%2Cuser%2Cwarehouse%2CtotalDuration%2CstartTime&preset=PRESET_LAST_3_DAYS&type=relative&relative=%7B%22tense%22%3A%22past%22%2C%22value%22%3A3%2C%22unit%22%3A%22day%22%2C%22excludePartial%22%3Afalse%2C%22exclusionSize%22%3A%22day%22%2C%22exclusionSizeParam%22%3A%22%22%7D&startDate=2025-03-30T00%3A00%3A00Z&endDate=2025-03-31T00%3A00%3A00Z&page=history%2Fqueries&session_id=3563545552865851): 2 min 19 secs
 
 To reduce the scope following will be done in separate PRs:
 we don't infer the columns types yet, that will be a follow up PR.
 We still use old implementation for DataFrame.apply. In a follow up PR I will use new implementation for this as well.