### PR TITLE
NOSNOW: Refactor functions.py for AST generation

### DIFF
--- a/src/snowflake/snowpark/dataframe_analytics_functions.py
+++ b/src/snowflake/snowpark/dataframe_analytics_functions.py
@@ -13,8 +13,8 @@ from snowflake.snowpark._internal.ast.utils import (
 from snowflake.snowpark._internal.utils import experimental, publicapi
 from snowflake.snowpark.column import Column, _to_col_if_str
 from snowflake.snowpark.functions import (
+    _call_function,
     add_months,
-    builtin,
     col,
     dateadd,
     from_unixtime,
@@ -262,9 +262,9 @@ class DataFrameAnalyticsFunctions:
                     if col_formatter
                     else f"{column}_{func}{rename_suffix}"
                 )
-                agg_expression = builtin(func)(col(column + rename_suffix)).alias(
-                    agg_column_name
-                )
+                agg_expression = _call_function(
+                    func, col(column + rename_suffix, _emit_ast=False), _emit_ast=False
+                ).alias(agg_column_name, _emit_ast=False)
                 agg_df = input_df.group_by(group_by_cols, _emit_ast=False).agg(
                     agg_expression, _emit_ast=False
                 )
@@ -369,7 +369,9 @@ class DataFrameAnalyticsFunctions:
                     )
 
                     # Apply the user-specified aggregation function directly. Snowflake will handle any errors for invalid functions.
-                    agg_col = builtin(agg_func)(col(column)).over(window_spec)
+                    agg_col = _call_function(
+                        agg_func, col(column, _emit_ast=False), _emit_ast=False
+                    ).over(window_spec, _emit_ast=False)
 
                     formatted_col_name = col_formatter(column, agg_func, window_size)
                     if (
@@ -479,7 +481,9 @@ class DataFrameAnalyticsFunctions:
         for column, agg_funcs in aggs.items():
             for agg_func in agg_funcs:
                 # Apply the user-specified aggregation function directly. Snowflake will handle any errors for invalid functions.
-                agg_col = builtin(agg_func)(col(column)).over(window_spec)
+                agg_col = _call_function(
+                    agg_func, col(column, _emit_ast=False), _emit_ast=False
+                ).over(window_spec, _emit_ast=False)
 
                 formatted_col_name = col_formatter(column, agg_func)
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -170,7 +170,6 @@ import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.table_function
 from snowflake.snowpark._internal.analyzer.expression import (
     CaseWhen,
-    Expression,
     FunctionExpression,
     Interval,
     ListAgg,
@@ -191,8 +190,6 @@ from snowflake.snowpark._internal.ast.utils import (
     build_call_table_function_apply,
     build_expr_from_snowpark_column_or_python_val,
     build_expr_from_snowpark_column_or_sql_str,
-    set_builtin_fn_alias,
-    snowpark_expression_to_ast,
     with_src_position,
     build_function_expr,
 )
@@ -489,13 +486,20 @@ def system_reference(
     privileges = privileges or []
     ast = (
         build_function_expr(
-            "system_reference", [object_type, object_identifier, scope, privileges]
+            "system_reference",
+            [object_type, object_identifier, scope] + privileges,
         )
         if _emit_ast
         else None
     )
-    return builtin("system$reference", _ast=ast, _emit_ast=_emit_ast)(
-        object_type, object_identifier, scope, *privileges
+    return _call_function(
+        "system$reference",
+        object_type,
+        object_identifier,
+        scope,
+        *privileges,
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -510,7 +514,7 @@ def current_session(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_session()).collect()
         >>> assert result[0]['CURRENT_SESSION()'] is not None
     """
-    return builtin("current_session", _emit_ast=_emit_ast)()
+    return _call_function("current_session", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -523,7 +527,7 @@ def current_statement(_emit_ast: bool = True) -> Column:
         >>> session.create_dataframe([1]).select(current_statement()).collect()
         [Row(CURRENT_STATEMENT()='SELECT current_statement() FROM ( SELECT "_1" FROM ( SELECT $1 AS "_1" FROM  VALUES (1 :: INT)))')]
     """
-    return builtin("current_statement", _emit_ast=_emit_ast)()
+    return _call_function("current_statement", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -536,7 +540,7 @@ def current_user(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_user()).collect()
         >>> assert result[0]['CURRENT_USER()'] is not None
     """
-    return builtin("current_user", _emit_ast=_emit_ast)()
+    return _call_function("current_user", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -549,7 +553,7 @@ def current_version(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_version()).collect()
         >>> assert result[0]['CURRENT_VERSION()'] is not None
     """
-    return builtin("current_version", _emit_ast=_emit_ast)()
+    return _call_function("current_version", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -562,7 +566,7 @@ def current_warehouse(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_warehouse()).collect()
         >>> assert result[0]['CURRENT_WAREHOUSE()'] is not None
     """
-    return builtin("current_warehouse", _emit_ast=_emit_ast)()
+    return _call_function("current_warehouse", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -574,7 +578,7 @@ def current_database(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_database()).collect()
         >>> assert result[0]['CURRENT_DATABASE()'] is not None
     """
-    return builtin("current_database", _emit_ast=_emit_ast)()
+    return _call_function("current_database", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -586,7 +590,7 @@ def current_role(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_role()).collect()
         >>> assert result[0]['CURRENT_ROLE()'] is not None
     """
-    return builtin("current_role", _emit_ast=_emit_ast)()
+    return _call_function("current_role", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -598,7 +602,7 @@ def current_schema(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_schema()).collect()
         >>> assert result[0]['CURRENT_SCHEMA()'] is not None
     """
-    return builtin("current_schema", _emit_ast=_emit_ast)()
+    return _call_function("current_schema", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -610,7 +614,7 @@ def current_schemas(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_schemas()).collect()
         >>> assert result[0]['CURRENT_SCHEMAS()'] is not None
     """
-    return builtin("current_schemas", _emit_ast=_emit_ast)()
+    return _call_function("current_schemas", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -622,7 +626,7 @@ def current_region(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_region()).collect()
         >>> assert result[0]['CURRENT_REGION()'] is not None
     """
-    return builtin("current_region", _emit_ast=_emit_ast)()
+    return _call_function("current_region", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -634,7 +638,7 @@ def current_account(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_account()).collect()
         >>> assert result[0]['CURRENT_ACCOUNT()'] is not None
     """
-    return builtin("current_account", _emit_ast=_emit_ast)()
+    return _call_function("current_account", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -646,7 +650,7 @@ def current_available_roles(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_available_roles()).collect()
         >>> assert result[0]['CURRENT_AVAILABLE_ROLES()'] is not None
     """
-    return builtin("current_available_roles", _emit_ast=_emit_ast)()
+    return _call_function("current_available_roles", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -664,7 +668,7 @@ def add_months(
         datetime.date(2022, 8, 6)
     """
     c = _to_col_if_str(date_or_timestamp, "add_months")
-    return builtin("add_months", _emit_ast=_emit_ast)(c, number_of_months)
+    return _call_function("add_months", c, number_of_months, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -678,7 +682,7 @@ def any_value(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         >>> assert len(result) == 1  # non-deterministic value in result.
     """
     c = _to_col_if_str(e, "any_value")
-    return call_builtin("any_value", c, _emit_ast=_emit_ast)
+    return _call_function("any_value", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -691,7 +695,7 @@ def bitnot(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         -2
     """
     c = _to_col_if_str(e, "bitnot")
-    return call_builtin("bitnot", c, _emit_ast=_emit_ast)
+    return _call_function("bitnot", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -706,7 +710,7 @@ def bitshiftleft(
         4
     """
     c = _to_col_if_str(to_shift_column, "bitshiftleft")
-    return call_builtin("bitshiftleft", c, n, _emit_ast=_emit_ast)
+    return _call_function("bitshiftleft", c, n, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -729,10 +733,11 @@ def bitshiftright_unsigned(
         9223372036854775797
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "bitshiftright_unsigned", to_shift_column, n)
+    ast = (
+        build_function_expr("bitshiftright_unsigned", [to_shift_column, n])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(to_shift_column, "bitshiftright_unsigned")
     max_bit = bitshiftleft(lit(1, _emit_ast=False), 64, _emit_ast=False)
@@ -742,9 +747,9 @@ def bitshiftright_unsigned(
         bitshiftright(c, n, _emit_ast=False),
         _emit_ast=False,
     )
-    col = call_builtin("bitand", unsigned_c, max_bit - 1, _emit_ast=False)
-    col._ast = ast
-    return col
+    return _call_function(
+        "bitand", unsigned_c, max_bit - 1, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -759,7 +764,7 @@ def bitshiftright(
         1
     """
     c = _to_col_if_str(to_shift_column, "bitshiftright")
-    return call_builtin("bitshiftright", c, n, _emit_ast=_emit_ast)
+    return _call_function("bitshiftright", c, n, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -802,20 +807,20 @@ def bround(
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "bround", col, scale)
+    ast = build_function_expr("bround", [col, scale]) if _emit_ast else None
 
     col = _to_col_if_str(col, "bround")
     scale = _to_col_if_lit(scale, "bround")
 
     # Note: Original Snowpark python code capitalized here.
-    col = call_builtin(
-        "ROUND", col, scale, lit("HALF_TO_EVEN", _emit_ast=False), _emit_ast=False
+    return _call_function(
+        "ROUND",
+        col,
+        scale,
+        lit("HALF_TO_EVEN", _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
-    col._ast = ast
-    return col
 
 
 @publicapi
@@ -866,26 +871,27 @@ def convert_timezone(
     ast = (
         build_function_expr(
             "convert_timezone",
-            [target_timezone, source_time, source_timezone],
+            [target_timezone, source_time]
+            + ([] if source_timezone is None else [source_timezone]),
         )
         if _emit_ast
         else None
     )
     if source_timezone is None:
-        return call_builtin(
+        return _call_function(
             "convert_timezone",
             target_tz,
             source_time_to_convert,
             _ast=ast,
-            _emit_ast=False,
+            _emit_ast=_emit_ast,
         )
-    return call_builtin(
+    return _call_function(
         "convert_timezone",
         source_tz,
         target_tz,
         source_time_to_convert,
         _ast=ast,
-        _emit_ast=False,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -906,7 +912,7 @@ def approx_count_distinct(e: ColumnOrName, _emit_ast: bool = True) -> Column:
 
     """
     c = _to_col_if_str(e, "approx_count_distinct")
-    return builtin("approx_count_distinct", _emit_ast=_emit_ast)(c)
+    return _call_function("approx_count_distinct", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -925,7 +931,7 @@ def avg(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "avg")
-    return builtin("avg", _emit_ast=_emit_ast)(c)
+    return _call_function("avg", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -946,7 +952,7 @@ def corr(
     """
     c1 = _to_col_if_str(column1, "corr")
     c2 = _to_col_if_str(column2, "corr")
-    return builtin("corr", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("corr", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -971,17 +977,12 @@ def count(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         ------------
         <BLANKLINE>
     """
-
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "count", e)
+    # Build AST here to avoid building from Snowflake Expression.
+    ast = build_function_expr("count", [e]) if _emit_ast else None
 
     c = _to_col_if_str(e, "count")
     expr = Literal(1) if isinstance(c._expression, Star) else c._expression
-    ans = builtin("count", _emit_ast=False)(expr)
-    ans._ast = ast
-    return ans
+    return _call_function("count", expr, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1001,17 +1002,12 @@ def count_distinct(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
         >>> #  The result should be 2 for {[1,2],[2,3]} since the rest are either duplicate or NULL records
     """
-
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "count_distinct", *cols)
-
     cs = [_to_col_if_str(c, "count_distinct") for c in cols]
+    ast = build_function_expr("count_distinct", cs) if _emit_ast else None
     return Column(
         FunctionExpression("count", [c._expression for c in cs], is_distinct=True),
         _ast=ast,
-        _emit_ast=False,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -1034,7 +1030,7 @@ def covar_pop(
     """
     col1 = _to_col_if_str(column1, "covar_pop")
     col2 = _to_col_if_str(column2, "covar_pop")
-    return builtin("covar_pop", _emit_ast=_emit_ast)(col1, col2)
+    return _call_function("covar_pop", col1, col2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1056,7 +1052,7 @@ def covar_samp(
     """
     col1 = _to_col_if_str(column1, "covar_samp")
     col2 = _to_col_if_str(column2, "covar_samp")
-    return builtin("covar_samp", _emit_ast=_emit_ast)(col1, col2)
+    return _call_function("covar_samp", col1, col2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1106,10 +1102,12 @@ def create_map(
         <BLANKLINE>
     """
     variadic = check_create_map_parameter(*cols)
-    ast = proto.Expr()
-    build_builtin_fn_apply(
-        ast, "create_map", *cols if variadic else cols
-    ) if _emit_ast else None
+    ast = None
+    if _emit_ast:
+        ast = proto.Expr()
+        build_builtin_fn_apply(
+            ast, "create_map", *cols if variadic else cols
+        ) if _emit_ast else None
 
     # TODO SNOW-1790918: Remove as part of refactoring with alias.
     if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
@@ -1134,7 +1132,7 @@ def kurtosis(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(X=Decimal('3.613736609956'))]
     """
     c = _to_col_if_str(e, "kurtosis")
-    return builtin("kurtosis", _emit_ast=_emit_ast)(c)
+    return _call_function("kurtosis", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1150,7 +1148,7 @@ def max(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(X=10)]
     """
     c = _to_col_if_str(e, "max")
-    return builtin("max", _emit_ast=_emit_ast)(c)
+    return _call_function("max", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1165,7 +1163,7 @@ def mean(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(X=Decimal('3.600000'))]
     """
     c = _to_col_if_str(e, "mean")
-    ans = avg(c, _emit_ast=_emit_ast)
+    ans = avg(c, _emit_ast=False)
     ans._ast = build_function_expr("mean", [c]) if _emit_ast else None
     return ans
 
@@ -1183,7 +1181,7 @@ def median(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(X=Decimal('3.000'))]
     """
     c = _to_col_if_str(e, "median")
-    return builtin("median", _emit_ast=_emit_ast)(c)
+    return _call_function("median", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1199,7 +1197,7 @@ def min(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(X=1)]
     """
     c = _to_col_if_str(e, "min")
-    return builtin("min", _emit_ast=_emit_ast)(c)
+    return _call_function("min", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1215,7 +1213,7 @@ def mode(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(X=1)]
     """
     c = _to_col_if_str(e, "mode")
-    return builtin("mode", _emit_ast=_emit_ast)(c)
+    return _call_function("mode", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1233,7 +1231,7 @@ def skew(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CAST (SKEW("A") AS NUMBER(38, 4))=Decimal('0.0524'))]
     """
     c = _to_col_if_str(e, "skew")
-    return builtin("skew", _emit_ast=_emit_ast)(c)
+    return _call_function("skew", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1251,7 +1249,7 @@ def stddev(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CAST (STDDEV("N") AS NUMBER(38, 4))=Decimal('3.5355'))]
     """
     c = _to_col_if_str(e, "stddev")
-    return builtin("stddev", _emit_ast=_emit_ast)(c)
+    return _call_function("stddev", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1270,7 +1268,7 @@ def stddev_samp(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CAST (STDDEV_SAMP("N") AS NUMBER(38, 4))=Decimal('3.5355'))]
     """
     c = _to_col_if_str(e, "stddev_samp")
-    return builtin("stddev_samp", _emit_ast=_emit_ast)(c)
+    return _call_function("stddev_samp", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1287,7 +1285,7 @@ def stddev_pop(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(STDDEV_POP("N")=2.5)]
     """
     c = _to_col_if_str(e, "stddev_pop")
-    return builtin("stddev_pop", _emit_ast=_emit_ast)(c)
+    return _call_function("stddev_pop", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1305,7 +1303,7 @@ def sum(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(SUM("N")=13)]
     """
     c = _to_col_if_str(e, "sum")
-    return builtin("sum", _emit_ast=_emit_ast)(c)
+    return _call_function("sum", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1322,14 +1320,11 @@ def sum_distinct(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         >>> df.collect()
         [Row(SUM( DISTINCT "N")=6)]
     """
+    # AST.
+    ast = build_function_expr("sum_distinct", [e]) if _emit_ast else None
+
     c = _to_col_if_str(e, "sum_distinct")
-    col = _call_function("sum", True, c, _emit_ast=_emit_ast)
-
-    # alias to keep sum_distinct
-    if _emit_ast:
-        set_builtin_fn_alias(col._ast, "sum_distinct")
-
-    return col
+    return _call_function("sum", c, is_distinct=True, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1357,7 +1352,7 @@ def variance(e: ColumnOrName, _emit_ast: bool = True) -> Column:
 
     """
     c = _to_col_if_str(e, "variance")
-    return builtin("variance", _emit_ast=_emit_ast)(c)
+    return _call_function("variance", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1385,10 +1380,11 @@ def var_samp(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(VARIANCE("A")=None)]
 
     """
+    # AST.
+    ast = build_function_expr("var_samp", [e]) if _emit_ast else None
+
     c = _to_col_if_str(e, "var_samp")
-    ans = variance(c, _emit_ast=_emit_ast)
-    ans._ast = build_function_expr("var_samp", [c]) if _emit_ast else None
-    return ans
+    return _call_function("variance", c, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1416,7 +1412,7 @@ def var_pop(e: ColumnOrName, _emit_ast: bool = True) -> Column:
 
     """
     c = _to_col_if_str(e, "var_pop")
-    return builtin("var_pop", _emit_ast=_emit_ast)(c)
+    return _call_function("var_pop", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1440,8 +1436,12 @@ def approx_percentile(
     ast = (
         build_function_expr("approx_percentile", [c, percentile]) if _emit_ast else None
     )
-    return builtin("approx_percentile", _ast=ast, _emit_ast=False)(
-        c, lit(percentile, _emit_ast=False)
+    return _call_function(
+        "approx_percentile",
+        c,
+        lit(percentile, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -1479,7 +1479,7 @@ def approx_percentile_accumulate(col: ColumnOrName, _emit_ast: bool = True) -> C
         <BLANKLINE>
     """
     c = _to_col_if_str(col, "approx_percentile_accumulate")
-    return builtin("approx_percentile_accumulate", _emit_ast=_emit_ast)(c)
+    return _call_function("approx_percentile_accumulate", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1508,8 +1508,12 @@ def approx_percentile_estimate(
         if _emit_ast
         else None
     )
-    return builtin("approx_percentile_estimate", _ast=ast, _emit_ast=False)(
-        c, lit(percentile, _emit_ast=False)
+    return _call_function(
+        "approx_percentile_estimate",
+        c,
+        lit(percentile, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -1560,7 +1564,7 @@ def approx_percentile_combine(state: ColumnOrName, _emit_ast: bool = True) -> Co
         <BLANKLINE>
     """
     c = _to_col_if_str(state, "approx_percentile_combine")
-    return builtin("approx_percentile_combine", _emit_ast=_emit_ast)(c)
+    return _call_function("approx_percentile_combine", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1617,14 +1621,13 @@ def explode(
         --------------------------------
         <BLANKLINE>
     """
-    col = _to_col_if_str(col, "explode")
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "explode", col)
+    ast = build_function_expr("explode", [col]) if _emit_ast else None
 
-    func_call = snowflake.snowpark.table_function._ExplodeFunctionCall(col, lit(False))
+    col = _to_col_if_str(col, "explode")
+    func_call = snowflake.snowpark.table_function._ExplodeFunctionCall(
+        col, lit(False, _emit_ast=False)
+    )
     func_call._set_api_call_source("functions.explode")
     func_call._ast = ast
 
@@ -1674,15 +1677,13 @@ def explode_outer(
     See Also:
         :func:`explode`
     """
-    col = _to_col_if_str(col, "explode_outer")
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "explode_outer", col)
+    ast = build_function_expr("explode_outer", [col]) if _emit_ast else None
 
-    func_call = snowflake.snowpark.table_function._ExplodeFunctionCall(col, lit(True))
+    col = _to_col_if_str(col, "explode_outer")
+    func_call = snowflake.snowpark.table_function._ExplodeFunctionCall(
+        col, lit(True, _emit_ast=False)
+    )
     func_call._set_api_call_source("functions.explode_outer")
     func_call._ast = ast
 
@@ -1760,14 +1761,14 @@ def flatten(
         - :func:`explode`
         - `Flatten <https://docs.snowflake.com/en/sql-reference/functions/flatten>`_
     """
-    col = _to_col_if_str(col, "flatten")
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "flatten", col, path, outer, recursive, mode)
+    ast = (
+        build_function_expr("flatten", [col, path, outer, recursive, mode])
+        if _emit_ast
+        else None
+    )
 
+    col = _to_col_if_str(col, "flatten")
     func_call = snowflake.snowpark.table_function.TableFunctionCall(
         "flatten",
         input=col,
@@ -1775,6 +1776,7 @@ def flatten(
         outer=lit(outer),
         recursive=lit(recursive),
         mode=lit(mode),
+        _emit_ast=False,
     )
     func_call._set_api_call_source("functions.flatten")
     func_call._ast = ast
@@ -1802,7 +1804,7 @@ Row(A=4, B=None, COUNT_C=1, GA=0, GB=1, GAB=1), \
 Row(A=4, B=5, COUNT_C=1, GA=0, GB=0, GAB=0)]
     """
     columns = [_to_col_if_str(c, "grouping") for c in cols]
-    return builtin("grouping", _emit_ast=_emit_ast)(*columns)
+    return _call_function("grouping", *columns, _emit_ast=_emit_ast)
 
 
 grouping_id = grouping
@@ -1828,7 +1830,7 @@ def coalesce(*e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = [_to_col_if_str(ex, "coalesce") for ex in e]
-    return builtin("coalesce", _emit_ast=_emit_ast)(*c)
+    return _call_function("coalesce", *c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1844,10 +1846,7 @@ def equal_nan(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(EQUAL_NAN=False), Row(EQUAL_NAN=True), Row(EQUAL_NAN=False)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "equal_nan", e)
+    ast = build_function_expr("equal_nan", [e]) if _emit_ast else None
 
     c = _to_col_if_str(e, "equal_nan")
     ans = c.equal_nan(_emit_ast=False)
@@ -1868,10 +1867,7 @@ def is_null(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=False), Row(A=False), Row(A=True), Row(A=False)]
     """
     # AST
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "is_null", e)
+    ast = build_function_expr("is_null", [e]) if _emit_ast else None
 
     c = _to_col_if_str(e, "is_null")
     ans = c.is_null(_emit_ast=False)
@@ -1895,10 +1891,7 @@ def negate(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     # AST
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "negate", e)
+    ast = build_function_expr("negate", [e]) if _emit_ast else None
 
     c = _to_col_if_str(e, "negate")
     ans = -c
@@ -1922,10 +1915,7 @@ def not_(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     # AST
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "not_", e)
+    ast = build_function_expr("not_", [e]) if _emit_ast else None
 
     c = _to_col_if_str(e, "not_")
     ans = ~c
@@ -1943,18 +1933,14 @@ def random(seed: Optional[int] = None, _emit_ast: bool = True) -> Column:
     """
 
     # Create AST here to encode whether a seed was supplied by the user or not.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        args = (seed,) if seed is not None else ()
-        build_builtin_fn_apply(ast, "random", *args)
+    ast = (
+        build_function_expr("random", [] if seed is None else [seed])
+        if _emit_ast
+        else None
+    )
 
     s = seed if seed is not None else randint(-(2**63), 2**63 - 1)
-    col = builtin("random", _emit_ast=False)(Literal(s))
-    if _emit_ast:
-        col._ast = ast
-
-    return col
+    return _call_function("random", Literal(s), _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -1994,7 +1980,6 @@ def uniform(
     )
     return _call_function(
         "uniform",
-        False,
         min_col,
         max_col,
         gen_col,
@@ -2022,8 +2007,9 @@ def seq1(sign: int = 0, _emit_ast: bool = True) -> Column:
         >>> df.collect()
         [Row(SEQ1(0)=0), Row(SEQ1(0)=1), Row(SEQ1(0)=2)]
     """
+    ast = build_function_expr("seq1", [sign]) if _emit_ast else None
     return _call_function(
-        "seq1", False, Literal(sign), is_data_generator=True, _emit_ast=_emit_ast
+        "seq1", Literal(sign), is_data_generator=True, _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -2045,8 +2031,9 @@ def seq2(sign: int = 0, _emit_ast: bool = True) -> Column:
         >>> df.collect()
         [Row(SEQ2(0)=0), Row(SEQ2(0)=1), Row(SEQ2(0)=2)]
     """
+    ast = build_function_expr("seq2", [sign]) if _emit_ast else None
     return _call_function(
-        "seq2", False, Literal(sign), is_data_generator=True, _emit_ast=_emit_ast
+        "seq2", Literal(sign), is_data_generator=True, _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -2068,8 +2055,9 @@ def seq4(sign: int = 0, _emit_ast: bool = True) -> Column:
         >>> df.collect()
         [Row(SEQ4(0)=0), Row(SEQ4(0)=1), Row(SEQ4(0)=2)]
     """
+    ast = build_function_expr("seq4", [sign]) if _emit_ast else None
     return _call_function(
-        "seq4", False, Literal(sign), is_data_generator=True, _emit_ast=_emit_ast
+        "seq4", Literal(sign), is_data_generator=True, _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -2091,8 +2079,9 @@ def seq8(sign: int = 0, _emit_ast: bool = True) -> Column:
         >>> df.collect()
         [Row(SEQ8(0)=0), Row(SEQ8(0)=1), Row(SEQ8(0)=2)]
     """
+    ast = build_function_expr("seq8", [sign]) if _emit_ast else None
     return _call_function(
-        "seq8", False, Literal(sign), is_data_generator=True, _emit_ast=_emit_ast
+        "seq8", Literal(sign), is_data_generator=True, _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -2106,7 +2095,7 @@ def to_boolean(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ANS=True), Row(ANS=False)]
     """
     c = _to_col_if_str(e, "to_boolean")
-    return builtin("to_boolean", _emit_ast=_emit_ast)(c)
+    return _call_function("to_boolean", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2123,13 +2112,18 @@ def to_decimal(
         >>> df.select(to_decimal(col('a'), 38, 2).as_('ans')).collect()
         [Row(ANS=Decimal('12.00')), Row(ANS=Decimal('11.30')), Row(ANS=Decimal('-90.12'))]
     """
-    c = _to_col_if_str(e, "to_decimal")
     # Build AST here to prevent `precision` and `scale` from being recorded as a literal instead of int.
     ast = (
-        build_function_expr("to_decimal", [c, precision, scale]) if _emit_ast else None
+        build_function_expr("to_decimal", [e, precision, scale]) if _emit_ast else None
     )
-    return builtin("to_decimal", _ast=ast, _emit_ast=False)(
-        c, lit(precision, _emit_ast=False), lit(scale, _emit_ast=False)
+    c = _to_col_if_str(e, "to_decimal")
+    return _call_function(
+        "to_decimal",
+        c,
+        lit(precision, _emit_ast=False),
+        lit(scale, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -2149,22 +2143,18 @@ def to_double(
         >>> df.select(to_double(col('a'), "999.99MI").as_('ans')).collect()
         [Row(ANS=12.0), Row(ANS=11.3), Row(ANS=-90.12)]
     """
-
-    # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "to_double", e, fmt)
-
-    c = _to_col_if_str(e, "to_double")
-    fmt_col = c if fmt is None else _to_col_if_lit(fmt, "to_double")
-    ans = (
-        builtin("to_double", _emit_ast=False)(c)
-        if fmt is None
-        else builtin("to_double", _emit_ast=False)(c, fmt_col)
+    ast = (
+        build_function_expr("to_double", [e] if fmt is None else [e, fmt])
+        if _emit_ast
+        else None
     )
-    ans._ast = ast
-    return ans
+    c = _to_col_if_str(e, "to_double")
+    fmt_col = _to_col_if_lit(fmt, "to_double") if fmt is not None else None
+    return (
+        _call_function("to_double", c, _ast=ast, _emit_ast=_emit_ast)
+        if fmt_col is None
+        else _call_function("to_double", c, fmt_col, _ast=ast, _emit_ast=_emit_ast)
+    )
 
 
 @publicapi
@@ -2195,7 +2185,9 @@ def div0(
         if isinstance(divisor, (int, float))
         else _to_col_if_str(divisor, "div0")
     )
-    return builtin("div0", _ast=ast, _emit_ast=False)(dividend_col, divisor_col)
+    return _call_function(
+        "div0", dividend_col, divisor_col, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -2241,7 +2233,7 @@ def nullifzero(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(RESULT=None), Row(RESULT=1)]
     """
     c = _to_col_if_str(e, "nullifzero")
-    return builtin("nullifzero", _emit_ast=_emit_ast)(c)
+    return _call_function("nullifzero", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2257,7 +2249,7 @@ def sqrt(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(SQRT("N")=2.0), Row(SQRT("N")=3.0)]
     """
     c = _to_col_if_str(e, "sqrt")
-    return builtin("sqrt", _emit_ast=_emit_ast)(c)
+    return _call_function("sqrt", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2275,7 +2267,7 @@ def abs(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "abs")
-    return builtin("abs", _emit_ast=_emit_ast)(c)
+    return _call_function("abs", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2295,7 +2287,7 @@ def acos(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "acos")
-    return builtin("acos", _emit_ast=_emit_ast)(c)
+    return _call_function("acos", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2315,7 +2307,7 @@ def asin(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "asin")
-    return builtin("asin", _emit_ast=_emit_ast)(c)
+    return _call_function("asin", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2335,7 +2327,7 @@ def atan(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "atan")
-    return builtin("atan", _emit_ast=_emit_ast)(c)
+    return _call_function("atan", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2356,7 +2348,7 @@ def atan2(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Column:
     """
     y_col = _to_col_if_str(y, "atan2")
     x_col = _to_col_if_str(x, "atan2")
-    return builtin("atan2", _emit_ast=_emit_ast)(y_col, x_col)
+    return _call_function("atan2", y_col, x_col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2371,7 +2363,7 @@ def ceil(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CEIL=136.0), Row(CEIL=-975.0)]
     """
     c = _to_col_if_str(e, "ceil")
-    return builtin("ceil", _emit_ast=_emit_ast)(c)
+    return _call_function("ceil", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2390,7 +2382,7 @@ def cos(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "cos")
-    return builtin("cos", _emit_ast=_emit_ast)(c)
+    return _call_function("cos", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2409,7 +2401,7 @@ def cosh(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "cosh")
-    return builtin("cosh", _emit_ast=_emit_ast)(c)
+    return _call_function("cosh", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2426,7 +2418,7 @@ def exp(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(EXP=1), Row(EXP=10)]
     """
     c = _to_col_if_str(e, "exp")
-    return builtin("exp", _emit_ast=_emit_ast)(c)
+    return _call_function("exp", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2442,7 +2434,7 @@ def factorial(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(FACTORIAL=1), Row(FACTORIAL=1), Row(FACTORIAL=120), Row(FACTORIAL=3628800)]
     """
     c = _to_col_if_str(e, "factorial")
-    return builtin("factorial", _emit_ast=_emit_ast)(c)
+    return _call_function("factorial", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2458,7 +2450,7 @@ def floor(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(FLOOR=135.0), Row(FLOOR=-976.0)]
     """
     c = _to_col_if_str(e, "floor")
-    return builtin("floor", _emit_ast=_emit_ast)(c)
+    return _call_function("floor", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2489,15 +2481,8 @@ def format_number(col: ColumnOrName, d: Union[Column, int], _emit_ast: bool = Tr
             <BLANKLINE>
     """
     col = _to_col_if_str(col, "format_number")
-
     c = bround(col, d, _emit_ast=False).cast(StringType(), _emit_ast=False)
-
-    # AST.
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "format_number", col, d)
-        c._ast = ast
-
+    c._ast = build_function_expr("format_number", [col, d]) if _emit_ast else None
     return c
 
 
@@ -2512,7 +2497,7 @@ def sin(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CAST (SIN(SEQ1(0)) AS NUMBER(38, 4))=Decimal('0.0000')), Row(CAST (SIN(SEQ1(0)) AS NUMBER(38, 4))=Decimal('0.8415')), Row(CAST (SIN(SEQ1(0)) AS NUMBER(38, 4))=Decimal('0.9093'))]
     """
     c = _to_col_if_str(e, "sin")
-    return builtin("sin", _emit_ast=_emit_ast)(c)
+    return _call_function("sin", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2526,7 +2511,7 @@ def sinh(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CAST (SINH(SEQ1(0)) AS NUMBER(38, 4))=Decimal('0.0000')), Row(CAST (SINH(SEQ1(0)) AS NUMBER(38, 4))=Decimal('1.1752')), Row(CAST (SINH(SEQ1(0)) AS NUMBER(38, 4))=Decimal('3.6269'))]
     """
     c = _to_col_if_str(e, "sinh")
-    return builtin("sinh", _emit_ast=_emit_ast)(c)
+    return _call_function("sinh", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2542,7 +2527,7 @@ def tan(e: ColumnOrName, _emit_ast: bool = True) -> Column:
        [Row(CAST (TAN("N") AS NUMBER(38, 4))=Decimal('0.0000')), Row(CAST (TAN("N") AS NUMBER(38, 4))=Decimal('1.5574'))]
     """
     c = _to_col_if_str(e, "tan")
-    return builtin("tan", _emit_ast=_emit_ast)(c)
+    return _call_function("tan", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2558,7 +2543,7 @@ def tanh(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(TANH( CAST ("N" AS NUMBER(38, 4)))=0.0), Row(TANH( CAST ("N" AS NUMBER(38, 4)))=0.7615941559557649)]
     """
     c = _to_col_if_str(e, "tanh")
-    return builtin("tanh", _emit_ast=_emit_ast)(c)
+    return _call_function("tanh", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2578,7 +2563,7 @@ def degrees(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DEGREES=60), Row(DEGREES=180), Row(DEGREES=540)]
     """
     c = _to_col_if_str(e, "degrees")
-    return builtin("degrees", _emit_ast=_emit_ast)(c)
+    return _call_function("degrees", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2599,7 +2584,7 @@ def radians(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "radians")
-    return builtin("radians", _emit_ast=_emit_ast)(c)
+    return _call_function("radians", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2614,7 +2599,7 @@ def md5(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(MD5("COL")='0cc175b9c0f1b6a831c399e269772661'), Row(MD5("COL")='92eb5ffee6ae2fec3ad71c777531578f')]
     """
     c = _to_col_if_str(e, "md5")
-    return builtin("md5", _emit_ast=_emit_ast)(c)
+    return _call_function("md5", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2627,7 +2612,7 @@ def sha1(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(SHA1("COL")='86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'), Row(SHA1("COL")='e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98')]
     """
     c = _to_col_if_str(e, "sha1")
-    return builtin("sha1", _emit_ast=_emit_ast)(c)
+    return _call_function("sha1", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2646,7 +2631,7 @@ def sha2(e: ColumnOrName, num_bits: int, _emit_ast: bool = True) -> Column:
             f"num_bits {num_bits} is not in the permitted values {permitted_values}"
         )
     c = _to_col_if_str(e, "sha2")
-    return builtin("sha2", _emit_ast=_emit_ast)(c, num_bits)
+    return _call_function("sha2", c, num_bits, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2664,7 +2649,7 @@ def hash(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ONE=8817975702393619368, TWO=953963258351104160, THREE=2941948363845684412)]
     """
     columns = [_to_col_if_str(c, "hash") for c in cols]
-    return builtin("hash", _emit_ast=_emit_ast)(columns)
+    return _call_function("hash", *columns, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2679,7 +2664,7 @@ def ascii(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A='!', ASCII=33), Row(A='A', ASCII=65), Row(A='a', ASCII=97), Row(A='', ASCII=0), Row(A='bcd', ASCII=98), Row(A=None, ASCII=None)]
     """
     c = _to_col_if_str(e, "ascii")
-    return builtin("ascii", _emit_ast=_emit_ast)(c)
+    return _call_function("ascii", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2708,10 +2693,10 @@ def initcap(
     """
     c = _to_col_if_str(e, "initcap")
     if delimiters is None:
-        return builtin("initcap", _emit_ast=_emit_ast)(c)
+        return _call_function("initcap", c, _emit_ast=_emit_ast)
 
     delimiter_col = _to_col_if_str(delimiters, "initcap")
-    return builtin("initcap", _emit_ast=_emit_ast)(c, delimiter_col)
+    return _call_function("initcap", c, delimiter_col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2728,7 +2713,7 @@ def length(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(LENGTH=15), Row(LENGTH=18), Row(LENGTH=7), Row(LENGTH=None)]
     """
     c = _to_col_if_str(e, "length")
-    return builtin("length", _emit_ast=_emit_ast)(c)
+    return _call_function("length", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2743,7 +2728,7 @@ def lower(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(LOWER("A")='abc'), Row(LOWER("A")='abc'), Row(LOWER("A")='abc'), Row(LOWER("A")='anführungszeichen'), Row(LOWER("A")='14.95 €')]
     """
     c = _to_col_if_str(e, "lower")
-    return builtin("lower", _emit_ast=_emit_ast)(c)
+    return _call_function("lower", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2772,8 +2757,13 @@ def lpad(
     p = _to_col_if_str(pad, "lpad")
     # Build AST here to prevent `len` from being recorded as a literal instead of int.
     ast = build_function_expr("lpad", [c, len, p]) if _emit_ast else None
-    return builtin("lpad", _ast=ast, _emit_ast=False)(
-        c, len if isinstance(len, Column) else lit(len), p
+    return _call_function(
+        "lpad",
+        c,
+        len if isinstance(len, Column) else lit(len, _emit_ast=False),
+        p,
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -2801,9 +2791,9 @@ def ltrim(
     c = _to_col_if_str(e, "ltrim")
     t = _to_col_if_str(trim_string, "ltrim") if trim_string is not None else None
     return (
-        builtin("ltrim", _emit_ast=_emit_ast)(c, t)
+        _call_function("ltrim", c, t, _emit_ast=_emit_ast)
         if t is not None
-        else builtin("ltrim", _emit_ast=_emit_ast)(c)
+        else _call_function("ltrim", c, _emit_ast=_emit_ast)
     )
 
 
@@ -2833,8 +2823,13 @@ def rpad(
     p = _to_col_if_str(pad, "rpad")
     # Build AST here to prevent `len` from being recorded as a literal instead of int.
     ast = build_function_expr("rpad", [c, len, p]) if _emit_ast else None
-    return builtin("rpad", _ast=ast, _emit_ast=False)(
-        c, len if isinstance(len, Column) else lit(len), p
+    return _call_function(
+        "rpad",
+        c,
+        len if isinstance(len, Column) else lit(len, _emit_ast=False),
+        p,
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -2861,9 +2856,9 @@ def rtrim(
     c = _to_col_if_str(e, "rtrim")
     t = _to_col_if_str(trim_string, "rtrim") if trim_string is not None else None
     return (
-        builtin("rtrim", _emit_ast=_emit_ast)(c, t)
+        _call_function("rtrim", c, t, _emit_ast=_emit_ast)
         if t is not None
-        else builtin("rtrim", _emit_ast=_emit_ast)(c)
+        else _call_function("rtrim", c, _emit_ast=_emit_ast)
     )
 
 
@@ -2887,8 +2882,12 @@ def repeat(s: ColumnOrName, n: Union[Column, int], _emit_ast: bool = True) -> Co
     c = _to_col_if_str(s, "repeat")
     # Build AST here to prevent `n` from being recorded as a literal instead of int.
     ast = build_function_expr("repeat", [c, n]) if _emit_ast else None
-    return builtin("repeat", _ast=ast, _emit_ast=False)(
-        c, n if isinstance(n, Column) else lit(n)
+    return _call_function(
+        "repeat",
+        c,
+        n if isinstance(n, Column) else lit(n, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -2909,7 +2908,7 @@ def reverse(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     col = _to_col_if_str(col, "reverse")
-    return builtin("reverse", _emit_ast=_emit_ast)(col)
+    return _call_function("reverse", col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2922,7 +2921,7 @@ def soundex(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(SOUNDEX("V")='M620'), Row(SOUNDEX("V")='M620')]
     """
     c = _to_col_if_str(e, "soundex")
-    return builtin("soundex", _emit_ast=_emit_ast)(c)
+    return _call_function("soundex", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -2955,9 +2954,9 @@ def trim(
     c = _to_col_if_str(e, "trim")
     t = _to_col_if_str(trim_string, "trim") if trim_string is not None else None
     return (
-        builtin("trim", _emit_ast=_emit_ast)(c, t)
+        _call_function("trim", c, t, _emit_ast=_emit_ast)
         if t is not None
-        else builtin("trim", _emit_ast=_emit_ast)(c)
+        else _call_function("trim", c, _emit_ast=_emit_ast)
     )
 
 
@@ -2973,7 +2972,7 @@ def upper(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(UPPER("A")='ABC'), Row(UPPER("A")='ABC'), Row(UPPER("A")='ABC'), Row(UPPER("A")='ANFÜHRUNGSZEICHEN'), Row(UPPER("A")='14.95 €')]
     """
     c = _to_col_if_str(e, "upper")
-    return builtin("upper", _emit_ast=_emit_ast)(c)
+    return _call_function("upper", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3000,9 +2999,9 @@ def strtok_to_array(
         else None
     )
     return (
-        builtin("strtok_to_array", _emit_ast=_emit_ast)(t, d)
+        _call_function("strtok_to_array", t, d, _emit_ast=_emit_ast)
         if (delimiter is not None)
-        else builtin("strtok_to_array", _emit_ast=_emit_ast)(t)
+        else _call_function("strtok_to_array", t, _emit_ast=_emit_ast)
     )
 
 
@@ -3030,10 +3029,7 @@ def struct(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "struct", *cols)
+    ast = build_function_expr("struct", cols) if _emit_ast else None
 
     def flatten_col_list(obj):
         if isinstance(obj, str) or isinstance(obj, Column):
@@ -3048,7 +3044,7 @@ def struct(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
     for c in flatten_col_list(cols):
         # first insert field_name
         if isinstance(c, str):
-            new_cols.append(lit(c))
+            new_cols.append(lit(c, _emit_ast=False))
         else:
             name = c._expression.name
             name = name[1:] if name.startswith('"') else name
@@ -3071,7 +3067,6 @@ def log(
     base: Union[ColumnOrName, int, float],
     x: Union[ColumnOrName, int, float],
     _emit_ast: bool = True,
-    _ast: Optional[proto.Expr] = None,
 ) -> Column:
     """
     Returns the logarithm of a numeric expression.
@@ -3084,7 +3079,7 @@ def log(
         [Row(LOG=0), Row(LOG=1)]
     """
     # Build AST here to prevent `base` and `x` from being recorded as a literal instead of int/float.
-    ast = build_function_expr("log", [base, x]) if _emit_ast else _ast
+    ast = build_function_expr("log", [base, x]) if _emit_ast else None
     b = (
         lit(base, _emit_ast=False)
         if isinstance(base, (int, float))
@@ -3095,7 +3090,7 @@ def log(
         if isinstance(x, (int, float))
         else _to_col_if_str(x, "log")
     )
-    return builtin("log", _ast=ast, _emit_ast=False)(b, arg)
+    return _call_function("log", b, arg, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3119,7 +3114,9 @@ def log1p(
         else _to_col_if_str(x, "log")
     )
     one_plus_x = _to_col_if_str(x, "log1p") + lit(1, _emit_ast=False)
-    return ln(one_plus_x, _emit_ast=_emit_ast, _ast=ast)
+    ans = ln(one_plus_x, _emit_ast=False)
+    ans._ast = ast
+    return ans
 
 
 @publicapi
@@ -3136,8 +3133,9 @@ def log10(
         >>> df.select(log10(df["a"]).alias("log10")).collect()
         [Row(LOG10=0.0), Row(LOG10=1.0)]
     """
-    ast = build_function_expr("log10", [x]) if _emit_ast else None
-    return _log10(x, _emit_ast=False, _ast=ast)
+    ans = _log10(x)
+    ans._ast = build_function_expr("log10", [x]) if _emit_ast else None
+    return ans
 
 
 @publicapi
@@ -3154,25 +3152,22 @@ def log2(
         >>> df.select(log2(df["a"]).alias("log2")).collect()
         [Row(LOG2=0.0), Row(LOG2=1.0), Row(LOG2=3.0)]
     """
-    ast = build_function_expr("log2", [x]) if _emit_ast else None
-    return _log2(x, _emit_ast=False, _ast=ast)
+    ans = _log2(x)
+    ans._ast = build_function_expr("log2", [x]) if _emit_ast else None
+    return ans
 
 
 # Create base 2 and base 10 wrappers for use with the Modin log2 and log10 functions
 def _log2(
     x: Union[ColumnOrName, int, float],
-    _emit_ast: bool = True,
-    _ast: Optional[proto.Expr] = None,
 ) -> Column:
-    return log(2, x, _emit_ast=_emit_ast, _ast=_ast)
+    return log(2, x, _emit_ast=False)
 
 
 def _log10(
     x: Union[ColumnOrName, int, float],
-    _emit_ast: bool = True,
-    _ast: Optional[proto.Expr] = None,
 ) -> Column:
-    return log(10, x, _emit_ast=_emit_ast, _ast=_ast)
+    return log(10, x, _emit_ast=False)
 
 
 @publicapi
@@ -3206,7 +3201,7 @@ def pow(
         if isinstance(right, (int, float))
         else _to_col_if_str(right, "pow")
     )
-    return builtin("pow", _ast=ast, _emit_ast=False)(number, power)
+    return _call_function("pow", number, power, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3228,23 +3223,17 @@ def round(
         ------------
         <BLANKLINE>
     """
-    c = _to_col_if_str(e, "round")
     # Build AST here to prevent `scale` from being recorded as a literal instead of int/float.
-    ast = build_function_expr("round", [c, scale]) if _emit_ast else None
+    ast = build_function_expr("round", [e, scale]) if _emit_ast else None
+
+    c = _to_col_if_str(e, "round")
     scale_col = (
         lit(scale, _emit_ast=False)
         if isinstance(scale, (int, float))
         else _to_col_if_str(scale, "round")
     )
 
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "round", e, scale)
-
-    col = builtin("round", _ast=ast, _emit_ast=False)(c, scale_col)
-    col._ast = ast
-    return col
+    return _call_function("round", c, scale_col, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3269,7 +3258,8 @@ def sign(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         ----------------------------------
         <BLANKLINE>
     """
-    return builtin("sign", _emit_ast=_emit_ast)(_to_col_if_str(col, "sign"))
+    c = _to_col_if_str(col, "sign")
+    return _call_function("sign", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3321,7 +3311,7 @@ def split(str: ColumnOrName, pattern: ColumnOrName, _emit_ast: bool = True) -> C
     """
     s = _to_col_if_str(str, "split")
     p = _to_col_if_str(pattern, "split")
-    return builtin("split", _emit_ast=_emit_ast)(s, p)
+    return _call_function("split", s, p, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3359,12 +3349,16 @@ def substring(
     """
     s = _to_col_if_str(str, "substring")
     # Build AST here to prevent `pos` and `len` from being recorded as a literal instead of int/None.
-    ast = build_function_expr("substring", [s, pos, len]) if _emit_ast else None
+    ast = (
+        build_function_expr("substring", [s, pos] if len is None else [s, pos, len])
+        if _emit_ast
+        else None
+    )
     p = pos if isinstance(pos, Column) else lit(pos, _emit_ast=False)
     if len is None:
-        return builtin("substring", _emit_ast=False)(s, p)
+        return _call_function("substring", s, p, _ast=ast, _emit_ast=_emit_ast)
     length = len if isinstance(len, Column) else lit(len, _emit_ast=False)
-    return builtin("substring", _ast=ast, _emit_ast=False)(s, p, length)
+    return _call_function("substring", s, p, length, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3405,29 +3399,31 @@ def substring_index(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "substring_index", text, delim, count)
+    ast = (
+        build_function_expr("substring_index", [text, delim, count])
+        if _emit_ast
+        else None
+    )
 
     s = _to_col_if_str(text, "substring_index")
-    strtok_array = builtin("strtok_to_array", _emit_ast=False)(s, delim)
-    c = builtin("array_to_string", _emit_ast=False)(
-        builtin("array_slice", _emit_ast=False)(
+    strtok_array = _call_function("strtok_to_array", s, delim, _emit_ast=False)
+    return _call_function(
+        "array_to_string",
+        _call_function(
+            "array_slice",
             strtok_array,
             0
             if count >= 0
-            else builtin("array_size", _emit_ast=False)(strtok_array) + count,
+            else _call_function("array_size", strtok_array, _emit_ast=False) + count,
             count
             if count >= 0
-            else builtin("array_size", _emit_ast=False)(strtok_array),
+            else _call_function("array_size", strtok_array, _emit_ast=False),
+            _emit_ast=False,
         ),
         delim,
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
-
-    c._ast = ast
-
-    return c
 
 
 @publicapi
@@ -3458,7 +3454,7 @@ def regexp_count(
 
     # Build AST here to prevent `pattern` and `position` from being recorded as a literal instead of int/str.
     ast = (
-        build_function_expr(sql_func_name, [sub, pattern, position] + list(parameters))
+        build_function_expr(sql_func_name, [sub, pattern, position, *parameters])
         if _emit_ast
         else None
     )
@@ -3467,7 +3463,9 @@ def regexp_count(
     pos = position if isinstance(position, Column) else lit(position, _emit_ast=False)
 
     params = [lit(p, _emit_ast=False) for p in parameters]
-    return builtin(sql_func_name, _ast=ast, _emit_ast=False)(sub, pat, pos, *params)
+    return _call_function(
+        sql_func_name, sub, pat, pos, *params, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -3497,16 +3495,17 @@ def regexp_extract(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "regexp_extract", value, regexp, idx)
+    ast = (
+        build_function_expr("regexp_extract", [value, regexp, idx])
+        if _emit_ast
+        else None
+    )
 
     value = _to_col_if_str(value, "regexp_extract")
     regexp = _to_col_if_lit(regexp, "regexp_extract")
     idx = _to_col_if_lit(idx, "regexp_extract")
     c = coalesce(
-        call_builtin(
+        _call_function(
             "regexp_substr",
             value,
             regexp,
@@ -3550,18 +3549,19 @@ def regexp_replace(
         --------------------------------------------
         <BLANKLINE>
     """
-    sql_func_name = "regexp_replace"
-    sub = _to_col_if_str(subject, sql_func_name)
     # Build AST here to prevent `pattern`, `replacement`, `position`, `occurrences` from being recorded as a literal
     # instead of int/str.
     ast = (
         build_function_expr(
-            sql_func_name,
-            [sub, pattern, replacement, position, occurrences] + list(parameters),
+            "regexp_replace",
+            [subject, pattern, replacement, position, occurrences, *parameters],
         )
         if _emit_ast
         else None
     )
+
+    sql_func_name = "regexp_replace"
+    sub = _to_col_if_str(subject, sql_func_name)
 
     pat = pattern if isinstance(pattern, Column) else lit(pattern, _emit_ast=False)
     rep = (
@@ -3579,8 +3579,8 @@ def regexp_replace(
     params = [
         p if isinstance(p, Column) else lit(p, _emit_ast=False) for p in parameters
     ]
-    return builtin(sql_func_name, _ast=ast, _emit_ast=False)(
-        sub, pat, rep, pos, occ, *params
+    return _call_function(
+        sql_func_name, sub, pat, rep, pos, occ, *params, _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -3607,21 +3607,21 @@ def replace(
         ----------------
         <BLANKLINE>
     """
-    sql_func_name = "replace"
-    sub = _to_col_if_str(subject, sql_func_name)
     # Build AST here to prevent `pattern` and `replacement` from being recorded as a literal instead of str.
     ast = (
-        build_function_expr(sql_func_name, [sub, pattern, replacement])
+        build_function_expr("replace", [subject, pattern, replacement])
         if _emit_ast
         else None
     )
-    pat = pattern if isinstance(pattern, Column) else lit(pattern, _emit_ast=_emit_ast)
+    sql_func_name = "replace"
+    sub = _to_col_if_str(subject, sql_func_name)
+    pat = pattern if isinstance(pattern, Column) else lit(pattern, _emit_ast=False)
     rep = (
         replacement
         if isinstance(replacement, Column)
-        else lit(replacement, _emit_ast=_emit_ast)
+        else lit(replacement, _emit_ast=False)
     )
-    return builtin(sql_func_name, _ast=ast, _emit_ast=False)(sub, pat, rep)
+    return _call_function(sql_func_name, sub, pat, rep, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3657,20 +3657,32 @@ def charindex(
         ------------
         <BLANKLINE>
     """
+    # Build AST here to prevent `position` from being recorded as a literal instead of int/None.
+    ast = (
+        build_function_expr(
+            "charindex",
+            [target_expr, source_expr]
+            if position is None
+            else [target_expr, source_expr, position],
+        )
+        if _emit_ast
+        else None
+    )
     t = _to_col_if_str(target_expr, "charindex")
     s = _to_col_if_str(source_expr, "charindex")
-    # Build AST here to prevent `position` from being recorded as a literal instead of int/None.
-    ast = build_function_expr("charindex", [t, s, position]) if _emit_ast else None
     return (
-        builtin("charindex", _ast=ast, _emit_ast=False)(
+        _call_function(
+            "charindex",
             t,
             s,
             position
             if isinstance(position, Column)
             else lit(position, _emit_ast=False),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
         if position is not None
-        else builtin("charindex", _ast=ast, _emit_ast=False)(t, s)
+        else _call_function("charindex", t, s, _ast=ast, _emit_ast=_emit_ast)
     )
 
 
@@ -3693,7 +3705,7 @@ def collate(e: Column, collation_spec: str, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "collate")
-    return builtin("collate", _emit_ast=_emit_ast)(c, collation_spec)
+    return _call_function("collate", c, collation_spec, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3711,7 +3723,7 @@ def collation(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "collation")
-    return builtin("collation", _emit_ast=_emit_ast)(c)
+    return _call_function("collation", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3728,9 +3740,8 @@ def concat(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         --------------------------
         <BLANKLINE>
     """
-
     columns = [_to_col_if_str(c, "concat") for c in cols]
-    return builtin("concat", _emit_ast=_emit_ast)(*columns)
+    return _call_function("concat", *columns, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3759,10 +3770,13 @@ def concat_ws(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     columns = [_to_col_if_str(c, "concat_ws") for c in cols]
-    return builtin("concat_ws", _emit_ast=_emit_ast)(*columns)
+    return _call_function("concat_ws", *columns, _emit_ast=_emit_ast)
 
 
-def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
+@publicapi
+def _concat_ws_ignore_nulls(
+    sep: str, *cols: ColumnOrName, _emit_ast: bool = True
+) -> Column:
     """Concatenates two or more strings, or concatenates two or more binary values. Null values are ignored.
 
     Args:
@@ -3807,7 +3821,11 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
         -----------------------------------------------------
         <BLANKLINE>
     """
-    # TODO: SNOW-1831917 create ast
+    ast = (
+        build_function_expr("_concat_ws_ignore_nulls", [sep, *cols])
+        if _emit_ast
+        else None
+    )
     columns = [_to_col_if_str(c, "_concat_ws_ignore_nulls") for c in cols]
     names = ",".join([c.get_name() or f"COL{i}" for i, c in enumerate(columns)])
 
@@ -3826,11 +3844,14 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
 
     def array_remove_nulls(col: Column) -> Column:
         """Expects an array and returns an array with nulls removed."""
-        return builtin("filter", _emit_ast=False)(
-            col, sql_expr("x -> NOT IS_NULL_VALUE(x)", _emit_ast=False)
+        return _call_function(
+            "filter",
+            col,
+            sql_expr("x -> NOT IS_NULL_VALUE(x)", _emit_ast=False),
+            _emit_ast=False,
         )
 
-    return array_to_string(
+    res = array_to_string(
         array=array_remove_nulls(
             array_flatten(
                 array_construct_compact(
@@ -3843,6 +3864,8 @@ def _concat_ws_ignore_nulls(sep: str, *cols: ColumnOrName) -> Column:
         separator=lit(sep, _emit_ast=False),
         _emit_ast=False,
     )._alias(f"CONCAT_WS_IGNORE_NULLS('{sep}', {names})")
+    res._ast = ast
+    return res
 
 
 @publicapi
@@ -3871,8 +3894,8 @@ def translate(
     source = _to_col_if_str(src, "translate")
     source_alphabet = _to_col_if_str(source_alphabet, "translate")
     target_alphabet = _to_col_if_str(target_alphabet, "translate")
-    return builtin("translate", _emit_ast=_emit_ast)(
-        source, source_alphabet, target_alphabet
+    return _call_function(
+        "translate", source, source_alphabet, target_alphabet, _emit_ast=_emit_ast
     )
 
 
@@ -3894,7 +3917,7 @@ def contains(col: ColumnOrName, string: ColumnOrName, _emit_ast: bool = True) ->
     """
     c = _to_col_if_str(col, "contains")
     s = _to_col_if_str(string, "contains")
-    return builtin("contains", _emit_ast=_emit_ast)(c, s)
+    return _call_function("contains", c, s, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3911,7 +3934,7 @@ def startswith(col: ColumnOrName, str: ColumnOrName, _emit_ast: bool = True) -> 
     """
     c = _to_col_if_str(col, "startswith")
     s = _to_col_if_str(str, "startswith")
-    return builtin("startswith", _emit_ast=_emit_ast)(c, s)
+    return _call_function("startswith", c, s, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3927,7 +3950,7 @@ def endswith(col: ColumnOrName, str: ColumnOrName, _emit_ast: bool = True) -> Co
     """
     c = _to_col_if_str(col, "endswith")
     s = _to_col_if_str(str, "endswith")
-    return builtin("endswith", _emit_ast=_emit_ast)(c, s)
+    return _call_function("endswith", c, s, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -3948,15 +3971,22 @@ def insert(
         >>> df.select(insert(df["a"], 1, 2, lit("Z")).alias("insert")).collect()
         [Row(INSERT='Zc')]
     """
+    # Build AST here to prevent `position` and `length` from being recorded as a literal instead of int.
+    ast = (
+        build_function_expr("insert", [base_expr, position, length, insert_expr])
+        if _emit_ast
+        else None
+    )
     b = _to_col_if_str(base_expr, "insert")
     i = _to_col_if_str(insert_expr, "insert")
-    # Build AST here to prevent `position` and `length` from being recorded as a literal instead of int.
-    ast = build_function_expr("insert", [b, position, length, i]) if _emit_ast else None
-    return builtin("insert", _ast=ast, _emit_ast=False)(
+    return _call_function(
+        "insert",
         b,
         position if isinstance(position, Column) else lit(position, _emit_ast=False),
         length if isinstance(length, Column) else lit(length, _emit_ast=False),
         i,
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -3978,11 +4008,15 @@ def left(
         ------------
         <BLANKLINE>
     """
-    s = _to_col_if_str(str_expr, "left")
     # Build AST here to prevent `length` from being recorded as a literal instead of int.
-    ast = build_function_expr("left", [s, length]) if _emit_ast else None
-    return builtin("left", _ast=ast, _emit_ast=False)(
-        s, length if isinstance(length, Column) else lit(length, _emit_ast=False)
+    ast = build_function_expr("left", [str_expr, length]) if _emit_ast else None
+    s = _to_col_if_str(str_expr, "left")
+    return _call_function(
+        "left",
+        s,
+        length if isinstance(length, Column) else lit(length, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -4004,11 +4038,15 @@ def right(
         ------------
         <BLANKLINE>
     """
-    s = _to_col_if_str(str_expr, "right")
     # Build AST here to prevent `length` from being recorded as a literal instead of int.
-    ast = build_function_expr("right", [s, length]) if _emit_ast else None
-    return builtin("right", _ast=ast, _emit_ast=False)(
-        s, length if isinstance(length, Column) else lit(length, _emit_ast=False)
+    ast = build_function_expr("right", [str_expr, length]) if _emit_ast else None
+    s = _to_col_if_str(str_expr, "right")
+    return _call_function(
+        "right",
+        s,
+        length if isinstance(length, Column) else lit(length, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -4033,7 +4071,7 @@ def char(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(col, "char")
-    return builtin("char", _emit_ast=_emit_ast)(c)
+    return _call_function("char", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4056,15 +4094,23 @@ def to_char(
         [Row(ANS='2023-04-16 00:00:00.000'), Row(ANS='2017-04-03 02:59:37.000')]
 
     """
-    c = _to_col_if_str(c, "to_char")
     # Build AST here to prevent `format` from being recorded as a literal instead of str/None.
-    ast = build_function_expr("to_char", [c, format]) if _emit_ast else None
+    ast = (
+        build_function_expr("to_char", [c] if format is None else [c, format])
+        if _emit_ast
+        else None
+    )
+    c = _to_col_if_str(c, "to_char")
     return (
-        builtin("to_char", _ast=ast, _emit_ast=False)(
-            c, format if isinstance(format, Column) else lit(format, _emit_ast=False)
+        _call_function(
+            "to_char",
+            c,
+            format if isinstance(format, Column) else lit(format, _emit_ast=False),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
         if format is not None
-        else builtin("to_char", _ast=ast, _emit_ast=False)(c)
+        else _call_function("to_char", c, _ast=ast, _emit_ast=_emit_ast)
     )
 
 
@@ -4112,10 +4158,7 @@ def date_format(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "date_format", c, fmt)
+    ast = build_function_expr("date_format", [c, fmt]) if _emit_ast else None
 
     ans = to_char(
         try_cast(to_char(c, _emit_ast=False), TimestampType(), _emit_ast=False),
@@ -4140,9 +4183,9 @@ def to_time(
     """
     c = _to_col_if_str(e, "to_time")
     return (
-        builtin("to_time", _emit_ast=_emit_ast)(c, fmt)
+        _call_function("to_time", c, fmt, _emit_ast=_emit_ast)
         if fmt is not None
-        else builtin("to_time", _emit_ast=_emit_ast)(c)
+        else _call_function("to_time", c, _emit_ast=_emit_ast)
     )
 
 
@@ -4195,9 +4238,9 @@ def to_timestamp(
     """
     c = _to_col_if_str(e, "to_timestamp")
     return (
-        builtin("to_timestamp", _emit_ast=_emit_ast)(c, fmt)
+        _call_function("to_timestamp", c, fmt, _emit_ast=_emit_ast)
         if fmt is not None
-        else builtin("to_timestamp", _emit_ast=_emit_ast)(c)
+        else _call_function("to_timestamp", c, _emit_ast=_emit_ast)
     )
 
 
@@ -4222,21 +4265,24 @@ def to_timestamp_ntz(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "to_timestamp_ntz", e, fmt)
+    ast = (
+        build_function_expr("to_timestamp_ntz", [e] if fmt is None else [e, fmt])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(e, "to_timestamp_ntz")
-    ans = (
-        builtin("to_timestamp_ntz", _emit_ast=False)(
-            c, _to_col_if_lit(fmt, "to_timestamp_ntz")
+    return (
+        _call_function(
+            "to_timestamp_ntz",
+            c,
+            _to_col_if_lit(fmt, "to_timestamp_ntz"),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
         if fmt is not None
-        else builtin("to_timestamp_ntz", _emit_ast=False)(c)
+        else _call_function("to_timestamp_ntz", c, _ast=ast, _emit_ast=_emit_ast)
     )
-    ans._ast = ast
-    return ans
 
 
 @publicapi
@@ -4251,21 +4297,24 @@ def to_timestamp_ltz(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "to_timestamp_ltz", e, fmt)
+    ast = (
+        build_function_expr("to_timestamp_ltz", [e] if fmt is None else [e, fmt])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(e, "to_timestamp_ltz")
-    ans = (
-        builtin("to_timestamp_ltz", _emit_ast=False)(
-            c, _to_col_if_lit(fmt, "to_timestamp_ltz")
+    return (
+        _call_function(
+            "to_timestamp_ltz",
+            c,
+            _to_col_if_lit(fmt, "to_timestamp_ltz"),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
         if fmt is not None
-        else builtin("to_timestamp_ltz", _emit_ast=False)(c)
+        else _call_function("to_timestamp_ltz", c, _ast=ast, _emit_ast=_emit_ast)
     )
-    ans._ast = ast
-    return ans
 
 
 @publicapi
@@ -4280,21 +4329,24 @@ def to_timestamp_tz(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "to_timestamp_tz", e, fmt)
+    ast = (
+        build_function_expr("to_timestamp_tz", [e] if fmt is None else [e, fmt])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(e, "to_timestamp_tz")
-    ans = (
-        builtin("to_timestamp_tz", _emit_ast=False)(
-            c, _to_col_if_lit(fmt, "to_timestamp_tz")
+    return (
+        _call_function(
+            "to_timestamp_tz",
+            c,
+            _to_col_if_lit(fmt, "to_timestamp_tz"),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
         if fmt is not None
-        else builtin("to_timestamp_tz", _emit_ast=False)(c)
+        else _call_function("to_timestamp_tz", c, _ast=ast, _emit_ast=_emit_ast)
     )
-    ans._ast = ast
-    return ans
 
 
 @publicapi
@@ -4322,18 +4374,14 @@ def from_utc_timestamp(
         >>> df.select(from_utc_timestamp(col("t"), col("tz")).alias("ans")).collect()
         [Row(ANS=datetime.datetime(2019, 1, 30, 17, 2, 3, 4000))]
     """
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "from_utc_timestamp", e, tz)
+    ast = build_function_expr("from_utc_timestamp", [e, tz]) if _emit_ast else None
 
     c = _to_col_if_str(e, "from_utc_timestamp")
     tz_c = _to_col_if_lit(tz, "from_utc_timestamp")
-    ans = builtin("convert_timezone", _emit_ast=False)("UTC", tz_c, c)
-    ans._ast = ast
-    return ans
+    return _call_function(
+        "convert_timezone", "UTC", tz_c, c, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -4361,18 +4409,14 @@ def to_utc_timestamp(
         >>> df.select(to_utc_timestamp(col("t"), col("tz")).alias("ans")).collect()
         [Row(ANS=datetime.datetime(2019, 1, 31, 9, 2, 3, 4000))]
     """
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "to_utc_timestamp", e, tz)
+    ast = build_function_expr("to_utc_timestamp", [e, tz]) if _emit_ast else None
 
     c = _to_col_if_str(e, "to_utc_timestamp")
     tz_c = _to_col_if_lit(tz, "to_utc_timestamp")
-    ans = builtin("convert_timezone", _emit_ast=False)(tz_c, "UTC", c)
-    ans._ast = ast
-    return ans
+    return _call_function(
+        "convert_timezone", tz_c, "UTC", c, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -4400,22 +4444,22 @@ def to_date(
         [Row(ANS=datetime.date(1971, 1, 1)), Row(ANS=datetime.date(1972, 4, 7))]
 
     """
-    c = _to_col_if_str(e, "to_date")
-
-    ans = (
-        builtin("to_date", _emit_ast=False)(c)
-        if fmt is None
-        else builtin("to_date", _emit_ast=False)(c, Column._to_expr(fmt))
+    # AST.
+    ast = (
+        build_function_expr("to_date", [e] if fmt is None else [e, fmt])
+        if _emit_ast
+        else None
     )
 
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        args = (e, fmt) if fmt is not None else (e,)
-        build_builtin_fn_apply(ast, "to_date", *args)
-    ans._ast = ast
+    c = _to_col_if_str(e, "to_date")
 
-    return ans
+    return (
+        _call_function("to_date", c, _ast=ast, _emit_ast=_emit_ast)
+        if fmt is None
+        else _call_function(
+            "to_date", c, Column._to_expr(fmt), _ast=ast, _emit_ast=_emit_ast
+        )
+    )
 
 
 @publicapi
@@ -4427,8 +4471,7 @@ def current_timestamp(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_timestamp()).collect()
         >>> assert isinstance(result[0]["CURRENT_TIMESTAMP()"], datetime.datetime)
     """
-
-    return builtin("current_timestamp", _emit_ast=_emit_ast)()
+    return _call_function("current_timestamp", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4440,7 +4483,7 @@ def current_date(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_date()).collect()
         >>> assert isinstance(result[0]["CURRENT_DATE()"], datetime.date)
     """
-    return builtin("current_date", _emit_ast=_emit_ast)()
+    return _call_function("current_date", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4452,7 +4495,7 @@ def current_time(_emit_ast: bool = True) -> Column:
         >>> result = session.create_dataframe([1]).select(current_time()).collect()
         >>> assert isinstance(result[0]["CURRENT_TIME()"], datetime.time)
     """
-    return builtin("current_time", _emit_ast=_emit_ast)()
+    return _call_function("current_time", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4471,7 +4514,7 @@ def hour(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(HOUR("A")=13), Row(HOUR("A")=1)]
     """
     c = _to_col_if_str(e, "hour")
-    return builtin("hour", _emit_ast=_emit_ast)(c)
+    return _call_function("hour", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4499,13 +4542,19 @@ def last_day(
         >>> df.select(last_day("a", "YEAR")).collect()
         [Row(LAST_DAY("A", "YEAR")=datetime.date(2020, 12, 31)), Row(LAST_DAY("A", "YEAR")=datetime.date(2020, 12, 31))]
     """
+    ast = (
+        build_function_expr("last_day", [expr] if part is None else [expr, part])
+        if _emit_ast
+        else None
+    )
+
     expr_col = _to_col_if_str(expr, "last_day")
     if part is None:
         # Ensure we do not change the column name
-        return builtin("last_day", _emit_ast=_emit_ast)(expr_col)
+        return _call_function("last_day", expr_col, _ast=ast, _emit_ast=_emit_ast)
 
     part_col = _to_col_if_str(part, "last_day")
-    return builtin("last_day", _emit_ast=_emit_ast)(expr_col, part_col)
+    return _call_function("last_day", expr_col, part_col, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4524,7 +4573,7 @@ def minute(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(MINUTE("A")=11), Row(MINUTE("A")=30)]
     """
     c = _to_col_if_str(e, "minute")
-    return builtin("minute", _emit_ast=_emit_ast)(c)
+    return _call_function("minute", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4546,12 +4595,12 @@ def next_day(
         >>> df.select(next_day("a", "fr")).collect()
         [Row(NEXT_DAY("A", 'FR')=datetime.date(2020, 8, 7)), Row(NEXT_DAY("A", 'FR')=datetime.date(2020, 12, 4))]
     """
-    c = _to_col_if_str(date, "next_day")
     # Build AST here to prevent `date` from being recorded as a Column instead of a literal and
     # `day_of_week` from being recorded as a literal instead of Column.
     ast = build_function_expr("next_day", [date, day_of_week]) if _emit_ast else None
-    return builtin("next_day", _ast=ast, _emit_ast=False)(
-        c, Column._to_expr(day_of_week)
+    c = _to_col_if_str(date, "next_day")
+    return _call_function(
+        "next_day", c, Column._to_expr(day_of_week), _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -4574,14 +4623,14 @@ def previous_day(
         >>> df.select(previous_day("a", "fr")).collect()
         [Row(PREVIOUS_DAY("A", 'FR')=datetime.date(2020, 7, 31)), Row(PREVIOUS_DAY("A", 'FR')=datetime.date(2020, 11, 27))]
     """
-    c = _to_col_if_str(date, "previous_day")
     # Build AST here to prevent `date` from being recorded as a Column instead of a literal and
     # `day_of_week` from being recorded as a literal instead of Column.
     ast = (
         build_function_expr("previous_day", [date, day_of_week]) if _emit_ast else None
     )
-    return builtin("previous_day", _ast=ast, _emit_ast=False)(
-        c, Column._to_expr(day_of_week)
+    c = _to_col_if_str(date, "previous_day")
+    return _call_function(
+        "previous_day", c, Column._to_expr(day_of_week), _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -4601,7 +4650,7 @@ def second(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(SECOND("A")=20), Row(SECOND("A")=5)]
     """
     c = _to_col_if_str(e, "second")
-    return builtin("second", _emit_ast=_emit_ast)(c)
+    return _call_function("second", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4620,7 +4669,7 @@ def month(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(MONTH("A")=5), Row(MONTH("A")=8)]
     """
     c = _to_col_if_str(e, "month")
-    return builtin("month", _emit_ast=_emit_ast)(c)
+    return _call_function("month", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4639,7 +4688,7 @@ def monthname(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(MONTHNAME("A")='May'), Row(MONTHNAME("A")='Aug')]
     """
     c = _to_col_if_str(e, "monthname")
-    return builtin("monthname", _emit_ast=_emit_ast)(c)
+    return _call_function("monthname", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4658,7 +4707,7 @@ def quarter(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(QUARTER("A")=2), Row(QUARTER("A")=3)]
     """
     c = _to_col_if_str(e, "quarter")
-    return builtin("quarter", _emit_ast=_emit_ast)(c)
+    return _call_function("quarter", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4677,7 +4726,7 @@ def year(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(YEAR("A")=2020), Row(YEAR("A")=2020)]
     """
     c = _to_col_if_str(e, "year")
-    return builtin("year", _emit_ast=_emit_ast)(c)
+    return _call_function("year", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4691,7 +4740,7 @@ def sysdate(_emit_ast: bool = True) -> Column:
         >>> df.select(sysdate()).collect() is not None
         True
     """
-    return builtin("sysdate", _emit_ast=_emit_ast)()
+    return _call_function("sysdate", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4713,7 +4762,7 @@ def months_between(
     """
     c1 = _to_col_if_str(date1, "months_between")
     c2 = _to_col_if_str(date2, "months_between")
-    return builtin("months_between", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("months_between", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4737,7 +4786,7 @@ def to_geography(e: ColumnOrName, _emit_ast: bool = True) -> Column:
     For all supported formats confer https://docs.snowflake.com/en/sql-reference/data-types-geospatial#supported-geospatial-object-types.
     """
     c = _to_col_if_str(e, "to_geography")
-    return builtin("to_geography", _emit_ast=_emit_ast)(c)
+    return _call_function("to_geography", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4761,7 +4810,7 @@ def to_geometry(e: ColumnOrName, _emit_ast: bool = True) -> Column:
     For all supported formats confer https://docs.snowflake.com/en/sql-reference/data-types-geospatial#supported-geospatial-object-types.
     """
     c = _to_col_if_str(e, "to_geometry")
-    return builtin("to_geometry", _emit_ast=_emit_ast)(c)
+    return _call_function("to_geometry", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4786,7 +4835,7 @@ def arrays_overlap(
     """
     a1 = _to_col_if_str(array1, "arrays_overlap")
     a2 = _to_col_if_str(array2, "arrays_overlap")
-    return builtin("arrays_overlap", _emit_ast=_emit_ast)(a1, a2)
+    return _call_function("arrays_overlap", a1, a2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4823,7 +4872,7 @@ def array_distinct(col: ColumnOrName, _emit_ast: bool = True):
         <BLANKLINE>
     """
     col = _to_col_if_str(col, "array_distinct")
-    return builtin("array_distinct", _emit_ast=_emit_ast)(col)
+    return _call_function("array_distinct", col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4853,7 +4902,7 @@ def array_intersection(
     """
     a1 = _to_col_if_str(array1, "array_intersection")
     a2 = _to_col_if_str(array2, "array_intersection")
-    return builtin("array_intersection", _emit_ast=_emit_ast)(a1, a2)
+    return _call_function("array_intersection", a1, a2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -4976,30 +5025,28 @@ def array_except(
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(
-            ast,
+    ast = (
+        build_function_expr(
             "array_except",
-            source_array,
-            array_of_elements_to_exclude,
-            allow_duplicates,
+            [source_array, array_of_elements_to_exclude, allow_duplicates],
         )
+        if _emit_ast
+        else None
+    )
 
     array1 = _to_col_if_str(source_array, "array_except")
     array2 = _to_col_if_str(array_of_elements_to_exclude, "array_except")
-    ans = (
-        builtin("array_except", _emit_ast=False)(array1, array2)
+    return (
+        _call_function("array_except", array1, array2, _ast=ast, _emit_ast=_emit_ast)
         if allow_duplicates
-        else builtin("array_except", _emit_ast=False)(
-            builtin("array_distinct", _emit_ast=False)(array1),
-            builtin("array_distinct", _emit_ast=False)(array2),
+        else _call_function(
+            "array_except",
+            _call_function("array_distinct", array1, _emit_ast=False),
+            _call_function("array_distinct", array2, _emit_ast=False),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
     )
-
-    ans._ast = ast
-    return ans
 
 
 @publicapi
@@ -5032,7 +5079,7 @@ def array_min(array: ColumnOrName, _emit_ast: bool = True) -> Column:
                 [Row(MIN_A='null')]
     """
     array = _to_col_if_str(array, "array_min")
-    return builtin("array_min", _emit_ast=_emit_ast)(array)
+    return _call_function("array_min", array, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5065,7 +5112,7 @@ def array_max(array: ColumnOrName, _emit_ast: bool = True) -> Column:
             [Row(MAX_A='null')]
     """
     array = _to_col_if_str(array, "array_max")
-    return builtin("array_max", _emit_ast=_emit_ast)(array)
+    return _call_function("array_max", array, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5079,7 +5126,7 @@ def array_flatten(array: ColumnOrName, _emit_ast: bool = True) -> Column:
         array: the input array
     """
     array = _to_col_if_str(array, "array_flatten")
-    return builtin("array_flatten", _emit_ast=_emit_ast)(array)
+    return _call_function("array_flatten", array, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5105,7 +5152,7 @@ def array_reverse(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     array = _to_col_if_str(col, "array_reverse")
-    return builtin("array_reverse", _emit_ast=_emit_ast)(array)
+    return _call_function("array_reverse", array, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5195,17 +5242,20 @@ def array_sort(
         - https://docs.snowflake.com/en/user-guide/semistructured-considerations#null-values
         - :func:`~snowflake.snowpark.functions.sort_array` which is an alias of :meth:`~snowflake.snowpark.functions.array_sort`.
     """
-    array = _to_col_if_str(array, "array_sort")
     # Build AST here to prevent `sort_ascending` and `nulls_first` from being recorded as a literal instead of bool.
     ast = (
         build_function_expr("array_sort", [array, sort_ascending, nulls_first])
         if _emit_ast
         else None
     )
-    return builtin("array_sort", _ast=ast, _emit_ast=False)(
+    array = _to_col_if_str(array, "array_sort")
+    return _call_function(
+        "array_sort",
         array,
         lit(sort_ascending, _emit_ast=False),
         lit(nulls_first, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -5251,7 +5301,7 @@ def arrays_to_object(
     """
     keys_c = _to_col_if_str(keys, "arrays_to_object")
     values_c = _to_col_if_str(values, "arrays_to_object")
-    return builtin("arrays_to_object", _emit_ast=_emit_ast)(keys_c, values_c)
+    return _call_function("arrays_to_object", keys_c, values_c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5312,7 +5362,7 @@ def arrays_zip(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     cols = [_to_col_if_str(c, "arrays_zip") for c in cols]
-    return builtin("arrays_zip", _emit_ast=_emit_ast)(*cols)
+    return _call_function("arrays_zip", *cols, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5362,10 +5412,12 @@ def array_generate_range(
     start_col = _to_col_if_str(start, "array_generate_range")
     stop_col = _to_col_if_str(stop, "array_generate_range")
     if step is None:
-        return builtin("array_generate_range")(start_col, stop_col)
+        return _call_function(
+            "array_generate_range", start_col, stop_col, _emit_ast=_emit_ast
+        )
     step_col = _to_col_if_str(step, "array_generate_range")
-    return builtin("array_generate_range", _emit_ast=_emit_ast)(
-        start_col, stop_col, step_col
+    return _call_function(
+        "array_generate_range", start_col, stop_col, step_col, _emit_ast=_emit_ast
     )
 
 
@@ -5417,28 +5469,44 @@ def sequence(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "sequence", start, stop, step)
+    ast = (
+        build_function_expr(
+            "sequence", [start, stop] if step is None else [start, stop, step]
+        )
+        if _emit_ast
+        else None
+    )
 
     start_col = _to_col_if_str(start, "sequence")
     stop_col = _to_col_if_str(stop, "sequence")
     if step is None:
-        step = iff(builtin("sign")(stop_col - start_col) > 0, 1, -1)
-        ans = builtin("array_generate_range", _emit_ast=False)(
-            start_col, stop_col + step, step
+        step = iff(
+            _call_function("sign", stop_col - start_col, _emit_ast=False) > 0,
+            1,
+            -1,
+            _emit_ast=False,
         )
-        ans._ast = ast
-        return ans
+        return _call_function(
+            "array_generate_range",
+            start_col,
+            stop_col + step,
+            step,
+            _ast=ast,
+            _emit_ast=_emit_ast,
+        )
 
     step_col = _to_col_if_str(step, "sequence")
-    step_sign = iff(builtin("sign")(step_col) > 0, 1, -1)
-    ans = builtin("array_generate_range", _emit_ast=False)(
-        start_col, stop_col + step_sign, step_col
+    step_sign = iff(
+        _call_function("sign", step_col, _emit_ast=False) > 0, 1, -1, _emit_ast=False
     )
-    ans._ast = ast
-    return ans
+    return _call_function(
+        "array_generate_range",
+        start_col,
+        stop_col + step_sign,
+        step_col,
+        _ast=ast,
+        _emit_ast=_emit_ast,
+    )
 
 
 @publicapi
@@ -5466,10 +5534,7 @@ def date_add(
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "date_add", col, num_of_days)
+    ast = build_function_expr("date_add", [col, num_of_days]) if _emit_ast else None
 
     # Convert the input to a column if it is a string
     col = _to_col_if_str(col, "date_add")
@@ -5509,10 +5574,7 @@ def date_sub(
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "date_sub", col, num_of_days)
+    ast = build_function_expr("date_sub", [col, num_of_days]) if _emit_ast else None
 
     # Convert the input parameters to the appropriate type
     col = _to_col_if_str(col, "date_sub")
@@ -5561,7 +5623,7 @@ def datediff(
         raise ValueError("part must be a string")
     c1 = _to_col_if_str(col1, "datediff")
     c2 = _to_col_if_str(col2, "datediff")
-    return builtin("datediff", _emit_ast=_emit_ast)(part, c1, c2)
+    return _call_function("datediff", part, c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5580,18 +5642,19 @@ def daydiff(col1: ColumnOrName, col2: ColumnOrName, _emit_ast: bool = True) -> C
         ----------
         <BLANKLINE>
     """
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "daydiff", col1, col2)
+    ast = build_function_expr("daydiff", [col1, col2]) if _emit_ast else None
 
     col1 = _to_col_if_str(col1, "daydiff")
     col2 = _to_col_if_str(col2, "daydiff")
-    ans = builtin("datediff", _emit_ast=False)(lit("day", _emit_ast=False), col2, col1)
-    ans._ast = ast
-    return ans
+    return _call_function(
+        "datediff",
+        lit("day", _emit_ast=False),
+        col2,
+        col1,
+        _ast=ast,
+        _emit_ast=_emit_ast,
+    )
 
 
 @publicapi
@@ -5634,10 +5697,7 @@ def trunc(
 
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "trunc", e, scale)
+    ast = build_function_expr("trunc", [e, scale]) if _emit_ast else None
 
     c = _to_col_if_str(e, "trunc")
     scale_col = (
@@ -5645,9 +5705,7 @@ def trunc(
         if isinstance(scale, (int, float))
         else _to_col_if_str(scale, "trunc")
     )
-    ans = builtin("trunc", _emit_ast=False)(c, scale_col)
-    ans._ast = ast
-    return ans
+    return _call_function("trunc", c, scale_col, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5694,7 +5752,7 @@ def dateadd(
         raise ValueError("part must be a string")
     c1 = _to_col_if_str(col1, "dateadd")
     c2 = _to_col_if_str(col2, "dateadd")
-    return builtin("dateadd", _emit_ast=_emit_ast)(part, c1, c2)
+    return _call_function("dateadd", part, c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5722,7 +5780,7 @@ def date_part(part: str, e: ColumnOrName, _emit_ast: bool = True) -> Column:
     if not isinstance(part, str):
         raise ValueError("part must be a string")
     c = _to_col_if_str(e, "date_part")
-    return builtin("date_part", _emit_ast=_emit_ast)(part, c)
+    return _call_function("date_part", part, c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5742,19 +5800,15 @@ def date_from_parts(
         >>> session.table("dual").select(date_from_parts(2022, 4, 1)).collect()
         [Row(DATE_FROM_PARTS(2022, 4, 1)=datetime.date(2022, 4, 1))]
     """
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "date_from_parts", y, m, d)
+    ast = build_function_expr("date_from_parts", [y, m, d]) if _emit_ast else None
 
     y_col = _to_col_if_str_or_int(y, "date_from_parts")
     m_col = _to_col_if_str_or_int(m, "date_from_parts")
     d_col = _to_col_if_str_or_int(d, "date_from_parts")
-    ans = builtin("date_from_parts", _emit_ast=False)(y_col, m_col, d_col)
-    ans._ast = ast
-    return ans
+    return _call_function(
+        "date_from_parts", y_col, m_col, d_col, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -5783,7 +5837,7 @@ def date_trunc(part: str, expr: ColumnOrName, _emit_ast: bool = True) -> Column:
     if not isinstance(part, str):
         raise ValueError("part must be a string")
     expr_col = _to_col_if_str(expr, "date_trunc")
-    return builtin("date_trunc", _emit_ast=_emit_ast)(part, expr_col)
+    return _call_function("date_trunc", part, expr_col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5801,7 +5855,7 @@ def dayname(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DAYNAME("A")='Fri')]
     """
     c = _to_col_if_str(e, "dayname")
-    return builtin("dayname", _emit_ast=_emit_ast)(c)
+    return _call_function("dayname", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5819,7 +5873,7 @@ def dayofmonth(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DAYOFMONTH("A")=1)]
     """
     c = _to_col_if_str(e, "dayofmonth")
-    return builtin("dayofmonth", _emit_ast=_emit_ast)(c)
+    return _call_function("dayofmonth", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5837,7 +5891,7 @@ def dayofweek(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DAYOFWEEK("A")=5)]
     """
     c = _to_col_if_str(e, "dayofweek")
-    return builtin("dayofweek", _emit_ast=_emit_ast)(c)
+    return _call_function("dayofweek", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5855,7 +5909,7 @@ def dayofyear(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DAYOFYEAR("A")=122)]
     """
     c = _to_col_if_str(e, "dayofyear")
-    return builtin("dayofyear", _emit_ast=_emit_ast)(c)
+    return _call_function("dayofyear", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -5956,7 +6010,10 @@ def window(
 
     ast = (
         build_function_expr(
-            "window", [time_column, window_duration, slide_duration, start_time]
+            "window",
+            [time_column, window_duration]
+            + ([] if slide_duration is None else [slide_duration])
+            + ([] if start_time is None else [start_time]),
         )
         if _emit_ast
         else None
@@ -6004,7 +6061,7 @@ def is_array(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(IS_ARRAY_A=True, IS_ARRAY_B=False)]
     """
     c = _to_col_if_str(col, "is_array")
-    return builtin("is_array", _emit_ast=_emit_ast)(c)
+    return _call_function("is_array", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6020,7 +6077,7 @@ def is_boolean(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(BOOLEAN=True, VARCHAR=False)]
     """
     c = _to_col_if_str(col, "is_boolean")
-    return builtin("is_boolean", _emit_ast=_emit_ast)(c)
+    return _call_function("is_boolean", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6036,7 +6093,7 @@ def is_binary(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(BINARY=True, VARCHAR=False)]
     """
     c = _to_col_if_str(col, "is_binary")
-    return builtin("is_binary", _emit_ast=_emit_ast)(c)
+    return _call_function("is_binary", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6052,7 +6109,7 @@ def is_char(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(VARCHAR=True, INT=False)]
     """
     c = _to_col_if_str(col, "is_char")
-    return builtin("is_char", _emit_ast=_emit_ast)(c)
+    return _call_function("is_char", c, _emit_ast=_emit_ast)
 
 
 is_varchar = is_char
@@ -6072,7 +6129,7 @@ def is_date(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DATE=True, INT=False)]
     """
     c = _to_col_if_str(col, "is_date")
-    return builtin("is_date", _emit_ast=_emit_ast)(c)
+    return _call_function("is_date", c, _emit_ast=_emit_ast)
 
 
 is_date_value = is_date
@@ -6092,7 +6149,7 @@ def is_decimal(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DECIMAL=True, VARCHAR=False)]
     """
     c = _to_col_if_str(col, "is_decimal")
-    return builtin("is_decimal", _emit_ast=_emit_ast)(c)
+    return _call_function("is_decimal", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6108,7 +6165,7 @@ def is_double(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(DOUBLE=True, VARCHAR=False)]
     """
     c = _to_col_if_str(col, "is_double")
-    return builtin("is_double", _emit_ast=_emit_ast)(c)
+    return _call_function("is_double", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6124,7 +6181,7 @@ def is_real(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=True, B=False)]
     """
     c = _to_col_if_str(col, "is_real")
-    return builtin("is_real", _emit_ast=_emit_ast)(c)
+    return _call_function("is_real", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6140,7 +6197,7 @@ def is_integer(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(INT=True, VARCHAR=False)]
     """
     c = _to_col_if_str(col, "is_integer")
-    return builtin("is_integer", _emit_ast=_emit_ast)(c)
+    return _call_function("is_integer", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6156,7 +6213,7 @@ def is_null_value(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=False), Row(A=True), Row(A=None)]
     """
     c = _to_col_if_str(col, "is_null_value")
-    return builtin("is_null_value", _emit_ast=_emit_ast)(c)
+    return _call_function("is_null_value", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6172,7 +6229,7 @@ def is_object(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=False, B=True)]
     """
     c = _to_col_if_str(col, "is_object")
-    return builtin("is_object", _emit_ast=_emit_ast)(c)
+    return _call_function("is_object", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6189,7 +6246,7 @@ def is_time(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=True, B=False)]
     """
     c = _to_col_if_str(col, "is_time")
-    return builtin("is_time", _emit_ast=_emit_ast)(c)
+    return _call_function("is_time", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6210,7 +6267,7 @@ def is_timestamp_ltz(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=False, B=True, C=False)]
     """
     c = _to_col_if_str(col, "is_timestamp_ltz")
-    return builtin("is_timestamp_ltz", _emit_ast=_emit_ast)(c)
+    return _call_function("is_timestamp_ltz", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6230,7 +6287,7 @@ def is_timestamp_ntz(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=True, B=False, C=False)]
     """
     c = _to_col_if_str(col, "is_timestamp_ntz")
-    return builtin("is_timestamp_ntz", _emit_ast=_emit_ast)(c)
+    return _call_function("is_timestamp_ntz", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6250,7 +6307,7 @@ def is_timestamp_tz(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=False, B=False, C=True)]
     """
     c = _to_col_if_str(col, "is_timestamp_tz")
-    return builtin("is_timestamp_tz", _emit_ast=_emit_ast)(c)
+    return _call_function("is_timestamp_tz", c, _emit_ast=_emit_ast)
 
 
 def _columns_from_timestamp_parts(
@@ -6326,23 +6383,29 @@ def time_from_parts(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(
-            ast, "time_from_parts", hour, minute, second, nanoseconds
+    ast = (
+        build_function_expr(
+            "time_from_parts",
+            [hour, minute, second] + ([] if nanoseconds is None else [nanoseconds]),
         )
+        if _emit_ast
+        else None
+    )
 
     h, m, s = _columns_from_timestamp_parts("time_from_parts", hour, minute, second)
-    ans = (
-        builtin("time_from_parts", _emit_ast=False)(
-            h, m, s, _to_col_if_str_or_int(nanoseconds, "time_from_parts")
+    return (
+        _call_function(
+            "time_from_parts",
+            h,
+            m,
+            s,
+            _to_col_if_str_or_int(nanoseconds, "time_from_parts"),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
         if nanoseconds
-        else builtin("time_from_parts", _emit_ast=False)(h, m, s)
+        else _call_function("time_from_parts", h, m, s, _ast=ast, _emit_ast=_emit_ast)
     )
-    ans._ast = ast
-    return ans
 
 
 @overload
@@ -6397,18 +6460,14 @@ def timestamp_from_parts(*args, _emit_ast: bool = True, **kwargs) -> Column:
         ... ).alias("TIMESTAMP_FROM_PARTS")).collect()
         [Row(TIMESTAMP_FROM_PARTS=datetime.datetime(2022, 4, 1, 11, 11)), Row(TIMESTAMP_FROM_PARTS=datetime.datetime(2022, 3, 31, 11, 11))]
     """
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "timestamp_from_parts", *args)
-
-    ans = builtin("timestamp_from_parts", _emit_ast=False)(
-        *_timestamp_from_parts_internal("timestamp_from_parts", *args, **kwargs)
+    ast = build_function_expr("timestamp_from_parts", args) if _emit_ast else None
+    return _call_function(
+        "timestamp_from_parts",
+        *_timestamp_from_parts_internal("timestamp_from_parts", *args, **kwargs),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
-    ans._ast = ast
-    return ans
 
 
 @publicapi
@@ -6437,27 +6496,30 @@ def timestamp_ltz_from_parts(
         ... ).alias("TIMESTAMP_LTZ_FROM_PARTS")).collect()
         [Row(TIMESTAMP_LTZ_FROM_PARTS=datetime.datetime(2022, 4, 1, 11, 11, tzinfo=<DstTzInfo 'America/Los_Angeles' PDT-1 day, 17:00:00 DST>)), Row(TIMESTAMP_LTZ_FROM_PARTS=datetime.datetime(2022, 3, 31, 11, 11, tzinfo=<DstTzInfo 'America/Los_Angeles' PDT-1 day, 17:00:00 DST>))]
     """
-    func_name = "timestamp_ltz_from_parts"
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(
-            ast, func_name, year, month, day, hour, minute, second, nanoseconds
+    ast = (
+        build_function_expr(
+            "timestamp_ltz_from_parts",
+            [year, month, day, hour, minute, second]
+            + ([] if nanoseconds is None else [nanoseconds]),
         )
+        if _emit_ast
+        else None
+    )
+
+    func_name = "timestamp_ltz_from_parts"
 
     y, m, d, h, min_, s = _columns_from_timestamp_parts(
         func_name, year, month, day, hour, minute, second
     )
     ns = None if nanoseconds is None else _to_col_if_str_or_int(nanoseconds, func_name)
-    ans = (
-        builtin(func_name, _emit_ast=False)(y, m, d, h, min_, s)
+    return (
+        _call_function(func_name, y, m, d, h, min_, s, _ast=ast, _emit_ast=_emit_ast)
         if ns is None
-        else builtin(func_name, _emit_ast=False)(y, m, d, h, min_, s, ns)
+        else _call_function(
+            func_name, y, m, d, h, min_, s, ns, _ast=ast, _emit_ast=_emit_ast
+        )
     )
-    ans._ast = ast
-    return ans
 
 
 @overload
@@ -6511,10 +6573,16 @@ def timestamp_ntz_from_parts(*args, _emit_ast: bool = True, **kwargs) -> Column:
         ... ).alias("TIMESTAMP_NTZ_FROM_PARTS")).collect()
         [Row(TIMESTAMP_NTZ_FROM_PARTS=datetime.datetime(2022, 4, 1, 11, 11)), Row(TIMESTAMP_NTZ_FROM_PARTS=datetime.datetime(2022, 3, 31, 11, 11))]
     """
-    return builtin("timestamp_ntz_from_parts", _emit_ast=_emit_ast)(
+    ast = build_function_expr("timestamp_ntz_from_parts", args) if _emit_ast else None
+    return _call_function(
+        "timestamp_ntz_from_parts",
         *_timestamp_from_parts_internal(
-            "timestamp_ntz_from_parts", *args, **kwargs, _emit_ast=_emit_ast
-        )
+            "timestamp_ntz_from_parts",
+            *args,
+            **kwargs,
+        ),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -6544,45 +6612,49 @@ def timestamp_tz_from_parts(
         ... ).alias("TIMESTAMP_TZ_FROM_PARTS")).collect()
         [Row(TIMESTAMP_TZ_FROM_PARTS=datetime.datetime(2022, 4, 1, 11, 11, tzinfo=pytz.FixedOffset(-420))), Row(TIMESTAMP_TZ_FROM_PARTS=datetime.datetime(2022, 3, 31, 11, 11, tzinfo=pytz.FixedOffset(-420)))]
     """
-    func_name = "timestamp_tz_from_parts"
-
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(
-            ast,
-            func_name,
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-            nanoseconds,
-            timezone,
+    ast = (
+        build_function_expr(
+            "timestamp_tz_from_parts",
+            [year, month, day, hour, minute, second]
+            + ([] if nanoseconds is None else [nanoseconds])
+            + ([] if timezone is None else [timezone]),
         )
+        if _emit_ast
+        else None
+    )
 
+    func_name = "timestamp_tz_from_parts"
     y, m, d, h, min_, s = _columns_from_timestamp_parts(
         func_name, year, month, day, hour, minute, second
     )
     ns = None if nanoseconds is None else _to_col_if_str_or_int(nanoseconds, func_name)
     tz = None if timezone is None else _to_col_if_sql_expr(timezone, func_name)
 
-    ans = None
     if nanoseconds is not None and timezone is not None:
-        ans = builtin(func_name, _emit_ast=False)(y, m, d, h, min_, s, ns, tz)
-    elif nanoseconds is not None:
-        ans = builtin(func_name, _emit_ast=False)(y, m, d, h, min_, s, ns)
-    elif timezone is not None:
-        ans = builtin(func_name, _emit_ast=False)(
-            y, m, d, h, min_, s, lit(0, _emit_ast=False), tz
+        return _call_function(
+            func_name, y, m, d, h, min_, s, ns, tz, _ast=ast, _emit_ast=_emit_ast
         )
-    else:
-        ans = builtin(func_name, _emit_ast=False)(y, m, d, h, min_, s)
+    elif nanoseconds is not None:
+        return _call_function(
+            func_name, y, m, d, h, min_, s, ns, _ast=ast, _emit_ast=_emit_ast
+        )
+    elif timezone is not None:
+        return _call_function(
+            func_name,
+            y,
+            m,
+            d,
+            h,
+            min_,
+            s,
+            lit(0, _emit_ast=False),
+            tz,
+            _ast=ast,
+            _emit_ast=_emit_ast,
+        )
 
-    ans._ast = ast
-    return ans
+    return _call_function(func_name, y, m, d, h, min_, s, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6601,7 +6673,7 @@ def weekofyear(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(WEEKOFYEAR("A")=18)]
     """
     c = _to_col_if_str(e, "weekofyear")
-    return builtin("weekofyear", _emit_ast=_emit_ast)(c)
+    return _call_function("weekofyear", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6628,7 +6700,7 @@ def typeof(col: ColumnOrName, _emit_ast: bool = True) -> Column:
 
     """
     c = _to_col_if_str(col, "typeof")
-    return builtin("typeof", _emit_ast=_emit_ast)(c)
+    return _call_function("typeof", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6653,7 +6725,7 @@ def check_json(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(col, "check_json")
-    return builtin("check_json", _emit_ast=_emit_ast)(c)
+    return _call_function("check_json", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6677,7 +6749,7 @@ def check_xml(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(col, "check_xml")
-    return builtin("check_xml", _emit_ast=_emit_ast)(c)
+    return _call_function("check_xml", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6697,7 +6769,7 @@ def json_extract_path_text(
     """
     c = _to_col_if_str(col, "json_extract_path_text")
     p = _to_col_if_str(path, "json_extract_path_text")
-    return builtin("json_extract_path_text", _emit_ast=_emit_ast)(c, p)
+    return _call_function("json_extract_path_text", c, p, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6719,7 +6791,7 @@ def parse_json(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "parse_json")
-    return builtin("parse_json", _emit_ast=_emit_ast)(c)
+    return _call_function("parse_json", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6758,8 +6830,8 @@ def from_json(
         ----------------------
         <BLANKLINE>
     """
+    ast = build_function_expr("from_json", [e, schema]) if _emit_ast else None
     c = _to_col_if_str(e, "from_json")
-    ast = build_function_expr("from_json", [c, schema]) if _emit_ast else None
     if isinstance(schema, str):
         schema = type_string_to_type_object(schema)
     ans = (
@@ -6796,7 +6868,7 @@ def parse_xml(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(e, "parse_xml")
-    return builtin("parse_xml", _emit_ast=_emit_ast)(c)
+    return _call_function("parse_xml", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6815,7 +6887,7 @@ def strip_null_value(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(B=None)]
     """
     c = _to_col_if_str(col, "strip_null_value")
-    return builtin("strip_null_value", _emit_ast=_emit_ast)(c)
+    return _call_function("strip_null_value", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6841,7 +6913,9 @@ def array_agg(
     """
     ast = build_function_expr("array_agg", [col, is_distinct]) if _emit_ast else None
     c = _to_col_if_str(col, "array_agg")
-    return _call_function("array_agg", is_distinct, c, _ast=ast, _emit_ast=_emit_ast)
+    return _call_function(
+        "array_agg", c, is_distinct=is_distinct, _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -6875,7 +6949,7 @@ def array_append(
     """
     a = _to_col_if_str(array, "array_append")
     e = _to_col_if_str(element, "array_append")
-    return builtin("array_append", _emit_ast=_emit_ast)(a, e)
+    return _call_function("array_append", a, e, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6939,10 +7013,7 @@ def array_remove(
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "array_remove", array, element)
+    ast = build_function_expr("array_remove", [array, element]) if _emit_ast else None
 
     a = _to_col_if_str(array, "array_remove")
     e = (
@@ -6950,9 +7021,7 @@ def array_remove(
         if isinstance(element, str)
         else element
     )
-    ans = builtin("array_remove", _emit_ast=False)(a, e)
-    ans._ast = ast
-    return ans
+    return _call_function("array_remove", a, e, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -6984,7 +7053,7 @@ def array_cat(
     """
     a1 = _to_col_if_str(array1, "array_cat")
     a2 = _to_col_if_str(array2, "array_cat")
-    return builtin("array_cat", _emit_ast=_emit_ast)(a1, a2)
+    return _call_function("array_cat", a1, a2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7011,7 +7080,7 @@ def array_compact(array: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     a = _to_col_if_str(array, "array_compact")
-    return builtin("array_compact", _emit_ast=_emit_ast)(a)
+    return _call_function("array_compact", a, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7040,7 +7109,7 @@ def array_construct(*cols: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     cs = [_to_col_if_str(c, "array_construct") for c in cols]
-    return builtin("array_construct", _emit_ast=_emit_ast)(*cs)
+    return _call_function("array_construct", *cs, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7070,7 +7139,7 @@ def array_construct_compact(*cols: ColumnOrName, _emit_ast: bool = True) -> Colu
         <BLANKLINE>
     """
     cs = [_to_col_if_str(c, "array_construct_compact") for c in cols]
-    return builtin("array_construct_compact", _emit_ast=_emit_ast)(*cs)
+    return _call_function("array_construct_compact", *cs, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7097,7 +7166,7 @@ def array_contains(
     """
     v = _to_col_if_str(variant, "array_contains")
     a = _to_col_if_str(array, "array_contains")
-    return builtin("array_contains", _emit_ast=_emit_ast)(v, a)
+    return _call_function("array_contains", v, a, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7145,7 +7214,7 @@ def array_insert(
     a = _to_col_if_str(array, "array_insert")
     p = _to_col_if_str(pos, "array_insert")
     e = _to_col_if_str(element, "array_insert")
-    return builtin("array_insert", _emit_ast=_emit_ast)(a, p, e)
+    return _call_function("array_insert", a, p, e, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7173,7 +7242,7 @@ def array_position(
     """
     v = _to_col_if_str(variant, "array_position")
     a = _to_col_if_str(array, "array_position")
-    return builtin("array_position", _emit_ast=_emit_ast)(v, a)
+    return _call_function("array_position", v, a, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7205,7 +7274,7 @@ def array_prepend(
     """
     a = _to_col_if_str(array, "array_prepend")
     e = _to_col_if_str(element, "array_prepend")
-    return builtin("array_prepend", _emit_ast=_emit_ast)(a, e)
+    return _call_function("array_prepend", a, e, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7227,7 +7296,7 @@ def array_size(array: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     a = _to_col_if_str(array, "array_size")
-    return builtin("array_size", _emit_ast=_emit_ast)(a)
+    return _call_function("array_size", a, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7261,7 +7330,7 @@ def array_slice(
     a = _to_col_if_str(array, "array_slice")
     f = _to_col_if_str(from_, "array_slice")
     t = _to_col_if_str(to, "array_slice")
-    return builtin("array_slice", _emit_ast=_emit_ast)(a, f, t)
+    return _call_function("array_slice", a, f, t, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7290,7 +7359,7 @@ def array_to_string(
     """
     a = _to_col_if_str(array, "array_to_string")
     s = _to_col_if_str(separator, "array_to_string")
-    return builtin("array_to_string", _emit_ast=_emit_ast)(a, s)
+    return _call_function("array_to_string", a, s, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7318,7 +7387,7 @@ def array_unique_agg(col: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(col, "array_unique_agg")
-    return _call_function("array_unique_agg", False, c, _emit_ast=_emit_ast)
+    return _call_function("array_unique_agg", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7362,13 +7431,15 @@ def map_cat(
     ast = build_function_expr("map_cat", [col1, col2, *cols]) if _emit_ast else None
 
     def map_cat_two_maps(first, second):
-        return builtin("map_cat", _ast=ast, _emit_ast=False)(first, second)
+        return _call_function("map_cat", first, second, _emit_ast=False)
 
     cols_to_concat = [m1, m2]
     for c in cols:
         cols_to_concat.append(_to_col_if_str(c, "map_cat"))
 
-    return reduce(map_cat_two_maps, cols_to_concat)
+    ans = reduce(map_cat_two_maps, cols_to_concat)
+    ans._ast = ast
+    return ans
 
 
 @publicapi
@@ -7400,7 +7471,7 @@ def map_contains_key(value: ColumnOrLiteral, col: ColumnOrName, _emit_ast: bool 
         <BLANKLINE>
     """
     m = _to_col_if_str(col, "map_contains")
-    return builtin("map_contains_key", _emit_ast=_emit_ast)(value, m)
+    return _call_function("map_contains_key", value, m, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7424,7 +7495,7 @@ def map_keys(col: ColumnOrName, _emit_ast: bool = True):
         <BLANKLINE>
     """
     m = _to_col_if_str(col, "map_keys")
-    return builtin("map_keys", _emit_ast=_emit_ast)(m)
+    return _call_function("map_keys", m, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7447,13 +7518,10 @@ def size(col: ColumnOrName, _emit_ast: bool = True) -> Column:
     """
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "size", col)
+    ast = build_function_expr("size", [col]) if _emit_ast else None
 
     c = _to_col_if_str(col, "size")
-    v = to_variant(c)
+    v = to_variant(c, _emit_ast=False)
 
     result = (
         when(
@@ -7500,7 +7568,7 @@ def object_agg(
     """
     k = _to_col_if_str(key, "object_agg")
     v = _to_col_if_str(value, "object_agg")
-    return builtin("object_agg", _emit_ast=_emit_ast)(k, v)
+    return _call_function("object_agg", k, v, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7530,7 +7598,7 @@ def object_construct(*key_values: ColumnOrName, _emit_ast: bool = True) -> Colum
         <BLANKLINE>
     """
     kvs = [_to_col_if_str(kv, "object_construct") for kv in key_values]
-    return builtin("object_construct", _emit_ast=_emit_ast)(*kvs)
+    return _call_function("object_construct", *kvs, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7561,7 +7629,7 @@ def object_construct_keep_null(
         <BLANKLINE>
     """
     kvs = [_to_col_if_str(kv, "object_construct_keep_null") for kv in key_values]
-    return builtin("object_construct_keep_null", _emit_ast=_emit_ast)(*kvs)
+    return _call_function("object_construct_keep_null", *kvs, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7597,7 +7665,7 @@ def object_delete(
     o = _to_col_if_str(obj, "object_delete")
     k1 = _to_col_if_str(key1, "object_delete")
     ks = [_to_col_if_str(k, "object_delete") for k in keys]
-    return builtin("object_delete", _emit_ast=_emit_ast)(o, k1, *ks)
+    return _call_function("object_delete", o, k1, *ks, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7642,9 +7710,9 @@ def object_insert(
     v = _to_col_if_str(value, "object_insert")
     uf = _to_col_if_str(update_flag, "update_flag") if update_flag is not None else None
     if uf is not None:
-        return builtin("object_insert", _emit_ast=_emit_ast)(o, k, v, uf)
+        return _call_function("object_insert", o, k, v, uf, _emit_ast=_emit_ast)
     else:
-        return builtin("object_insert", _emit_ast=_emit_ast)(o, k, v)
+        return _call_function("object_insert", o, k, v, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7683,7 +7751,7 @@ def object_pick(
     o = _to_col_if_str(obj, "object_pick")
     k1 = _to_col_if_str(key1, "object_pick")
     ks = [_to_col_if_str(k, "object_pick") for k in keys]
-    return builtin("object_pick", _emit_ast=_emit_ast)(o, k1, *ks)
+    return _call_function("object_pick", o, k1, *ks, _emit_ast=_emit_ast)
 
 
 # The following three vector functions have doctests that are disabled (">>" instead of ">>>")
@@ -7709,7 +7777,7 @@ def vector_cosine_distance(
     """
     v1 = _to_col_if_str(v1, "vector_cosine_distance")
     v2 = _to_col_if_str(v2, "vector_cosine_distance")
-    return builtin("vector_cosine_distance", _emit_ast=_emit_ast)(v1, v2)
+    return _call_function("vector_cosine_distance", v1, v2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7731,7 +7799,7 @@ def vector_l2_distance(
     """
     v1 = _to_col_if_str(v1, "vector_l2_distance")
     v2 = _to_col_if_str(v2, "vector_l2_distance")
-    return builtin("vector_l2_distance", _emit_ast=_emit_ast)(v1, v2)
+    return _call_function("vector_l2_distance", v1, v2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7753,13 +7821,11 @@ def vector_inner_product(
     """
     v1 = _to_col_if_str(v1, "vector_inner_product")
     v2 = _to_col_if_str(v2, "vector_inner_product")
-    return builtin("vector_inner_product", _emit_ast=_emit_ast)(v1, v2)
+    return _call_function("vector_inner_product", v1, v2, _emit_ast=_emit_ast)
 
 
 @publicapi
-def ln(
-    c: ColumnOrLiteral, _emit_ast: bool = True, _ast: Optional[proto.Expr] = None
-) -> Column:
+def ln(c: ColumnOrLiteral, _emit_ast: bool = True) -> Column:
     """Returns the natrual logarithm of given column expression.
 
     Example::
@@ -7774,16 +7840,8 @@ def ln(
         ------------
         <BLANKLINE>
     """
-
-    # AST.
-    if _ast is None and _emit_ast:
-        _ast = proto.Expr()
-        build_builtin_fn_apply(_ast, "ln", c)
-
     c = _to_col_if_str(c, "ln")
-    ans = builtin("ln", _emit_ast=False)(c)
-    ans._ast = _ast
-    return ans
+    return _call_function("ln", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7797,10 +7855,7 @@ def asc(c: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=None), Row(A=None), Row(A=1), Row(A=2), Row(A=3)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "asc", c)
+    ast = build_function_expr("asc", [c]) if _emit_ast else None
 
     c = _to_col_if_str(c, "asc")
     ans = c.asc(_emit_ast=False)
@@ -7820,10 +7875,7 @@ def asc_nulls_first(c: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=None), Row(A=None), Row(A=1), Row(A=2), Row(A=3)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "asc_nulls_first", c)
+    ast = build_function_expr("asc_nulls_first", [c]) if _emit_ast else None
 
     c = _to_col_if_str(c, "asc_nulls_first")
     ans = c.asc_nulls_first(_emit_ast=False)
@@ -7843,13 +7895,10 @@ def asc_nulls_last(c: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=1), Row(A=2), Row(A=3), Row(A=None), Row(A=None)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "asc_nulls_last", c)
+    ast = build_function_expr("asc_nulls_last", [c]) if _emit_ast else None
 
     c = _to_col_if_str(c, "asc_nulls_last")
-    ans = c.asc_nulls_last()
+    ans = c.asc_nulls_last(_emit_ast=False)
     ans._ast = ast
     return ans
 
@@ -7866,10 +7915,7 @@ def desc(c: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=3), Row(A=2), Row(A=1), Row(A=None), Row(A=None)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "desc", c)
+    ast = build_function_expr("desc", [c]) if _emit_ast else None
 
     c = _to_col_if_str(c, "desc")
     ans = c.desc(_emit_ast=False)
@@ -7890,10 +7936,7 @@ def desc_nulls_first(c: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=None), Row(A=None), Row(A=3), Row(A=2), Row(A=1)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "desc_nulls_first", c)
+    ast = build_function_expr("desc_nulls_first", [c]) if _emit_ast else None
 
     c = _to_col_if_str(c, "desc_nulls_first")
     ans = c.desc_nulls_first(_emit_ast=False)
@@ -7913,10 +7956,8 @@ def desc_nulls_last(c: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(A=3), Row(A=2), Row(A=1), Row(A=None), Row(A=None)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "desc_nulls_last", c)
+    ast = build_function_expr("desc_nulls_last", [c]) if _emit_ast else None
+
     c = _to_col_if_str(c, "desc_nulls_last")
     ans = c.desc_nulls_last(_emit_ast=False)
     ans._ast = ast
@@ -7941,7 +7982,7 @@ def as_array(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(variant, "as_array")
-    return builtin("as_array", _emit_ast=_emit_ast)(c)
+    return _call_function("as_array", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7959,7 +8000,7 @@ def as_binary(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(variant, "as_binary")
-    return builtin("as_binary", _emit_ast=_emit_ast)(c)
+    return _call_function("as_binary", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7977,7 +8018,7 @@ def as_char(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     c = _to_col_if_str(variant, "as_char")
-    return builtin("as_char", _emit_ast=_emit_ast)(c)
+    return _call_function("as_char", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -7995,7 +8036,7 @@ def as_varchar(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     c = _to_col_if_str(variant, "as_varchar")
-    return builtin("as_varchar", _emit_ast=_emit_ast)(c)
+    return _call_function("as_varchar", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8013,7 +8054,7 @@ def as_date(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(variant, "as_date")
-    return builtin("as_date", _emit_ast=_emit_ast)(c)
+    return _call_function("as_date", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8037,10 +8078,7 @@ def cast(
         <BLANKLINE>
     """
 
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "cast", column, to)
+    ast = build_function_expr("cast", [column, to]) if _emit_ast else None
 
     c = _to_col_if_str(column, "cast")
     ans = c.cast(to, _emit_ast=False)
@@ -8073,35 +8111,12 @@ def try_cast(
 
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "try_cast", column, to)
+    ast = build_function_expr("try_cast", [column, to]) if _emit_ast else None
 
     c = _to_col_if_str(column, "try_cast")
     ans = c.try_cast(to, _emit_ast=False)
     ans._ast = ast
     return ans
-
-
-def _as_decimal_or_number(
-    cast_type: str,
-    variant: ColumnOrName,
-    precision: Optional[int] = None,
-    scale: Optional[int] = None,
-) -> Column:
-    """Helper function that casts a VARIANT value to a decimal or number."""
-    c = _to_col_if_str(variant, cast_type)
-    if scale and not precision:
-        raise ValueError("Cannot define scale without precision")
-    if precision and scale:
-        return builtin(cast_type, _emit_ast=False)(
-            c, lit(precision, _emit_ast=False), lit(scale, _emit_ast=False)
-        )
-    elif precision:
-        return builtin(cast_type, _emit_ast=False)(c, lit(precision, _emit_ast=False))
-    else:
-        return builtin(cast_type, _emit_ast=False)(c)
 
 
 @publicapi
@@ -8124,14 +8139,36 @@ def as_decimal(
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "as_decimal", variant, precision, scale)
+    ast = (
+        build_function_expr(
+            "as_decimal",
+            [variant]
+            + ([] if precision is None else [precision])
+            + ([] if scale is None else [scale]),
+        )
+        if _emit_ast
+        else None
+    )
 
-    ans = _as_decimal_or_number("as_decimal", variant, precision, scale)
-    ans._ast = ast
-    return ans
+    cast_type = "as_decimal"
+    c = _to_col_if_str(variant, cast_type)
+    if scale and not precision:
+        raise ValueError("Cannot define scale without precision")
+    if precision and scale:
+        return _call_function(
+            cast_type,
+            c,
+            lit(precision, _emit_ast=False),
+            lit(scale, _emit_ast=False),
+            _ast=ast,
+            _emit_ast=_emit_ast,
+        )
+    elif precision:
+        return _call_function(
+            cast_type, c, lit(precision, _emit_ast=False), _ast=ast, _emit_ast=_emit_ast
+        )
+    else:
+        return _call_function(cast_type, c, _ast=ast, _emit_ast=_emit_ast)
 
 
 as_number = as_decimal
@@ -8152,7 +8189,7 @@ def as_double(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(variant, "as_double")
-    return builtin("as_double", _emit_ast=_emit_ast)(c)
+    return _call_function("as_double", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8171,7 +8208,7 @@ def as_real(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(REAL_RADIUS_V=2.0, RADIUS=2.0)]
     """
     c = _to_col_if_str(variant, "as_real")
-    return builtin("as_real", _emit_ast=_emit_ast)(c)
+    return _call_function("as_real", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8189,7 +8226,7 @@ def as_integer(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(variant, "as_integer")
-    return builtin("as_integer", _emit_ast=_emit_ast)(c)
+    return _call_function("as_integer", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8210,7 +8247,7 @@ def as_object(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(variant, "as_object")
-    return builtin("as_object", _emit_ast=_emit_ast)(c)
+    return _call_function("as_object", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8228,7 +8265,7 @@ def as_time(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     c = _to_col_if_str(variant, "as_time")
-    return builtin("as_time", _emit_ast=_emit_ast)(c)
+    return _call_function("as_time", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8246,7 +8283,7 @@ def as_timestamp_ltz(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     c = _to_col_if_str(variant, "as_timestamp_ltz")
-    return builtin("as_timestamp_ltz", _emit_ast=_emit_ast)(c)
+    return _call_function("as_timestamp_ltz", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8264,7 +8301,7 @@ def as_timestamp_ntz(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     c = _to_col_if_str(variant, "as_timestamp_ntz")
-    return builtin("as_timestamp_ntz", _emit_ast=_emit_ast)(c)
+    return _call_function("as_timestamp_ntz", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8282,7 +8319,7 @@ def as_timestamp_tz(variant: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     c = _to_col_if_str(variant, "as_timestamp_tz")
-    return builtin("as_timestamp_tz", _emit_ast=_emit_ast)(c)
+    return _call_function("as_timestamp_tz", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8306,9 +8343,9 @@ def to_binary(
     """
     c = _to_col_if_str(e, "to_binary")
     return (
-        builtin("to_binary", _emit_ast=_emit_ast)(c, fmt)
+        _call_function("to_binary", c, fmt, _emit_ast=_emit_ast)
         if fmt
-        else builtin("to_binary", _emit_ast=_emit_ast)(c)
+        else _call_function("to_binary", c, _emit_ast=_emit_ast)
     )
 
 
@@ -8329,7 +8366,7 @@ def to_array(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ANS='[\\n  1,\\n  2,\\n  3\\n]'), Row(ANS=None)]
     """
     c = _to_col_if_str(e, "to_array")
-    return builtin("to_array", _emit_ast=_emit_ast)(c)
+    return _call_function("to_array", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8346,7 +8383,7 @@ def to_json(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ANS=None), Row(ANS='12'), Row(ANS='3.141'), Row(ANS='{"a":10,"b":20}'), Row(ANS='[1,23,456]')]
     """
     c = _to_col_if_str(e, "to_json")
-    return builtin("to_json", _emit_ast=_emit_ast)(c)
+    return _call_function("to_json", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8362,7 +8399,7 @@ def to_object(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ANS='{\\n  "a": 10,\\n  "b": 20\\n}'), Row(ANS=None)]
     """
     c = _to_col_if_str(e, "to_object")
-    return builtin("to_object", _emit_ast=_emit_ast)(c)
+    return _call_function("to_object", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8386,7 +8423,7 @@ def to_variant(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ANS='ARRAY'), Row(ANS='INTEGER'), Row(ANS='INTEGER'), Row(ANS='INTEGER'), Row(ANS='INTEGER'), Row(ANS='INTEGER'), Row(ANS='OBJECT'), Row(ANS='VARCHAR')]
     """
     c = _to_col_if_str(e, "to_variant")
-    return builtin("to_variant", _emit_ast=_emit_ast)(c)
+    return _call_function("to_variant", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8403,7 +8440,7 @@ def to_xml(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ANS='<SnowflakeData type="INTEGER">10</SnowflakeData>'), Row(ANS='<SnowflakeData type="VARCHAR">test</SnowflakeData>'), Row(ANS='<SnowflakeData type="OBJECT"><a type="INTEGER">10</a><b type="INTEGER">20</b></SnowflakeData>'), Row(ANS='<SnowflakeData type="ARRAY"><e type="INTEGER">1</e><e type="INTEGER">2</e><e type="INTEGER">3</e></SnowflakeData>')]
     """
     c = _to_col_if_str(e, "to_xml")
-    return builtin("to_xml", _emit_ast=_emit_ast)(c)
+    return _call_function("to_xml", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8422,7 +8459,7 @@ def get_ignore_case(
     """
     c1 = _to_col_if_str(obj, "get_ignore_case")
     c2 = _to_col_if_str(field, "get_ignore_case")
-    return builtin("get_ignore_case", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("get_ignore_case", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8455,7 +8492,7 @@ def object_keys(obj: ColumnOrName, _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str(obj, "object_keys")
-    return builtin("object_keys", _emit_ast=_emit_ast)(c)
+    return _call_function("object_keys", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8509,7 +8546,7 @@ def xmlget(
         if isinstance(instance_num, int)
         else _to_col_if_str(instance_num, "xmlget")
     )
-    return builtin("xmlget", _emit_ast=_emit_ast)(c1, c2, c3)
+    return _call_function("xmlget", c1, c2, c3, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8525,7 +8562,7 @@ def get_path(col: ColumnOrName, path: ColumnOrName, _emit_ast: bool = True) -> C
     """
     c1 = _to_col_if_str(col, "get_path")
     c2 = _to_col_if_str(path, "get_path")
-    return builtin("get_path", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("get_path", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8559,7 +8596,7 @@ def get(
         <BLANKLINE>"""
     c1 = _to_col_if_str_or_int(col1, "get")
     c2 = _to_col_if_str_or_int(col2, "get")
-    return builtin("get", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("get", c1, c2, _emit_ast=_emit_ast)
 
 
 element_at = get
@@ -8618,6 +8655,7 @@ def when(
             ]
         ),
         _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -8645,8 +8683,14 @@ def iff(
         >>> df.select(iff(df["a"], lit("true"), lit("false")).alias("iff")).collect()
         [Row(IFF='true'), Row(IFF='false'), Row(IFF='false')]
     """
-    return builtin("iff", _emit_ast=_emit_ast)(
-        _to_col_if_sql_expr(condition, "iff"), expr1, expr2
+    ast = build_function_expr("iff", [condition, expr1, expr2]) if _emit_ast else None
+    return _call_function(
+        "iff",
+        _to_col_if_sql_expr(condition, "iff"),
+        expr1,
+        expr2,
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -8767,7 +8811,7 @@ def cume_dist(_emit_ast: bool = True) -> Column:
         ------------
         <BLANKLINE>
     """
-    return builtin("cume_dist", _emit_ast=_emit_ast)()
+    return _call_function("cume_dist", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8800,7 +8844,7 @@ def rank(_emit_ast: bool = True) -> Column:
         ------------
         <BLANKLINE>
     """
-    return builtin("rank", _emit_ast=_emit_ast)()
+    return _call_function("rank", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8833,7 +8877,7 @@ def percent_rank(_emit_ast: bool = True) -> Column:
         ------------
         <BLANKLINE>
     """
-    return builtin("percent_rank", _emit_ast=_emit_ast)()
+    return _call_function("percent_rank", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8851,7 +8895,7 @@ def dense_rank(_emit_ast: bool = True) -> Column:
         >>> df.select(dense_rank().over(window).as_("dense_rank")).collect()
         [Row(DENSE_RANK=1), Row(DENSE_RANK=1), Row(DENSE_RANK=2), Row(DENSE_RANK=2)]
     """
-    return builtin("dense_rank", _emit_ast=_emit_ast)()
+    return _call_function("dense_rank", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8885,7 +8929,7 @@ def row_number(_emit_ast: bool = True) -> Column:
         ------------
         <BLANKLINE>
     """
-    return builtin("row_number", _emit_ast=_emit_ast)()
+    return _call_function("row_number", _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -8917,10 +8961,11 @@ def lag(
         [Row(RESULT=None), Row(RESULT=10), Row(RESULT=1), Row(RESULT=None), Row(RESULT=1)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "lag", e, offset, default_value, ignore_nulls)
+    ast = (
+        build_function_expr("lag", [e, offset, default_value, ignore_nulls])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(e, "lag")
 
@@ -8961,10 +9006,11 @@ def lead(
         [Row(RESULT=1), Row(RESULT=3), Row(RESULT=None), Row(RESULT=3), Row(RESULT=None)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "lead", e, offset, default_value, ignore_nulls)
+    ast = (
+        build_function_expr("lead", [e, offset, default_value, ignore_nulls])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(e, "lead")
 
@@ -8992,10 +9038,7 @@ def last_value(
         [Row(COLUMN1=1, COLUMN2=10, COLUMN2_LAST=11), Row(COLUMN1=1, COLUMN2=11, COLUMN2_LAST=11), Row(COLUMN1=2, COLUMN2=20, COLUMN2_LAST=21), Row(COLUMN1=2, COLUMN2=21, COLUMN2_LAST=21)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "last_value", e, ignore_nulls)
+    ast = build_function_expr("last_value", [e, ignore_nulls]) if _emit_ast else None
 
     c = _to_col_if_str(e, "last_value")
 
@@ -9020,10 +9063,7 @@ def first_value(
         [Row(COLUMN1=1, COLUMN2=10, COLUMN2_FIRST=10), Row(COLUMN1=1, COLUMN2=11, COLUMN2_FIRST=10), Row(COLUMN1=2, COLUMN2=20, COLUMN2_FIRST=20), Row(COLUMN1=2, COLUMN2=21, COLUMN2_FIRST=20)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "first_value", e, ignore_nulls)
+    ast = build_function_expr("first_value", [e, ignore_nulls]) if _emit_ast else None
 
     c = _to_col_if_str(e, "first_value")
 
@@ -9048,10 +9088,7 @@ def nth_value(
         [Row(COLUMN1=1, COLUMN2=10, COLUMN2_2ND=11), Row(COLUMN1=1, COLUMN2=11, COLUMN2_2ND=11), Row(COLUMN1=2, COLUMN2=20, COLUMN2_2ND=21), Row(COLUMN1=2, COLUMN2=21, COLUMN2_2ND=21)]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "nth_value", e, n, ignore_nulls)
+    ast = build_function_expr("nth_value", [e, n, ignore_nulls]) if _emit_ast else None
 
     c = _to_col_if_str(e, "nth_value")
 
@@ -9089,7 +9126,7 @@ def ntile(e: Union[int, ColumnOrName], _emit_ast: bool = True) -> Column:
         <BLANKLINE>
     """
     c = _to_col_if_str_or_int(e, "ntile")
-    return builtin("ntile", _emit_ast=_emit_ast)(c)
+    return _call_function("ntile", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -9119,7 +9156,7 @@ Row(K=2, PERCENTILE=Decimal('17.500')), \
 Row(K=3, PERCENTILE=Decimal('60.000')), \
 Row(K=4, PERCENTILE=None)]
     """
-    return builtin("percentile_cont", _emit_ast=_emit_ast)(percentile)
+    return _call_function("percentile_cont", percentile, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -9136,7 +9173,7 @@ def greatest(*columns: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(GREATEST=3), Row(GREATEST=4), Row(GREATEST=None)]
     """
     c = [_to_col_if_str(ex, "greatest") for ex in columns]
-    return builtin("greatest", _emit_ast=_emit_ast)(*c)
+    return _call_function("greatest", *c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -9153,7 +9190,7 @@ def least(*columns: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(LEAST=1), Row(LEAST=-1), Row(LEAST=None)]
     """
     c = [_to_col_if_str(ex, "least") for ex in columns]
-    return builtin("least", _emit_ast=_emit_ast)(*c)
+    return _call_function("least", *c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -9180,10 +9217,11 @@ def listagg(
         [Row(RESULT='1,2,2,3,4,5')]
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "listagg", e, delimiter, is_distinct)
+    ast = (
+        build_function_expr("listagg", [e, delimiter, is_distinct])
+        if _emit_ast
+        else None
+    )
 
     c = _to_col_if_str(e, "listagg")
 
@@ -10233,30 +10271,10 @@ def call_udf(udf_name: str, *args: ColumnOrLiteral, _emit_ast: bool = True) -> C
     """
     validate_object_name(udf_name)
 
-    ast = None
-    # AST.
-    if _emit_ast:
-        args_list = parse_positional_args_to_list(*args)
-        ast = proto.Expr()
-        # Note: The type hint says ColumnOrLiteral, but in Snowpark sometimes arbitrary
-        #       Python objects are passed.
-        build_builtin_fn_apply(
-            ast,
-            "call_udf",
-            *(
-                (udf_name,)
-                + tuple(
-                    snowpark_expression_to_ast(arg)
-                    if isinstance(arg, Expression)
-                    else arg
-                    for arg in args_list
-                )
-            ),
-        )
+    ast = build_function_expr("call_udf", [udf_name, *args]) if _emit_ast else None
 
     return _call_function(
         udf_name,
-        False,
         *args,
         api_call_source="functions.call_udf",
         _ast=ast,
@@ -10292,7 +10310,7 @@ def call_table_function(
         build_call_table_function_apply(ast, function_name, *args, **kwargs)
 
     func_call = snowflake.snowpark.table_function.TableFunctionCall(
-        function_name, *args, _ast=ast, **kwargs
+        function_name, *args, _ast=ast, _emit_ast=_emit_ast, **kwargs
     )
 
     return func_call
@@ -10316,10 +10334,7 @@ def table_function(function_name: str, _emit_ast: bool = True) -> Callable:
     )
 
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "table_function", function_name)
+    ast = build_function_expr("table_function", [function_name]) if _emit_ast else None
     fn._ast = ast
 
     return fn
@@ -10329,7 +10344,6 @@ def table_function(function_name: str, _emit_ast: bool = True) -> Callable:
 def call_function(
     function_name: str,
     *args: ColumnOrLiteral,
-    _ast: proto.Expr = None,
     _emit_ast: bool = True,
 ) -> Column:
     """Invokes a Snowflake `system-defined function <https://docs.snowflake.com/en/sql-reference-functions.html>`_ (built-in function) with the specified name
@@ -10353,13 +10367,16 @@ def call_function(
         <BLANKLINE>
 
     """
-    return _call_function(function_name, False, *args, _ast=_ast, _emit_ast=_emit_ast)
+    ast = (
+        build_function_expr("call_function", [function_name, *args])
+        if _emit_ast
+        else None
+    )
+    return _call_function(function_name, *args, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
-def function(
-    function_name: str, _ast: proto.Expr = None, _emit_ast: bool = True
-) -> Callable:
+def function(function_name: str, _emit_ast: bool = True) -> Callable:
     """
     Function object to invoke a Snowflake `system-defined function <https://docs.snowflake.com/en/sql-reference-functions.html>`_ (built-in function). Use this to invoke
     any built-in functions not explicitly listed in this object.
@@ -10388,36 +10405,23 @@ def function(
         ----------------
         <BLANKLINE>
     """
-    return lambda *args: call_function(
-        function_name, *args, _ast=_ast, _emit_ast=_emit_ast
-    )
+    return lambda *args: call_function(function_name, *args, _emit_ast=_emit_ast)
 
 
 def _call_function(
     name: str,
-    is_distinct: bool = False,
     *args: ColumnOrLiteral,
+    is_distinct: bool = False,
     api_call_source: Optional[str] = None,
     is_data_generator: bool = False,
     _ast: proto.Expr = None,
     _emit_ast: bool = True,
 ) -> Column:
 
-    args_list = parse_positional_args_to_list(*args)
-    ast = _ast
-    if ast is None and _emit_ast:
-        ast = proto.Expr()
-        # Note: The type hint says ColumnOrLiteral, but in Snowpark sometimes arbitrary
-        #       Python objects are passed.
-        build_builtin_fn_apply(
-            ast,
-            name,
-            *tuple(
-                snowpark_expression_to_ast(arg) if isinstance(arg, Expression) else arg
-                for arg in args_list
-            ),
-        )
+    if _emit_ast and _ast is None:
+        _ast = build_function_expr(name, args)
 
+    args_list = parse_positional_args_to_list(*args)
     expressions = [Column._to_expr(arg) for arg in args_list]
     return Column(
         FunctionExpression(
@@ -10427,7 +10431,7 @@ def _call_function(
             api_call_source=api_call_source,
             is_data_generator=is_data_generator,
         ),
-        _ast=ast,
+        _ast=_ast,
         _emit_ast=_emit_ast,
     )
 
@@ -10691,10 +10695,14 @@ def unix_timestamp(
         <BLANKLINE>
     """
     # AST.
-    ast = None
-    if _emit_ast:
-        ast = proto.Expr()
-        build_builtin_fn_apply(ast, "unix_timestamp", e, fmt)
+    ast = (
+        build_function_expr(
+            "unix_timestamp",
+            [e, fmt] if fmt is not None else [e],
+        )
+        if _emit_ast
+        else None
+    )
 
     ans = date_part(
         "epoch_second", to_timestamp(e, fmt, _emit_ast=False), _emit_ast=False
@@ -10728,9 +10736,14 @@ def locate(
         -----------
         <BLANKLINE>
     """
+    ast = (
+        build_function_expr("locate", [expr1, expr2, start_pos]) if _emit_ast else None
+    )
     _substr = lit(expr1)
     _str = _to_col_if_str(expr2, "locate")
-    return builtin("charindex", _emit_ast=_emit_ast)(_substr, _str, lit(start_pos))
+    return _call_function(
+        "charindex", _substr, _str, lit(start_pos), _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 @publicapi
@@ -10781,33 +10794,25 @@ def make_interval(
         ast = proto.Expr()
         # Encode the parameters as kwargs to make them more readable.
         # If any of the parameters are None, ignore them.
-        kwargs = {}
-        if years is not None:
-            kwargs["years"] = years
-        if quarters is not None:
-            kwargs["quarters"] = quarters
-        if months is not None:
-            kwargs["months"] = months
-        if weeks is not None:
-            kwargs["weeks"] = weeks
-        if days is not None:
-            kwargs["days"] = days
-        if hours is not None:
-            kwargs["hours"] = hours
-        if minutes is not None:
-            kwargs["minutes"] = minutes
-        if seconds is not None:
-            kwargs["seconds"] = seconds
-        if milliseconds is not None:
-            kwargs["milliseconds"] = milliseconds
-        if microseconds is not None:
-            kwargs["microseconds"] = microseconds
-        if nanoseconds is not None:
-            kwargs["nanoseconds"] = nanoseconds
-        if mins is not None:
-            kwargs["mins"] = mins
-        if secs is not None:
-            kwargs["secs"] = secs
+        kwargs = {
+            k: v
+            for k, v in {
+                "years": years,
+                "quarters": quarters,
+                "months": months,
+                "weeks": weeks,
+                "days": days,
+                "hours": hours,
+                "minutes": minutes,
+                "seconds": seconds,
+                "milliseconds": milliseconds,
+                "microseconds": microseconds,
+                "nanoseconds": nanoseconds,
+                "mins": mins,
+                "secs": secs,
+            }.items()
+            if v is not None
+        }
         build_builtin_fn_apply(ast, "make_interval", **kwargs)
 
     # for migration purpose
@@ -10858,7 +10863,7 @@ def snowflake_cortex_summarize(
 
     sql_func_name = "snowflake.cortex.summarize"
     text_col = _to_col_if_lit(text, sql_func_name)
-    return builtin(sql_func_name, _ast=ast, _emit_ast=_emit_ast)(text_col)
+    return _call_function(sql_func_name, text_col, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10884,7 +10889,7 @@ def snowflake_cortex_sentiment(
 
     sql_func_name = "snowflake.cortex.sentiment"
     text_col = _to_col_if_lit(text, sql_func_name)
-    return builtin(sql_func_name, _ast=ast, _emit_ast=_emit_ast)(text_col)
+    return _call_function(sql_func_name, text_col, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10899,7 +10904,7 @@ def acosh(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ACOSH=1.4999999998857607)]
     """
     c = _to_col_if_str(e, "acosh")
-    return builtin("acosh", _emit_ast=_emit_ast)(c)
+    return _call_function("acosh", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10914,7 +10919,7 @@ def asinh(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(ASINH=1.4999999999596934)]
     """
     c = _to_col_if_str(e, "asinh")
-    return builtin("asinh", _emit_ast=_emit_ast)(c)
+    return _call_function("asinh", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10929,7 +10934,7 @@ def atanh(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(RESULT=1.4999999997517164)]
     """
     c = _to_col_if_str(e, "atanh")
-    return builtin("atanh", _emit_ast=_emit_ast)(c)
+    return _call_function("atanh", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10945,7 +10950,7 @@ def bit_length(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(BIT_LENGTH_V=24, BIT_LENGTH_B=16), Row(BIT_LENGTH_V=16, BIT_LENGTH_B=16)]
     """
     c = _to_col_if_str(e, "bit_length")
-    return builtin("bit_length", _emit_ast=_emit_ast)(c)
+    return _call_function("bit_length", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10960,7 +10965,7 @@ def bitmap_bit_position(numeric_expr: ColumnOrName, _emit_ast: bool = True) -> C
         [Row(BIT_POSITION=0), Row(BIT_POSITION=1), Row(BIT_POSITION=2), Row(BIT_POSITION=32767), Row(BIT_POSITION=0)]
     """
     c = _to_col_if_str(numeric_expr, "bitmap_bit_position")
-    return builtin("bitmap_bit_position", _emit_ast=_emit_ast)(c)
+    return _call_function("bitmap_bit_position", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10977,7 +10982,7 @@ def bitmap_bucket_number(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(BUCKET_NUMBER=1), Row(BUCKET_NUMBER=1), Row(BUCKET_NUMBER=1), Row(BUCKET_NUMBER=1), Row(BUCKET_NUMBER=2)]
     """
     c = _to_col_if_str(e, "bitmap_bucket_number")
-    return builtin("bitmap_bucket_number", _emit_ast=_emit_ast)(c)
+    return _call_function("bitmap_bucket_number", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -10994,7 +10999,7 @@ def bitmap_construct_agg(
         [Row(BITMAP_ID=1, BITMAP=bytearray(b'\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00')), Row(BITMAP_ID=2, BITMAP=bytearray(b'\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00'))]
     """
     c = _to_col_if_str(relative_position, "bitmap_construct_agg")
-    return builtin("bitmap_construct_agg", _emit_ast=_emit_ast)(c)
+    return _call_function("bitmap_construct_agg", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11009,7 +11014,7 @@ def cbrt(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(CBRT_X=0.0), Row(CBRT_X=1.2599210498948734), Row(CBRT_X=-2.1544346900318834), Row(CBRT_X=None)]
     """
     c = _to_col_if_str(e, "cbrt")
-    return builtin("cbrt", _emit_ast=_emit_ast)(c)
+    return _call_function("cbrt", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11027,7 +11032,7 @@ def equal_null(e1: ColumnOrName, e2: ColumnOrName, _emit_ast: bool = True) -> Co
     """
     c1 = _to_col_if_str(e1, "equal_null")
     c2 = _to_col_if_str(e2, "equal_null")
-    return builtin("equal_null", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("equal_null", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11043,7 +11048,7 @@ def ifnull(e1: ColumnOrName, e2: ColumnOrName, _emit_ast: bool = True) -> Column
     """
     c1 = _to_col_if_str(e1, "ifnull")
     c2 = _to_col_if_str(e2, "ifnull")
-    return builtin("ifnull", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("ifnull", c1, c2, _emit_ast=_emit_ast)
 
 
 nvl = ifnull
@@ -11064,8 +11069,11 @@ def localtimestamp(fract_sec_precision: int = 9, _emit_ast: bool = True) -> Colu
         if _emit_ast
         else None
     )
-    return builtin("localtimestamp", _ast=ast, _emit_ast=_emit_ast)(
-        lit(fract_sec_precision, _emit_ast=False)
+    return _call_function(
+        "localtimestamp",
+        lit(fract_sec_precision, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -11101,11 +11109,16 @@ def max_by(
             if _emit_ast
             else None
         )
-        return builtin("max_by", _ast=ast, _emit_ast=_emit_ast)(
-            c1, c2, lit(maximum_number_of_values_to_return, _emit_ast=False)
+        return _call_function(
+            "max_by",
+            c1,
+            c2,
+            lit(maximum_number_of_values_to_return, _emit_ast=False),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
     else:
-        return builtin("max_by", _emit_ast=_emit_ast)(c1, c2)
+        return _call_function("max_by", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11137,15 +11150,20 @@ def min_by(
     c2 = _to_col_if_str(col_containing_minimum, "min_by")
     if maximum_number_of_values_to_return is not None:
         ast = (
-            build_function_expr("max_by", [c1, c2, maximum_number_of_values_to_return])
+            build_function_expr("min_by", [c1, c2, maximum_number_of_values_to_return])
             if _emit_ast
             else None
         )
-        return builtin("min_by", _ast=ast, _emit_ast=_emit_ast)(
-            c1, c2, lit(maximum_number_of_values_to_return, _emit_ast=False)
+        return _call_function(
+            "min_by",
+            c1,
+            c2,
+            lit(maximum_number_of_values_to_return, _emit_ast=False),
+            _ast=ast,
+            _emit_ast=_emit_ast,
         )
     else:
-        return builtin("min_by", _emit_ast=_emit_ast)(c1, c2)
+        return _call_function("min_by", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11162,7 +11180,7 @@ def octet_length(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         [Row(OCTET_LENGTH=3), Row(OCTET_LENGTH=2), Row(OCTET_LENGTH=7)]
     """
     c = _to_col_if_str(e, "octet_length")
-    return builtin("octet_length", _emit_ast=_emit_ast)(c)
+    return _call_function("octet_length", c, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11171,7 +11189,6 @@ def position(
     expr2: ColumnOrName,
     start_pos: int = 1,
     _emit_ast: bool = True,
-    _ast: Optional[proto.Expr] = None,
 ) -> Column:
     """
     Searches for the first occurrence of the first argument in the second argument and, if successful, returns
@@ -11183,12 +11200,20 @@ def position(
         >>> df.select(position(df["expr1"], df["expr2"], 3).alias("position")).collect()
         [Row(POSITION=4), Row(POSITION=3)]
     """
+    ast = (
+        build_function_expr("position", [expr1, expr2, start_pos])
+        if _emit_ast
+        else None
+    )
     c1 = _to_col_if_str(expr1, "position")
     c2 = _to_col_if_str(expr2, "position")
-    if _ast is None and _emit_ast:
-        _ast = build_function_expr("position", [c1, c2, start_pos])
-    return builtin("position", _ast=_ast, _emit_ast=_emit_ast)(
-        c1, c2, lit(start_pos, _emit_ast=False)
+    return _call_function(
+        "position",
+        c1,
+        c2,
+        lit(start_pos, _emit_ast=False),
+        _ast=ast,
+        _emit_ast=_emit_ast,
     )
 
 
@@ -11206,7 +11231,7 @@ def regr_avgx(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Colum
     """
     c1 = _to_col_if_str(y, "regr_avgx")
     c2 = _to_col_if_str(x, "regr_avgx")
-    return builtin("regr_avgx", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("regr_avgx", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11224,7 +11249,7 @@ def regr_avgy(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Colum
     """
     y = _to_col_if_str(y, "regr_avgy")
     x = _to_col_if_str(x, "regr_avgy")
-    return builtin("regr_avgy", _emit_ast=_emit_ast)(y, x)
+    return _call_function("regr_avgy", y, x, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11240,7 +11265,7 @@ def regr_count(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Colu
     """
     c1 = _to_col_if_str(y, "regr_count")
     c2 = _to_col_if_str(x, "regr_count")
-    return builtin("regr_count", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("regr_count", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11258,7 +11283,7 @@ def regr_intercept(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> 
     """
     c1 = _to_col_if_str(y, "regr_intercept")
     c2 = _to_col_if_str(x, "regr_intercept")
-    return builtin("regr_intercept", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("regr_intercept", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11277,7 +11302,7 @@ def regr_r2(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Column:
     """
     y = _to_col_if_str(y, "regr_r2")
     x = _to_col_if_str(x, "regr_r2")
-    return builtin("regr_r2", _emit_ast=_emit_ast)(y, x)
+    return _call_function("regr_r2", y, x, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11296,7 +11321,7 @@ def regr_slope(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Colu
     """
     c1 = _to_col_if_str(y, "regr_slope")
     c2 = _to_col_if_str(x, "regr_slope")
-    return builtin("regr_slope", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("regr_slope", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11312,7 +11337,7 @@ def regr_sxx(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Column
     """
     y_col = _to_col_if_str(y, "regr_sxx")
     x_col = _to_col_if_str(x, "regr_sxx")
-    return builtin("regr_sxx", _emit_ast=_emit_ast)(y_col, x_col)
+    return _call_function("regr_sxx", y_col, x_col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11329,7 +11354,7 @@ def regr_sxy(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Column
     """
     y_col = _to_col_if_str(y, "regr_sxy")
     x_col = _to_col_if_str(x, "regr_sxy")
-    return builtin("regr_sxy", _emit_ast=_emit_ast)(y_col, x_col)
+    return _call_function("regr_sxy", y_col, x_col, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11345,7 +11370,7 @@ def regr_syy(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Column
     """
     c1 = _to_col_if_str(y, "regr_syy")
     c2 = _to_col_if_str(x, "regr_syy")
-    return builtin("regr_syy", _emit_ast=_emit_ast)(c1, c2)
+    return _call_function("regr_syy", c1, c2, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11365,9 +11390,9 @@ def try_to_binary(
     """
     c = _to_col_if_str(e, "try_to_binary")
     return (
-        builtin("try_to_binary", _emit_ast=_emit_ast)(c, fmt)
+        _call_function("try_to_binary", c, fmt, _emit_ast=_emit_ast)
         if fmt
-        else builtin("try_to_binary", _emit_ast=_emit_ast)(c)
+        else _call_function("try_to_binary", c, _emit_ast=_emit_ast)
     )
 
 
@@ -11388,7 +11413,10 @@ def base64_encode(
     """
     # Convert input to a column if it is not already one.
     ast = (
-        build_function_expr("base64_encode", [e, max_line_length, alphabet])
+        build_function_expr(
+            "base64_encode",
+            [e, max_line_length] + ([] if alphabet is None else [alphabet]),
+        )
         if _emit_ast
         else None
     )
@@ -11404,7 +11432,7 @@ def base64_encode(
         args.append(lit(alphabet))
 
     # Call the built-in Base64 encode function.
-    return builtin("base64_encode", _ast=ast, _emit_ast=False)(*args)
+    return _call_function("base64_encode", *args, _ast=ast, _emit_ast=_emit_ast)
 
 
 base64 = base64_encode
@@ -11424,7 +11452,9 @@ def base64_decode_string(
     """
     # Convert input to a column if it is not already one.
     ast = (
-        build_function_expr("base64_decode_string", [e, alphabet])
+        build_function_expr(
+            "base64_decode_string", [e] if alphabet is None else [e, alphabet]
+        )
         if _emit_ast
         else None
     )
@@ -11437,7 +11467,7 @@ def base64_decode_string(
         args.append(lit(alphabet))
 
     # Call the built-in Base64 encode function.
-    return builtin("base64_decode_string", _ast=ast, _emit_ast=False)(*args)
+    return _call_function("base64_decode_string", *args, _ast=ast, _emit_ast=_emit_ast)
 
 
 unbase64 = base64_decode_string
@@ -11455,7 +11485,9 @@ def hex_encode(e: ColumnOrName, case: int = 1, _emit_ast: bool = True):
     """
     ast = build_function_expr("hex_encode", [e, case]) if _emit_ast else None
     col_input = _to_col_if_str(e, "hex_encode")
-    return builtin("hex_encode", _ast=ast, _emit_ast=False)(col_input, lit(case))
+    return _call_function(
+        "hex_encode", col_input, lit(case), _ast=ast, _emit_ast=_emit_ast
+    )
 
 
 hex = hex_encode
@@ -11485,20 +11517,27 @@ def editdistance(
         ... ).collect()
         [Row(DISTANCE=3, MAX_2_DISTANCE=2), Row(DISTANCE=3, MAX_2_DISTANCE=2), Row(DISTANCE=5, MAX_2_DISTANCE=2)]
     """
-    ast = build_function_expr("editdistance", [e1, e2]) if _emit_ast else None
+    ast = (
+        build_function_expr(
+            "editdistance",
+            [e1, e2] if max_distance is None else [e1, e2, max_distance],
+        )
+        if _emit_ast
+        else None
+    )
     s1 = _to_col_if_str(e1, "editdistance")
     s2 = _to_col_if_str(e2, "editdistance")
 
     args = [s1, s2]
     if max_distance is not None:
         max_dist = (
-            lit(max_distance)
+            lit(max_distance, _emit_ast=False)
             if isinstance(max_distance, int)
             else _to_col_if_str(max_distance, "editdistance")
         )
         args.append(max_dist)
 
-    return builtin("editdistance", _ast=ast, _emit_ast=False)(*args)
+    return _call_function("editdistance", *args, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11511,9 +11550,10 @@ def instr(str: ColumnOrName, substr: str, _emit_ast: bool = True):
         >>> df.select(instr(col("text"), "world").alias("position")).collect()
         [Row(POSITION=7), Row(POSITION=1)]
     """
-    ast = build_function_expr("instr", [str, substr]) if _emit_ast else None
     s1 = _to_col_if_str(str, "instr")
-    return position(lit(substr), s1, _emit_ast=False, _ast=ast)
+    ans = position(lit(substr, _emit_ast=False), s1, _emit_ast=False)
+    ans._ast = build_function_expr("instr", [str, substr]) if _emit_ast else None
+    return ans
 
 
 @publicapi
@@ -11522,7 +11562,6 @@ def normal(
     stddev: Union[int, float],
     gen: Union[ColumnOrName, int, float],
     _emit_ast: bool = True,
-    _ast: Optional[proto.Expr] = None,
 ):
     """
     Generates a normally-distributed pseudo-random floating point number with specified mean and stddev (standard deviation).
@@ -11536,7 +11575,7 @@ def normal(
     # the following fails: SELECT normal("A", "A", 2) FROM ( SELECT $1 AS "A" FROM  VALUES (0 :: BIGINT))
     # but it supports reading from a table, we don't do type validation on mean and stddev here so users can still
     # use the functions on normal table
-    ast = build_function_expr("normal", [mean, stddev, gen]) if _emit_ast else _ast
+    ast = build_function_expr("normal", [mean, stddev, gen]) if _emit_ast else None
     mean = lit(mean, _emit_ast=False) if isinstance(mean, (int, float)) else mean
     stddev = (
         lit(stddev, _emit_ast=False) if isinstance(stddev, (int, float)) else stddev
@@ -11546,7 +11585,7 @@ def normal(
         if isinstance(gen, (int, float))
         else _to_col_if_str(gen, "normal")
     )
-    return builtin("normal", _emit_ast=_emit_ast, _ast=ast)(mean, stddev, gen)
+    return _call_function("normal", mean, stddev, gen, _ast=ast, _emit_ast=_emit_ast)
 
 
 @publicapi
@@ -11562,16 +11601,21 @@ def randn(
         [Row(RANDN=-1.143416214223267), Row(RANDN=-0.78469958830255), Row(RANDN=-0.365971322006404)]
         >>> df.select(randn().alias("randn")).collect()  # doctest: +SKIP
     """
-    ast = build_function_expr("randn", [seed]) if _emit_ast else None
+    ast = (
+        build_function_expr("randn", [] if seed is None else [seed])
+        if _emit_ast
+        else None
+    )
     if seed is None:
         seed = random(_emit_ast=False)  # pragma: no cover
-    return normal(
+    ans = normal(
         lit(0, _emit_ast=False),
         lit(1, _emit_ast=False),
         seed,
         _emit_ast=False,
-        _ast=ast,
     )
+    ans._ast = ast
+    return ans
 
 
 @publicapi
@@ -11598,14 +11642,8 @@ def build_stage_file_url(
 
         >>> df.select(build_stage_file_url("@images_stage", "/us/yosemite/half_dome.jpg").alias("url")).collect()  # doctest: +SKIP
     """
-    function_name = "build_stage_file_url"
-    ast = (
-        build_function_expr(function_name, [stage_name, relative_file_path])
-        if _emit_ast
-        else None
-    )
-    return builtin(function_name, _emit_ast=_emit_ast, _ast=ast)(
-        stage_name, relative_file_path
+    return _call_function(
+        "build_stage_file_url", stage_name, relative_file_path, _emit_ast=_emit_ast
     )
 
 
@@ -11635,14 +11673,16 @@ def to_file(stage_file_uri: str, _emit_ast: bool = True) -> Column:
         >>> result["CONTENT_TYPE"]
         'text/csv'
     """
-    ast = build_function_expr("to_file", [stage_file_uri]) if _emit_ast else None
     # TODO: SNOW-1950688: Remove parsing workaround once the server is ready for accepting full stage URI
     parts = validate_stage_location(stage_file_uri).split("/", maxsplit=1)
     if len(parts) != 2:
         raise ValueError(f"Invalid stage file URI: {stage_file_uri}")
+
+    ast = build_function_expr("to_file", [stage_file_uri]) if _emit_ast else None
+
     stage_name, relative_file_path = parts
     c = build_stage_file_url(stage_name, relative_file_path, _emit_ast=False)
-    return builtin("to_file", _ast=ast, _emit_ast=_emit_ast)(c)
+    return _call_function("to_file", c, _ast=ast, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11663,9 +11703,8 @@ def fl_get_content_type(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         'text/csv'
     """
     function_name = "fl_get_content_type"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11685,9 +11724,8 @@ def fl_get_etag(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         >>> len(df.collect()[0][0])  # doctest: +SKIP
     """
     function_name = "fl_get_etag"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11720,9 +11758,8 @@ def fl_get_file_type(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         'document'
     """
     function_name = "fl_get_file_type"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11743,9 +11780,8 @@ def fl_get_last_modified(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         <class 'datetime.datetime'>
     """
     function_name = "fl_get_last_modified"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11766,9 +11802,8 @@ def fl_get_relative_path(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         'testCSV.csv'
     """
     function_name = "fl_get_relative_path"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11788,9 +11823,8 @@ def fl_get_scoped_file_url(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         >>> df.collect()[0][0]
     """
     function_name = "fl_get_scoped_file_url"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11811,9 +11845,8 @@ def fl_get_size(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         32
     """
     function_name = "fl_get_size"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11834,9 +11867,8 @@ def fl_get_stage(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         'MYSTAGE'
     """
     function_name = "fl_get_stage"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11857,9 +11889,8 @@ def fl_get_stage_file_url(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         'https://'
     """
     function_name = "fl_get_stage_file_url"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11880,9 +11911,8 @@ def fl_is_audio(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         False
     """
     function_name = "fl_is_audio"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11903,9 +11933,8 @@ def fl_is_video(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         False
     """
     function_name = "fl_is_video"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11926,9 +11955,8 @@ def fl_is_document(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         True
     """
     function_name = "fl_is_document"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11949,9 +11977,8 @@ def fl_is_compressed(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         False
     """
     function_name = "fl_is_compressed"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -11972,9 +11999,8 @@ def fl_is_image(e: ColumnOrName, _emit_ast: bool = True) -> Column:
         False
     """
     function_name = "fl_is_image"
-    ast = build_function_expr(function_name, [e]) if _emit_ast else None
     col_input = _to_col_if_str(e, function_name)
-    return builtin(function_name, _ast=ast, _emit_ast=_emit_ast)(col_input)
+    return _call_function(function_name, col_input, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -12023,8 +12049,8 @@ def ai_filter(
     sql_func_name = "snowflake.cortex.ai_filter"
     predicate_col = _to_col_if_lit(predicate, sql_func_name)
     expr_col = _to_col_if_lit(expr, sql_func_name)
-    return builtin(sql_func_name, _ast=ast, _emit_ast=_emit_ast)(
-        predicate_col, expr_col
+    return _call_function(
+        sql_func_name, predicate_col, expr_col, _ast=ast, _emit_ast=_emit_ast
     )
 
 
@@ -12057,7 +12083,7 @@ def summarize_agg(expr: ColumnOrLiteralStr, _emit_ast: bool = True) -> Column:
     sql_func_name = "summarize_agg"
     ast = build_function_expr(sql_func_name, [expr]) if _emit_ast else None
     expr_col = _to_col_if_lit(expr, sql_func_name)
-    return builtin(sql_func_name, _ast=ast, _emit_ast=_emit_ast)(expr_col)
+    return _call_function(sql_func_name, expr_col, _ast=ast, _emit_ast=_emit_ast)
 
 
 @private_preview(version="1.29.0")
@@ -12117,6 +12143,6 @@ def ai_agg(
     )
     expr_col = _to_col_if_lit(expr, sql_func_name)
     task_description_col = _to_col_if_lit(task_description, sql_func_name)
-    return builtin(sql_func_name, _ast=ast, _emit_ast=_emit_ast)(
-        expr_col, task_description_col
+    return _call_function(
+        sql_func_name, expr_col, task_description_col, _ast=ast, _emit_ast=_emit_ast
     )

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -362,9 +362,9 @@ df27 = df.select(bitshiftright("A", col("B")), bitshiftright("A", -10), bitshift
 
 df28 = df.select(bround("A", 10), bround("A", 2), bround(col("A"), col("B")))
 
-df29 = df.select(convert_timezone("A", col("B"), None), convert_timezone(col("A"), "B", None), convert_timezone("A", "B", None), convert_timezone(col("A"), col("B"), None), convert_timezone("A", "B", None), convert_timezone("A", "B", "A"))
+df29 = df.select(convert_timezone("A", col("B")), convert_timezone(col("A"), "B"), convert_timezone("A", "B"), convert_timezone(col("A"), col("B")), convert_timezone("A", "B"), convert_timezone("A", "B", "A"))
 
-df30 = df.select(convert_timezone(lit("UTC"), col("a"), None), convert_timezone(lit("UTC"), col("b"), lit("Asia/Shanghai")))
+df30 = df.select(convert_timezone(lit("UTC"), col("a")), convert_timezone(lit("UTC"), col("b"), lit("Asia/Shanghai")))
 
 df31 = df.select(approx_count_distinct("A"), approx_count_distinct(col("A")))
 
@@ -452,7 +452,7 @@ df72 = df.select(seq8(324))
 
 df73 = df.select(to_decimal("A", 10, 3), to_decimal(col("B"), 12, 3))
 
-df74 = df.select(to_double(col("A"), None), to_double("A", None), to_double("A", "999.9"), to_double(col("A"), col("B")))
+df74 = df.select(to_double(col("A")), to_double("A"), to_double("A", "999.9"), to_double(col("A"), col("B")))
 
 df75 = df.select(div0(0, 1), div0(1.2, 9.3), div0(10, 89.2), div0("A", 1), div0(0.2, "A"), div0(0.3, col("B")))
 
@@ -554,7 +554,7 @@ df123 = df111.select(regexp_replace("A", "B", "", 1, 0), regexp_replace(col("A")
 
 df124 = df111.select(replace(col("A"), "", ""), replace("A", "B", "ahsgj"))
 
-df125 = df111.select(charindex(col("A"), col("B"), None), charindex("A", "B", None), charindex("A", "B", 20), charindex("A", "B", col("C")))
+df125 = df111.select(charindex(col("A"), col("B")), charindex("A", "B"), charindex("A", "B", 20), charindex("A", "B", col("C")))
 
 df126 = df111.select(collate(col("A"), "sp-upper"))
 
@@ -580,7 +580,7 @@ df136 = df111.select(right("A", col("B")), right(col("A"), 10))
 
 df137 = df111.select(char("A"))
 
-df138 = df111.select(to_char("A", None), to_char(col("B"), None), to_char("A", "bcd"))
+df138 = df111.select(to_char("A"), to_char(col("B")), to_char("A", "bcd"))
 
 df139 = df111.select(date_format(col("A"), col("B")), date_format("A", "YYYY"))
 
@@ -588,11 +588,11 @@ df140 = df111.select(to_time("A"), to_time("A", "YYYY"), to_time(col("A"), col("
 
 df141 = df111.select(to_timestamp("A"), to_timestamp("C"), to_timestamp(col("A"), col("B")))
 
-df142 = df111.select(to_timestamp_ntz("A", None), to_timestamp_ntz(col("A"), None), to_timestamp_ntz("A", "auto"), to_timestamp_ntz(col("A"), col("B")))
+df142 = df111.select(to_timestamp_ntz("A"), to_timestamp_ntz(col("A")), to_timestamp_ntz("A", "auto"), to_timestamp_ntz(col("A"), col("B")))
 
-df143 = df111.select(to_timestamp_ltz("A", None), to_timestamp_ltz(col("A"), None), to_timestamp_ltz("A", "auto"), to_timestamp_ltz(col("A"), col("B")))
+df143 = df111.select(to_timestamp_ltz("A"), to_timestamp_ltz(col("A")), to_timestamp_ltz("A", "auto"), to_timestamp_ltz(col("A"), col("B")))
 
-df144 = df111.select(to_timestamp_tz("A", None), to_timestamp_tz(col("A"), None), to_timestamp_tz("A", "auto"), to_timestamp_tz(col("A"), col("B")))
+df144 = df111.select(to_timestamp_tz("A"), to_timestamp_tz(col("A")), to_timestamp_tz("A", "auto"), to_timestamp_tz(col("A"), col("B")))
 
 df145 = df111.select(from_utc_timestamp("A", lit(1234)), from_utc_timestamp(col("A"), col("B")))
 
@@ -600,7 +600,7 @@ df146 = df111.select(to_utc_timestamp("A", lit(1234)), to_utc_timestamp(col("A")
 
 df147 = df111.select(to_date("A"), to_date("A", col("A")), to_date(col("A")))
 
-df148 = df111.select(system_reference("table", "table1", "CALL", []))
+df148 = df111.select(system_reference("table", "table1", "CALL"))
 
 df149 = df111.select(to_boolean("A"), to_boolean(col("A")))
 
@@ -3327,17 +3327,6 @@ body {
                   }
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 56
-                    end_line: 85
-                    file: 2
-                    start_column: 25
-                    start_line: 85
-                  }
-                }
-              }
               src {
                 end_column: 56
                 end_line: 85
@@ -3406,17 +3395,6 @@ body {
                   v: "B"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 89
-                    end_line: 85
-                    file: 2
-                    start_column: 58
-                    start_line: 85
-                  }
-                }
-              }
               src {
                 end_column: 89
                 end_line: 85
@@ -3461,17 +3439,6 @@ body {
                     start_line: 85
                   }
                   v: "B"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 117
-                    end_line: 85
-                    file: 2
-                    start_column: 91
-                    start_line: 85
-                  }
                 }
               }
               src {
@@ -3564,17 +3531,6 @@ body {
                   }
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 155
-                    end_line: 85
-                    file: 2
-                    start_column: 119
-                    start_line: 85
-                  }
-                }
-              }
               src {
                 end_column: 155
                 end_line: 85
@@ -3619,17 +3575,6 @@ body {
                     start_line: 85
                   }
                   v: "B"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 187
-                    end_line: 85
-                    file: 2
-                    start_column: 157
-                    start_line: 85
-                  }
                 }
               }
               src {
@@ -3804,17 +3749,6 @@ body {
                     end_line: 87
                     file: 2
                     start_column: 54
-                    start_line: 87
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 63
-                    end_line: 87
-                    file: 2
-                    start_column: 25
                     start_line: 87
                   }
                 }
@@ -7901,17 +7835,6 @@ body {
                   }
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 44
-                    end_line: 175
-                    file: 2
-                    start_column: 25
-                    start_line: 175
-                  }
-                }
-              }
               src {
                 end_column: 44
                 end_line: 175
@@ -7944,17 +7867,6 @@ body {
                     start_line: 175
                   }
                   v: "A"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 66
-                    end_line: 175
-                    file: 2
-                    start_column: 46
-                    start_line: 175
-                  }
                 }
               }
               src {
@@ -14949,17 +14861,6 @@ body {
                   }
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 55
-                    end_line: 277
-                    file: 2
-                    start_column: 26
-                    start_line: 277
-                  }
-                }
-              }
               src {
                 end_column: 55
                 end_line: 277
@@ -15004,17 +14905,6 @@ body {
                     start_line: 277
                   }
                   v: "B"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 82
-                    end_line: 277
-                    file: 2
-                    start_column: 57
-                    start_line: 277
-                  }
                 }
               }
               src {
@@ -16691,17 +16581,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 38
-                    end_line: 303
-                    file: 2
-                    start_column: 26
-                    start_line: 303
-                  }
-                }
-              }
               src {
                 end_column: 38
                 end_line: 303
@@ -16754,17 +16633,6 @@ body {
                     end_line: 303
                     file: 2
                     start_column: 48
-                    start_line: 303
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 63
-                    end_line: 303
-                    file: 2
-                    start_column: 40
                     start_line: 303
                   }
                 }
@@ -17425,17 +17293,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 47
-                    end_line: 311
-                    file: 2
-                    start_column: 26
-                    start_line: 311
-                  }
-                }
-              }
               src {
                 end_column: 47
                 end_line: 311
@@ -17488,17 +17345,6 @@ body {
                     end_line: 311
                     file: 2
                     start_column: 66
-                    start_line: 311
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 81
-                    end_line: 311
-                    file: 2
-                    start_column: 49
                     start_line: 311
                   }
                 }
@@ -17701,17 +17547,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 47
-                    end_line: 313
-                    file: 2
-                    start_column: 26
-                    start_line: 313
-                  }
-                }
-              }
               src {
                 end_column: 47
                 end_line: 313
@@ -17764,17 +17599,6 @@ body {
                     end_line: 313
                     file: 2
                     start_column: 66
-                    start_line: 313
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 81
-                    end_line: 313
-                    file: 2
-                    start_column: 49
                     start_line: 313
                   }
                 }
@@ -17977,17 +17801,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 46
-                    end_line: 315
-                    file: 2
-                    start_column: 26
-                    start_line: 315
-                  }
-                }
-              }
               src {
                 end_column: 46
                 end_line: 315
@@ -18040,17 +17853,6 @@ body {
                     end_line: 315
                     file: 2
                     start_column: 64
-                    start_line: 315
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 79
-                    end_line: 315
-                    file: 2
-                    start_column: 48
                     start_line: 315
                   }
                 }
@@ -18833,17 +18635,6 @@ body {
                     start_line: 323
                   }
                   v: "CALL"
-                }
-              }
-              pos_args {
-                list_val {
-                  src {
-                    end_column: 61
-                    end_line: 323
-                    file: 2
-                    start_column: 26
-                    start_line: 323
-                  }
                 }
               }
               src {

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -444,6 +444,10 @@ df375 = df.select(try_to_binary("A"), try_to_binary("A", "BASE64"), try_to_binar
 
 df376 = df.select(build_stage_file_url("@images_stage", "/us/yosemite/half_dome.jpg"))
 
+df350 = df.select(call_function("avg", col("B")))
+
+df351 = df.select(function("avg")("B"))
+
 ## EXPECTED UNPARSER OUTPUT
 
 df = session.table("table1")
@@ -502,7 +506,7 @@ df182 = df.select(arrays_to_object("A", "B"), arrays_to_object("A", col("A")))
 
 df183 = df.select(array_generate_range("A", "B"), array_generate_range("A", col("B")), array_generate_range(col("A"), "B", "C"))
 
-df184 = df.select(sequence("A", "B", None), sequence("A", col("B"), None), sequence(col("A"), "B", "C"))
+df184 = df.select(sequence("A", "B"), sequence("A", col("B")), sequence(col("A"), "B", "C"))
 
 df185 = df.select(date_add("A", "B"), date_add("A", 10), date_add(col("A"), 0), date_add(col("A"), col("B")))
 
@@ -560,7 +564,7 @@ df211 = df.select(is_timestamp_ntz("A"))
 
 df212 = df.select(is_timestamp_tz("A"))
 
-df213 = df.select(time_from_parts(1, 2, 3, None), time_from_parts("A", "B", "A", None), time_from_parts(1, "A", col("B"), None))
+df213 = df.select(time_from_parts(1, 2, 3), time_from_parts("A", "B", "A"), time_from_parts(1, "A", col("B")))
 
 df214 = df.select(timestamp_from_parts("A", "A"), timestamp_from_parts(col("A"), "B"), timestamp_from_parts(col("A"), col("B")))
 
@@ -568,11 +572,11 @@ df215 = df.select(timestamp_from_parts(2000, 12, 0, 12, 3, 1), timestamp_from_pa
 
 df216 = df.select(timestamp_from_parts("year", "month", "day", "hour", "minute", "second"), timestamp_from_parts(to_date("date"), to_time("time")))
 
-df217 = df.select(timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1, None), timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1, None), timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1, None), timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1, 12))
+df217 = df.select(timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_ltz_from_parts(2000, 12, 0, 12, 3, 1, 12))
 
 df218 = df.select(timestamp_ntz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_ntz_from_parts(2000, 12, 0, 12, 3, 1, "A"), timestamp_ntz_from_parts(2000, 12, 0, 12, 3, 1, timestamp_ntz_from_parts(2000, 12, 0, 12, 3, 1, 12)))
 
-df219 = df.select(timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1, None, None), timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1, None, None), timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1, None, None), timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1, None, "us"))
+df219 = df.select(timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1), timestamp_tz_from_parts(2000, 12, 0, 12, 3, 1, "us"))
 
 df220 = df.select(weekofyear("A"))
 
@@ -662,9 +666,9 @@ df262 = df.select(cast("A", "int"), cast("A", LongType()))
 
 df263 = df.select(try_cast("A", "int"), try_cast("A", LongType()))
 
-df264 = df.select(as_decimal("A", None, None), as_decimal("A", None, None), as_decimal("A", 10, None), as_decimal(col("A"), 10, 2))
+df264 = df.select(as_decimal("A"), as_decimal("A"), as_decimal("A", 10), as_decimal(col("A"), 10, 2))
 
-df265 = df.select(as_decimal("A", None, None), as_decimal("A", None, None), as_decimal("A", 10, None), as_decimal(col("A"), 10, 2))
+df265 = df.select(as_decimal("A"), as_decimal("A"), as_decimal("A", 10), as_decimal(col("A"), 10, 2))
 
 df266 = df.select(as_double("A"))
 
@@ -740,15 +744,15 @@ df301 = df.select(listagg("A", "", False), listagg(col("B"), "", False), listagg
 
 df302 = df.select(call_udf("name"), call_udf("test", col("A"), lit(10)))
 
-df303 = df.select(unix_timestamp("A", None), unix_timestamp("A", None), unix_timestamp(col("B"), lit("YYYY")))
+df303 = df.select(unix_timestamp("A"), unix_timestamp("A"), unix_timestamp(col("B"), lit("YYYY")))
 
-df304 = df.select(charindex(lit("needle"), col("expr"), lit(1)), charindex(lit("needle"), lit("test string"), lit(2)))
+df304 = df.select(locate("needle", col("expr"), 1), locate("needle", lit("test string"), 2))
 
 df305 = df.select(size(col("expr")), size("A"))
 
-df306 = df.select(base64_encode("A", 0, None))
+df306 = df.select(base64_encode("A", 0))
 
-df307 = df.select(base64_decode_string("A", None))
+df307 = df.select(base64_decode_string("A"))
 
 df308 = df.select(hex_encode("A", 1))
 
@@ -826,7 +830,7 @@ df344 = df.select(fl_is_video("A"))
 
 df345 = df.select(arrays_zip("A", lit(1)), arrays_zip("A", "B"), arrays_zip(col("A"), col("B")))
 
-df346 = df.select(window("A", "1 minute", None, None), window(col("A"), "1 minute", None, "2 minutes"))
+df346 = df.select(window("A", "1 minute"), window(col("A"), "1 minute", "2 minutes"))
 
 df347 = df.select(from_json(col("B"), StringType()), from_json("A", "array<integer>"))
 
@@ -834,9 +838,9 @@ df348 = df.select(array_remove("A", lit(1)), array_remove("A", "B"), array_remov
 
 df349 = df.select(ln("A"))
 
-df350 = df.select(avg(col("B")))
+df350 = df.select(call_function("avg", col("B")))
 
-df351 = df.select(avg("B"))
+df351 = df.select(call_function("avg", "B"))
 
 df352 = df.select(acosh("A"), acosh(col("B")))
 
@@ -860,7 +864,7 @@ df361 = df.select(localtimestamp(9), localtimestamp(0), localtimestamp(1), local
 
 df362 = df.select(max_by("A", "B"), max_by(col("A"), "B", 3))
 
-df363 = df.select(min_by("A", "B"), max_by(col("A"), "B", 3))
+df363 = df.select(min_by("A", "B"), min_by(col("A"), "B", 3))
 
 df364 = df.select(octet_length("A"), octet_length(col("B")))
 
@@ -887,6 +891,10 @@ df374 = df.select(regr_syy("A", "B"), regr_syy(col("A"), col("B")))
 df375 = df.select(try_to_binary("A"), try_to_binary("A", "BASE64"), try_to_binary(col("A"), "UTF-8"))
 
 df376 = df.select(build_stage_file_url("@images_stage", "/us/yosemite/half_dome.jpg"))
+
+df350 = df.select(call_function("avg", col("B")))
+
+df351 = df.select(call_function("avg", "B"))
 
 ## EXPECTED ENCODED AST
 
@@ -3995,17 +4003,6 @@ body {
                   v: "B"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 44
-                    end_line: 83
-                    file: 2
-                    start_column: 26
-                    start_line: 83
-                  }
-                }
-              }
               src {
                 end_column: 44
                 end_line: 83
@@ -4070,17 +4067,6 @@ body {
                     end_line: 83
                     file: 2
                     start_column: 60
-                    start_line: 83
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 75
-                    end_line: 83
-                    file: 2
-                    start_column: 46
                     start_line: 83
                   }
                 }
@@ -7345,17 +7331,6 @@ body {
                   v: 3
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 50
-                    end_line: 141
-                    file: 2
-                    start_column: 26
-                    start_line: 141
-                  }
-                }
-              }
               src {
                 end_column: 50
                 end_line: 141
@@ -7412,17 +7387,6 @@ body {
                     start_line: 141
                   }
                   v: "A"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 82
-                    end_line: 141
-                    file: 2
-                    start_column: 52
-                    start_line: 141
-                  }
                 }
               }
               src {
@@ -7501,17 +7465,6 @@ body {
                     end_line: 141
                     file: 2
                     start_column: 108
-                    start_line: 141
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 117
-                    end_line: 141
-                    file: 2
-                    start_column: 84
                     start_line: 141
                   }
                 }
@@ -8537,17 +8490,6 @@ body {
                   v: 1
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 73
-                    end_line: 149
-                    file: 2
-                    start_column: 26
-                    start_line: 149
-                  }
-                }
-              }
               src {
                 end_column: 73
                 end_line: 149
@@ -8641,17 +8583,6 @@ body {
                   v: 1
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 128
-                    end_line: 149
-                    file: 2
-                    start_column: 75
-                    start_line: 149
-                  }
-                }
-              }
               src {
                 end_column: 128
                 end_line: 149
@@ -8743,17 +8674,6 @@ body {
                     start_line: 149
                   }
                   v: 1
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 183
-                    end_line: 149
-                    file: 2
-                    start_column: 130
-                    start_line: 149
-                  }
                 }
               }
               src {
@@ -9406,28 +9326,6 @@ body {
                   v: 1
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 72
-                    end_line: 153
-                    file: 2
-                    start_column: 26
-                    start_line: 153
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 72
-                    end_line: 153
-                    file: 2
-                    start_column: 26
-                    start_line: 153
-                  }
-                }
-              }
               src {
                 end_column: 72
                 end_line: 153
@@ -9519,28 +9417,6 @@ body {
                     start_line: 153
                   }
                   v: 1
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 126
-                    end_line: 153
-                    file: 2
-                    start_column: 74
-                    start_line: 153
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 126
-                    end_line: 153
-                    file: 2
-                    start_column: 74
-                    start_line: 153
-                  }
                 }
               }
               src {
@@ -9636,28 +9512,6 @@ body {
                   v: 1
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 186
-                    end_line: 153
-                    file: 2
-                    start_column: 128
-                    start_line: 153
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 186
-                    end_line: 153
-                    file: 2
-                    start_column: 128
-                    start_line: 153
-                  }
-                }
-              }
               src {
                 end_column: 186
                 end_line: 153
@@ -9749,17 +9603,6 @@ body {
                     start_line: 153
                   }
                   v: 1
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 246
-                    end_line: 153
-                    file: 2
-                    start_column: 188
-                    start_line: 153
-                  }
                 }
               }
               pos_args {
@@ -15094,28 +14937,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 41
-                    end_line: 243
-                    file: 2
-                    start_column: 26
-                    start_line: 243
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 41
-                    end_line: 243
-                    file: 2
-                    start_column: 26
-                    start_line: 243
-                  }
-                }
-              }
               src {
                 end_column: 41
                 end_line: 243
@@ -15148,28 +14969,6 @@ body {
                     start_line: 243
                   }
                   v: "A"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 64
-                    end_line: 243
-                    file: 2
-                    start_column: 43
-                    start_line: 243
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 64
-                    end_line: 243
-                    file: 2
-                    start_column: 43
-                    start_line: 243
-                  }
                 }
               }
               src {
@@ -15216,17 +15015,6 @@ body {
                     start_line: 243
                   }
                   v: 10
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 85
-                    end_line: 243
-                    file: 2
-                    start_column: 66
-                    start_line: 243
-                  }
                 }
               }
               src {
@@ -15371,28 +15159,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 40
-                    end_line: 245
-                    file: 2
-                    start_column: 26
-                    start_line: 245
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 40
-                    end_line: 245
-                    file: 2
-                    start_column: 26
-                    start_line: 245
-                  }
-                }
-              }
               src {
                 end_column: 40
                 end_line: 245
@@ -15425,28 +15191,6 @@ body {
                     start_line: 245
                   }
                   v: "A"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 62
-                    end_line: 245
-                    file: 2
-                    start_column: 42
-                    start_line: 245
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 62
-                    end_line: 245
-                    file: 2
-                    start_column: 42
-                    start_line: 245
-                  }
                 }
               }
               src {
@@ -15493,17 +15237,6 @@ body {
                     start_line: 245
                   }
                   v: 10
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 82
-                    end_line: 245
-                    file: 2
-                    start_column: 64
-                    start_line: 245
-                  }
                 }
               }
               src {
@@ -20847,17 +20580,6 @@ body {
                   v: "A"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 45
-                    end_line: 321
-                    file: 2
-                    start_column: 26
-                    start_line: 321
-                  }
-                }
-              }
               src {
                 end_column: 45
                 end_line: 321
@@ -20890,17 +20612,6 @@ body {
                     start_line: 321
                   }
                   v: "A"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 72
-                    end_line: 321
-                    file: 2
-                    start_column: 47
-                    start_line: 321
-                  }
                 }
               }
               src {
@@ -21037,37 +20748,14 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "charindex"
+                        name: "locate"
                       }
                     }
                   }
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    string_val {
-                      src {
-                        end_column: 55
-                        end_line: 323
-                        file: 2
-                        start_column: 26
-                        start_line: 323
-                      }
-                      v: "needle"
-                    }
-                  }
+                string_val {
                   src {
                     end_column: 55
                     end_line: 323
@@ -21075,6 +20763,7 @@ body {
                     start_column: 26
                     start_line: 323
                   }
+                  v: "needle"
                 }
               }
               pos_args {
@@ -21112,30 +20801,7 @@ body {
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 55
-                        end_line: 323
-                        file: 2
-                        start_column: 26
-                        start_line: 323
-                      }
-                      v: 1
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 55
                     end_line: 323
@@ -21143,6 +20809,7 @@ body {
                     start_column: 26
                     start_line: 323
                   }
+                  v: 1
                 }
               }
               src {
@@ -21161,37 +20828,14 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "charindex"
+                        name: "locate"
                       }
                     }
                   }
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    string_val {
-                      src {
-                        end_column: 96
-                        end_line: 323
-                        file: 2
-                        start_column: 57
-                        start_line: 323
-                      }
-                      v: "needle"
-                    }
-                  }
+                string_val {
                   src {
                     end_column: 96
                     end_line: 323
@@ -21199,6 +20843,7 @@ body {
                     start_column: 57
                     start_line: 323
                   }
+                  v: "needle"
                 }
               }
               pos_args {
@@ -21236,30 +20881,7 @@ body {
                 }
               }
               pos_args {
-                apply_expr {
-                  fn {
-                    builtin_fn {
-                      name {
-                        name {
-                          name_flat {
-                            name: "lit"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  pos_args {
-                    int64_val {
-                      src {
-                        end_column: 96
-                        end_line: 323
-                        file: 2
-                        start_column: 57
-                        start_line: 323
-                      }
-                      v: 2
-                    }
-                  }
+                int64_val {
                   src {
                     end_column: 96
                     end_line: 323
@@ -21267,6 +20889,7 @@ body {
                     start_column: 57
                     start_line: 323
                   }
+                  v: 2
                 }
               }
               src {
@@ -21460,17 +21083,6 @@ body {
                   }
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 44
-                    end_line: 327
-                    file: 2
-                    start_column: 26
-                    start_line: 327
-                  }
-                }
-              }
               src {
                 end_column: 44
                 end_line: 327
@@ -21531,17 +21143,6 @@ body {
                     start_line: 329
                   }
                   v: "A"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 51
-                    end_line: 329
-                    file: 2
-                    start_column: 26
-                    start_line: 329
-                  }
                 }
               }
               src {
@@ -25092,28 +24693,6 @@ body {
                   v: "1 minute"
                 }
               }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 49
-                    end_line: 407
-                    file: 2
-                    start_column: 26
-                    start_line: 407
-                  }
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 49
-                    end_line: 407
-                    file: 2
-                    start_column: 26
-                    start_line: 407
-                  }
-                }
-              }
               src {
                 end_column: 49
                 end_line: 407
@@ -25180,17 +24759,6 @@ body {
                     start_line: 407
                   }
                   v: "1 minute"
-                }
-              }
-              pos_args {
-                null_val {
-                  src {
-                    end_column: 119
-                    end_line: 407
-                    file: 2
-                    start_column: 51
-                    start_line: 407
-                  }
                 }
               }
               pos_args {
@@ -25690,10 +25258,22 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "avg"
+                        name: "call_function"
                       }
                     }
                   }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 55
+                    end_line: 415
+                    file: 2
+                    start_column: 26
+                    start_line: 415
+                  }
+                  v: "avg"
                 }
               }
               pos_args {
@@ -25774,10 +25354,22 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "avg"
+                        name: "call_function"
                       }
                     }
                   }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 45
+                    end_line: 417
+                    file: 2
+                    start_column: 26
+                    start_line: 417
+                  }
+                  v: "avg"
                 }
               }
               pos_args {
@@ -27307,7 +26899,7 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "max_by"
+                        name: "min_by"
                       }
                     }
                   }
@@ -29411,6 +29003,176 @@ body {
       value: "df376"
     }
     uid: 221
+  }
+}
+body {
+  bind {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "call_function"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 56
+                    end_line: 469
+                    file: 2
+                    start_column: 26
+                    start_line: 469
+                  }
+                  v: "avg"
+                }
+              }
+              pos_args {
+                apply_expr {
+                  fn {
+                    builtin_fn {
+                      name {
+                        name {
+                          name_flat {
+                            name: "col"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  pos_args {
+                    string_val {
+                      src {
+                        end_column: 55
+                        end_line: 469
+                        file: 2
+                        start_column: 47
+                        start_line: 469
+                      }
+                      v: "B"
+                    }
+                  }
+                  src {
+                    end_column: 55
+                    end_line: 469
+                    file: 2
+                    start_column: 47
+                    start_line: 469
+                  }
+                }
+              }
+              src {
+                end_column: 56
+                end_line: 469
+                file: 2
+                start_column: 26
+                start_line: 469
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id: 1
+          }
+        }
+        src {
+          end_column: 57
+          end_line: 469
+          file: 2
+          start_column: 16
+          start_line: 469
+        }
+      }
+    }
+    first_request_id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"
+    symbol {
+      value: "df350"
+    }
+    uid: 222
+  }
+}
+body {
+  bind {
+    expr {
+      dataframe_select {
+        cols {
+          args {
+            apply_expr {
+              fn {
+                builtin_fn {
+                  name {
+                    name {
+                      name_flat {
+                        name: "call_function"
+                      }
+                    }
+                  }
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 471
+                    file: 2
+                    start_column: 26
+                    start_line: 471
+                  }
+                  v: "avg"
+                }
+              }
+              pos_args {
+                string_val {
+                  src {
+                    end_column: 46
+                    end_line: 471
+                    file: 2
+                    start_column: 26
+                    start_line: 471
+                  }
+                  v: "B"
+                }
+              }
+              src {
+                end_column: 46
+                end_line: 471
+                file: 2
+                start_column: 26
+                start_line: 471
+              }
+            }
+          }
+          variadic: true
+        }
+        df {
+          dataframe_ref {
+            id: 1
+          }
+        }
+        src {
+          end_column: 47
+          end_line: 471
+          file: 2
+          start_column: 16
+          start_line: 471
+        }
+      }
+    }
+    first_request_id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"
+    symbol {
+      value: "df351"
+    }
+    uid: 223
   }
 }
 client_ast_version: 1


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   No JIRA ticket, but required for Phase 0 Client Closeout.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Due to widespread internal use of the `functions.builtin` method (an alias for `functions.function`), as well as `functions.call_builtin` (an alias for `functions.call_function`), we had set up the propagation of the AST directly through these methods down to the eventual call to the internal helper `_call_function`.

   As a result, despite these being public APIs which are required to support Snowflake SQL functions not explicitly supported in Snowpark, we could not capture an AST to represent `call_function("foo", *args)` when no such `functions.foo` method exists in Snowpark.

   Public APIs should NOT be accepting `_ast` parameters to route generated ASTs through them as this complicates the scenario in which `_ast` is not provided but `_emit_ast` is `True`. If this Public API is used extensively internally, we then have an unresolvable question of whether to route `_ast=None` to the eventual internal helper (e.g. `_call_function`) which **will** eventually perform AST generation based on the other arguments, or whether to generate the Public API's own AST and pass it to the internal helper function.

   The only resolutions to the above issue are
     - To add **another** parameter to the extensively internally used public API to signal whether to pass down the provided input `_ast` parameter (regardless of whether it is `None` or not), or whether to confidently generate its own AST and assign it to the result.
     - To avoid the use of public APIs internally entirely.

   This PR takes the latter approach. I argue that using public APIs internally as helper functions is bad practice to motivate this refactor. Either we extract the common functionality into a separate internal helper function to be used by all Public APIs which rely on it, or (especially in this case) if all calls are eventually routed into the same internal helper (like `_call_function`), then we should avoid adding unnecessary calls to wrappers to the stack internally and call this helper directly.

   The refactor is quite simple overall but `functions.py` is large:
    - Replace all internal uses of `builtin/function` and `call_builtin/call_function` with direct calls to `_call_function`
    - Simplify AST generation wherever possible by using `build_function_expr`
    - Remove `_ast` parameters from public APIs and leave the assignment of the AST to the result as the caller's responsibility.