### PR TITLE
SNOW-2034834: [Local Testing] Add support for array_construct function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 #### New Features
 
 - Added support for Interval experssion to `Window.range_between`.
+- Added support for `array_construct` function
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/mock/__init__.py
+++ b/src/snowflake/snowpark/mock/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 from json import JSONEncoder
-from uuid import uuid4
 
 from ._functions import patch
 from ._snowflake_data_type import ColumnEmulator, ColumnType, TableEmulator
@@ -22,16 +21,6 @@ class NumpyEncoder(JSONEncoder):
             return bool(obj)
 
         return super().default(obj)
-
-    def encode(self, obj):
-        # Snowflake encodes null values inside of lists as 'undefined' rather than 'null'
-        if isinstance(obj, list):
-            sentinel = uuid4().hex
-            obj = [sentinel if item is None else item for item in obj]
-            result = super().encode(obj)
-            return result.replace(f'"{sentinel}"', "undefined")
-
-        return super().encode(obj)
 
 
 CUSTOM_JSON_ENCODER = NumpyEncoder

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -498,6 +498,15 @@ def mock_array_agg(column: ColumnEmulator, is_distinct: bool) -> ColumnEmulator:
     )
 
 
+@patch("array_construct")
+def mock_array_construct(*columns):
+    if len(columns) == 0:
+        data = [[]]
+    else:
+        data = pandas.concat(columns, axis=1).apply(lambda x: list(x), axis=1)
+    return ColumnEmulator(data, sf_type=ColumnType(ArrayType(), False))
+
+
 @patch("listagg")
 def mock_listagg(column: ColumnEmulator, delimiter: str, is_distinct: bool):
     columns_data = ColumnEmulator(column.unique()) if is_distinct else column

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -2986,12 +2986,15 @@ def test_array_compact(session):
     )
 
 
-def test_array_construct(session):
+def test_array_construct(session, local_testing_mode):
+    # SNOW-2046349: Local testing down not encode Null values the same
+    null_value = "null" if local_testing_mode else "undefined"
+
     assert (
         TestData.zero1(session)
         .select(array_construct(lit(1), lit(1.2), lit("string"), lit(""), lit(None)))
         .collect()[0][0]
-        == '[\n  1,\n  1.2,\n  "string",\n  "",\n  undefined\n]'
+        == f'[\n  1,\n  1.2,\n  "string",\n  "",\n  {null_value}\n]'
     )
 
     assert TestData.zero1(session).select(array_construct()).collect()[0][0] == "[]"
@@ -3001,9 +3004,9 @@ def test_array_construct(session):
             array_construct(col("a"), lit(1.2), lit(None))
         ),
         [
-            Row("[\n  1,\n  1.2,\n  undefined\n]"),
-            Row("[\n  2,\n  1.2,\n  undefined\n]"),
-            Row("[\n  3,\n  1.2,\n  undefined\n]"),
+            Row(f"[\n  1,\n  1.2,\n  {null_value}\n]"),
+            Row(f"[\n  2,\n  1.2,\n  {null_value}\n]"),
+            Row(f"[\n  3,\n  1.2,\n  {null_value}\n]"),
         ],
         sort=False,
     )
@@ -3012,9 +3015,9 @@ def test_array_construct(session):
     Utils.check_answer(
         TestData.integer1(session).select(array_construct("a", lit(1.2), lit(None))),
         [
-            Row("[\n  1,\n  1.2,\n  undefined\n]"),
-            Row("[\n  2,\n  1.2,\n  undefined\n]"),
-            Row("[\n  3,\n  1.2,\n  undefined\n]"),
+            Row(f"[\n  1,\n  1.2,\n  {null_value}\n]"),
+            Row(f"[\n  2,\n  1.2,\n  {null_value}\n]"),
+            Row(f"[\n  3,\n  1.2,\n  {null_value}\n]"),
         ],
         sort=False,
     )

--- a/tests/integ/scala/test_function_suite.py
+++ b/tests/integ/scala/test_function_suite.py
@@ -2986,10 +2986,6 @@ def test_array_compact(session):
     )
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="array_construct is not yet supported in local testing mode.",
-)
 def test_array_construct(session):
     assert (
         TestData.zero1(session)

--- a/tests/integ/scala/test_udf_suite.py
+++ b/tests/integ/scala/test_udf_suite.py
@@ -122,10 +122,6 @@ def test_empty_expression(session):
     Utils.check_answer(df.select(const_udf()).collect(), [Row(1), Row(1), Row(1)])
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="array_construct is not yet supported in local testing mode.",
-)
 def test_udf_with_arrays(session):
     tmp_df = session.create_dataframe([("1", "2", "3"), ("4", "5", "6")]).to_df(
         ["a", "b", "c"]
@@ -161,10 +157,6 @@ def test_udf_with_map_input(session):
     )
 
 
-@pytest.mark.skipif(
-    "config.getoption('local_testing_mode', default=False)",
-    reason="array_construct is not yet supported in local testing mode.",
-)
 def test_udf_with_map_return(session):
     tmp_df = session.create_dataframe([("1", "2", "3"), ("4", "5", "6")]).to_df(
         ["a", "b", "c"]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2034834

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR adds local testing support for array_construct.
   Enabling those tests showed that local testing was not encoding null values contained in lists the same as Snowflake would. I've also patched the local testing json encoder to better cover that.
