### PR TITLE
SNOW-1708651: Keep original exception for invalid identifier message

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 
 import snowflake.connector
 import snowflake.snowpark
-from snowflake.connector.errors import ProgrammingError
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
     TEMPORARY_STRING_SET,
@@ -273,8 +272,9 @@ class SnowflakePlan(LogicalPlan):
                                         match = [identifier]
                                     msg = f"{msg}\nDo you mean {' or '.join(add_single_quote(q) for q in match)}?"
 
+                            e.msg = f"{e.msg}\n{msg}"
                             ne = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
-                                ProgrammingError(msg=f"{e.msg}\n{msg}")
+                                e
                             )
                             raise ne.with_traceback(tb) from None
                     else:

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -439,6 +439,7 @@ def test_invalid_identifier_error_message(session):
     df = session.create_dataframe([[1, 2, 3]], schema=['"abc"', '"abd"', '"def"'])
     with pytest.raises(SnowparkSQLException) as ex:
         df.select("abc").collect()
+    assert ex.value.sql_error_code == 904
     assert "invalid identifier 'ABC'" in str(ex.value)
     assert (
         "There are existing quoted column identifiers: ['\"abc\"', '\"abd\"', '\"def\"']"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1708651

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   We shouldn't create a new ProgrammingError. 
