### PR TITLE
SNOW-1336091: Update pandas tests that previously caused fallback to stored procedure

### DIFF
--- a/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
+++ b/tests/integ/modin/groupby/test_groupby_idxmax_idxmin.py
@@ -15,7 +15,6 @@ from tests.integ.modin.utils import (
     eval_snowpark_pandas_result,
 )
 from tests.integ.utils.sql_counter import sql_count_checker
-from tests.utils import running_on_public_ci
 
 
 @pytest.mark.parametrize(
@@ -134,25 +133,13 @@ def test_df_groupby_idxmax_idxmin_with_dates_on_axis_0(func):
     )
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
 @pytest.mark.parametrize("func", ["idxmax", "idxmin"])
-@sql_count_checker(
-    query_count=11,
-    fallback_count=1,
-    sproc_count=1,
-    high_count_expected=True,
-    high_count_reason="Snowpark pandas defaults to pandas for idxmax/idxmin when DataFrame is grouped by axis=1.",
-)
-def test_df_groupby_idxmax_idxmin_on_groupby_axis_1_default_to_pandas(func):
+@sql_count_checker(query_count=0)
+def test_df_groupby_idxmax_idxmin_on_groupby_axis_1_unimplemented(func):
     """
     Test DataFrameGroupBy.idxmax and DataFrameGroupBy.idxmin.
-    Here, the DataFrames are grouped by `by` and should execute using native pandas.
-    Only testing with idxmax/idxmin axis=0 since we raise NotImplementedError when axis=1.
+    Here, the DataFrames are grouped by `by` and should raise NotImplementedError
+    Only testing with idxmax/idxmin(axis=0) since we already raise NotImplementedError when axis=1 is passed.
     """
     # Example from discussion comment:
     # https://github.com/pandas-dev/pandas/issues/51203#issuecomment-1426864317
@@ -168,8 +155,12 @@ def test_df_groupby_idxmax_idxmin_on_groupby_axis_1_default_to_pandas(func):
     costs = np.random.default_rng().uniform(low=1, high=10_000, size=(50, len(items)))
     df = native_pd.DataFrame(costs, columns=items)
     native_res = df.groupby(by=grouper, axis=1).idxmax(axis=0)
-    snow_res = pd.DataFrame(df).groupby(by=grouper, axis=1).idxmax(axis=0)
-    assert_frame_equal(native_res, snow_res, check_index_type=False)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas GroupBy.aggregate does not yet support axis == 1, by != None and level != None, or by containing any non-pandas hashable labels.",
+    ):
+        snow_res = pd.DataFrame(df).groupby(by=grouper, axis=1).idxmax(axis=0)
+        assert_frame_equal(native_res, snow_res, check_index_type=False)
 
 
 @pytest.mark.parametrize("agg_func", ["idxmin", "idxmax"])

--- a/tests/integ/modin/groupby/test_quantile.py
+++ b/tests/integ/modin/groupby/test_quantile.py
@@ -11,7 +11,6 @@ import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from tests.utils import running_on_public_ci
 
 
 @pytest.mark.parametrize(
@@ -110,8 +109,7 @@ def test_quantile(interpolation, a_vals, b_vals, q):
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
-@sql_count_checker(query_count=16, fallback_count=2, sproc_count=2)
+@sql_count_checker(query_count=2)
 def test_quantile_array():
     # https://github.com/pandas-dev/pandas/issues/27526
     df = pd.DataFrame({"A": [0, 1, 2, 3, 4]})
@@ -138,8 +136,7 @@ def test_quantile_array():
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
+@sql_count_checker(query_count=2)
 def test_quantile_array_list_like_q():
     # https://github.com/pandas-dev/pandas/pull/28085#issuecomment-524066959
     arr = np.random.RandomState(0).randint(0, 5, size=(10, 3), dtype=np.int64)
@@ -162,8 +159,7 @@ def test_quantile_array_list_like_q():
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
-@sql_count_checker(query_count=16, fallback_count=2, sproc_count=2)
+@sql_count_checker(query_count=2)
 def test_quantile_array_no_sort():
     df = pd.DataFrame({"A": [0, 1, 2], "B": [3, 4, 5]})
     key = np.array([1, 0, 1], dtype=np.int64)
@@ -187,8 +183,7 @@ def test_quantile_array_no_sort():
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
+@sql_count_checker(query_count=2)
 def test_quantile_array_multiple_levels():
     df = pd.DataFrame(
         {"A": [0, 1, 2], "B": [3, 4, 5], "c": ["a", "a", "a"], "d": ["a", "a", "b"]}
@@ -209,7 +204,6 @@ def test_quantile_array_multiple_levels():
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
 @pytest.mark.parametrize("frame_size", [(2, 3), (100, 10)])
 @pytest.mark.parametrize("groupby", [[0], [0, 1]])
 @pytest.mark.parametrize("q", [[0.5, 0.6]])
@@ -257,7 +251,6 @@ def test_quantile_raises():
         df.groupby("key").quantile().to_pandas()
 
 
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
 @sql_count_checker(query_count=1)
 def test_quantile_out_of_bounds_q_raises():
     # https://github.com/pandas-dev/pandas/issues/27470
@@ -307,11 +300,10 @@ def test_quantile_missing_group_values_correct_results(
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
 @pytest.mark.parametrize(
     "interpolation, val1, val2", [("lower", 2, 2), ("higher", 2, 3), ("nearest", 2, 2)]
 )
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
+@sql_count_checker(query_count=1)
 def test_groupby_quantile_all_na_group_masked(interpolation, val1, val2):
     # GH#37493
     df = pd.DataFrame({"a": [1, 1, 1, 2], "b": [1, 2, 3, pd.NA]})
@@ -331,8 +323,7 @@ def test_groupby_quantile_all_na_group_masked(interpolation, val1, val2):
     strict=True,
     raises=AttributeError,
 )
-@pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
+@sql_count_checker(query_count=1)
 def test_groupby_quantile_nonmulti_levels_order():
     # Non-regression test for GH #53009
     ind = pd.MultiIndex.from_tuples(

--- a/tests/integ/modin/series/test_rename.py
+++ b/tests/integ/modin/series/test_rename.py
@@ -180,7 +180,7 @@ class TestRename:
         with pytest.raises(KeyError, match=match):
             ser.rename({2: 9}, errors="raise")
 
-    @pytest.mark.skipif(running_on_public_ci(), reason="slow fallback test")
+    @pytest.mark.skipif(running_on_public_ci(), reason="slow test")
     @sql_count_checker(query_count=8, join_count=12)
     def test_rename_copy_false(self):
         # GH 46889

--- a/tests/integ/modin/strings/test_cat.py
+++ b/tests/integ/modin/strings/test_cat.py
@@ -4,13 +4,10 @@
 
 import modin.pandas as pd
 import numpy as np
-import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from snowflake.snowpark.exceptions import SnowparkSQLException
-from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
-from tests.integ.utils.sql_counter import SqlCounter
+from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import running_on_public_ci
 
 
@@ -28,70 +25,61 @@ def snow_series():
     return pd.Series(["a", "a", "b", "b", "c", np.nan])
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 # TODO (SNOW-863786): import whole pandas/tests/strings/test_cat.py
 @pytest.mark.parametrize(
-    "sep, na_rep, expected, query_count, sproc_count",
+    "sep, na_rep, expected",
     [
-        (None, None, "aabbc", 8, 1),
-        (None, "-", "aabbc-", 8, 1),
-        ("_", "NA", "a_a_b_b_c_NA", 8, 1),
+        (None, None, "aabbc"),
+        (None, "-", "aabbc-"),
+        ("_", "NA", "a_a_b_b_c_NA"),
     ],
 )
-def test_str_cat_single_array(
-    snow_series, sep, na_rep, expected, query_count, sproc_count
-):
+@sql_count_checker(query_count=0)
+def test_str_cat_single_array(snow_series, sep, na_rep, expected):
     # "str.cat" Series/Index to ndarray/list
-    with SqlCounter(query_count=query_count, sproc_count=sproc_count):
-        result = snow_series.str.cat(sep=sep, na_rep=na_rep)
-        assert result == expected
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.cat",
+    ):
+        snow_series.str.cat(sep=sep, na_rep=na_rep)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
+@sql_count_checker(query_count=0)
 def test_str_cat_series_with_array(snow_series):
     t = np.array(["a", np.nan, "b", "d", "foo", np.nan], dtype=object)
-    expected = native_pd.Series(["aa", "a-", "bb", "bd", "cfoo", "--"])
+    # expected = native_pd.Series(["aa", "a-", "bb", "bd", "cfoo", "--"])
 
     # Series/Index with array
-    with SqlCounter(query_count=8, sproc_count=1):
-        result = snow_series.str.cat(t, na_rep="-")
-        assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.cat",
+    ):
+        snow_series.str.cat(t, na_rep="-")
     # Series/Index with list
-    with SqlCounter(query_count=8, sproc_count=1):
-        result = snow_series.str.cat(list(t), na_rep="-")
-        assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.cat",
+    ):
+        snow_series.str.cat(list(t), na_rep="-")
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 def test_str_cat_incorrect_lengths(snow_series):
     # errors for incorrect lengths
     # rgx = r"If `others` contains arrays or lists \(or other list-likes.*"
     z = pd.Series(["1", "2", "3"])
 
-    with SqlCounter(query_count=5):
-        with pytest.raises(SnowparkSQLException):
-            # This call is expected to raise SnowparkSQLException after
-            # calling the stored procedure, which should produce 5 queries
-            # as expected
+    with SqlCounter(query_count=1):
+        with pytest.raises(
+            NotImplementedError,
+            match="Snowpark pandas does not yet support the method Series.str.cat",
+        ):
             snow_series.str.cat(z.values)
 
-    with SqlCounter(query_count=6):
-        with pytest.raises(SnowparkSQLException):
-            # This call is expected to raise SnowparkSQLException after
-            # calling the stored procedure, which should produce 5 queries.
-            # However, in this case an additional row COUNT() query is
-            # executed before the stored procedure fallback to get the number
-            # of rows in z.
+    with SqlCounter(query_count=2):
+        with pytest.raises(
+            NotImplementedError,
+            match="Snowpark pandas does not yet support the method Series.str.cat",
+        ):
+            # in this case additional row COUNT() query is
+            # executed before the error to get the number of rows in z.
             snow_series.str.cat(list(z))

--- a/tests/integ/modin/strings/test_cat.py
+++ b/tests/integ/modin/strings/test_cat.py
@@ -10,6 +10,10 @@ import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import running_on_public_ci
 
+# NOTE: Many tests in this file previously fell back to native pandas in stored procedures. These
+# have since been updated to expect NotImplementedError, and the original "expected" result has
+# been left as a comment to make properly implementing these methods easier.
+
 
 @pytest.fixture(scope="module", autouse=True)
 def skip(pytestconfig):

--- a/tests/integ/modin/strings/test_extract.py
+++ b/tests/integ/modin/strings/test_extract.py
@@ -2,15 +2,16 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+from contextlib import contextmanager
+
 import modin.pandas as pd
 import numpy as np
 import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from snowflake.snowpark.exceptions import SnowparkSQLException
 from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
-from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from tests.integ.utils.sql_counter import SqlCounter
 from tests.utils import running_on_public_ci
 
 
@@ -25,57 +26,60 @@ def skip(pytestconfig):
         )
 
 
+@contextmanager
+def extract_unimplemented_counter():
+    """
+    In old versions of Snowpark pandas, Series.str.extract ran the native pandas implementation
+    in a stored procedure. Snowpark pandas no longer does this due to performance concerns, instead
+    raising a NotImplementedError.
+
+    These tests are left as-is should we choose to implement the feature in the future.
+    """
+    with SqlCounter(query_count=0), pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.extract",
+    ):
+        yield
+
+
 # TODO (SNOW-863786): import whole pandas/tests/strings/test_extract.py
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=4)
 def test_extract_expand_kwarg_wrong_type_raises():
     values = pd.Series(["fooBAD__barBAD", np.nan, "foo"], dtype=object)
-    with pytest.raises(SnowparkSQLException):
+    with extract_unimplemented_counter():
         values.str.extract(".*(BAD[_]+).*(BAD)", expand=None)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=24, fallback_count=3, sproc_count=3)
 def test_extract_expand_kwarg():
     s = pd.Series(["fooBAD__barBAD", np.nan, "foo"], dtype=object)
     expected = native_pd.DataFrame(["BAD__", np.nan, np.nan], dtype=object)
 
-    result = s.str.extract(".*(BAD[_]+).*")
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with extract_unimplemented_counter():
+        result = s.str.extract(".*(BAD[_]+).*")
+        assert_snowpark_pandas_equal_to_pandas(result, expected)
 
-    result = s.str.extract(".*(BAD[_]+).*", expand=True)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with extract_unimplemented_counter():
+        result = s.str.extract(".*(BAD[_]+).*", expand=True)
+        assert_snowpark_pandas_equal_to_pandas(result, expected)
 
     expected = native_pd.DataFrame(
         [["BAD__", "BAD"], [np.nan, np.nan], [np.nan, np.nan]], dtype=object
     )
-    result = s.str.extract(".*(BAD[_]+).*(BAD)", expand=False)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with extract_unimplemented_counter():
+        result = s.str.extract(".*(BAD[_]+).*(BAD)", expand=False)
+        assert_snowpark_pandas_equal_to_pandas(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 def test_extract_expand_capture_groups():
     s = pd.Series(["A1", "B2", "C3"], dtype=object)
+
     # one group, no matches
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("(_)", expand=False)
         expected = native_pd.Series([np.nan, np.nan, np.nan], dtype=object)
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # two groups, no matches
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("(_)(_)", expand=False)
         expected = native_pd.DataFrame(
             [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]], dtype=object
@@ -83,13 +87,13 @@ def test_extract_expand_capture_groups():
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # one group, some matches
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("([AB])[123]", expand=False)
         expected = native_pd.Series(["A", "B", np.nan], dtype=object)
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # two groups, some matches
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("([AB])([123])", expand=False)
         expected = native_pd.DataFrame(
             [["A", "1"], ["B", "2"], [np.nan, np.nan]], dtype=object
@@ -97,13 +101,13 @@ def test_extract_expand_capture_groups():
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # one named group
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("(?P<letter>[AB])", expand=False)
         expected = native_pd.Series(["A", "B", np.nan], name="letter", dtype=object)
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # two named groups
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("(?P<letter>[AB])(?P<number>[123])", expand=False)
         expected = native_pd.DataFrame(
             [["A", "1"], ["B", "2"], [np.nan, np.nan]],
@@ -113,7 +117,7 @@ def test_extract_expand_capture_groups():
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # mix named and unnamed groups
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("([AB])(?P<number>[123])", expand=False)
         expected = native_pd.DataFrame(
             [["A", "1"], ["B", "2"], [np.nan, np.nan]],
@@ -123,13 +127,13 @@ def test_extract_expand_capture_groups():
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # one normal group, one non-capturing group
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         result = s.str.extract("([AB])(?:[123])", expand=False)
         expected = native_pd.Series(["A", "B", np.nan], dtype=object)
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # two normal groups, one non-capturing group
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         s = pd.Series(["A11", "B22", "C33"], dtype=object)
         result = s.str.extract("([AB])([123])(?:[123])", expand=False)
         expected = native_pd.DataFrame(
@@ -138,7 +142,7 @@ def test_extract_expand_capture_groups():
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # one optional group followed by one normal group
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         s = pd.Series(["A1", "B2", "3"], dtype=object)
         result = s.str.extract("(?P<letter>[AB])?(?P<number>[123])", expand=False)
         expected = native_pd.DataFrame(
@@ -149,7 +153,7 @@ def test_extract_expand_capture_groups():
         assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
 
     # one normal group followed by one optional group
-    with SqlCounter(query_count=8, sproc_count=1):
+    with extract_unimplemented_counter():
         s = pd.Series(["A1", "B2", "C"], dtype=object)
         result = s.str.extract("(?P<letter>[ABC])(?P<number>[123])?", expand=False)
         expected = native_pd.DataFrame(

--- a/tests/integ/modin/strings/test_get_dummies.py
+++ b/tests/integ/modin/strings/test_get_dummies.py
@@ -10,6 +10,10 @@ from pandas import _testing as tm
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.utils.sql_counter import sql_count_checker
 
+# NOTE: Many tests in this file previously fell back to native pandas in stored procedures. These
+# have since been updated to expect NotImplementedError, and the original "expected" result has
+# been left as a comment to make properly implementing these methods easier.
+
 
 # TODO (SNOW-863786): import whole pandas/tests/strings/test_get_dummies.py
 @sql_count_checker(query_count=0)

--- a/tests/integ/modin/strings/test_get_dummies.py
+++ b/tests/integ/modin/strings/test_get_dummies.py
@@ -4,65 +4,50 @@
 
 import modin.pandas as pd
 import numpy as np
-import pandas as native_pd
 import pytest
 from pandas import _testing as tm
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from tests.integ.modin.utils import assert_snowpark_pandas_equal_to_pandas
 from tests.integ.utils.sql_counter import sql_count_checker
-from tests.utils import running_on_public_ci
 
 
-# TODO (SNOW-767685): This whole suite is skipped in ci run because those are tests for unsupported
-#   APIs, which is time consuming. we will set up a daily jenkins job to run those daily.
-@pytest.fixture(scope="module", autouse=True)
-def skip(pytestconfig):
-    if running_on_public_ci():
-        pytest.skip(
-            "Disable series str tests for public ci",
-            allow_module_level=True,
-        )
-
-
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 # TODO (SNOW-863786): import whole pandas/tests/strings/test_get_dummies.py
-@sql_count_checker(query_count=16, fallback_count=2, sproc_count=2)
-def test_get_dummies():
+@sql_count_checker(query_count=0)
+def test_get_dummies_unimplemented():
     s = pd.Series(["a|b", "a|c", np.nan], dtype=object)
-    result = s.str.get_dummies("|")
-    expected = native_pd.DataFrame(
-        [[1, 1, 0], [1, 0, 1], [0, 0, 0]], columns=list("abc")
-    )
-    assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
+    # expected = native_pd.DataFrame(
+    #     [[1, 1, 0], [1, 0, 1], [0, 0, 0]], columns=list("abc")
+    # )
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.get_dummies",
+    ):
+        s.str.get_dummies("|")
 
     s = pd.Series(["a;b", "a", 7], dtype=object)
-    result = s.str.get_dummies(";")
-    expected = native_pd.DataFrame(
-        [[0, 1, 1], [0, 1, 0], [1, 0, 0]], columns=list("7ab")
-    )
-    assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
+    # expected = native_pd.DataFrame(
+    #     [[0, 1, 1], [0, 1, 0], [1, 0, 0]], columns=list("7ab")
+    # )
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.get_dummies",
+    ):
+        s.str.get_dummies(";")
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
-def test_get_dummies_with_name_dummy():
+@sql_count_checker(query_count=0)
+def test_get_dummies_with_name_dummy_unimplemented():
     # GH 12180
     # Dummies named 'name' should work as expected
     s = pd.Series(["a", "b,name", "b"], dtype=object)
-    result = s.str.get_dummies(",")
-    expected = native_pd.DataFrame(
-        [[1, 0, 0], [0, 1, 1], [0, 1, 0]], columns=["a", "b", "name"]
-    )
-    assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
+    # expected = native_pd.DataFrame(
+    #     [[1, 0, 0], [0, 1, 1], [0, 1, 0]], columns=["a", "b", "name"]
+    # )
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.get_dummies",
+    ):
+        s.str.get_dummies(",")
 
 
 @sql_count_checker(query_count=1)

--- a/tests/integ/modin/strings/test_strings.py
+++ b/tests/integ/modin/strings/test_strings.py
@@ -16,6 +16,10 @@ from tests.integ.modin.utils import (
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import running_on_public_ci
 
+# NOTE: Many tests in this file previously fell back to native pandas in stored procedures. These
+# have since been updated to expect NotImplementedError, and the original "expected" result has
+# been left as a comment to make properly implementing these methods easier.
+
 
 # This whole suite is skipped in ci run because those are tests for unsupported
 # APIs, which is time-consuming, and it will run the daily jenkins job.

--- a/tests/integ/modin/strings/test_strings.py
+++ b/tests/integ/modin/strings/test_strings.py
@@ -8,7 +8,6 @@ import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
-from snowflake.snowpark.exceptions import SnowparkSQLException
 from tests.integ.modin.utils import (
     assert_snowpark_pandas_equal_to_pandas,
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
@@ -53,11 +52,6 @@ def test_count():
     assert_snowpark_pandas_equal_to_pandas(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "repeat, expected_result_data",
     [
@@ -65,37 +59,37 @@ def test_count():
         ([1, 2, 3, 4, 5, 6], ["a", "bb", np.nan, "cccc", np.nan, "dddddd"]),
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_repeat(repeat, expected_result_data):
     ser = pd.Series(["a", "b", np.nan, "c", np.nan, "d"], dtype=object)
 
-    result = ser.str.repeat(repeat)
-    expected = native_pd.Series(expected_result_data, dtype=object)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.repeat",
+    ):
+        ser.str.repeat(repeat)
+    # expected = native_pd.Series(expected_result_data, dtype=object)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize("arg, repeat", [[None, 4], ["b", None]])
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_repeat_with_null(arg, repeat):
     ser = pd.Series(["a", arg], dtype=object)
-    result = ser.str.repeat([3, repeat])
-    expected = native_pd.Series(["aaa", None], dtype=object)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.repeat",
+    ):
+        ser.str.repeat([3, repeat])
+    # expected = native_pd.Series(["aaa", None], dtype=object)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_empty_str_empty_cat():
-    assert pd.Series(dtype=object).str.cat() == ""
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.cat",
+    ):
+        assert pd.Series(dtype=object).str.cat() == ""
 
 
 @sql_count_checker(query_count=0)
@@ -104,23 +98,14 @@ def test_empty_df_float_raises():
         pd.Series(dtype="float64").str.cat()
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=10, sproc_count=1)
+@sql_count_checker(query_count=1)
 def test_empty_str_self_cat():
-    # The query count is higher in this test because of the creation of a temp table for the
-    # second series argument being passed in as argument to the cat sproc
-    # Related: SNOW-960061
-
-    eval_snowpark_pandas_result(
-        pd.Series(dtype=object),
-        native_pd.Series(dtype=object),
-        lambda ser: ser.str.cat(ser),
-        comparator=assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
-    )
+    ser = pd.Series(dtype=object)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.cat",
+    ):
+        ser.str.cat(ser)
 
 
 @pytest.mark.parametrize(
@@ -147,98 +132,72 @@ def test_empty_str_methods(fn, query_count=1, sproc_count=0):
 
 
 @pytest.mark.parametrize(
-    "method, expected, query_count, sproc_count",
+    "method, expected, query_count",
     [
         pytest.param(
             "isalnum",
             [True, True, True, True, True, False, True, True, False, False],
-            9,
-            1,
-            marks=pytest.mark.xfail(
-                reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-                strict=True,
-                raises=RuntimeError,
-            ),
+            0,
         ),
         pytest.param(
             "isalpha",
             [True, True, True, False, False, False, True, False, False, False],
-            9,
-            1,
-            marks=pytest.mark.xfail(
-                reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-                strict=True,
-                raises=RuntimeError,
-            ),
+            0,
         ),
         (
             "isdigit",
             [False, False, False, True, False, False, False, True, False, False],
             2,
-            0,
         ),
         pytest.param(
             "isnumeric",
             [False, False, False, True, False, False, False, True, False, False],
-            9,
-            1,
-            marks=pytest.mark.xfail(
-                reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-                strict=True,
-                raises=RuntimeError,
-            ),
+            0,
         ),
         pytest.param(
             "isspace",
             [False, False, False, False, False, False, False, False, False, True],
-            9,
-            1,
-            marks=pytest.mark.xfail(
-                reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-                strict=True,
-                raises=RuntimeError,
-            ),
+            0,
         ),
         (
             "islower",
             [False, True, False, False, False, False, False, False, False, False],
             2,
-            0,
         ),
         (
             "isupper",
             [True, False, False, False, True, False, True, False, False, False],
             2,
-            0,
         ),
         (
             "istitle",
             [True, False, True, False, True, False, False, False, False, False],
             2,
-            0,
         ),
     ],
 )
-def test_ismethods(method, expected, query_count, sproc_count):
+def test_ismethods(method, expected, query_count):
     data = ["A", "b", "Xy", "4", "3A", "", "TT", "55", "-", "  "]
     native_ser = native_pd.Series(data, dtype=object)
     ser = pd.Series(data, dtype=object)
 
     expected = native_pd.Series(expected, dtype=bool)
-    with SqlCounter(query_count=query_count, sproc_count=sproc_count):
-        result = getattr(ser.str, method)()
-        assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with SqlCounter(query_count=query_count):
+        if query_count == 0:  # indicates unimplemented method
+            with pytest.raises(
+                NotImplementedError,
+                match=f"Snowpark pandas does not yet support the method Series.str.{method}",
+            ):
+                result = getattr(ser.str, method)()
+        else:
+            result = getattr(ser.str, method)()
+            assert_snowpark_pandas_equal_to_pandas(result, expected)
 
-        # compare with standard library
-        expected = [getattr(item, method)() for item in native_ser]
-        assert list(result.to_pandas()) == expected
+            # compare with standard library
+            expected = [getattr(item, method)() for item in native_ser]
+            assert list(result.to_pandas()) == expected
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "method, expected",
     [
@@ -246,29 +205,26 @@ def test_ismethods(method, expected, query_count, sproc_count):
         ("isdecimal", [False, True, False, False, False, True, False]),
     ],
 )
-@sql_count_checker(query_count=9, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_isnumeric_unicode(method, expected):
     # 0x00bc: ¼ VULGAR FRACTION ONE QUARTER
     # 0x2605: ★ not number
     # 0x1378: ፸ ETHIOPIC NUMBER SEVENTY
     # 0xFF13: ３ Em 3
     data = ["A", "3", "¼", "★", "፸", "３", "four"]
-    native_ser = native_pd.Series(data, dtype=object)
+    # native_ser = native_pd.Series(data, dtype=object)
     ser = pd.Series(data, dtype=object)
-    expected = native_pd.Series(expected, dtype=bool)
-    result = getattr(ser.str, method)()
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    with pytest.raises(
+        NotImplementedError,
+        match=f"Snowpark pandas does not yet support the method Series.str.{method}",
+    ):
+        getattr(ser.str, method)()
+    # expected = native_pd.Series(expected, dtype=bool)
 
     # compare with standard library
-    expected = [getattr(item, method)() for item in native_ser]
-    assert list(result.to_pandas()) == expected
+    # expected = [getattr(item, method)() for item in native_ser]
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "method, expected",
     [
@@ -276,29 +232,29 @@ def test_isnumeric_unicode(method, expected):
         ("isdecimal", [False, np.nan, False, False, np.nan, True, False]),
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_isnumeric_unicode_missing(method, expected):
     values = ["A", np.nan, "¼", "★", np.nan, "３", "four"]
     ser = pd.Series(values, dtype=object)
-    expected = native_pd.Series(expected, dtype=object)
-    result = getattr(ser.str, method)()
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(expected, dtype=object)
+    with pytest.raises(
+        NotImplementedError,
+        match=f"Snowpark pandas does not yet support the method Series.str.{method}",
+    ):
+        getattr(ser.str, method)()
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=9, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_split_join_roundtrip():
-    ser = pd.Series(["a_b_c", "c_d_e", np.nan, "f_g_h"], dtype=object)
-    result = ser.str.split("_").str.join("_")
-    expected = ser.to_pandas().astype(object)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    native_ser = native_pd.Series(["a_b_c", "c_d_e", np.nan, "f_g_h"], dtype=object)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.join",
+    ):
+        pd.Series(native_ser).str.split("_").str.join("_")
 
 
-@sql_count_checker(query_count=1, sproc_count=0)
+@sql_count_checker(query_count=1)
 def test_len():
     ser = pd.Series(
         ["foo", "fooo", "fooooo", np.nan, "fooooooo", "foo\n", "あ"],
@@ -309,11 +265,6 @@ def test_len():
     assert_snowpark_pandas_equal_to_pandas(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "method,sub,start,end,expected",
     [
@@ -325,30 +276,29 @@ def test_len():
         ("rindex", "E", 0, 5, [4, 3, 1, 4]),
     ],
 )
-@sql_count_checker(query_count=9, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_index(method, sub, start, end, expected):
     data = ["ABCDEFG", "BCDEFEF", "DEFGHIJEF", "EFGHEF"]
-    native_obj = native_pd.Series(data, dtype=object)
+    # native_obj = native_pd.Series(data, dtype=object)
     obj = pd.Series(data, dtype=object)
-    expected = native_pd.Series(expected, dtype=np.int8)
-    result = getattr(obj.str, method)(sub, start, end)
-
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(expected, dtype=np.int8)
+    with pytest.raises(
+        NotImplementedError,
+        match=f"Snowpark pandas does not yet support the method Series.str.{method}",
+    ):
+        getattr(obj.str, method)(sub, start, end)
 
     # compare with standard library
-    expected = [getattr(item, method)(sub, start, end) for item in native_obj]
-    assert list(result.to_pandas()) == expected
+    # expected = [getattr(item, method)(sub, start, end) for item in native_obj]
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=0)
 def test_index_not_found_raises():
     obj = pd.Series(["ABCDEFG", "BCDEFEF", "DEFGHIJEF", "EFGHEF"], dtype=object)
-    with pytest.raises(SnowparkSQLException):
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.index",
+    ):
         obj.str.index("DE")
 
 
@@ -362,11 +312,6 @@ def test_index_raises_not_implemented_error(method):
         getattr(obj.str, method)("sub")
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "method, exp",
     [
@@ -374,13 +319,16 @@ def test_index_raises_not_implemented_error(method):
         ["rindex", [3, 1, 2]],
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_index_missing(method, exp):
     ser = pd.Series(["abcb", "ab", "bcbe", np.nan], dtype=object)
 
-    result = getattr(ser.str, method)("b")
-    expected = native_pd.Series(exp + [np.nan], dtype=np.float64)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(exp + [np.nan], dtype=np.float64)
+    with pytest.raises(
+        NotImplementedError,
+        match=f"Snowpark pandas does not yet support the method Series.str.{method}",
+    ):
+        getattr(ser.str, method)("b")
 
 
 @pytest.mark.parametrize(
@@ -401,11 +349,6 @@ def test_slice(start, stop, step, expected):
     assert_snowpark_pandas_equal_to_pandas(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "start,stop,repl,expected",
     [
@@ -419,15 +362,18 @@ def test_slice(start, stop, step, expected):
         (-10, 3, "z", ["zrt", "a zit longer", "evenlongzerthanthat", "z", np.nan]),
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_slice_replace(start, stop, repl, expected):
     ser = pd.Series(
         ["short", "a bit longer", "evenlongerthanthat", "", np.nan],
         dtype=object,
     )
-    expected = native_pd.Series(expected, dtype=object)
-    result = ser.str.slice_replace(start, stop, repl)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(expected, dtype=object)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.slice_replace",
+    ):
+        ser.str.slice_replace(start, stop, repl)
 
 
 @pytest.mark.parametrize(
@@ -446,57 +392,45 @@ def test_lstrip_rstrip(method, exp):
     assert_snowpark_pandas_equal_to_pandas(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "prefix, expected", [("a", ["b", " b c", "bc"]), ("ab", ["", "a b c", "bc"])]
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_removeprefix(prefix, expected):
     ser = pd.Series(["ab", "a b c", "bc"], dtype=object)
-    result = ser.str.removeprefix(prefix)
-    ser_expected = native_pd.Series(expected, dtype=object)
-    assert_snowpark_pandas_equal_to_pandas(result, ser_expected)
+    # ser_expected = native_pd.Series(expected, dtype=object)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.removeprefix",
+    ):
+        ser.str.removeprefix(prefix)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "suffix, expected", [("c", ["ab", "a b ", "b"]), ("bc", ["ab", "a b c", ""])]
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_removesuffix(suffix, expected):
     ser = pd.Series(["ab", "a b c", "bc"], dtype=object)
-    result = ser.str.removesuffix(suffix)
-    ser_expected = native_pd.Series(expected, dtype=object)
-    assert_snowpark_pandas_equal_to_pandas(result, ser_expected)
+    # ser_expected = native_pd.Series(expected, dtype=object)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.removesuffix",
+    ):
+        ser.str.removesuffix(suffix)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=16, sproc_count=2)
+@sql_count_checker(query_count=0)
 def test_encode_decode():
-    ser = pd.Series(["a", "b", "a\xe4"], dtype=object).str.encode("utf-8")
-    result = ser.str.decode("utf-8")
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.encode",
+    ):
+        pd.Series(["a", "b", "a\xe4"], dtype=object).str.encode("utf-8")
+    # expected = ser.to_pandas().str.decode("utf-8")
+    # result = ser.str.decode("utf-8")
 
-    expected = ser.to_pandas().str.decode("utf-8")
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
 
-
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "form, expected",
     [
@@ -504,7 +438,7 @@ def test_encode_decode():
         ("NFC", ["ABC", "ＡＢＣ", "１２３", np.nan, "ｱｲｴ"]),
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_normalize(
     form,
     expected,
@@ -514,16 +448,16 @@ def test_normalize(
         index=["a", "b", "c", "d", "e"],
         dtype=object,
     )
-    expected = native_pd.Series(expected, index=["a", "b", "c", "d", "e"], dtype=object)
-    result = ser.str.normalize(form)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(
+    #     expected, index=["a", "b", "c", "d", "e"], dtype=object
+    # )
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.normalize",
+    ):
+        ser.str.normalize(form)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "width, data, expected_data",
     [
@@ -531,33 +465,29 @@ def test_normalize(
         (5, ["-2", "+5"], ["-0002", "+0005"]),
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_zfill(width, data, expected_data):
     # https://github.com/pandas-dev/pandas/issues/20868
     value = pd.Series(data)
-    result = value.str.zfill(width)
-    expected = native_pd.Series(expected_data)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(expected_data)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.zfill",
+    ):
+        value.str.zfill(width)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_zfill_with_leading_sign():
     value = pd.Series(["-cat", "-1", "+dog"])
-    expected = native_pd.Series(["-0cat", "-0001", "+0dog"])
-    result = value.str.zfill(5)
-    assert_snowpark_pandas_equal_to_pandas(result, expected)
+    # expected = native_pd.Series(["-0cat", "-0001", "+0dog"])
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas does not yet support the method Series.str.zfill",
+    ):
+        value.str.zfill(5)
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
 @pytest.mark.parametrize(
     "key, expected_result",
     [
@@ -565,7 +495,7 @@ def test_zfill_with_leading_sign():
         ("value", ["World", "Planet", "Sea"]),
     ],
 )
-@sql_count_checker(query_count=8, sproc_count=1)
+@sql_count_checker(query_count=0)
 def test_get_with_dict_label(key, expected_result):
     # GH47911
     s = pd.Series(
@@ -575,6 +505,9 @@ def test_get_with_dict_label(key, expected_result):
             {"value": "Sea"},
         ]
     )
-    result = s.str.get(key)
-    expected = native_pd.Series(expected_result)
-    assert_snowpark_pandas_equal_to_pandas(result, expected, check_dtype=False)
+    # expected = native_pd.Series(expected_result)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas method 'Series.str.get' doesn't yet support non-numeric 'i' argument",
+    ):
+        s.str.get(key)

--- a/tests/integ/modin/test_sql_counter.py
+++ b/tests/integ/modin/test_sql_counter.py
@@ -4,13 +4,10 @@
 
 import threading
 import modin.pandas as pd
-import numpy as np
-import pandas as native_pd
 import pytest
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from snowflake.snowpark import QueryRecord
-from tests.integ.modin.utils import assert_frame_equal
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
 
@@ -109,23 +106,6 @@ def test_sql_counter_with_context_manager_outside_loop(session):
         df = pd.DataFrame({"a": [1, 2, 3]})
         assert len(df) == 3
     sc.__exit__(None, None, None)
-
-
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=8, fallback_count=1, sproc_count=1)
-def test_sql_counter_with_fallback_count():
-    df_data = {
-        "name": ["Alfred", "Batman", "Catwoman"],
-        "toy": [np.nan, "Batmobile", "Bullwhip"],
-        "born": [pd.NaT, pd.Timestamp("1940-04-25"), pd.NaT],
-    }
-
-    df = pd.DataFrame(df_data).dropna(axis="columns")
-    assert len(df) == 3
 
 
 @sql_count_checker(query_count=5, join_count=2, udtf_count=1)
@@ -234,21 +214,6 @@ def test_sql_count_instances_by_query_substr():
             )
             == 0
         )
-
-
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-# This test passes even though it exceeds the high query count because it is adjusted down based on the fallback count.
-@sql_count_checker(query_count=16, fallback_count=2, sproc_count=2)
-def test_high_sql_count_with_fallback_pass():
-    for _ in range(2):
-        df = pd.DataFrame({"A": [1, 2], "B": [1, 2]}, index=["X", "Y"])
-        expected = native_pd.DataFrame({"A": [1, 2], "B": [1, 2]}, index=["x", "y"])
-        result = df.rename(str.lower, axis=0)
-        assert_frame_equal(result, expected, check_dtype=False, check_index_type=False)
 
 
 @pytest.mark.xfail(

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -319,19 +319,15 @@ def test_telemetry_args():
     ) == ["arg7_no_default_dataframe", "arg8_nodefault_detaframe"]
 
 
-@pytest.mark.xfail(
-    reason="SNOW-1336091: Snowpark pandas cannot run in sprocs until modin 0.28.1 is available in conda",
-    strict=True,
-    raises=RuntimeError,
-)
-@sql_count_checker(query_count=7, fallback_count=1, sproc_count=1)
+# TODO file ticket and fix this
+@pytest.mark.xfail(reason="TODO telemetry should be reported here")
+@sql_count_checker(query_count=1)
 def test_property_methods_telemetry():
     datetime_series = pd.Series(pd.date_range("2000-01-01", periods=3, freq="h"))
-    ret_series = datetime_series.dt.timetz
+    ret_series = datetime_series.dt.date
     assert len(ret_series._query_compiler.snowpark_pandas_api_calls) == 1
     api_call = ret_series._query_compiler.snowpark_pandas_api_calls[0]
-    assert api_call["is_fallback"]
-    assert api_call["name"] == "Series.<property fget:timetz>"
+    assert api_call["name"] == "Series.<property fget:date>"
 
 
 @sql_count_checker(query_count=1)

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -319,8 +319,9 @@ def test_telemetry_args():
     ) == ["arg7_no_default_dataframe", "arg8_nodefault_detaframe"]
 
 
-# TODO file ticket and fix this
-@pytest.mark.xfail(reason="TODO telemetry should be reported here")
+@pytest.mark.xfail(
+    reason="SNOW-2031975: Investigate why no telemetry is reported for accessor properties"
+)
 @sql_count_checker(query_count=1)
 def test_property_methods_telemetry():
     datetime_series = pd.Series(pd.date_range("2000-01-01", periods=3, freq="h"))


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1336091

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

When Snowpark pandas originally merged with the Snowpark repository, it would default to running native pandas in a stored procedure for certain operations that we did not directly provide distributed support for. This has since changed, and we no longer do any stored procedure fallback due to the prohibitive runtime cost of doing so. When we previously upgraded modin from 0.26.0 -> 0.28.1, the lag in time for the package becoming available in the conda channel meant we had to XFAIL many tests, but the `strict=True` modifier did not warn of us any changes in behavior because the newly-raised `NotImplementedError` is a subclass of the previously-raised `RuntimeError`.

Most of the old tests have been modified to directly check for NotImplementedError, and take relatively little CI time because of how quicklky they error out.