### PR TITLE
SNOW-1990241: Fixed reserved name bug in append mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed a bug in local testing where transient `__pycache__` directory was unintentionally copied during stored procedure execution via import.
 - Fixed a bug in `DataFrameReader.dbapi` (PrPr) where a `TypeError` was raised when `create_connection` returned a connection object of an unsupported driver type.
 - Fixed a bug where `df.limit(0)` call would not properly apply.
+- Fixed a bug in `DataFrameWriter.save_as_table` that caused reserved names to throw errors when using append mode.
 
 #### Deprecations
 

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -456,9 +456,11 @@ class DataFrameWriter:
             )
             if column_order is None or column_order.lower() not in ("name", "index"):
                 raise ValueError("'column_order' must be either 'name' or 'index'")
-            column_names = (
-                self._dataframe.columns if column_order.lower() == "name" else None
-            )
+
+            column_names = None
+            if column_order.lower() == "name":
+                column_names = [x.name for x in self._dataframe.schema._to_attributes()]
+
             clustering_exprs = (
                 [
                     _to_col_if_str(col, "DataFrameWriter.save_as_table")._expression


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1990241

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   When running in `overwrite` mode save_as_table has no issue writing reserved names to tables. This is due to the downstream query generation using the attribute names instead of the column names. This change modifies how column names are fetched for other save modes so that they also use the attribute names instead of schema names.