### PR TITLE
SNOW-1956688: dbapi add insert batch size support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Snowpark Python API Updates
 
+- Added parameter `batch_size` to `DataFrameReader.dbapi` (PrPr) for batching fetched data into a single Parquet file.
+
 #### Deprecations
 
 - Deprecated support for Python3.8.

--- a/src/snowflake/snowpark/_internal/data_source/datasource_partitioner.py
+++ b/src/snowflake/snowpark/_internal/data_source/datasource_partitioner.py
@@ -45,6 +45,7 @@ class DataSourcePartitioner:
         custom_schema: Optional[Union[str, StructType]] = None,
         predicates: Optional[List[str]] = None,
         session_init_statement: Optional[List[str]] = None,
+        batch_size: Optional[int] = 1,
     ) -> None:
         self.create_connection = create_connection
         self.table_or_query = table_or_query
@@ -57,6 +58,7 @@ class DataSourcePartitioner:
         self.custom_schema = custom_schema
         self.predicates = predicates
         self.session_init_statement = session_init_statement
+        self.batch_size = batch_size
         conn = create_connection()
         dbms_type, driver = detect_dbms(conn)
         self.dialect_class = DBMS_MAP.get(dbms_type, BaseDialect)
@@ -72,6 +74,7 @@ class DataSourcePartitioner:
             self.fetch_size,
             self.query_timeout,
             self.session_init_statement,
+            self.batch_size,
         )
 
     @cached_property

--- a/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
+++ b/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
@@ -28,12 +28,14 @@ class DataSourceReader:
         fetch_size: Optional[int] = 0,
         query_timeout: Optional[int] = 0,
         session_init_statement: Optional[List[str]] = None,
+        batch_size: Optional[int] = 1,
     ) -> None:
         self.driver = driver_class(create_connection)
         self.schema = schema
         self.fetch_size = fetch_size
         self.query_timeout = query_timeout
         self.session_init_statement = session_init_statement
+        self.batch_size = batch_size
 
     def read(self, partition: str) -> Iterator[List[Any]]:
         conn = self.driver.prepare_connection(
@@ -54,12 +56,19 @@ class DataSourceReader:
                 result = cursor.fetchall()
                 yield result
             elif self.fetch_size > 0:
+                cap_size = self.batch_size * self.fetch_size
                 cursor = cursor.execute(partition)
+                batch = []
                 while True:
                     rows = cursor.fetchmany(self.fetch_size)
                     if not rows:
+                        if batch:
+                            yield batch
                         break
-                    yield rows
+                    batch.extend(rows)
+                    if len(batch) >= cap_size:
+                        yield batch
+                        batch = []
             else:
                 raise ValueError("fetch size cannot be smaller than 0")
         finally:

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1116,6 +1116,7 @@ class DataFrameReader:
         custom_schema: Optional[Union[str, StructType]] = None,
         predicates: Optional[List[str]] = None,
         session_init_statement: Optional[Union[str, List[str]]] = None,
+        batch_size: int = 1,
         _emit_ast: bool = True,
     ) -> DataFrame:
         """
@@ -1159,7 +1160,10 @@ class DataFrameReader:
             fetch_size: The number of rows to fetch per batch from the external data source.
                 This determines how many rows are retrieved in each round trip,
                 which can improve performance for drivers with a low default fetch size.
-            custom_schema: a custom snowflake table schema to read data from external data source, the column names should be identical to corresponded column names external data source. This can be a schema string, for example: "id INTEGER, int_col INTEGER, text_col STRING", or StructType, for example: StructType([StructField("ID", IntegerType(), False)])
+            custom_schema: a custom snowflake table schema to read data from external data source,
+                the column names should be identical to corresponded column names external data source.
+                This can be a schema string, for example: "id INTEGER, int_col INTEGER, text_col STRING",
+                or StructType, for example: StructType([StructField("ID", IntegerType(), False), StructField("INT_COL", IntegerType(), False), StructField("TEXT_COL", StringType(), False)])
             predicates: A list of expressions suitable for inclusion in WHERE clauses, where each expression defines a partition.
                 Partitions will be retrieved in parallel.
                 If both `column` and `predicates` are specified, `column` takes precedence.
@@ -1169,6 +1173,12 @@ class DataFrameReader:
                 For example, `"SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"` can be used in SQL Server
                 to avoid row locks and improve read performance.
                 The `session_init_statement` is executed only once at the beginning of each partition read.
+            batch_size: The number of fetched batches to combine into a single Parquet file.
+                his is used for performance optimization. This improves performance by reducing the
+                number of small Parquet files. If set, up to `batch_size` fetched batches will be merged before
+                writing to a Parquet file.
+                The default value is 1, meaning each `fetch_size` chunk of data retrieved from
+                the external source is written as a separate batch.
 
         Example::
             .. code-block:: python

--- a/tests/integ/test_data_source_api.py
+++ b/tests/integ/test_data_source_api.py
@@ -40,18 +40,7 @@ from snowflake.snowpark.types import (
     IntegerType,
     DateType,
     MapType,
-    FloatType,
     StringType,
-    BinaryType,
-    NullType,
-    TimestampType,
-    TimeType,
-    ShortType,
-    LongType,
-    DoubleType,
-    DecimalType,
-    ArrayType,
-    VariantType,
     BooleanType,
 )
 from tests.resources.test_data_source_dir.test_data_source_data import (
@@ -398,29 +387,7 @@ def test_telemetry_tracking(caplog, session):
 )
 @pytest.mark.parametrize(
     "custom_schema",
-    [
-        SQLITE3_DB_CUSTOM_SCHEMA_STRING,
-        StructType(
-            [
-                StructField("id", IntegerType()),
-                StructField("int_col", IntegerType()),
-                StructField("real_col", FloatType()),
-                StructField("text_col", StringType()),
-                StructField("blob_col", BinaryType()),
-                StructField("null_col", NullType()),
-                StructField("ts_col", TimestampType()),
-                StructField("date_col", DateType()),
-                StructField("time_col", TimeType()),
-                StructField("short_col", ShortType()),
-                StructField("long_col", LongType()),
-                StructField("double_col", DoubleType()),
-                StructField("decimal_col", DecimalType()),
-                StructField("map_col", MapType()),
-                StructField("array_col", ArrayType()),
-                StructField("var_col", VariantType()),
-            ]
-        ),
-    ],
+    [SQLITE3_DB_CUSTOM_SCHEMA_STRING, SQLITE3_DB_CUSTOM_SCHEMA_STRUCT_TYPE],
 )
 def test_custom_schema(session, custom_schema):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/resources/test_data_source_dir/test_data_source_data.py
+++ b/tests/resources/test_data_source_dir/test_data_source_data.py
@@ -9,6 +9,26 @@ from collections import namedtuple
 from decimal import Decimal
 from dateutil import parser
 
+from snowflake.snowpark.types import (
+    StructType,
+    StructField,
+    IntegerType,
+    FloatType,
+    StringType,
+    BinaryType,
+    LongType,
+    VariantType,
+    ArrayType,
+    MapType,
+    DecimalType,
+    DoubleType,
+    ShortType,
+    TimeType,
+    DateType,
+    TimestampType,
+    NullType,
+)
+
 
 # we manually mock these objects because mock object cannot be used in multi-process as they are not pickleable
 class FakeConnection:
@@ -651,6 +671,31 @@ def sql_server_create_connection_with_exception():
     )
 
 
+SQLITE3_DB_CUSTOM_SCHEMA_STRING = "id INTEGER, int_col INTEGER, real_col FLOAT, text_col STRING, blob_col BINARY, null_col STRING, ts_col TIMESTAMP, date_col DATE, time_col TIME, short_col SHORT, long_col LONG, double_col DOUBLE, decimal_col DECIMAL, map_col MAP, array_col ARRAY, var_col VARIANT"
+SQLITE3_DB_CUSTOM_SCHEMA_STRUCT_TYPE = (
+    StructType(
+        [
+            StructField("id", IntegerType()),
+            StructField("int_col", IntegerType()),
+            StructField("real_col", FloatType()),
+            StructField("text_col", StringType()),
+            StructField("blob_col", BinaryType()),
+            StructField("null_col", NullType()),
+            StructField("ts_col", TimestampType()),
+            StructField("date_col", DateType()),
+            StructField("time_col", TimeType()),
+            StructField("short_col", ShortType()),
+            StructField("long_col", LongType()),
+            StructField("double_col", DoubleType()),
+            StructField("decimal_col", DecimalType()),
+            StructField("map_col", MapType()),
+            StructField("array_col", ArrayType()),
+            StructField("var_col", VariantType()),
+        ]
+    ),
+)
+
+
 def sqlite3_db(db_path):
     conn = create_connection_to_sqlite3_db(db_path)
     cursor = conn.cursor()
@@ -773,6 +818,60 @@ def sqlite3_db(db_path):
             "[1, 2, 3]",
             "4",
         ),
+        (
+            5,
+            0,
+            123.456,
+            "Data",
+            b"\x0C\x0D\x0E\x0F",
+            None,
+            test_datetime.isoformat(),
+            test_date.isoformat(),
+            test_time.isoformat(),
+            1,
+            2,
+            3.0,
+            4.0,
+            '{"a": 1, "b": 2}',
+            "[1, 2, 3]",
+            "5",
+        ),
+        (
+            6,
+            0,
+            123.456,
+            "Data",
+            b"\x0C\x0D\x0E\x0F",
+            None,
+            test_datetime.isoformat(),
+            test_date.isoformat(),
+            test_time.isoformat(),
+            1,
+            2,
+            3.0,
+            4.0,
+            '{"a": 1, "b": 2}',
+            "[1, 2, 3]",
+            "6",
+        ),
+        (
+            7,
+            0,
+            123.456,
+            "Data",
+            b"\x0C\x0D\x0E\x0F",
+            None,
+            test_datetime.isoformat(),
+            test_date.isoformat(),
+            test_time.isoformat(),
+            1,
+            2,
+            3.0,
+            4.0,
+            '{"a": 1, "b": 2}',
+            "[1, 2, 3]",
+            "7",
+        ),
     ]
     assert_data = [
         (
@@ -846,6 +945,60 @@ def sqlite3_db(db_path):
             '{\n  "a": 1,\n  "b": 2\n}',
             '[\n  "[1, 2, 3]"\n]',
             '"4"',
+        ),
+        (
+            5,
+            0,
+            123.456,
+            "Data",
+            b"\x0C\x0D\x0E\x0F",
+            None,
+            test_datetime,
+            test_date,
+            test_time,
+            1,
+            2,
+            3.0,
+            4.0,
+            '{\n  "a": 1,\n  "b": 2\n}',
+            '[\n  "[1, 2, 3]"\n]',
+            '"5"',
+        ),
+        (
+            6,
+            0,
+            123.456,
+            "Data",
+            b"\x0C\x0D\x0E\x0F",
+            None,
+            test_datetime,
+            test_date,
+            test_time,
+            1,
+            2,
+            3.0,
+            4.0,
+            '{\n  "a": 1,\n  "b": 2\n}',
+            '[\n  "[1, 2, 3]"\n]',
+            '"6"',
+        ),
+        (
+            7,
+            0,
+            123.456,
+            "Data",
+            b"\x0C\x0D\x0E\x0F",
+            None,
+            test_datetime,
+            test_date,
+            test_time,
+            1,
+            2,
+            3.0,
+            4.0,
+            '{\n  "a": 1,\n  "b": 2\n}',
+            '[\n  "[1, 2, 3]"\n]',
+            '"7"',
         ),
     ]
     cursor.executemany(

--- a/tests/resources/test_data_source_dir/test_data_source_data.py
+++ b/tests/resources/test_data_source_dir/test_data_source_data.py
@@ -672,27 +672,25 @@ def sql_server_create_connection_with_exception():
 
 
 SQLITE3_DB_CUSTOM_SCHEMA_STRING = "id INTEGER, int_col INTEGER, real_col FLOAT, text_col STRING, blob_col BINARY, null_col STRING, ts_col TIMESTAMP, date_col DATE, time_col TIME, short_col SHORT, long_col LONG, double_col DOUBLE, decimal_col DECIMAL, map_col MAP, array_col ARRAY, var_col VARIANT"
-SQLITE3_DB_CUSTOM_SCHEMA_STRUCT_TYPE = (
-    StructType(
-        [
-            StructField("id", IntegerType()),
-            StructField("int_col", IntegerType()),
-            StructField("real_col", FloatType()),
-            StructField("text_col", StringType()),
-            StructField("blob_col", BinaryType()),
-            StructField("null_col", NullType()),
-            StructField("ts_col", TimestampType()),
-            StructField("date_col", DateType()),
-            StructField("time_col", TimeType()),
-            StructField("short_col", ShortType()),
-            StructField("long_col", LongType()),
-            StructField("double_col", DoubleType()),
-            StructField("decimal_col", DecimalType()),
-            StructField("map_col", MapType()),
-            StructField("array_col", ArrayType()),
-            StructField("var_col", VariantType()),
-        ]
-    ),
+SQLITE3_DB_CUSTOM_SCHEMA_STRUCT_TYPE = StructType(
+    [
+        StructField("id", IntegerType()),
+        StructField("int_col", IntegerType()),
+        StructField("real_col", FloatType()),
+        StructField("text_col", StringType()),
+        StructField("blob_col", BinaryType()),
+        StructField("null_col", NullType()),
+        StructField("ts_col", TimestampType()),
+        StructField("date_col", DateType()),
+        StructField("time_col", TimeType()),
+        StructField("short_col", ShortType()),
+        StructField("long_col", LongType()),
+        StructField("double_col", DoubleType()),
+        StructField("decimal_col", DecimalType()),
+        StructField("map_col", MapType()),
+        StructField("array_col", ArrayType()),
+        StructField("var_col", VariantType()),
+    ]
 )
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

SNOW-1956688: dbapi add insert batch size support

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

- Added parameter `batch_size` to `DataFrameReader.dbapi` (PrPr) for batching fetched data into a single Parquet file.
