### PR TITLE
SNOW-2049277: Fix XML reader when an XML record has nested self-closing tag

### DIFF
--- a/src/snowflake/snowpark/_internal/xml_reader.py
+++ b/src/snowflake/snowpark/_internal/xml_reader.py
@@ -57,9 +57,11 @@ def tag_is_self_closing(
     chunk_size: int = DEFAULT_CHUNK_SIZE,
 ) -> Tuple[bool, int]:
     """
-    Return ``(is_self_closing, end_pos)`` for the opening tag at `start_pos`.
+    Return ``(is_self_closing, end_pos)`` after searching the terminating ``>`` .
     ``end_pos`` is the byte offset one past the terminating ``>`` of that
     same tag.
+    This method is quote-aware and will not consider a ``>`` inside a quote, e.g.,
+    ``<book title="a<b>c">``.
     """
     in_quote = False
     last_byte = b""

--- a/src/snowflake/snowpark/_internal/xml_reader.py
+++ b/src/snowflake/snowpark/_internal/xml_reader.py
@@ -6,12 +6,12 @@ import os
 import re
 import html.entities
 import logging
+import struct
 import xml.etree.ElementTree as ET
-from typing import Optional, Dict, Any, Iterator, BinaryIO, Union
+from typing import Optional, Dict, Any, Iterator, BinaryIO, Union, Tuple
 from snowflake.snowpark.files import SnowflakeFile
 
 
-SELF_CLOSING_TAG: bytes = b"/>"
 DEFAULT_CHUNK_SIZE: int = 1024
 
 
@@ -52,6 +52,36 @@ def get_file_size(filename: str) -> Optional[int]:
         return file_obj.tell()
 
 
+def tag_is_self_closing(
+    file_obj: Union[BinaryIO, SnowflakeFile],
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+) -> Tuple[bool, int]:
+    """
+    Return ``(is_self_closing, end_pos)`` for the opening tag at `start_pos`.
+    ``end_pos`` is the byte offset one past the terminating ``>`` of that
+    same tag.
+    """
+    in_quote = False
+    last_byte = b""
+
+    while True:
+        chunk_start_pos = file_obj.tell()
+        chunk = file_obj.read(chunk_size)
+        if not chunk:
+            raise EOFError("EOF reached before end of opening tag")
+
+        for idx, b in enumerate(struct.unpack(f"{len(chunk)}c", chunk)):
+            # '>' inside quote should not be considered as the end of the tag
+            if b == b'"':
+                in_quote = not in_quote
+            # '>' outside quotes
+            elif b == b">" and not in_quote:
+                is_self = last_byte == b"/"
+                absolute_pos = chunk_start_pos + idx + 1
+                return is_self, absolute_pos
+            last_byte = b
+
+
 def find_next_closing_tag_pos(
     file_obj: Union[BinaryIO, SnowflakeFile],
     closing_tag: bytes,
@@ -73,8 +103,7 @@ def find_next_closing_tag_pos(
     Raises:
         EOFError: If end of file is reached before finding a closing tag.
     """
-    # We'll use the maximum length among our tags as our overlap.
-    overlap_size = max(len(closing_tag), len(SELF_CLOSING_TAG))
+    overlap_size = len(closing_tag)
     # Ensure chunk_size is at least the overlap size + 2, which ensures no infinite loop.
     chunk_size = max(overlap_size + 2, chunk_size)
 
@@ -87,33 +116,13 @@ def find_next_closing_tag_pos(
         # If the chunk is smaller than the requested chunk_size, we may be at the file end.
         if len(chunk) < chunk_size:
             # Check if the tag exists in this last chunk.
-            if chunk.find(SELF_CLOSING_TAG) == -1 and chunk.find(closing_tag) == -1:
+            if chunk.find(closing_tag) == -1:
                 raise EOFError("Reached end of file before finding tag end")
         data = chunk
 
-        # Look for both self-closing and normal closing tag occurrences.
-        self_close_pos = data.find(SELF_CLOSING_TAG)
-        close_pos = data.find(closing_tag)
-
-        # Determine the earliest occurrence (if any).
-        chosen = None
-        tag_len = 0
-        if self_close_pos != -1 and close_pos != -1:
-            if self_close_pos < close_pos:
-                chosen = self_close_pos
-                tag_len = len(SELF_CLOSING_TAG)
-            else:
-                chosen = close_pos
-                tag_len = len(closing_tag)
-        elif self_close_pos != -1:
-            chosen = self_close_pos
-            tag_len = len(SELF_CLOSING_TAG)
-        elif close_pos != -1:
-            chosen = close_pos
-            tag_len = len(closing_tag)
-
-        if chosen is not None:
-            absolute_pos = file_obj.tell() - len(data) + chosen + tag_len
+        idx = data.find(closing_tag)
+        if idx != -1:
+            absolute_pos = file_obj.tell() - len(data) + idx + overlap_size
             file_obj.seek(absolute_pos)
             return absolute_pos
 
@@ -317,10 +326,23 @@ def process_xml_range(
 
             record_start = open_pos
             f.seek(record_start)
+
+            # decide whether the row element is self‑closing
             try:
-                record_end = find_next_closing_tag_pos(f, closing_tag, chunk_size)
+                is_self_close, tag_end = tag_is_self_closing(f, record_start)
             except EOFError:
+                # malformed XML record
                 break
+
+            if is_self_close:
+                record_end = tag_end
+            else:
+                f.seek(tag_end)
+                try:
+                    record_end = find_next_closing_tag_pos(f, closing_tag, chunk_size)
+                except EOFError:
+                    # incomplete XML record
+                    break
 
             # Read the complete XML record.
             f.seek(record_start)

--- a/src/snowflake/snowpark/_internal/xml_reader.py
+++ b/src/snowflake/snowpark/_internal/xml_reader.py
@@ -62,6 +62,8 @@ def tag_is_self_closing(
     same tag.
     This method is quote-aware and will not consider a ``>`` inside a quote, e.g.,
     ``<book title="a<b>c">``.
+    Note that There is no back‑slash escaping (\") inside XML attribute values.
+    If we want to embed a double‑quote inside a double‑quoted attribute, we must use the entity ``&quot;``.
     """
     in_quote = False
     quote_char = None

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -64,6 +64,7 @@ test_file_orc = "test.orc"
 test_file_xml = "test.xml"
 test_broken_csv = "broken.csv"
 test_file_books_xml = "books.xml"
+test_file_books2_xml = "books2.xml"
 test_file_house_xml = "fias_house.xml"
 test_file_house_large_xml = "fias_house.large.xml"
 test_file_xxe_xml = "xxe.xml"
@@ -244,6 +245,9 @@ def setup(session, resources_path, local_testing_mode):
     )
     Utils.upload_to_stage(
         session, "@" + tmp_stage_name1, test_files.test_books_xml, compress=False
+    )
+    Utils.upload_to_stage(
+        session, "@" + tmp_stage_name1, test_files.test_books2_xml, compress=False
     )
     Utils.upload_to_stage(
         session, "@" + tmp_stage_name1, test_files.test_house_xml, compress=False
@@ -1954,6 +1958,7 @@ def test_read_multiple_csvs(session):
     "file,row_tag,expected_row_count,expected_column_count",
     [
         [test_file_books_xml, "book", 12, 7],
+        [test_file_books2_xml, "book", 2, 6],
         [test_file_house_xml, "House", 37, 22],
         [test_file_house_large_xml, "House", 740, 22],
     ],

--- a/tests/resources/books2.xml
+++ b/tests/resources/books2.xml
@@ -1,0 +1,38 @@
+<library>
+  <book id="1">
+    <title>The Art of Snowflake</title>
+    <author>Jane Doe</author>
+    <price>29.99</price>
+    <reviews>
+      <review>
+        <user>tech_guru_87</user>
+        <rating>5</rating>
+        <comment>Very insightful and practical.</comment>
+      </review>
+      <review>
+        <user>datawizard</user>
+        <rating>4</rating>
+        <comment>Great read for data engineers.</comment>
+      </review>
+    </reviews>
+    <editions>
+      <edition year="2023" format="Hardcover"/>
+      <edition year="2024" format="eBook"/>
+    </editions>
+  </book>
+  <book id="2">
+    <title>XML for Data Engineers</title>
+    <author>John Smith</author>
+    <price>35.50</price>
+    <reviews>
+      <review>
+        <user>xml_master</user>
+        <rating>5</rating>
+        <comment>Perfect for mastering XML parsing.</comment>
+      </review>
+    </reviews>
+    <editions>
+      <edition year="2022" format="Paperback"/>
+    </editions>
+  </book>
+</library>

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -277,6 +277,7 @@ def test_zip_file_or_directory_to_stream():
             [
                 "resources/",
                 "resources/books.xml",
+                "resources/books2.xml",
                 "resources/broken.csv",
                 "resources/diamonds.csv",
                 "resources/fias_house.xml",

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -14,7 +14,7 @@ from snowflake.snowpark._internal.xml_reader import (
     strip_namespaces,
     find_next_closing_tag_pos,
     find_next_opening_tag_pos,
-    SELF_CLOSING_TAG,
+    tag_is_self_closing,
     DEFAULT_CHUNK_SIZE,
 )
 
@@ -165,28 +165,6 @@ def test_find_next_closing_tag_pos_normal(chunk_size):
 
 
 @pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])
-def test_find_next_closing_tag_pos_self_closing(chunk_size):
-    # Test a self-closing tag.
-    record = b"<row attr='value'/> trailing content"
-    file_obj = io.BytesIO(record)
-    closing_tag = b"</row>"  # Function should detect the self-closing tag.
-    pos = find_next_closing_tag_pos(file_obj, closing_tag, chunk_size=chunk_size)
-    expected_pos = record.find(SELF_CLOSING_TAG) + len(SELF_CLOSING_TAG)
-    assert pos == expected_pos
-
-
-@pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])
-def test_find_next_closing_tag_pos_both_variants(chunk_size):
-    # When both self-closing and full closing tags exist, the earliest occurrence should be chosen.
-    record = b"start <row attr='value'/> some text </row> end"
-    file_obj = io.BytesIO(record)
-    closing_tag = b"</row>"
-    pos = find_next_closing_tag_pos(file_obj, closing_tag, chunk_size=chunk_size)
-    expected_pos = record.find(SELF_CLOSING_TAG) + len(SELF_CLOSING_TAG)
-    assert pos == expected_pos
-
-
-@pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])
 def test_find_next_closing_tag_pos_split(chunk_size):
     # Simulate a closing tag (</row>) split across chunk boundaries.
     part1 = b"data <row>some content</ro"
@@ -208,6 +186,45 @@ def test_find_next_closing_tag_pos_no_tag(chunk_size):
     closing_tag = b"</row>"
     with pytest.raises(EOFError):
         find_next_closing_tag_pos(file_obj, closing_tag, chunk_size=chunk_size)
+
+
+@pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])
+def test_tag_not_self_closing(chunk_size):
+    record = b'<row attr="abc">payload</row>'
+    f = io.BytesIO(record)
+    is_self, end_pos = tag_is_self_closing(f, chunk_size=chunk_size)
+    assert is_self is False
+    assert end_pos == record.find(b">") + 1
+
+
+@pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])
+def test_tag_self_closing(chunk_size):
+    record = b'<row attr="abc"/> trailing text'
+    f = io.BytesIO(record)
+    is_self, end_pos = tag_is_self_closing(f, chunk_size=chunk_size)
+    assert is_self is True
+    assert end_pos == record.find(b">") + 1
+
+
+@pytest.mark.parametrize("chunk_size", [1, 4, 8, DEFAULT_CHUNK_SIZE])
+def test_tag_with_gt_inside_quotes(chunk_size):
+    record = b'<row note="1 > 0" id="42">content</row>'
+    f = io.BytesIO(record)
+    is_self, end_pos = tag_is_self_closing(f, chunk_size=chunk_size)
+    assert is_self is False
+    # '>' before 'content' is the correct end pos
+    assert end_pos == record.find(b"content")
+
+
+@pytest.mark.parametrize("chunk_size", [2, 5])
+def test_tag_split_across_chunks(chunk_size):
+    record = (
+        b'<row verylongattribute="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"/>' b" tail"
+    )
+    f = io.BytesIO(record)
+    is_self, end_pos = tag_is_self_closing(f, chunk_size=chunk_size)
+    assert is_self is True
+    assert end_pos == record.find(b">") + 1
 
 
 @pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -199,7 +199,16 @@ def test_tag_not_self_closing(chunk_size):
 
 @pytest.mark.parametrize("chunk_size", [3, 10, DEFAULT_CHUNK_SIZE])
 def test_tag_self_closing(chunk_size):
-    record = b'<row attr="abc"/> trailing text'
+    record = b'<row attr1="abc" attr2="cde"/> trailing text'
+    f = io.BytesIO(record)
+    is_self, end_pos = tag_is_self_closing(f, chunk_size=chunk_size)
+    assert is_self is True
+    assert end_pos == record.find(b">") + 1
+
+
+@pytest.mark.parametrize("chunk_size", [2, 5, DEFAULT_CHUNK_SIZE])
+def test_tag_with_mixed_quote_chars_self_closing(chunk_size):
+    record = b"<row note='She said \"Hi\"'/> trailing"
     f = io.BytesIO(record)
     is_self, end_pos = tag_is_self_closing(f, chunk_size=chunk_size)
     assert is_self is True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1534,6 +1534,10 @@ class TestFiles:
         return os.path.join(self.resources_path, "books.xml")
 
     @property
+    def test_books2_xml(self):
+        return os.path.join(self.resources_path, "books2.xml")
+
+    @property
     def test_house_xml(self):
         return os.path.join(self.resources_path, "fias_house.xml")
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2049277

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   For such an XML record:
   ```
   <a>
      <b .../>
   </a>
   ```
   The original implementation will fail because we look for the self-closing tag right away. This PR fixes this bug by looking for a ">" directly after the opening tag. 
