### PR TITLE
SNOW-2049599 Fix missing publicapi decorators and don't send dataframeAST if ast_enabled is set.

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -57,6 +57,7 @@ from snowflake.snowpark._internal.utils import (
     create_rlock,
     create_thread_local,
     escape_quotes,
+    is_ast_enabled,
     get_application_name,
     get_version,
     is_in_stored_procedure,
@@ -430,7 +431,7 @@ class ServerConnection:
         self, query: str, **kwargs: Any
     ) -> SnowflakeCursor:
         notify_kwargs = {}
-        if DATAFRAME_AST_PARAMETER in kwargs:
+        if DATAFRAME_AST_PARAMETER in kwargs and is_ast_enabled():
             notify_kwargs["dataframeAst"] = kwargs[DATAFRAME_AST_PARAMETER]
 
         try:

--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -826,6 +826,7 @@ class Column:
 
     # Note: For the operator overrides we always emit ast, it simply gets ignored in a call chain.
 
+    @publicapi
     def __neg__(self) -> "Column":
         """Unary minus."""
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -4732,6 +4732,7 @@ class DataFrame:
             + line
         )
 
+    @publicapi
     def _show_string_spark(
         self,
         num_rows: int = 20,

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -611,6 +611,7 @@ class DataFrameWriter:
             **copy_options,
         )
 
+
     def _internal_copy_into_location(
         self,
         caller: str,

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -611,7 +611,6 @@ class DataFrameWriter:
             **copy_options,
         )
 
-
     def _internal_copy_into_location(
         self,
         caller: str,

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -81,7 +81,7 @@ class WhenMatchedClause:
         condition: An optional :class:`Column` object representing the
             specified condition. For example, ``col("a") == 1``.
     """
-
+    @publicapi
     def __init__(
         self, condition: Optional[Column] = None, _emit_ast: bool = True
     ) -> None:
@@ -178,7 +178,7 @@ class WhenNotMatchedClause:
         condition: An optional :class:`Column` object representing the
             specified condition.
     """
-
+    @publicapi
     def __init__(
         self, condition: Optional[Column] = None, _emit_ast: bool = True
     ) -> None:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2049599 Fix missing publicapi decorators and don't send dataframeAST if ast_enabled is set

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
