### PR TITLE
SNOW-2046103: Fix no pandas and AST daily test failures

### DIFF
--- a/tests/ast/test_ast_driver.py
+++ b/tests/ast/test_ast_driver.py
@@ -95,11 +95,15 @@ def load_test_cases():
     Returns: a list of test cases.
     """
     test_files = DATA_DIR.glob("*.test")
-    if sys.version_info[0] == 3 and sys.version_info[1] < 9:
+    major_version, minor_version = sys.version_info[0], sys.version_info[1]
+    if major_version == 3 and minor_version < 9:
         # Remove the `to_snowpark_pandas` test since Snowpark pandas is only supported in Python 3.9+.
         test_files = filter(
             lambda file: "to_snowpark_pandas" not in file.name, test_files
         )
+    if major_version == 3 and minor_version == 12:
+        # Skip df_copy when run in Python 3.12 due to differences in reported source positions.
+        test_files = filter(lambda file: "df_copy" not in file.name, test_files)
     return [parse_file(file) for file in test_files]
 
 

--- a/tests/integ/test_df_to_snowpark_pandas.py
+++ b/tests/integ/test_df_to_snowpark_pandas.py
@@ -40,6 +40,13 @@ def tmp_table_basic(session):
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_to_snowpark_pandas_no_modin(session, tmp_table_basic, enforce_ordering):
     snowpark_df = session.table(tmp_table_basic)
+    # If pandas isn't installed, then an error is raised immediately.
+    try:
+        import pandas  # noqa: F401
+    except ModuleNotFoundError:
+        with pytest.raises(ModuleNotFoundError, match="No module named 'pandas'"):
+            snowpark_df.to_snowpark_pandas(enforce_ordering=enforce_ordering)
+        return
     # Check if modin is installed (if so, we're running in Snowpark pandas; if not, we're just in Snowpark Python)
     try:
         import modin  # noqa: F401


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2046103

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Fixes a failure in the daily test that occurs when pandas is not installed due to an incorrect expected error message.

Also skips `test_ast[df_copy.test]` in Python 3.12 environments ([slack discussion](https://snowflake.slack.com/archives/C06UKGN5HJP/p1745344602123719?thread_ts=1744840132.805579&cid=C06UKGN5HJP)).

Relevant daily tests passing: https://github.com/snowflakedb/snowpark-python/actions/runs/14601741926/job/40961489775 (failures are either unrelated or transient).