### PR TITLE
SNOW-2014299: Query XML dataframe with dot notation

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -1403,7 +1403,7 @@ def split_dot_string(s: str) -> list:
           -> ['"a.b"', 'c', '"d.e.f"', 'g']
     """
     # ensures that dots inside quotes are not used for splitting.
-    parts = re.split(r'\.(?=(?:[^"]*"[^"]*")*[^"]*$)', s)
+    parts = re.compile(r'"(?:[^"]|"")*"|[^.]+').findall(s)
     return parts
 
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -1391,10 +1391,11 @@ def escape_quotes(unescaped: str) -> str:
     return unescaped.replace(DOUBLE_QUOTE, DOUBLE_QUOTE + DOUBLE_QUOTE)
 
 
-def split_dot_string(s: str) -> list:
+def split_snowflake_identifier_with_dot(s: str) -> list:
     """
-    Splits the string by dots that are not within double-quoted parts.
+    Splits the Snowflake identifier by dots that are not within double-quoted parts.
     Tokens that appear quoted in the input remain unchanged (quotes are kept).
+    See details in https://docs.snowflake.com/en/sql-reference/identifiers-syntax.
 
     Examples:
       'foo.bar."hello.world".baz'

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -1391,6 +1391,22 @@ def escape_quotes(unescaped: str) -> str:
     return unescaped.replace(DOUBLE_QUOTE, DOUBLE_QUOTE + DOUBLE_QUOTE)
 
 
+def split_dot_string(s: str) -> list:
+    """
+    Splits the string by dots that are not within double-quoted parts.
+    Tokens that appear quoted in the input remain unchanged (quotes are kept).
+
+    Examples:
+      'foo.bar."hello.world".baz'
+          -> ['foo', 'bar', '"hello.world"', 'baz']
+      '"a.b".c."d.e.f".g'
+          -> ['"a.b"', 'c', '"d.e.f"', 'g']
+    """
+    # ensures that dots inside quotes are not used for splitting.
+    parts = re.split(r'\.(?=(?:[^"]*"[^"]*")*[^"]*$)', s)
+    return parts
+
+
 # Define the full-width regex pattern, copied from Spark
 full_width_regex = re.compile(
     r"[\u1100-\u115F"

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -86,7 +86,7 @@ from snowflake.snowpark._internal.utils import (
     parse_positional_args_to_list,
     publicapi,
     quote_name,
-    split_dot_string,
+    split_snowflake_identifier_with_dot,
 )
 from snowflake.snowpark.types import (
     DataType,
@@ -270,7 +270,7 @@ class Column:
             expr: str, df_alias: Optional[str] = None
         ) -> UnresolvedAttribute:
             """Note that this method does not work for full column name like <db>.<schema>.<table>.column."""
-            parts = split_dot_string(expr)
+            parts = split_snowflake_identifier_with_dot(expr)
             if len(parts) == 1:
                 return UnresolvedAttribute(quote_name(parts[0]), df_alias=df_alias)
             else:

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -269,6 +269,7 @@ class Column:
         def derive_qualified_name_expr(
             expr: str, df_alias: Optional[str] = None
         ) -> UnresolvedAttribute:
+            """Note that this method does not work for full column name like <db>.<schema>.<table>.column."""
             parts = split_dot_string(expr)
             if len(parts) == 1:
                 return UnresolvedAttribute(quote_name(parts[0]), df_alias=df_alias)

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -86,6 +86,7 @@ from snowflake.snowpark._internal.utils import (
     parse_positional_args_to_list,
     publicapi,
     quote_name,
+    split_dot_string,
 )
 from snowflake.snowpark.types import (
     DataType,
@@ -262,11 +263,13 @@ class Column:
         _is_qualified_name: bool = False,
     ) -> None:
         self._ast = _ast
+        self._expr1 = expr1
+        self._expr2 = expr2
 
         def derive_qualified_name_expr(
             expr: str, df_alias: Optional[str] = None
         ) -> UnresolvedAttribute:
-            parts = expr.split(".")
+            parts = split_dot_string(expr)
             if len(parts) == 1:
                 return UnresolvedAttribute(quote_name(parts[0]), df_alias=df_alias)
             else:

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -75,6 +75,7 @@ from snowflake.snowpark._internal.analyzer.snowflake_plan_node import (
     SaveMode,
     SnowflakeCreateTable,
     TableCreationSource,
+    ReadFileNode,
 )
 from snowflake.snowpark._internal.analyzer.sort_expression import (
     Ascending,
@@ -610,6 +611,20 @@ class DataFrame:
             self._select_statement = None
         self._statement_params = None
         self.is_cached: bool = is_cached  #: Whether the dataframe is cached.
+
+        # Whether all columns are VARIANT data type,
+        # which support querying nested fields via dot notations
+        # If SQL simplifier is enabled, we need to get logical plan from plan.from_
+        if isinstance(plan, (SelectStatement, MockSelectStatement)):
+            self._all_variant_cols = (
+                isinstance(plan.from_, SelectSnowflakePlan)
+                and isinstance(plan.from_.snowflake_plan.source_plan, ReadFileNode)
+                and plan.from_.snowflake_plan.source_plan.xml_reader_udtf is not None
+            )
+        else:
+            self._all_variant_cols = bool(
+                isinstance(plan, ReadFileNode) and plan.xml_reader_udtf is not None
+            )
 
         self._reader: Optional["snowflake.snowpark.DataFrameReader"] = None
         self._writer = DataFrameWriter(self, _emit_ast=False)
@@ -1541,7 +1556,14 @@ class DataFrame:
 
         for e in exprs:
             if isinstance(e, Column):
-                names.append(e._named())
+                if self._all_variant_cols:
+                    names.append(
+                        Column(
+                            e._expr1, e._expr2, e._ast, _is_qualified_name=True
+                        )._named()
+                    )
+                else:
+                    names.append(e._named())
                 if _emit_ast and _ast_stmt is None:
                     ast_cols.append(e._ast)
 
@@ -1552,7 +1574,9 @@ class DataFrame:
                     fill_ast_for_column(col_expr_ast, e, None)
                     ast_cols.append(col_expr_ast)
 
-                col = Column(e, _ast=col_expr_ast)
+                col = Column(
+                    e, _ast=col_expr_ast, _is_qualified_name=self._all_variant_cols
+                )
                 names.append(col._named())
 
             elif isinstance(e, TableFunctionCall):

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1978,6 +1978,10 @@ def test_read_xml_no_xxe(session):
     "config.getoption('local_testing_mode', default=False)",
     reason="xml not supported in local testing mode",
 )
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="SNOW-2044853: Flaky in stored procedure test",
+)
 def test_read_xml_query_nested_data(session):
     row_tag = "tag"
     df = session.read.option("rowTag", row_tag).xml(

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -67,6 +67,7 @@ test_file_books_xml = "books.xml"
 test_file_house_xml = "fias_house.xml"
 test_file_house_large_xml = "fias_house.large.xml"
 test_file_xxe_xml = "xxe.xml"
+test_file_nested_xml = "nested.xml"
 
 
 # In the tests below, we test both scenarios: SELECT & COPY
@@ -252,6 +253,9 @@ def setup(session, resources_path, local_testing_mode):
     )
     Utils.upload_to_stage(
         session, "@" + tmp_stage_name1, test_files.test_xxe_xml, compress=False
+    )
+    Utils.upload_to_stage(
+        session, "@" + tmp_stage_name1, test_files.test_nested_xml, compress=False
     )
     Utils.upload_to_stage(
         session, "@" + tmp_stage_name2, test_files.test_file_csv, compress=False
@@ -1968,3 +1972,21 @@ def test_read_xml_no_xxe(session):
     stage_file_path = f"@{tmp_stage_name1}/{test_file_xxe_xml}"
     df = session.read.option("rowTag", row_tag).xml(stage_file_path)
     Utils.check_answer(df, [Row("null")])
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="xml not supported in local testing mode",
+)
+def test_read_xml_query_nested_data(session):
+    row_tag = "tag"
+    df = session.read.option("rowTag", row_tag).xml(
+        f"@{tmp_stage_name1}/{test_file_nested_xml}"
+    )
+    assert df._all_variant_cols is True
+    Utils.check_answer(
+        df.select(
+            "'test'.num", "'test'.str", col("'test'.obj"), col("'test'.obj.bool")
+        ),
+        [Row('"1"', '"str1"', '{\n  "bool": "true",\n  "str": "str2"\n}', '"true"')],
+    )

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -223,6 +223,7 @@ def test_col_is_qualified_name(session):
         df.select(col("name.firstname")).collect()
 
     df = session.sql('select parse_json(\'{"l1": {"l2": "xyz"}}\') as value')
+    df.show()
     Utils.check_answer(
         df.select(col("value.l1.l2", _is_qualified_name=True)), Row('"xyz"')
     )
@@ -241,6 +242,15 @@ def test_col_is_qualified_name(session):
 
     with pytest.raises(SnowparkSQLException, match="invalid identifier"):
         df.select(col("value.l1.l2")).collect()
+
+    # dots inside quotes should not be treated as separators
+    df = session.sql('select parse_json(\'{"a.b": {"b.c": "xyz"}}\') as value')
+    Utils.check_answer(
+        df.select(col('value."a.b"."b.c"', _is_qualified_name=True)), Row('"xyz"')
+    )
+    Utils.check_answer(
+        df.select(col("value.a.b.b.c", _is_qualified_name=True)).collect(), Row(None)
+    )
 
 
 def test_order(session):

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -223,7 +223,6 @@ def test_col_is_qualified_name(session):
         df.select(col("name.firstname")).collect()
 
     df = session.sql('select parse_json(\'{"l1": {"l2": "xyz"}}\') as value')
-    df.show()
     Utils.check_answer(
         df.select(col("value.l1.l2", _is_qualified_name=True)), Row('"xyz"')
     )

--- a/tests/resources/nested.xml
+++ b/tests/resources/nested.xml
@@ -1,0 +1,10 @@
+<tag>
+    <test>
+        <num>1</num>
+        <str>str1</str>
+        <obj>
+            <str>str2</str>
+            <bool>true</bool>
+        </obj>>
+    </test>
+</tag>

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -282,6 +282,7 @@ def test_zip_file_or_directory_to_stream():
                 "resources/fias_house.xml",
                 "resources/fias_house.large.xml",
                 "resources/iris.csv",
+                "resources/nested.xml",
                 "resources/test.avro",
                 "resources/test.orc",
                 "resources/test.parquet",

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -10,7 +10,7 @@ from snowflake.snowpark._internal import utils
 from snowflake.snowpark._internal.utils import (
     _pandas_importer,
     generate_random_alphanumeric,
-    split_dot_string,
+    split_snowflake_identifier_with_dot,
 )
 
 
@@ -130,7 +130,11 @@ def test_generate_random_alphanumeric():
             '"open.quotes.end',
             ['"open', "quotes", "end"],
         ),
+        (
+            'a."b.""c".d."e.f.g".h.i.j."k"".""l."',
+            ["a", '"b.""c"', "d", '"e.f.g"', "h", "i", "j", '"k"".""l."'],
+        ),
     ],
 )
-def test_split_dot_string(string, expected_result):
-    assert split_dot_string(string) == expected_result
+def test_split_snowflake_identifier_with_dot(string, expected_result):
+    assert split_snowflake_identifier_with_dot(string) == expected_result

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -126,6 +126,10 @@ def test_generate_random_alphanumeric():
             '"quoted with ""embedded.and.some.dots"" quotes escaped".end',
             ['"quoted with ""embedded.and.some.dots"" quotes escaped"', "end"],
         ),
+        (
+            '"open.quotes.end',
+            ['"open', "quotes", "end"],
+        ),
     ],
 )
 def test_split_dot_string(string, expected_result):

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -118,6 +118,14 @@ def test_generate_random_alphanumeric():
             '"quoted with ""embedded"" quotes".end',
             ['"quoted with ""embedded"" quotes"', "end"],
         ),
+        (
+            '"quoted with ""embedded.and.some.dots"" quotes".end',
+            ['"quoted with ""embedded.and.some.dots"" quotes"', "end"],
+        ),
+        (
+            '"quoted with ""embedded.and.some.dots"" quotes escaped".end',
+            ['"quoted with ""embedded.and.some.dots"" quotes escaped"', "end"],
+        ),
     ],
 )
 def test_split_dot_string(string, expected_result):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1545,6 +1545,10 @@ class TestFiles:
     def test_xxe_xml(self):
         return os.path.join(self.resources_path, "xxe.xml")
 
+    @property
+    def test_nested_xml(self):
+        return os.path.join(self.resources_path, "nested.xml")
+
 
 class TypeMap(NamedTuple):
     col_name: str


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2014299

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR does three things: 1) add a private property to DataFrame class to indicate whether all columns are variant 2) When calling select() on a dataframe, if this property is true, it means all columns are variants and we should support query nested fields using dot notation 3) Handling double quotes when querying nested fields using dot notation 
