### PR TITLE
SNOW-2044844: Fix preprod/qa6 iceberg failure

### DIFF
--- a/tests/integ/modin/io/test_read_snowflake_iceberg.py
+++ b/tests/integ/modin/io/test_read_snowflake_iceberg.py
@@ -11,15 +11,13 @@ from tests.integ.modin.utils import (
     assert_snowpark_pandas_equals_to_pandas_without_dtypecheck,
 )
 from tests.integ.utils.sql_counter import SqlCounter
-from tests.utils import Utils
+from tests.utils import Utils, iceberg_supported
 
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
-def test_read_snowflake_iceberg(session, enforce_ordering):
-    if "azure" in session.connection.host.split("."):
-        pytest.skip("This test doesn't work for Azure.")
-    if "gcp" in session.connection.host.split("."):
-        pytest.skip("This test doesn't work for GCP.")
+def test_read_snowflake_iceberg(session, enforce_ordering, local_testing_mode):
+    if not iceberg_supported(session, local_testing_mode):
+        pytest.skip("Test requires iceberg support.")
 
     with SqlCounter(query_count=2):
         # create iceberg table


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2044844

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

  Fix preprod/qa6 iceberg failure, where the following error was being raised:
  ```
  E       snowflake.snowpark.exceptions.SnowparkSQLException: (1304): 01bbadf1-0108-e88a-0001-122608a93082: 393921 (42601): External volume PYTHON_CONNECTOR_ICEBERG_EXVOL must have STORAGE_LOCATIONS defined.
  ```
