### PR TITLE
SNOW-2025063: Fix read_snowflake iceberg table bug when relaxed pandas is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 - Improve performance of `DataFrame.groupby.apply` and `Series.groupby.apply` by avoiding expensive pivot step.
 
+#### Bug Fixes
+
+- Fixed a bug for `pd.read_snowflake` when reading iceberg tables and `relaxed_ordering=False`.
+
 ## 1.30.0 (2024-03-27)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -378,6 +378,7 @@ def create_initial_ordered_dataframe(
                     "Row access policy is not supported on read only table",  # case 1
                     "Cannot clone",  # case 2
                     "Unsupported feature",  # case 3
+                    "Clone Iceberg table should use CREATE ICEBERG TABLE CLONE command",  # case 3
                 )
                 if any(error in ex.message for error in known_errors):
                     readonly_table_name = _create_read_only_table(

--- a/tests/integ/modin/io/test_read_snowflake_iceberg.py
+++ b/tests/integ/modin/io/test_read_snowflake_iceberg.py
@@ -14,7 +14,8 @@ from tests.integ.utils.sql_counter import SqlCounter
 from tests.utils import Utils
 
 
-def test_read_snowflake_iceberg_relaxed_ordering(session):
+@pytest.mark.parametrize("relaxed_ordering", [True, False])
+def test_read_snowflake_iceberg(session, relaxed_ordering):
     if "azure" in session.connection.host.split("."):
         pytest.skip("This test doesn't work for Azure.")
     if "gcp" in session.connection.host.split("."):
@@ -46,11 +47,14 @@ def test_read_snowflake_iceberg_relaxed_ordering(session):
         """
         ).collect()
 
-    with SqlCounter(query_count=2):
+    expected_query_counts = [2, 0] if relaxed_ordering else [4, 2]
+
+    with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe directly from iceberg table
-        with SqlCounter(query_count=0):
+        with SqlCounter(query_count=expected_query_counts[1]):
             # no eager query is used when relaxed_ordering is enabled
-            df = pd.read_snowflake(table_name, relaxed_ordering=True)
+            # two eager queries are used when relaxed_ordering is disabled
+            df = pd.read_snowflake(table_name, relaxed_ordering=relaxed_ordering)
 
         # convert to pandas dataframe
         pdf = df.to_pandas()
@@ -58,70 +62,13 @@ def test_read_snowflake_iceberg_relaxed_ordering(session):
         # compare two dataframes
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
 
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe from a query referencing an iceberg table
         SQL_QUERY = f"""SELECT count(*) FROM {table_name}"""
-        with SqlCounter(query_count=0):
+        with SqlCounter(query_count=expected_query_counts[1]):
             # no eager query is used when relaxed_ordering is enabled
-            df = pd.read_snowflake(SQL_QUERY, relaxed_ordering=True)
-
-        # convert to pandas dataframe
-        pdf = df.to_pandas()
-
-        # compare two dataframes
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
-
-
-def test_read_snowflake_iceberg_no_relaxed_ordering(session):
-    if "azure" in session.connection.host.split("."):
-        pytest.skip("This test doesn't work for Azure.")
-    if "gcp" in session.connection.host.split("."):
-        pytest.skip("This test doesn't work for GCP.")
-
-    with SqlCounter(query_count=2):
-        # create iceberg table
-        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-        session.sql(
-            "CREATE EXTERNAL VOLUME if not exists python_connector_iceberg_exvol"
-        ).collect()
-        session.sql(
-            f"""
-        CREATE OR REPLACE ICEBERG TABLE {table_name} (
-            "NESTED_DATA" OBJECT(
-                camelCase STRING,
-                snake_case STRING,
-                PascalCase STRING,
-                nested_map MAP(
-                    STRING,
-                    OBJECT(
-                        inner_camelCase STRING,
-                        inner_snake_case STRING,
-                        inner_PascalCase STRING
-                    )
-                )
-            )
-        ) EXTERNAL_VOLUME = 'python_connector_iceberg_exvol' CATALOG = 'SNOWFLAKE' BASE_LOCATION = 'python_connector_merge_gate';
-        """
-        ).collect()
-
-    with SqlCounter(query_count=4):
-        # create dataframe directly from iceberg table
-        with SqlCounter(query_count=2):
             # two eager queries are used when relaxed_ordering is disabled
-            df = pd.read_snowflake(table_name, relaxed_ordering=False)
-
-        # convert to pandas dataframe
-        pdf = df.to_pandas()
-
-        # compare two dataframes
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
-
-    with SqlCounter(query_count=4):
-        # create dataframe from a query referencing an iceberg table
-        SQL_QUERY = f"""SELECT count(*) FROM {table_name}"""
-        with SqlCounter(query_count=2):
-            # two eager queries are used when relaxed_ordering is disabled
-            df = pd.read_snowflake(SQL_QUERY, relaxed_ordering=False)
+            df = pd.read_snowflake(SQL_QUERY, relaxed_ordering=relaxed_ordering)
 
         # convert to pandas dataframe
         pdf = df.to_pandas()

--- a/tests/integ/modin/io/test_read_snowflake_iceberg.py
+++ b/tests/integ/modin/io/test_read_snowflake_iceberg.py
@@ -7,98 +7,124 @@ import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark._internal.utils import TempObjectType
-from snowflake.snowpark.modin.plugin.utils.exceptions import SnowparkPandasException
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
 )
-from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from tests.integ.utils.sql_counter import SqlCounter
 from tests.utils import Utils
 
 
-@sql_count_checker(query_count=5)
 def test_read_snowflake_iceberg_relaxed_ordering(session):
-    # create iceberg table
-    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-    session.sql(
-        f"""
-    CREATE OR REPLACE ICEBERG TABLE {table_name} (
-        "NESTED_DATA" OBJECT(
-            camelCase STRING,
-            snake_case STRING,
-            PascalCase STRING,
-            nested_map MAP(
-                STRING,
-                OBJECT(
-                    inner_camelCase STRING,
-                    inner_snake_case STRING,
-                    inner_PascalCase STRING
+    if "azure" in session.connection.host.split("."):
+        pytest.skip("This test doesn't work for Azure.")
+    if "gcp" in session.connection.host.split("."):
+        pytest.skip("This test doesn't work for GCP.")
+
+    with SqlCounter(query_count=2):
+        # create iceberg table
+        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.sql(
+            "CREATE EXTERNAL VOLUME if not exists python_connector_iceberg_exvol"
+        ).collect()
+        session.sql(
+            f"""
+        CREATE OR REPLACE ICEBERG TABLE {table_name} (
+            "NESTED_DATA" OBJECT(
+                camelCase STRING,
+                snake_case STRING,
+                PascalCase STRING,
+                nested_map MAP(
+                    STRING,
+                    OBJECT(
+                        inner_camelCase STRING,
+                        inner_snake_case STRING,
+                        inner_PascalCase STRING
+                    )
                 )
             )
-        )
-    ) EXTERNAL_VOLUME = 'python_connector_iceberg_exvol' CATALOG = 'SNOWFLAKE' BASE_LOCATION = 'python_connector_merge_gate';
-    """
-    ).collect()
+        ) EXTERNAL_VOLUME = 'python_connector_iceberg_exvol' CATALOG = 'SNOWFLAKE' BASE_LOCATION = 'python_connector_merge_gate';
+        """
+        ).collect()
 
-    # create dataframe directly from iceberg table
-    with SqlCounter(query_count=1):
-        # Only one query is used when relaxed_ordering is enabled
-        df = pd.read_snowflake(table_name, relaxed_ordering=True)
+    with SqlCounter(query_count=2):
+        # create dataframe directly from iceberg table
+        with SqlCounter(query_count=0):
+            # no eager query is used when relaxed_ordering is enabled
+            df = pd.read_snowflake(table_name, relaxed_ordering=True)
 
-    # convert to pandas dataframe
-    pdf = df.to_pandas()
+        # convert to pandas dataframe
+        pdf = df.to_pandas()
 
-    # compare two dataframes
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
+        # compare two dataframes
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
 
-    # create dataframe from a query referencing an iceberg table
-    SQL_QUERY = f"""SELECT count(*) FROM {table_name}"""
-    with SqlCounter(query_count=1):
-        # Only one query is used when relaxed_ordering is enabled
-        df = pd.read_snowflake(SQL_QUERY, relaxed_ordering=True)
+    with SqlCounter(query_count=2):
+        # create dataframe from a query referencing an iceberg table
+        SQL_QUERY = f"""SELECT count(*) FROM {table_name}"""
+        with SqlCounter(query_count=0):
+            # no eager query is used when relaxed_ordering is enabled
+            df = pd.read_snowflake(SQL_QUERY, relaxed_ordering=True)
 
-    # convert to pandas dataframe
-    pdf = df.to_pandas()
+        # convert to pandas dataframe
+        pdf = df.to_pandas()
 
-    # compare two dataframes
-    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
+        # compare two dataframes
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
 
 
-@sql_count_checker(query_count=1)
-def test_read_snowflake_iceberg_no_relaxed_ordering_raises(session):
-    # create iceberg table
-    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-    session.sql(
-        f"""
-    CREATE OR REPLACE ICEBERG TABLE {table_name} (
-        "NESTED_DATA" OBJECT(
-            camelCase STRING,
-            snake_case STRING,
-            PascalCase STRING,
-            nested_map MAP(
-                STRING,
-                OBJECT(
-                    inner_camelCase STRING,
-                    inner_snake_case STRING,
-                    inner_PascalCase STRING
+def test_read_snowflake_iceberg_no_relaxed_ordering(session):
+    if "azure" in session.connection.host.split("."):
+        pytest.skip("This test doesn't work for Azure.")
+    if "gcp" in session.connection.host.split("."):
+        pytest.skip("This test doesn't work for GCP.")
+
+    with SqlCounter(query_count=2):
+        # create iceberg table
+        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.sql(
+            "CREATE EXTERNAL VOLUME if not exists python_connector_iceberg_exvol"
+        ).collect()
+        session.sql(
+            f"""
+        CREATE OR REPLACE ICEBERG TABLE {table_name} (
+            "NESTED_DATA" OBJECT(
+                camelCase STRING,
+                snake_case STRING,
+                PascalCase STRING,
+                nested_map MAP(
+                    STRING,
+                    OBJECT(
+                        inner_camelCase STRING,
+                        inner_snake_case STRING,
+                        inner_PascalCase STRING
+                    )
                 )
             )
-        )
-    ) EXTERNAL_VOLUME = 'python_connector_iceberg_exvol' CATALOG = 'SNOWFLAKE' BASE_LOCATION = 'python_connector_merge_gate';
-    """
-    ).collect()
+        ) EXTERNAL_VOLUME = 'python_connector_iceberg_exvol' CATALOG = 'SNOWFLAKE' BASE_LOCATION = 'python_connector_merge_gate';
+        """
+        ).collect()
 
-    # reading an iceberg table directly fails when relaxed_ordering is disabled
-    # TODO (SNOW-2025063): Fix this issue even when relaxed_ordering is disabled
-    with pytest.raises(
-        SnowparkPandasException,
-        match="Clone Iceberg table should use CREATE ICEBERG TABLE CLONE command",
-    ):
-        pd.read_snowflake(table_name, relaxed_ordering=False)
+    with SqlCounter(query_count=4):
+        # create dataframe directly from iceberg table
+        with SqlCounter(query_count=2):
+            # two eager queries are used when relaxed_ordering is disabled
+            df = pd.read_snowflake(table_name, relaxed_ordering=False)
 
-    # reading an iceberg table indirectly via a query fails when relaxed_ordering is disabled
-    SQL_QUERY = f"""SELECT count(*) FROM {table_name}"""
-    with pytest.raises(
-        SnowparkPandasException,
-        match="Clone Iceberg table should use CREATE ICEBERG TABLE CLONE command",
-    ):
-        pd.read_snowflake(SQL_QUERY, relaxed_ordering=False)
+        # convert to pandas dataframe
+        pdf = df.to_pandas()
+
+        # compare two dataframes
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
+
+    with SqlCounter(query_count=4):
+        # create dataframe from a query referencing an iceberg table
+        SQL_QUERY = f"""SELECT count(*) FROM {table_name}"""
+        with SqlCounter(query_count=2):
+            # two eager queries are used when relaxed_ordering is disabled
+            df = pd.read_snowflake(SQL_QUERY, relaxed_ordering=False)
+
+        # convert to pandas dataframe
+        pdf = df.to_pandas()
+
+        # compare two dataframes
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)


### PR DESCRIPTION


<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2025063

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Fix read_snowflake iceberg table bug when relaxed pandas is not enabled.
