### PR TITLE
SNOW-2042660: Update modin dependency to modin 0.32.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ cd snowpark-python
 
 - Create a new Python virtual environment with any Python version that we support.
   - The Snowpark Python API supports **Python 3.9, Python 3.10, Python 3.11 and Python 3.12**.
-  - The Snowpark pandas API supports **Python 3.9, Python 3.10, and Python 3.11**. Additionally, Snowpark pandas requires **Modin 0.30.1** and **pandas 2.2.x**.
+  - The Snowpark pandas API supports **Python 3.9, Python 3.10, and Python 3.11**. Additionally, Snowpark pandas requires **Modin 0.32.0** and **pandas 2.2.x**.
 
     ```bash
     conda create --name snowpark-dev python=3.9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - tzlocal
   run_constrained:
     # Snowpark pandas
-    - modin==0.30.1
+    - modin==0.32.0
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ from setuptools.command.build_py import build_py as _build_py
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
-MODIN_DEPENDENCY_VERSION = "==0.30.1"  # Snowpark pandas requires modin 0.30.1, which is compatible with pandas 2.2.x
 CONNECTOR_DEPENDENCY_VERSION = ">=3.14.0, <4.0.0"
 CONNECTOR_DEPENDENCY = f"snowflake-connector-python{CONNECTOR_DEPENDENCY_VERSION}"
 INSTALL_REQ_LIST = [
@@ -40,7 +39,7 @@ PANDAS_REQUIREMENTS = [
 ]
 MODIN_REQUIREMENTS = [
     *PANDAS_REQUIREMENTS,
-    f"modin{MODIN_DEPENDENCY_VERSION}",
+    "modin @ git+https://github.com/modin-project/modin.git@hybrid-execution",  # Use branch designed for hybrid client
 ]
 DEVELOPMENT_REQUIREMENTS = [
     "pytest<8.0.0",  # check SNOW-1022240 for more details on the pin here

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ from setuptools.command.build_py import build_py as _build_py
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SRC_DIR = os.path.join(THIS_DIR, "src")
 SNOWPARK_SRC_DIR = os.path.join(SRC_DIR, "snowflake", "snowpark")
+MODIN_DEPENDENCY_VERSION = "==0.32.0"  # Snowpark pandas requires modin 0.32.0, which is compatible with pandas 2.2.x
 CONNECTOR_DEPENDENCY_VERSION = ">=3.14.0, <4.0.0"
 CONNECTOR_DEPENDENCY = f"snowflake-connector-python{CONNECTOR_DEPENDENCY_VERSION}"
 INSTALL_REQ_LIST = [
@@ -39,7 +40,7 @@ PANDAS_REQUIREMENTS = [
 ]
 MODIN_REQUIREMENTS = [
     *PANDAS_REQUIREMENTS,
-    "modin @ git+https://github.com/modin-project/modin.git@hybrid-execution",  # Use branch designed for hybrid client
+    f"modin{MODIN_DEPENDENCY_VERSION}",
 ]
 DEVELOPMENT_REQUIREMENTS = [
     "pytest<8.0.0",  # check SNOW-1022240 for more details on the pin here

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -42,6 +42,14 @@ except ModuleNotFoundError:  # pragma: no cover
         "Modin is not installed. " + install_msg
     )  # pragma: no cover
 
+supported_modin_version = "0.32.0"
+if version.parse(modin.__version__) != version.parse(supported_modin_version):
+    raise ImportError(
+        f"The Modin version installed ({modin.__version__}) does not match the supported Modin version in"
+        + f" Snowpark pandas ({supported_modin_version}). "
+        + install_msg
+    )  # pragma: no cover
+
 
 # === INITIALIZE EXTENSION SYSTEM ===
 # Initialize all extension modules.

--- a/src/snowflake/snowpark/modin/plugin/__init__.py
+++ b/src/snowflake/snowpark/modin/plugin/__init__.py
@@ -42,14 +42,6 @@ except ModuleNotFoundError:  # pragma: no cover
         "Modin is not installed. " + install_msg
     )  # pragma: no cover
 
-supported_modin_version = "0.30.1"
-if version.parse(modin.__version__) != version.parse(supported_modin_version):
-    raise ImportError(
-        f"The Modin version installed ({modin.__version__}) does not match the supported Modin version in"
-        + f" Snowpark pandas ({supported_modin_version}). "
-        + install_msg
-    )  # pragma: no cover
-
 
 # === INITIALIZE EXTENSION SYSTEM ===
 # Initialize all extension modules.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -530,8 +530,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
     this class is best explained by looking at https://github.com/modin-project/modin/blob/a8be482e644519f2823668210cec5cf1564deb7e/modin/experimental/core/storage_formats/hdk/query_compiler.py
     """
 
-    # When lazy_execution=True, upstream Modin elides some length checks that would incur queries.
-    lazy_execution = True
+    # When these laziness flags are set, upstream Modin elides some length checks that would incur queries.
+    lazy_row_labels = True
+    lazy_row_count = True
+    lazy_column_types = False
+    lazy_column_labels = False
+    lazy_column_count = False
 
     def __init__(self, frame: InternalFrame) -> None:
         """this stores internally a local pandas object (refactor this)"""

--- a/src/snowflake/snowpark/modin/plugin/docstrings/series.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series.py
@@ -406,7 +406,7 @@ class Series(BasePandasDataset):
         pass
 
     __iadd__ = __add__
-    __imul__ = __add__
+    __imul__ = __mul__
     __ipow__ = __pow__
     __isub__ = __sub__
     __itruediv__ = __truediv__

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_overrides.py
@@ -1001,7 +1001,6 @@ def __rtruediv__(self, left):
 
 
 register_series_accessor("__iadd__")(__add__)
-# In upstream modin, imul is typo'd to be __add__ instead of __mul__
 register_series_accessor("__imul__")(__mul__)
 register_series_accessor("__ipow__")(__pow__)
 register_series_accessor("__isub__")(__sub__)
@@ -1094,26 +1093,6 @@ def argmin(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, 
     if not is_integer(result):  # if result is None, return -1
         result = -1
     return result
-
-
-# Modin uses the same implementation as Snowpark pandas starting form 0.31.0.
-# Until then, upstream Modin does not convert arguments in the caselist into query compilers.
-@register_series_accessor("case_when")
-def case_when(self, caselist) -> Series:  # noqa: PR01, RT01, D200
-    """
-    Replace values where the conditions are True.
-    """
-    modin_type = type(self)
-    caselist = [
-        tuple(
-            data._query_compiler if isinstance(data, modin_type) else data
-            for data in case_tuple
-        )
-        for case_tuple in caselist
-    ]
-    return self.__constructor__(
-        query_compiler=self._query_compiler.case_when(caselist=caselist)
-    )
 
 
 # Upstream Modin has a bug:

--- a/tests/integ/modin/index/test_monotonic.py
+++ b/tests/integ/modin/index/test_monotonic.py
@@ -12,7 +12,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 
 
 @pytest.mark.parametrize(
-    "values", [[], [1], [3, 2], [1, 3, 2], [1, 2, 2], [1, np.NaN, 3]]
+    "values", [[], [1], [3, 2], [1, 3, 2], [1, 2, 2], [1, np.nan, 3]]
 )
 @sql_count_checker(query_count=1)
 def test_monotonic_increasing_numbers(values):
@@ -23,7 +23,7 @@ def test_monotonic_increasing_numbers(values):
 
 
 @pytest.mark.parametrize(
-    "values", [[], [3], [1, 2], [3, 1, 2], [2, 2, 1], [3, np.NaN, 1]]
+    "values", [[], [3], [1, 2], [3, 1, 2], [2, 2, 1], [3, np.nan, 1]]
 )
 @sql_count_checker(query_count=1)
 def test_monotonic_decreasing_numbers(values):

--- a/tests/integ/modin/series/test_monotonic.py
+++ b/tests/integ/modin/series/test_monotonic.py
@@ -12,7 +12,7 @@ from tests.integ.utils.sql_counter import sql_count_checker
 
 
 @pytest.mark.parametrize(
-    "values", [[], [1], [3, 2], [1, 3, 2], [1, 2, 2], [1, np.NaN, 3]]
+    "values", [[], [1], [3, 2], [1, 3, 2], [1, 2, 2], [1, np.nan, 3]]
 )
 @sql_count_checker(query_count=1)
 def test_monotonic_increasing_numbers(values):
@@ -23,7 +23,7 @@ def test_monotonic_increasing_numbers(values):
 
 
 @pytest.mark.parametrize(
-    "values", [[], [3], [1, 2], [3, 1, 2], [2, 2, 1], [3, np.NaN, 1]]
+    "values", [[], [3], [1, 2], [3, 1, 2], [2, 2, 1], [3, np.nan, 1]]
 )
 @sql_count_checker(query_count=1)
 def test_monotonic_decreasing_numbers(values):

--- a/tests/integ/modin/series/test_to_list.py
+++ b/tests/integ/modin/series/test_to_list.py
@@ -31,7 +31,7 @@ def to_list_comparator(snow, native):
     [
         [1, 2, 3],
         ["a", "b", "c"],
-        [1.1, np.NaN],
+        [1.1, np.nan],
         [1.1, 2.2],
         [True, False],
         [True, False, None],


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2042660

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

To our surprise, modin 0.32.0 showed up in the Anaconda Snowflake channel today, and because the Snowsight package picker dropdown chooses the latest version of a package (ignoring solver constraints) by default, customers must currently manually select modin 0.30.1 to get the desired behavior.

Most changes are pretty minor, only thing worth noting is this version of modin officially includes support for numpy 2.0+, which causes some errors in tests using deprecated items like `np.NaN` (rather than `np.nan`).