### PR TITLE
SNOW-2020943, SNOW-2020944: Support optional index retaining in DataFrame/Series.create_or_replace_dynamic_table

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -380,6 +380,7 @@ from snowflake.snowpark.modin.utils import MODIN_UNNAMED_SERIES_LABEL
 from snowflake.snowpark.modin.plugin.utils.numpy_to_pandas import (
     NUMPY_UNIVERSAL_FUNCTION_TO_SNOWFLAKE_FUNCTION,
 )
+from snowflake.snowpark.row import Row
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.types import (
     ArrayType,
@@ -20068,3 +20069,41 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
         )
         return (qc, min_val, max_val, bin_size)
+
+    def create_or_replace_dynamic_table(
+        self,
+        name: Union[str, Iterable[str]],
+        *,
+        warehouse: str,
+        lag: str,
+        comment: Optional[str] = None,
+        mode: str = "overwrite",
+        refresh_mode: Optional[str] = None,
+        initialize: Optional[str] = None,
+        clustering_keys: Optional[Iterable[ColumnOrName]] = None,
+        is_transient: bool = False,
+        data_retention_time: Optional[int] = None,
+        max_data_extension_time: Optional[int] = None,
+        iceberg_config: Optional[dict] = None,
+        index: bool = True,
+        index_label: Optional[IndexLabel] = None,
+    ) -> List[Row]:
+        snowpark_df = self._to_snowpark_dataframe_from_snowpark_pandas_dataframe(
+            index, index_label
+        )
+
+        return snowpark_df.create_or_replace_dynamic_table(
+            name=name,
+            warehouse=warehouse,
+            lag=lag,
+            comment=comment,
+            mode=mode,
+            refresh_mode=refresh_mode,
+            initialize=initialize,
+            clustering_keys=clustering_keys,
+            is_transient=is_transient,
+            data_retention_time=data_retention_time,
+            max_data_extension_time=max_data_extension_time,
+            statement_params=get_default_snowpark_pandas_statement_params(),
+            iceberg_config=iceberg_config,
+        )

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -302,9 +302,9 @@ def create_or_replace_dynamic_table(
     is_transient: bool = False,
     data_retention_time: Optional[int] = None,
     max_data_extension_time: Optional[int] = None,
-    statement_params: Optional[Dict[str, str]] = None,
     iceberg_config: Optional[dict] = None,
-    _emit_ast: bool = True,
+    index: bool = True,
+    index_label: Optional[IndexLabel] = None,
 ) -> List[Row]:
     """
     Creates a dynamic table that captures the computation expressed by this DataFrame.
@@ -348,13 +348,18 @@ def create_or_replace_dynamic_table(
             - base_location: the base directory that snowflake can write iceberg metadata and files to.
             - catalog_sync: optionally sets the catalog integration configured for Polaris Catalog.
             - storage_serialization_policy: specifies the storage serialization policy for the table.
+        index: default True
+            If true, save DataFrame index columns as table columns.
+        index_label:
+            Column label for index column(s). If None is given (default) and index is True,
+            then the index names are used. A sequence should be given if the DataFrame uses MultiIndex.
 
 
     Note:
         See `understanding dynamic table refresh <https://docs.snowflake.com/en/user-guide/dynamic-tables-refresh>`_.
         for more details on refresh mode.
     """
-    return self.to_snowpark().create_or_replace_dynamic_table(
+    return self._query_compiler.create_or_replace_dynamic_table(
         name=name,
         warehouse=warehouse,
         lag=lag,
@@ -366,6 +371,7 @@ def create_or_replace_dynamic_table(
         is_transient=is_transient,
         data_retention_time=data_retention_time,
         max_data_extension_time=max_data_extension_time,
-        statement_params=statement_params,
         iceberg_config=iceberg_config,
+        index=index,
+        index_label=index_label,
     )

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -292,9 +292,9 @@ def create_or_replace_dynamic_table(
     is_transient: bool = False,
     data_retention_time: Optional[int] = None,
     max_data_extension_time: Optional[int] = None,
-    statement_params: Optional[Dict[str, str]] = None,
     iceberg_config: Optional[dict] = None,
-    _emit_ast: bool = True,
+    index: bool = True,
+    index_label: Optional[IndexLabel] = None,
 ) -> List[Row]:
     """
     Creates a dynamic table that captures the computation expressed by this Series.
@@ -338,13 +338,18 @@ def create_or_replace_dynamic_table(
             - base_location: the base directory that snowflake can write iceberg metadata and files to.
             - catalog_sync: optionally sets the catalog integration configured for Polaris Catalog.
             - storage_serialization_policy: specifies the storage serialization policy for the table.
+        index: default True
+            If true, save DataFrame index columns as table columns.
+        index_label:
+            Column label for index column(s). If None is given (default) and index is True,
+            then the index names are used. A sequence should be given if the DataFrame uses MultiIndex.
 
 
     Note:
         See `understanding dynamic table refresh <https://docs.snowflake.com/en/user-guide/dynamic-tables-refresh>`_.
         for more details on refresh mode.
     """
-    return self.to_snowpark().create_or_replace_dynamic_table(
+    return self._query_compiler.create_or_replace_dynamic_table(
         name=name,
         warehouse=warehouse,
         lag=lag,
@@ -356,6 +361,7 @@ def create_or_replace_dynamic_table(
         is_transient=is_transient,
         data_retention_time=data_retention_time,
         max_data_extension_time=max_data_extension_time,
-        statement_params=statement_params,
         iceberg_config=iceberg_config,
+        index=index,
+        index_label=index_label,
     )

--- a/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
@@ -52,7 +52,7 @@ def test_create_or_replace_dynamic_table_no_relaxed_ordering_raises(session) -> 
 def test_create_or_replace_dynamic_table_relaxed_ordering(session) -> None:
     try:
         # create table
-        table_name = Utils.random_name_for_temp_object(TempObjectType.DYNAMIC_TABLE)
+        table_name = Utils.random_table_name()
         session.create_dataframe(
             [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
         ).write.save_as_table(table_name)
@@ -91,7 +91,7 @@ def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
 ) -> None:
     try:
         # create table
-        table_name = Utils.random_name_for_temp_object(TempObjectType.DYNAMIC_TABLE)
+        table_name = Utils.random_table_name()
         session.create_dataframe(
             [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
         ).write.save_as_table(table_name)
@@ -127,3 +127,95 @@ def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
         Utils.drop_dynamic_table(session, dynamic_table_name)
         Utils.drop_table(session, table_name)
         pd.session = session
+
+
+@pytest.mark.parametrize("index", [True, False])
+@pytest.mark.parametrize("index_labels", [None, ["my_index"]])
+@sql_count_checker(query_count=6)
+def test_create_or_replace_dynamic_table_index(session, index, index_labels):
+    try:
+        # create table
+        table_name = Utils.random_table_name()
+        session.create_dataframe(
+            [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
+        ).write.save_as_table(table_name)
+
+        # create dataframe with relaxed_ordering enabled
+        snow_dataframe = pd.read_snowflake(
+            f"(((SELECT * FROM {table_name})))", relaxed_ordering=True
+        )
+
+        dynamic_table_name = Utils.random_name_for_temp_object(
+            TempObjectType.DYNAMIC_TABLE
+        )
+        snow_dataframe.create_or_replace_dynamic_table(
+            name=dynamic_table_name,
+            warehouse=session.get_current_warehouse(),
+            lag="1000 minutes",
+            index=index,
+            index_label=index_labels,
+        )
+        expected_columns = []
+        if index:
+            # if index is retained in the result, add it as the first expected column
+            expected_index = ["index"]
+            if index_labels:
+                expected_index = index_labels
+            expected_columns = expected_columns + expected_index
+        # add the expected data columns
+        expected_columns = expected_columns + ["_1", "_2", "_3", "_4", "_5", "_6", "_7"]
+
+        # verify columns
+        actual = pd.read_snowflake(dynamic_table_name).columns
+        assert actual.tolist() == expected_columns
+    finally:
+        # cleanup
+        Utils.drop_dynamic_table(session, dynamic_table_name)
+        Utils.drop_table(session, table_name)
+
+
+@sql_count_checker(query_count=6)
+def test_create_or_replace_dynamic_table_multiindex(session):
+    try:
+        # create table
+        table_name = Utils.random_table_name()
+        session.create_dataframe(
+            [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
+        ).write.save_as_table(table_name)
+
+        # create dataframe with relaxed_ordering enabled
+        snow_dataframe = pd.read_snowflake(
+            f"(((SELECT * FROM {table_name})))", relaxed_ordering=True
+        )
+
+        # make sure dataframe has a multi-index
+        snow_dataframe = snow_dataframe.set_index(["_1", "_2"])
+
+        dynamic_table_name = Utils.random_name_for_temp_object(
+            TempObjectType.DYNAMIC_TABLE
+        )
+        snow_dataframe.create_or_replace_dynamic_table(
+            name=dynamic_table_name,
+            warehouse=session.get_current_warehouse(),
+            lag="1000 minutes",
+            index=True,
+        )
+
+        # verify columns
+        actual = pd.read_snowflake(dynamic_table_name).columns
+        assert actual.tolist() == ["_1", "_2", "_3", "_4", "_5", "_6", "_7"]
+
+        with pytest.raises(
+            ValueError, match="Length of 'index_label' should match number of levels"
+        ):
+            snow_dataframe.create_or_replace_dynamic_table(
+                name=dynamic_table_name,
+                warehouse=session.get_current_warehouse(),
+                lag="1000 minutes",
+                index=True,
+                index_label=["a"],
+            )
+    finally:
+        # cleanup
+        Utils.drop_dynamic_table(session, dynamic_table_name)
+        Utils.drop_table(session, table_name)

--- a/tests/integ/modin/series/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/series/test_create_or_replace_dynamic_table.py
@@ -52,7 +52,7 @@ def test_create_or_replace_dynamic_table_no_relaxed_ordering_raises(session) -> 
 def test_create_or_replace_dynamic_table_relaxed_ordering(session) -> None:
     try:
         # create table
-        table_name = Utils.random_name_for_temp_object(TempObjectType.DYNAMIC_TABLE)
+        table_name = Utils.random_table_name()
         session.create_dataframe(
             [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
         ).write.save_as_table(table_name)
@@ -91,7 +91,7 @@ def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
 ) -> None:
     try:
         # create table
-        table_name = Utils.random_name_for_temp_object(TempObjectType.DYNAMIC_TABLE)
+        table_name = Utils.random_table_name()
         session.create_dataframe(
             [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
         ).write.save_as_table(table_name)
@@ -127,3 +127,98 @@ def test_create_or_replace_dynamic_table_multiple_sessions_relaxed_ordering(
         Utils.drop_dynamic_table(session, dynamic_table_name)
         Utils.drop_table(session, table_name)
         pd.session = session
+
+
+@pytest.mark.parametrize("index", [True, False])
+@pytest.mark.parametrize("index_labels", [None, ["my_index"]])
+@sql_count_checker(query_count=6)
+def test_create_or_replace_dynamic_table_index(session, index, index_labels):
+    try:
+        # create table
+        table_name = Utils.random_table_name()
+        session.create_dataframe(
+            [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
+        ).write.save_as_table(table_name)
+
+        # create series with relaxed_ordering enabled
+        snow_series = pd.read_snowflake(
+            f"(((SELECT * FROM {table_name})))", relaxed_ordering=True
+        ).iloc[:, 0]
+
+        dynamic_table_name = Utils.random_name_for_temp_object(
+            TempObjectType.DYNAMIC_TABLE
+        )
+        snow_series.create_or_replace_dynamic_table(
+            name=dynamic_table_name,
+            warehouse=session.get_current_warehouse(),
+            lag="1000 minutes",
+            index=index,
+            index_label=index_labels,
+        )
+        expected_columns = []
+        if index:
+            # if index is retained in the result, add it as the first expected column
+            expected_index = ["index"]
+            if index_labels:
+                expected_index = index_labels
+            expected_columns = expected_columns + expected_index
+        # add the expected data columns
+        expected_columns = expected_columns + ["_1"]
+
+        # verify columns
+        actual = pd.read_snowflake(dynamic_table_name).columns
+        assert actual.tolist() == expected_columns
+    finally:
+        # cleanup
+        Utils.drop_dynamic_table(session, dynamic_table_name)
+        Utils.drop_table(session, table_name)
+
+
+@sql_count_checker(query_count=6)
+def test_create_or_replace_dynamic_table_multiindex(session):
+    try:
+        # create table
+        table_name = Utils.random_table_name()
+        session.create_dataframe(
+            [BASIC_TYPE_DATA1, BASIC_TYPE_DATA2]
+        ).write.save_as_table(table_name)
+
+        # create dataframe with relaxed_ordering enabled
+        snow_dataframe = pd.read_snowflake(
+            f"(((SELECT * FROM {table_name})))", relaxed_ordering=True
+        )
+
+        # make sure dataframe has a multi-index
+        snow_dataframe = snow_dataframe.set_index(["_1", "_2"])
+
+        # create series
+        snow_series = snow_dataframe.iloc[:, 0]
+
+        dynamic_table_name = Utils.random_name_for_temp_object(
+            TempObjectType.DYNAMIC_TABLE
+        )
+        snow_series.create_or_replace_dynamic_table(
+            name=dynamic_table_name,
+            warehouse=session.get_current_warehouse(),
+            lag="1000 minutes",
+            index=True,
+        )
+
+        # verify columns
+        actual = pd.read_snowflake(dynamic_table_name).columns
+        assert actual.tolist() == ["_1", "_2", "_3"]
+
+        with pytest.raises(
+            ValueError, match="Length of 'index_label' should match number of levels"
+        ):
+            snow_series.create_or_replace_dynamic_table(
+                name=dynamic_table_name,
+                warehouse=session.get_current_warehouse(),
+                lag="1000 minutes",
+                index=True,
+                index_label=["a"],
+            )
+    finally:
+        # cleanup
+        Utils.drop_dynamic_table(session, dynamic_table_name)
+        Utils.drop_table(session, table_name)


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2020943, SNOW-2020944

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Support optional index retaining in DataFrame/Series.create_or_replace_dynamic_table.
