### PR TITLE
SNOW-2014497: Fix credit usage tracking for InternalFrame.has_unique_index()

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -759,8 +759,13 @@ class InternalFrame:
                 # we include it via IFF(MAX(<col> IS NULL), 1, 0) which will return 1 if there is
                 # at least one NULL contained within a column, and 0 if there are no NULL values.
                 return self.ordered_dataframe.select(
-                    (count_distinct(index_col) + iff(max_(index_col.is_null()), 1, 0))
-                    == count("*")
+                    (
+                        (
+                            count_distinct(index_col)
+                            + iff(max_(index_col.is_null()), 1, 0)
+                        )
+                        == count("*")
+                    ).as_("is_unique")
                 ).collect()[0][0]
             else:
                 # Note: We can't use 'count_distinct' directly on columns because it
@@ -770,7 +775,7 @@ class InternalFrame:
                     count_distinct(
                         array_construct(*self.index_column_snowflake_quoted_identifiers)
                     )
-                    == count("*"),
+                    == count("*").as_("is_unique"),
                 ).collect()[0][0]
 
     def validate_no_duplicated_data_columns_mapped_for_labels(

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -758,7 +758,7 @@ class InternalFrame:
                 # COUNT(DISTINCT) ignores NULL values, so if there is a NULL value in the column,
                 # we include it via IFF(MAX(<col> IS NULL), 1, 0) which will return 1 if there is
                 # at least one NULL contained within a column, and 0 if there are no NULL values.
-                return self.ordered_dataframe.select(
+                return self.ordered_dataframe.agg(
                     (
                         (
                             count_distinct(index_col)
@@ -771,11 +771,15 @@ class InternalFrame:
                 # Note: We can't use 'count_distinct' directly on columns because it
                 # ignores null values. As a workaround we first create an ARRAY and
                 # call 'count_distinct' on ARRAY column.
-                return self.ordered_dataframe.select(
-                    count_distinct(
-                        array_construct(*self.index_column_snowflake_quoted_identifiers)
-                    )
-                    == count("*").as_("is_unique"),
+                return self.ordered_dataframe.agg(
+                    (
+                        count_distinct(
+                            array_construct(
+                                *self.index_column_snowflake_quoted_identifiers
+                            )
+                        )
+                        == count("*")
+                    ).as_("is_unique"),
                 ).collect()[0][0]
 
     def validate_no_duplicated_data_columns_mapped_for_labels(

--- a/src/snowflake/snowpark/modin/plugin/_internal/frame.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/frame.py
@@ -758,7 +758,7 @@ class InternalFrame:
                 # COUNT(DISTINCT) ignores NULL values, so if there is a NULL value in the column,
                 # we include it via IFF(MAX(<col> IS NULL), 1, 0) which will return 1 if there is
                 # at least one NULL contained within a column, and 0 if there are no NULL values.
-                return self.ordered_dataframe._dataframe_ref.snowpark_dataframe.select(
+                return self.ordered_dataframe.select(
                     (count_distinct(index_col) + iff(max_(index_col.is_null()), 1, 0))
                     == count("*")
                 ).collect()[0][0]
@@ -766,7 +766,7 @@ class InternalFrame:
                 # Note: We can't use 'count_distinct' directly on columns because it
                 # ignores null values. As a workaround we first create an ARRAY and
                 # call 'count_distinct' on ARRAY column.
-                return self.ordered_dataframe._dataframe_ref.snowpark_dataframe.select(
+                return self.ordered_dataframe.select(
                     count_distinct(
                         array_construct(*self.index_column_snowflake_quoted_identifiers)
                     )


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2014497

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Fix credit usage tracking for InternalFrame.has_unique_index().
