### PR TITLE
SNOW-2036949: Sync artifact repositry ast changes

### DIFF
--- a/src/snowflake/snowpark/_internal/ast/utils.py
+++ b/src/snowflake/snowpark/_internal/ast/utils.py
@@ -1143,6 +1143,9 @@ def build_udf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function i
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
     comment: Optional[str] = None,
+    artifact_repository: Optional[str] = None,
+    artifact_repository_packages: Optional[List[str]] = None,
+    resource_constraint: Optional[Dict[str, str]] = None,
     statement_params: Optional[Dict[str, str]] = None,
     source_code_display: bool = True,
     is_permanent: bool = False,
@@ -1209,6 +1212,19 @@ def build_udf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function i
     ast.immutable = immutable
     if comment is not None:
         ast.comment.value = comment
+    if artifact_repository is not None:
+        ast.artifact_repository.value = artifact_repository
+    if (
+        artifact_repository_packages is not None
+        and len(artifact_repository_packages) != 0
+    ):
+        for package in artifact_repository_packages:
+            ast.artifact_repository_packages.append(package)
+    if resource_constraint is not None and len(resource_constraint) != 0:
+        for k, v in resource_constraint.items():
+            t = ast.resource_constraint.add()
+            t._1 = k
+            t._2 = v
     sorted_kwargs = dict(sorted(kwargs.items()))
     for k, v in sorted_kwargs.items():
         t = ast.kwargs.add()  # type: ignore[assignment] # TODO(SNOW-1491199) # Incompatible types in assignment (expression has type "Tuple_String_Expr", variable has type "Tuple_String_String")
@@ -1233,6 +1249,9 @@ def build_udaf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function 
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
     comment: Optional[str] = None,
+    artifact_repository: Optional[str] = None,
+    artifact_repository_packages: Optional[List[str]] = None,
+    resource_constraint: Optional[Dict[str, str]] = None,
     statement_params: Optional[Dict[str, str]] = None,
     is_permanent: bool = False,
     session: "snowflake.snowpark.session.Session" = None,
@@ -1293,6 +1312,19 @@ def build_udaf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function 
     ast.immutable = immutable
     if comment is not None:
         ast.comment.value = comment
+    if artifact_repository is not None:
+        ast.artifact_repository.value = artifact_repository
+    if (
+        artifact_repository_packages is not None
+        and len(artifact_repository_packages) != 0
+    ):
+        for package in artifact_repository_packages:
+            ast.artifact_repository_packages.append(package)
+    if resource_constraint is not None and len(resource_constraint) != 0:
+        for k, v in resource_constraint.items():
+            t = ast.resource_constraint.add()
+            t._1 = k
+            t._2 = v
     sorted_kwargs = dict(sorted(kwargs.items()))
     for k, v in sorted_kwargs.items():
         t = ast.kwargs.add()  # type: ignore[assignment] # TODO(SNOW-1491199) # Incompatible types in assignment (expression has type "Tuple_String_Expr", variable has type "Tuple_String_String")
@@ -1322,6 +1354,9 @@ def build_udtf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function 
     secrets: Optional[Dict[str, str]] = None,
     immutable: bool = False,
     comment: Optional[str] = None,
+    artifact_repository: Optional[str] = None,
+    artifact_repository_packages: Optional[List[str]] = None,
+    resource_constraint: Optional[Dict[str, str]] = None,
     statement_params: Optional[Dict[str, str]] = None,
     is_permanent: bool = False,
     session: "snowflake.snowpark.session.Session" = None,
@@ -1392,6 +1427,19 @@ def build_udtf(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function 
     ast.immutable = immutable
     if comment is not None:
         ast.comment.value = comment
+    if artifact_repository is not None:
+        ast.artifact_repository.value = artifact_repository
+    if (
+        artifact_repository_packages is not None
+        and len(artifact_repository_packages) != 0
+    ):
+        for package in artifact_repository_packages:
+            ast.artifact_repository_packages.append(package)
+    if resource_constraint is not None and len(resource_constraint) != 0:
+        for k, v in resource_constraint.items():
+            t = ast.resource_constraint.add()
+            t._1 = k
+            t._2 = v
     sorted_kwargs = dict(sorted(kwargs.items()))
     for k, v in sorted_kwargs.items():
         t = ast.kwargs.add()  # type: ignore[assignment] # TODO(SNOW-1491199) # Incompatible types in assignment (expression has type "Tuple_String_Expr", variable has type "Tuple_String_String")
@@ -1445,6 +1493,9 @@ def build_sproc(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function
     execute_as: typing.Literal["caller", "owner", "restricted caller"] = "owner",
     source_code_display: bool = True,
     is_permanent: bool = False,
+    artifact_repository: Optional[str] = None,
+    artifact_repository_packages: Optional[List[str]] = None,
+    resource_constraint: Optional[Dict[str, str]] = None,
     session: "snowflake.snowpark.session.Session" = None,
     _registered_object_name: Optional[Union[str, Iterable[str]]] = None,
     **kwargs,
@@ -1507,6 +1558,19 @@ def build_sproc(  # type: ignore[no-untyped-def] # TODO(SNOW-1491199) # Function
             t._2 = v
     if comment is not None:
         ast.comment.value = comment
+    if artifact_repository is not None:
+        ast.artifact_repository.value = artifact_repository
+    if (
+        artifact_repository_packages is not None
+        and len(artifact_repository_packages) != 0
+    ):
+        for package in artifact_repository_packages:
+            ast.artifact_repository_packages.append(package)
+    if resource_constraint is not None and len(resource_constraint) != 0:
+        for k, v in resource_constraint.items():
+            t = ast.resource_constraint.add()
+            t._1 = k
+            t._2 = v
     sorted_kwargs = dict(sorted(kwargs.items()))
     for k, v in sorted_kwargs.items():
         t = ast.kwargs.add()  # type: ignore[assignment] # TODO(SNOW-1491199) # Incompatible types in assignment (expression has type "Tuple_String_Expr", variable has type "Tuple_String_String")

--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -337,7 +337,7 @@ message TimestampTimeZone {
   }
 }
 
-// fn.ir:83
+// fn.ir:89
 message UdtfSchema {
   oneof sealed_value {
     UdtfSchema_Names udtf_schema__names = 1;
@@ -345,12 +345,12 @@ message UdtfSchema {
   }
 }
 
-// fn.ir:84
+// fn.ir:90
 message UdtfSchema_Type {
   DataType return_type = 1;
 }
 
-// fn.ir:85
+// fn.ir:91
 message UdtfSchema_Names {
   repeated string schema = 1;
 }
@@ -493,7 +493,7 @@ message BuiltinFn {
   SrcPosition src = 2;
 }
 
-// fn.ir:141
+// fn.ir:153
 message CallTableFunctionExpr {
   NameRef name = 1;
   SrcPosition src = 2;
@@ -1792,13 +1792,13 @@ message HasSrcPosition {
   }
 }
 
-// fn.ir:137
+// fn.ir:149
 message IndirectTableFnIdRef {
   int64 id = 1;
   SrcPosition src = 2;
 }
 
-// fn.ir:133
+// fn.ir:145
 message IndirectTableFnNameRef {
   NameRef name = 1;
   SrcPosition src = 2;
@@ -2152,27 +2152,30 @@ message Stmt {
 
 // fn.ir:37
 message StoredProcedure {
-  google.protobuf.StringValue comment = 1;
-  string execute_as = 2;
-  repeated string external_access_integrations = 3;
-  Callable func = 4;
-  bool if_not_exists = 5;
-  repeated NameRef imports = 6;
-  repeated DataType input_types = 7;
-  bool is_permanent = 8;
-  repeated Tuple_String_Expr kwargs = 9;
-  google.protobuf.BoolValue log_on_exception = 10;
-  NameRef name = 11;
-  repeated string packages = 12;
-  int64 parallel = 13;
-  bool replace = 14;
-  DataType return_type = 15;
-  repeated Tuple_String_String secrets = 16;
-  bool source_code_display = 17;
-  SrcPosition src = 18;
-  string stage_location = 19;
-  repeated Tuple_String_String statement_params = 20;
-  bool strict = 21;
+  google.protobuf.StringValue artifact_repository = 1;
+  repeated string artifact_repository_packages = 2;
+  google.protobuf.StringValue comment = 3;
+  string execute_as = 4;
+  repeated string external_access_integrations = 5;
+  Callable func = 6;
+  bool if_not_exists = 7;
+  repeated NameRef imports = 8;
+  repeated DataType input_types = 9;
+  bool is_permanent = 10;
+  repeated Tuple_String_Expr kwargs = 11;
+  google.protobuf.BoolValue log_on_exception = 12;
+  NameRef name = 13;
+  repeated string packages = 14;
+  int64 parallel = 15;
+  bool replace = 16;
+  repeated Tuple_String_String resource_constraint = 17;
+  DataType return_type = 18;
+  repeated Tuple_String_String secrets = 19;
+  bool source_code_display = 20;
+  SrcPosition src = 21;
+  string stage_location = 22;
+  repeated Tuple_String_String statement_params = 23;
+  bool strict = 24;
 }
 
 // const.ir:41
@@ -2212,14 +2215,14 @@ message TableDropTable {
   SrcPosition src = 2;
 }
 
-// fn.ir:157
+// fn.ir:169
 message TableFnCallAlias {
   ExprArgList aliases = 1;
   Expr lhs = 2;
   SrcPosition src = 3;
 }
 
-// fn.ir:151
+// fn.ir:163
 message TableFnCallOver {
   Expr lhs = 1;
   ExprArgList order_by = 2;
@@ -2284,76 +2287,85 @@ message TupleVal {
   repeated Expr vs = 2;
 }
 
-// fn.ir:112
+// fn.ir:121
 message Udaf {
-  google.protobuf.StringValue comment = 1;
-  repeated string external_access_integrations = 2;
-  Callable handler = 3;
-  bool if_not_exists = 4;
-  bool immutable = 5;
-  repeated NameRef imports = 6;
-  repeated DataType input_types = 7;
-  bool is_permanent = 8;
-  repeated Tuple_String_Expr kwargs = 9;
-  NameRef name = 10;
-  repeated string packages = 11;
-  int64 parallel = 12;
-  bool replace = 13;
-  DataType return_type = 14;
-  repeated Tuple_String_String secrets = 15;
-  SrcPosition src = 16;
-  google.protobuf.StringValue stage_location = 17;
-  repeated Tuple_String_String statement_params = 18;
-}
-
-// fn.ir:60
-message Udf {
-  google.protobuf.StringValue comment = 1;
-  repeated string external_access_integrations = 2;
-  Callable func = 3;
-  bool if_not_exists = 4;
-  bool immutable = 5;
-  repeated NameRef imports = 6;
-  repeated DataType input_types = 7;
-  bool is_permanent = 8;
-  repeated Tuple_String_Expr kwargs = 9;
-  google.protobuf.Int64Value max_batch_size = 10;
-  NameRef name = 11;
-  repeated string packages = 12;
-  int64 parallel = 13;
-  bool replace = 14;
-  DataType return_type = 15;
-  repeated Tuple_String_String secrets = 16;
-  bool secure = 17;
-  bool source_code_display = 18;
+  google.protobuf.StringValue artifact_repository = 1;
+  repeated string artifact_repository_packages = 2;
+  google.protobuf.StringValue comment = 3;
+  repeated string external_access_integrations = 4;
+  Callable handler = 5;
+  bool if_not_exists = 6;
+  bool immutable = 7;
+  repeated NameRef imports = 8;
+  repeated DataType input_types = 9;
+  bool is_permanent = 10;
+  repeated Tuple_String_Expr kwargs = 11;
+  NameRef name = 12;
+  repeated string packages = 13;
+  int64 parallel = 14;
+  bool replace = 15;
+  repeated Tuple_String_String resource_constraint = 16;
+  DataType return_type = 17;
+  repeated Tuple_String_String secrets = 18;
   SrcPosition src = 19;
-  string stage_location = 20;
+  google.protobuf.StringValue stage_location = 20;
   repeated Tuple_String_String statement_params = 21;
-  bool strict = 22;
 }
 
-// fn.ir:89
+// fn.ir:63
+message Udf {
+  google.protobuf.StringValue artifact_repository = 1;
+  repeated string artifact_repository_packages = 2;
+  google.protobuf.StringValue comment = 3;
+  repeated string external_access_integrations = 4;
+  Callable func = 5;
+  bool if_not_exists = 6;
+  bool immutable = 7;
+  repeated NameRef imports = 8;
+  repeated DataType input_types = 9;
+  bool is_permanent = 10;
+  repeated Tuple_String_Expr kwargs = 11;
+  google.protobuf.Int64Value max_batch_size = 12;
+  NameRef name = 13;
+  repeated string packages = 14;
+  int64 parallel = 15;
+  bool replace = 16;
+  repeated Tuple_String_String resource_constraint = 17;
+  DataType return_type = 18;
+  repeated Tuple_String_String secrets = 19;
+  bool secure = 20;
+  bool source_code_display = 21;
+  SrcPosition src = 22;
+  string stage_location = 23;
+  repeated Tuple_String_String statement_params = 24;
+  bool strict = 25;
+}
+
+// fn.ir:95
 message Udtf {
-  google.protobuf.StringValue comment = 1;
-  repeated string external_access_integrations = 2;
-  Callable handler = 3;
-  bool if_not_exists = 4;
-  bool immutable = 5;
-  repeated NameRef imports = 6;
-  repeated DataType input_types = 7;
-  bool is_permanent = 8;
-  repeated Tuple_String_Expr kwargs = 9;
-  NameRef name = 10;
-  UdtfSchema output_schema = 11;
-  repeated string packages = 12;
-  int64 parallel = 13;
-  bool replace = 14;
-  repeated Tuple_String_String secrets = 15;
-  bool secure = 16;
-  SrcPosition src = 17;
-  string stage_location = 18;
-  repeated Tuple_String_String statement_params = 19;
-  bool strict = 20;
+  google.protobuf.StringValue artifact_repository = 1;
+  repeated string artifact_repository_packages = 2;
+  google.protobuf.StringValue comment = 3;
+  repeated string external_access_integrations = 4;
+  Callable handler = 5;
+  bool if_not_exists = 6;
+  bool immutable = 7;
+  repeated NameRef imports = 8;
+  repeated DataType input_types = 9;
+  bool is_permanent = 10;
+  repeated Tuple_String_Expr kwargs = 11;
+  NameRef name = 12;
+  UdtfSchema output_schema = 13;
+  repeated string packages = 14;
+  int64 parallel = 15;
+  bool replace = 16;
+  repeated Tuple_String_String resource_constraint = 17;
+  repeated Tuple_String_String secrets = 18;
+  bool secure = 19;
+  SrcPosition src = 20;
+  string stage_location = 21;
+  repeated Tuple_String_String statement_params = 22;
+  bool strict = 23;
 }
 
 message UnaryOp {

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -60,7 +60,7 @@ res14 = df.group_by("a").count()
 
 df = session.create_dataframe([("SF", 21.0), ("SF", 17.5), ("SF", 24.0), ("NY", 30.9), ("NY", 33.6)], schema=["location", "temp_c"])
 
-res16 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+res16 = udtf("_ApplyInPandas", output_schema=PandasDataFrameType(StringType(), FloatType(), FloatType(), "LOCATION", "TEMP_C", "TEMP_F"), input_types=[StringType(), FloatType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.group_by("location").apply_in_pandas(convert, StructType(fields=[StructField("location", StringType(), nullable=True), StructField("temp_c", FloatType(), nullable=True), StructField("temp_f", FloatType(), nullable=True)], structured=False), input_types=[StringType(), FloatType()], input_names=["LOCATION", "TEMP_C"]).sort("temp_c").collect()
 
@@ -2059,51 +2059,9 @@ body {
           float_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 75
-                end_line: 50
-                file: 2
-                start_column: 8
-                start_line: 47
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 75
-                end_line: 50
-                file: 2
-                start_column: 8
-                start_line: 47
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 75
-                end_line: 50
-                file: 2
-                start_column: 8
-                start_line: 47
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 75
                 end_line: 50

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -13,7 +13,7 @@ df2 = session.call("my_sproc", 2, "one", dict(), False)
 
 ## EXPECTED UNPARSER OUTPUT
 
-my_sproc_sp = sproc("my_sproc", return_type=StringType(), input_types=[LongType(), StringType(), MapType(StringType(), StringType(), structured=False), BooleanType()], name="my_sproc", replace=True, comment="The parameters are useless.", artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_SPROC\"")
+my_sproc_sp = sproc("my_sproc", return_type=StringType(), input_types=[LongType(), StringType(), MapType(StringType(), StringType(), structured=False), BooleanType()], name="my_sproc", replace=True, comment="The parameters are useless.", _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_SPROC\"")
 
 df = session.call("my_sproc", 1, "two", {"param1": 10, "param2": "twenty"}, True)
 
@@ -79,48 +79,6 @@ body {
         }
         input_types {
           boolean_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 124
-                end_line: 30
-                file: 2
-                start_column: 22
-                start_line: 30
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 124
-                end_line: 30
-                file: 2
-                start_column: 22
-                start_line: 30
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 124
-                end_line: 30
-                file: 2
-                start_column: 22
-                start_line: 30
-              }
-            }
-          }
         }
         name {
           name {

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -32,9 +32,9 @@ df7 = session.table_function(fn4)
 
 ## EXPECTED UNPARSER OUTPUT
 
-my_sproc_sp = sproc("my_sproc", return_type=StringType(), input_types=[LongType(), StringType(), BooleanType()], name="my_fn1", replace=True, comment="The parameters are useless.", artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_FN1\"")
+my_sproc_sp = sproc("my_sproc", return_type=StringType(), input_types=[LongType(), StringType(), BooleanType()], name="my_fn1", replace=True, comment="The parameters are useless.", _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_FN1\"")
 
-my_sproc_sp2 = sproc("my_sproc", return_type=StringType(), input_types=[LongType(), StringType(), BooleanType()], name="my_fn2", replace=True, comment="Hello!", artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_FN2\"")
+my_sproc_sp2 = sproc("my_sproc", return_type=StringType(), input_types=[LongType(), StringType(), BooleanType()], name="my_fn2", replace=True, comment="Hello!", _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_FN2\"")
 
 df1 = session.table_function("my_fn1", lit(1), lit("two"), lit(True))
 
@@ -90,48 +90,6 @@ body {
         }
         input_types {
           boolean_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 122
-                end_line: 33
-                file: 2
-                start_column: 22
-                start_line: 33
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 122
-                end_line: 33
-                file: 2
-                start_column: 22
-                start_line: 33
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 122
-                end_line: 33
-                file: 2
-                start_column: 22
-                start_line: 33
-              }
-            }
-          }
         }
         name {
           name {
@@ -194,48 +152,6 @@ body {
         }
         input_types {
           boolean_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 102
-                end_line: 35
-                file: 2
-                start_column: 23
-                start_line: 35
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 102
-                end_line: 35
-                file: 2
-                start_column: 23
-                start_line: 35
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 102
-                end_line: 35
-                file: 2
-                start_column: 23
-                start_line: 35
-              }
-            }
-          }
         }
         name {
           name {

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -96,7 +96,7 @@ mod5_pandas_udf = udf("pandas_apply_mod5", return_type=IntegerType(), input_type
 
 df.select(mod5_pandas_udf("a"), mod5_pandas_udf("b")).collect()
 
-res10 = udf("test_urllib", return_type=StringType(), name="artifact_repository_udf", artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPOSITORY_UDF\"")
+res10 = udf("test_urllib", return_type=StringType(), name="artifact_repository_udf", artifact_repository="EXAMPLE_REPO", artifact_repository_packages=["urllib3", "requests"], resource_constraint={"architecture": "x86"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPOSITORY_UDF\"")
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -50,9 +50,23 @@ mod5_pandas_udf = session.udf.register_from_file(
 )
 df.select(mod5_pandas_udf("a"), mod5_pandas_udf("b")).collect()
 
+# Test artifact_repository parameters
+def test_urllib() -> str:
+    import urllib3
+
+    return str(urllib3.exceptions.HTTPError("test"))
+
+udf(
+    func=test_urllib,
+    name="artifact_repository_udf",
+    artifact_repository="EXAMPLE_REPO",
+    artifact_repository_packages=["urllib3", "requests"],
+    resource_constraint={"architecture": "x86"},
+)
+
 ## EXPECTED UNPARSER OUTPUT
 
-add_one = udf("<lambda>", return_type=IntegerType(), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
+add_one = udf("<lambda>", return_type=IntegerType(), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
 
 df = session.create_dataframe([1, 2, 3], schema=["a"])
 
@@ -60,27 +74,29 @@ df.select(add_one(col("a")).as_("ans")).collect()
 
 df = session.create_dataframe([1, 2, 3], schema=["a"])
 
-add_two = udf("<lambda [1]>", return_type=IntegerType(), input_types=[IntegerType()], name="add_two", replace=True, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ADD_TWO\"")
+add_two = udf("<lambda [1]>", return_type=IntegerType(), input_types=[IntegerType()], name="add_two", replace=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ADD_TWO\"")
 
 df.select(call_udf("add_two", col("A")).as_("a_Ans")).collect()
 
 df = session.create_dataframe([1, 2, 3], schema=["a"])
 
-param_udf = udf("<lambda [2]>", return_type=VariantType(), input_types=[IntegerType(), FloatType()], name="param_udf", is_permanent=True, stage_location="@", imports=["numpy"], packages=["bla"], replace=True, parallel=8, max_batch_size=2, source_code_display=False, strict=True, secure=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, immutable=True, comment="some udf", artifact_repository=None, artifact_repository_packages=None, force_inline_code=True, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"PARAM_UDF\"")
+param_udf = udf("<lambda [2]>", return_type=VariantType(), input_types=[IntegerType(), FloatType()], name="param_udf", is_permanent=True, stage_location="@", imports=["numpy"], packages=["bla"], replace=True, parallel=8, max_batch_size=2, source_code_display=False, strict=True, secure=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, immutable=True, comment="some udf", force_inline_code=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"PARAM_UDF\"")
 
-param_udf2 = udf("<lambda [3]>", return_type=VariantType(), input_types=[IntegerType(), FloatType()], name="param_udf2", is_permanent=True, stage_location="@", imports=["numpy"], packages=["bla"], if_not_exists=True, parallel=8, max_batch_size=2, source_code_display=False, strict=True, secure=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, immutable=True, comment="some udf", artifact_repository=None, artifact_repository_packages=None, force_inline_code=True, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"PARAM_UDF2\"")
+param_udf2 = udf("<lambda [3]>", return_type=VariantType(), input_types=[IntegerType(), FloatType()], name="param_udf2", is_permanent=True, stage_location="@", imports=["numpy"], packages=["bla"], if_not_exists=True, parallel=8, max_batch_size=2, source_code_display=False, strict=True, secure=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, immutable=True, comment="some udf", force_inline_code=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"PARAM_UDF2\"")
 
 res5 = df.select(param_udf(col("A"), col("A")))
 
-mod5_udf = udf("mod5", return_type=IntegerType(), input_types=[IntegerType()], max_batch_size=0, immutable=True, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
+mod5_udf = udf("mod5", return_type=IntegerType(), input_types=[IntegerType()], max_batch_size=0, immutable=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
 
 df.select(mod5_udf("a"), mod5_udf("b")).collect()
 
 df = session.create_dataframe([1, 2, 3], schema=["a"])
 
-mod5_pandas_udf = udf("pandas_apply_mod5", return_type=IntegerType(), input_types=[IntegerType()], max_batch_size=0, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
+mod5_pandas_udf = udf("pandas_apply_mod5", return_type=IntegerType(), input_types=[IntegerType()], max_batch_size=0, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_FUNCTION_xxx\"")
 
 df.select(mod5_pandas_udf("a"), mod5_pandas_udf("b")).collect()
+
+res10 = udf("test_urllib", return_type=StringType(), name="artifact_repository_udf", artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPOSITORY_UDF\"")
 
 ## EXPECTED ENCODED AST
 
@@ -109,48 +125,6 @@ body {
         }
         input_types {
           integer_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 94
-                end_line: 29
-                file: 2
-                start_column: 18
-                start_line: 29
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 94
-                end_line: 29
-                file: 2
-                start_column: 18
-                start_line: 29
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 94
-                end_line: 29
-                file: 2
-                start_column: 18
-                start_line: 29
-              }
-            }
-          }
         }
         parallel: 4
         return_type {
@@ -444,48 +418,6 @@ body {
         input_types {
           integer_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 124
-                end_line: 37
-                file: 2
-                start_column: 18
-                start_line: 37
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 124
-                end_line: 37
-                file: 2
-                start_column: 18
-                start_line: 37
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 124
-                end_line: 37
-                file: 2
-                start_column: 18
-                start_line: 37
-              }
-            }
-          }
-        }
         name {
           name {
             name_flat {
@@ -756,34 +688,6 @@ body {
         }
         is_permanent: true
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 83
-                end_line: 45
-                file: 2
-                start_column: 20
-                start_line: 41
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 83
-                end_line: 45
-                file: 2
-                start_column: 20
-                start_line: 41
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "force_inline_code"
           _2 {
             bool_val {
@@ -795,20 +699,6 @@ body {
                 start_line: 41
               }
               v: true
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 83
-                end_line: 45
-                file: 2
-                start_column: 20
-                start_line: 41
-              }
             }
           }
         }
@@ -891,34 +781,6 @@ body {
         }
         is_permanent: true
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 84
-                end_line: 52
-                file: 2
-                start_column: 21
-                start_line: 48
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 84
-                end_line: 52
-                file: 2
-                start_column: 21
-                start_line: 48
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "force_inline_code"
           _2 {
             bool_val {
@@ -930,20 +792,6 @@ body {
                 start_line: 48
               }
               v: true
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 84
-                end_line: 52
-                file: 2
-                start_column: 21
-                start_line: 48
-              }
             }
           }
         }
@@ -1118,48 +966,6 @@ body {
         immutable: true
         input_types {
           integer_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 63
-                file: 2
-                start_column: 19
-                start_line: 57
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 63
-                file: 2
-                start_column: 19
-                start_line: 57
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 63
-                file: 2
-                start_column: 19
-                start_line: 57
-              }
-            }
-          }
         }
         max_batch_size {
         }
@@ -1381,48 +1187,6 @@ body {
         input_types {
           integer_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 72
-                file: 2
-                start_column: 26
-                start_line: 67
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 72
-                file: 2
-                start_column: 26
-                start_line: 67
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 72
-                file: 2
-                start_column: 26
-                start_line: 67
-              }
-            }
-          }
-        }
         max_batch_size {
         }
         parallel: 4
@@ -1558,6 +1322,60 @@ body {
 body {
   eval {
     bind_id: 16
+  }
+}
+body {
+  bind {
+    expr {
+      udf {
+        artifact_repository {
+          value: "EXAMPLE_REPO"
+        }
+        artifact_repository_packages: "urllib3"
+        artifact_repository_packages: "requests"
+        func {
+          id: 6
+          name: "test_urllib"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPOSITORY_UDF\""
+              }
+            }
+          }
+        }
+        name {
+          name {
+            name_flat {
+              name: "artifact_repository_udf"
+            }
+          }
+        }
+        parallel: 4
+        resource_constraint {
+          _1: "architecture"
+          _2: "x86"
+        }
+        return_type {
+          string_type {
+            length {
+            }
+          }
+        }
+        source_code_display: true
+        src {
+          end_column: 9
+          end_line: 87
+          file: 2
+          start_column: 8
+          start_line: 81
+        }
+      }
+    }
+    first_request_id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"
+    symbol {
+    }
+    uid: 17
   }
 }
 client_ast_version: 1

--- a/tests/ast/data/df_map.test
+++ b/tests/ast/data/df_map.test
@@ -40,37 +40,37 @@ df6 = map_(
 
 df = session.create_dataframe([[10, "a", 22], [20, "b", 22]], schema=["col1", "col2", "col3"])
 
-df1 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+df1 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df1 = df.join_table_function(df1("COL1", "COL2", "COL3").over())
 
 df1 = df1.select(col("$4").alias("c_1"))
 
-df2 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", StringType(), nullable=True), StructField("c1", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+df2 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", StringType(), nullable=True), StructField("c1", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df2 = df.join_table_function(df2("COL1", "COL2", "COL3").over())
 
 df2 = df2.select(col("$4").alias("c_1"), col("$5").alias("c_2"))
 
-df3 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", StringType(), nullable=True), StructField("c1", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+df3 = udtf("_MapFunc", output_schema=StructType(fields=[StructField("c0", StringType(), nullable=True), StructField("c1", IntegerType(), nullable=True)], structured=False), input_types=[LongType(), StringType(), LongType()], packages=["snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df3 = df.join_table_function(df3("COL1", "COL2", "COL3").over())
 
 df3 = df3.select(col("$4").alias("col1"), col("$5").alias("col2"))
 
-df4 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), "c0"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+df4 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), "c0"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df4 = df.join_table_function(df4("COL1", "COL2", "COL3").over())
 
 df4 = df4.select(col("$4").alias("c_1"))
 
-df5 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), StringType(), "c0", "c1"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+df5 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), StringType(), "c0", "c1"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df5 = df.join_table_function(df5("COL1", "COL2", "COL3").over())
 
 df5 = df5.select(col("$4").alias("A"), col("$5").alias("B"))
 
-df6 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), IntegerType(), "c0", "c1"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+df6 = udtf("_MapFunc", output_schema=PandasDataFrameType(IntegerType(), IntegerType(), "c0", "c1"), input_types=[LongType(), StringType(), LongType()], packages=["pandas", "snowflake-snowpark-python"], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df6 = df.join_table_function(df6("COL1", "COL2", "COL3").over(partition_by="col3"))
 
@@ -239,51 +239,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 81
-                end_line: 29
-                file: 2
-                start_column: 14
-                start_line: 29
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 81
-                end_line: 29
-                file: 2
-                start_column: 14
-                start_line: 29
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 81
-                end_line: 29
-                file: 2
-                start_column: 14
-                start_line: 29
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 81
                 end_line: 29
@@ -548,51 +506,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 100
-                end_line: 31
-                file: 2
-                start_column: 14
-                start_line: 31
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 100
-                end_line: 31
-                file: 2
-                start_column: 14
-                start_line: 31
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 100
-                end_line: 31
-                file: 2
-                start_column: 14
-                start_line: 31
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 100
                 end_line: 31
@@ -920,51 +836,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 38
-                file: 2
-                start_column: 14
-                start_line: 33
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 38
-                file: 2
-                start_column: 14
-                start_line: 33
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 38
-                file: 2
-                start_column: 14
-                start_line: 33
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 38
@@ -1292,51 +1166,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 117
-                end_line: 40
-                file: 2
-                start_column: 14
-                start_line: 40
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 117
-                end_line: 40
-                file: 2
-                start_column: 14
-                start_line: 40
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 117
-                end_line: 40
-                file: 2
-                start_column: 14
-                start_line: 40
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 117
                 end_line: 40
@@ -1595,51 +1427,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 49
-                file: 2
-                start_column: 14
-                start_line: 42
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 49
-                file: 2
-                start_column: 14
-                start_line: 42
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 49
-                file: 2
-                start_column: 14
-                start_line: 42
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 49
@@ -1954,51 +1744,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 59
-                file: 2
-                start_column: 14
-                start_line: 51
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 59
-                file: 2
-                start_column: 14
-                start_line: 51
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 59
-                file: 2
-                start_column: 14
-                start_line: 51
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 59

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -4,7 +4,7 @@ from snowflake.snowpark.functions import sproc
 
 from snowflake.snowpark import DataFrame
 
-from snowflake.snowpark.types import IntegerType, StructField, StructType
+from snowflake.snowpark.types import IntegerType, StringType, StructField, StructType
 
 session.add_packages('snowflake-snowpark-python')
 
@@ -128,9 +128,26 @@ range5_sproc = session.sproc.register_from_file(
 )
 range5_sproc()
 
+
+# Test artifact_repository parameters
+def artifact_repo_test(_):
+    import urllib3
+
+    return str(urllib3.exceptions.HTTPError("test"))
+
+artifact_repo_sproc = session.sproc.register(
+    artifact_repo_test,
+    name="artifact_repo_sproc",
+    replace=True,
+    return_type=StringType(),
+    artifact_repository="EXAMPLE_REPO",
+    artifact_repository_packages=["urllib3", "requests"],
+    resource_constraint={"architecture": "x86"},
+)
+
 ## EXPECTED UNPARSER OUTPUT
 
-my_copy_sp = sproc("my_copy", return_type=StringType(), input_types=[StringType(), StringType(), LongType()], name="my_copy_sp", replace=True, comment="This is a comment", artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_COPY_SP\"")
+my_copy_sp = sproc("my_copy", return_type=StringType(), input_types=[StringType(), StringType(), LongType()], name="my_copy_sp", replace=True, comment="This is a comment", _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MY_COPY_SP\"")
 
 _ = session.sql("create or replace temp table test_from(test_str varchar) as select randstr(20, random()) from table (generator(rowCount => 100))")
 
@@ -158,13 +175,13 @@ session.table("test_from").limit(10, 0).write.save_as_table("test_to", mode="ove
 
 session.table("test_to").count()
 
-add_one_sp = sproc("<lambda [1]>", return_type=IntegerType(), input_types=[IntegerType()], parallel=2, execute_as="caller", artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+add_one_sp = sproc("<lambda [1]>", return_type=IntegerType(), input_types=[IntegerType()], parallel=2, execute_as="caller", _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
 
 res15 = add_one_sp(1)
 
 session.sql("select 1 + 1").collect()
 
-add_one_sp = sproc("<lambda [1]>", return_type=IntegerType(), input_types=[IntegerType()], parallel=2, execute_as="caller", artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+add_one_sp = sproc("<lambda [1]>", return_type=IntegerType(), input_types=[IntegerType()], parallel=2, execute_as="caller", _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
 
 add_one_sp(1)
 
@@ -174,47 +191,49 @@ _ = session.sql("create or replace temp stage mystage")
 
 _.collect()
 
-_ = sproc("<lambda [2]>", return_type=IntegerType(), input_types=[IntegerType(), IntegerType()], name="mul_sp", is_permanent=True, stage_location="@mystage", replace=True, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MUL_SP\"")
+_ = sproc("<lambda [2]>", return_type=IntegerType(), input_types=[IntegerType(), IntegerType()], name="mul_sp", is_permanent=True, stage_location="@mystage", replace=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MUL_SP\"")
 
 session.sql("call mul_sp(5, 6)").collect()
 
-_ = sproc("<lambda [3]>", return_type=IntegerType(), input_types=[IntegerType(), IntegerType()], name="mul_sp", is_permanent=True, stage_location="@mystage", if_not_exists=True, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MUL_SP\"")
+_ = sproc("<lambda [3]>", return_type=IntegerType(), input_types=[IntegerType(), IntegerType()], name="mul_sp", is_permanent=True, stage_location="@mystage", if_not_exists=True, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MUL_SP\"")
 
 session.sql("call mul_sp(5, 6)").collect()
 
-_ = sproc("<lambda [4]>", return_type=IntegerType(), input_types=[IntegerType(), IntegerType()], name="mul_sp", is_permanent=True, stage_location="@mystage", replace=True, strict=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MUL_SP\"")
+_ = sproc("<lambda [4]>", return_type=IntegerType(), input_types=[IntegerType(), IntegerType()], name="mul_sp", is_permanent=True, stage_location="@mystage", replace=True, strict=True, external_access_integrations=["s3"], secrets={"a": "b", "c": "d"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"MUL_SP\"")
 
 session.sql("call mul_sp(5, 6)").collect()
 
-sproc("sin_sp", return_type=FloatType(), input_types=[FloatType()], packages=["snowflake-snowpark-python", "numpy"], artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, statement_params={"SF_PARTNER": "FAKE_PARTNER"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1.5707963267948966)
+sproc("sin_sp", return_type=FloatType(), input_types=[FloatType()], packages=["snowflake-snowpark-python", "numpy"], statement_params={"SF_PARTNER": "FAKE_PARTNER"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1.5707963267948966)
 
-res31 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
-
-session.sql("SELECT 1 as A, 2 as B").show()
-
-res35 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res31 = sproc("select_sp", return_type=StructType(fields=[StructField("A", IntegerType(), nullable=True), StructField("B", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType(), IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-res39 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+res35 = sproc("select_sp", return_type=StructType(structured=False), input_types=[IntegerType(), IntegerType()], source_code_display=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
 
 session.sql("SELECT 1 as A, 2 as B").show()
 
-mod5_sp = sproc("mod5", return_type=IntegerType(), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+res39 = sproc("select_sp", return_type=StructType(structured=False), input_types=[LongType(), LongType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")(1, 2)
+
+session.sql("SELECT 1 as A, 2 as B").show()
+
+mod5_sp = sproc("mod5", return_type=IntegerType(), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
 
 res42 = mod5_sp(3)
 
 session.create_dataframe([[3]], schema=["a"]).select(col("a") % 5).collect()
 
-mod5_sp = sproc("mod5", return_type=IntegerType(), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+mod5_sp = sproc("mod5", return_type=IntegerType(), input_types=[IntegerType()], _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
 
 mod5_sp(3)
 
-range5_sproc = sproc("range5_sproc", return_type=StructType(structured=False), artifact_repository=None, artifact_repository_packages=None, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
+range5_sproc = sproc("range5_sproc", return_type=StructType(structured=False), _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"SNOWPARK_TEMP_PROCEDURE_xxx\"")
 
 res47 = range5_sproc()
 
 res48 = session.range(5, None, 1)
+
+artifact_repo_sproc = sproc("artifact_repo_test", return_type=StringType(), name="artifact_repo_sproc", replace=True, artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPO_SPROC\"")
 
 ## EXPECTED ENCODED AST
 
@@ -259,48 +278,6 @@ body {
         }
         input_types {
           long_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 114
-                end_line: 42
-                file: 2
-                start_column: 21
-                start_line: 42
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 114
-                end_line: 42
-                file: 2
-                start_column: 21
-                start_line: 42
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 114
-                end_line: 42
-                file: 2
-                start_column: 21
-                start_line: 42
-              }
-            }
-          }
         }
         name {
           name {
@@ -1030,48 +1007,6 @@ body {
         input_types {
           integer_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 65
-                file: 2
-                start_column: 21
-                start_line: 59
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 65
-                file: 2
-                start_column: 21
-                start_line: 59
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 65
-                file: 2
-                start_column: 21
-                start_line: 59
-              }
-            }
-          }
-        }
         parallel: 2
         return_type {
           integer_type: true
@@ -1198,48 +1133,6 @@ body {
         }
         input_types {
           integer_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 65
-                file: 2
-                start_column: 21
-                start_line: 59
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 65
-                file: 2
-                start_column: 21
-                start_line: 59
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 65
-                file: 2
-                start_column: 21
-                start_line: 59
-              }
-            }
-          }
         }
         parallel: 2
         return_type {
@@ -1429,48 +1322,6 @@ body {
           integer_type: true
         }
         is_permanent: true
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 83
-                file: 2
-                start_column: 12
-                start_line: 75
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 83
-                file: 2
-                start_column: 12
-                start_line: 75
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 83
-                file: 2
-                start_column: 12
-                start_line: 75
-              }
-            }
-          }
-        }
         name {
           name {
             name_flat {
@@ -1576,48 +1427,6 @@ body {
           integer_type: true
         }
         is_permanent: true
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 95
-                file: 2
-                start_column: 12
-                start_line: 87
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 95
-                file: 2
-                start_column: 12
-                start_line: 87
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 95
-                file: 2
-                start_column: 12
-                start_line: 87
-              }
-            }
-          }
-        }
         name {
           name {
             name_flat {
@@ -1722,48 +1531,6 @@ body {
           integer_type: true
         }
         is_permanent: true
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 110
-                file: 2
-                start_column: 12
-                start_line: 99
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 110
-                file: 2
-                start_column: 12
-                start_line: 99
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 110
-                file: 2
-                start_column: 12
-                start_line: 99
-              }
-            }
-          }
-        }
         name {
           name {
             name_flat {
@@ -1873,48 +1640,6 @@ body {
         input_types {
           float_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 112
-                end_line: 114
-                file: 2
-                start_column: 9
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 112
-                end_line: 114
-                file: 2
-                start_column: 9
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 112
-                end_line: 114
-                file: 2
-                start_column: 9
-                start_line: 114
-              }
-            }
-          }
-        }
         packages: "snowflake-snowpark-python"
         packages: "numpy"
         parallel: 4
@@ -2003,48 +1728,6 @@ body {
         }
         input_types {
           integer_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 150
-                end_line: 120
-                file: 2
-                start_column: 9
-                start_line: 120
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 150
-                end_line: 120
-                file: 2
-                start_column: 9
-                start_line: 120
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 150
-                end_line: 120
-                file: 2
-                start_column: 9
-                start_line: 120
-              }
-            }
-          }
         }
         parallel: 4
         return_type {
@@ -2209,48 +1892,6 @@ body {
         input_types {
           integer_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 123
-                end_line: 126
-                file: 2
-                start_column: 9
-                start_line: 126
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 123
-                end_line: 126
-                file: 2
-                start_column: 9
-                start_line: 126
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 123
-                end_line: 126
-                file: 2
-                start_column: 9
-                start_line: 126
-              }
-            }
-          }
-        }
         parallel: 4
         return_type {
           struct_type {
@@ -2391,48 +2032,6 @@ body {
         input_types {
           long_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 14
-                end_line: 132
-                file: 2
-                start_column: 9
-                start_line: 132
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 14
-                end_line: 132
-                file: 2
-                start_column: 9
-                start_line: 132
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 14
-                end_line: 132
-                file: 2
-                start_column: 9
-                start_line: 132
-              }
-            }
-          }
-        }
         parallel: 4
         return_type {
           struct_type {
@@ -2570,48 +2169,6 @@ body {
         }
         input_types {
           integer_type: true
-        }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 143
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 143
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 143
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
         }
         parallel: 4
         return_type {
@@ -2855,48 +2412,6 @@ body {
         input_types {
           integer_type: true
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 143
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 143
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 143
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
         parallel: 4
         return_type {
           integer_type: true
@@ -2975,48 +2490,6 @@ body {
             }
           }
         }
-        kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 150
-                file: 2
-                start_column: 23
-                start_line: 147
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 150
-                file: 2
-                start_column: 23
-                start_line: 147
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 150
-                file: 2
-                start_column: 23
-                start_line: 147
-              }
-            }
-          }
-        }
         parallel: 4
         return_type {
           struct_type {
@@ -3084,6 +2557,63 @@ body {
     symbol {
     }
     uid: 58
+  }
+}
+body {
+  bind {
+    expr {
+      stored_procedure {
+        artifact_repository {
+          value: "EXAMPLE_REPO"
+        }
+        artifact_repository_packages: "urllib3"
+        artifact_repository_packages: "requests"
+        execute_as: "owner"
+        func {
+          id: 11
+          name: "artifact_repo_test"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPO_SPROC\""
+              }
+            }
+          }
+        }
+        name {
+          name {
+            name_flat {
+              name: "artifact_repo_sproc"
+            }
+          }
+        }
+        parallel: 4
+        replace: true
+        resource_constraint {
+          _1: "architecture"
+          _2: "x86"
+        }
+        return_type {
+          string_type {
+            length {
+            }
+          }
+        }
+        source_code_display: true
+        src {
+          end_column: 9
+          end_line: 168
+          file: 2
+          start_column: 30
+          start_line: 160
+        }
+      }
+    }
+    first_request_id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"
+    symbol {
+      value: "artifact_repo_sproc"
+    }
+    uid: 59
   }
 }
 client_ast_version: 1

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -233,7 +233,7 @@ res47 = range5_sproc()
 
 res48 = session.range(5, None, 1)
 
-artifact_repo_sproc = sproc("artifact_repo_test", return_type=StringType(), name="artifact_repo_sproc", replace=True, artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPO_SPROC\"")
+artifact_repo_sproc = sproc("artifact_repo_test", return_type=StringType(), name="artifact_repo_sproc", replace=True, artifact_repository="EXAMPLE_REPO", artifact_repository_packages=["urllib3", "requests"], resource_constraint={"architecture": "x86"}, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".\"ARTIFACT_REPO_SPROC\"")
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -104,9 +104,39 @@ sum_udaf = session.udaf.register_from_file(
 )
 df.agg(sum_udaf("a"))
 
+# Test artifact_repository parameters
+class ArtifactRepositoryHandler:
+    def __init__(self) -> None:
+        self._result = ""
+
+    @property
+    def aggregate_state(self):
+        return self._result
+
+    def accumulate(self, input_value):
+        import urllib3
+
+        self._result = str(urllib3.exceptions.HTTPError("test"))
+
+    def merge(self, other_result):
+        self._result += other_result
+
+    def finish(self):
+        return self._result
+
+ar_udaf = udaf(
+    ArtifactRepositoryHandler,
+    return_type=StringType(),
+    input_types=[IntegerType()],
+    artifact_repository="EXAMPLE_REPO",
+    artifact_repository_packages=["urllib3", "requests"],
+    resource_constraint={"architecture": "x86"},
+)
+
+
 ## EXPECTED UNPARSER OUTPUT
 
-sum_udaf = udaf("PythonSumUDAF", return_type=IntegerType(), input_types=[IntegerType()], name="sum_int", replace=True, artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="sum_int")
+sum_udaf = udaf("PythonSumUDAF", return_type=IntegerType(), input_types=[IntegerType()], name="sum_int", replace=True, copy_grants=False, _registered_object_name="sum_int")
 
 df = session.create_dataframe([[1, 3], [1, 4], [2, 5], [2, 6]])
 
@@ -118,17 +148,19 @@ df = session.create_dataframe([[1, 3], [1, 4], [2, 5], [2, 6]])
 
 df = df.to_df("a", "b")
 
-u2 = udaf("PythonTopK", return_type=IntegerType(), input_types=[IntegerType()], name="top_k", is_permanent=True, stage_location="@", imports=["numpy"], packages=["numpy"], replace=True, parallel=8, statement_params={"a": "b", "d": "e"}, external_access_integrations=["s3"], secrets={"a": "c", "e": "f"}, immutable=True, comment="test udaf", artifact_repository=None, artifact_repository_packages=None, copy_grants=False, force_inline_code=True, resource_constraint=None, _registered_object_name="top_k")
+u2 = udaf("PythonTopK", return_type=IntegerType(), input_types=[IntegerType()], name="top_k", is_permanent=True, stage_location="@", imports=["numpy"], packages=["numpy"], replace=True, parallel=8, statement_params={"a": "b", "d": "e"}, external_access_integrations=["s3"], secrets={"a": "c", "e": "f"}, immutable=True, comment="test udaf", copy_grants=False, force_inline_code=True, _registered_object_name="top_k")
 
 res3 = df.agg(u2("a"))
 
-sum_udaf = udaf("MyUDAFWithoutTypeHints", return_type=IntegerType(), input_types=[IntegerType()], immutable=True, artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
+sum_udaf = udaf("MyUDAFWithoutTypeHints", return_type=IntegerType(), input_types=[IntegerType()], immutable=True, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
 
 res4 = df.agg(sum_udaf("a"))
 
-sum_udaf = udaf("MyUDAFWithTypeHints", return_type=LongType(), input_types=[LongType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
+sum_udaf = udaf("MyUDAFWithTypeHints", return_type=LongType(), input_types=[LongType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
 
 res5 = df.agg(sum_udaf("a"))
+
+ar_udaf = udaf("ArtifactRepositoryHandler", return_type=StringType(), input_types=[IntegerType()], artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
 
 ## EXPECTED ENCODED AST
 
@@ -159,51 +191,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 51
-                file: 2
-                start_column: 19
-                start_line: 45
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 51
-                file: 2
-                start_column: 19
-                start_line: 45
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 51
-                file: 2
-                start_column: 19
-                start_line: 45
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 51
@@ -792,34 +782,6 @@ body {
         }
         is_permanent: true
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 90
-                end_line: 108
-                file: 2
-                start_column: 13
-                start_line: 105
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 90
-                end_line: 108
-                file: 2
-                start_column: 13
-                start_line: 105
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
@@ -845,20 +807,6 @@ body {
                 start_line: 105
               }
               v: true
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 90
-                end_line: 108
-                file: 2
-                start_column: 13
-                start_line: 105
-              }
             }
           }
         }
@@ -985,51 +933,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 119
-                file: 2
-                start_column: 19
-                start_line: 113
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 119
-                file: 2
-                start_column: 19
-                start_line: 113
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 119
-                file: 2
-                start_column: 19
-                start_line: 113
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 119
@@ -1134,51 +1040,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 126
-                file: 2
-                start_column: 19
-                start_line: 123
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 126
-                file: 2
-                start_column: 19
-                start_line: 123
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 126
-                file: 2
-                start_column: 19
-                start_line: 123
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 126
@@ -1262,6 +1126,70 @@ body {
     symbol {
     }
     uid: 11
+  }
+}
+body {
+  bind {
+    expr {
+      udaf {
+        artifact_repository {
+          value: "EXAMPLE_REPO"
+        }
+        artifact_repository_packages: "urllib3"
+        artifact_repository_packages: "requests"
+        handler {
+          id: 4
+          name: "ArtifactRepositoryHandler"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        input_types {
+          integer_type: true
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 156
+                file: 2
+                start_column: 18
+                start_line: 149
+              }
+            }
+          }
+        }
+        parallel: 4
+        resource_constraint {
+          _1: "architecture"
+          _2: "x86"
+        }
+        return_type {
+          string_type {
+            length {
+            }
+          }
+        }
+        src {
+          end_column: 9
+          end_line: 156
+          file: 2
+          start_column: 18
+          start_line: 149
+        }
+      }
+    }
+    first_request_id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"
+    symbol {
+      value: "ar_udaf"
+    }
+    uid: 12
   }
 }
 client_ast_version: 1

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -160,7 +160,7 @@ sum_udaf = udaf("MyUDAFWithTypeHints", return_type=LongType(), input_types=[Long
 
 res5 = df.agg(sum_udaf("a"))
 
-ar_udaf = udaf("ArtifactRepositoryHandler", return_type=StringType(), input_types=[IntegerType()], artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
+ar_udaf = udaf("ArtifactRepositoryHandler", return_type=StringType(), input_types=[IntegerType()], artifact_repository="EXAMPLE_REPO", artifact_repository_packages=["urllib3", "requests"], resource_constraint={"architecture": "x86"}, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_AGGREGATE_FUNCTION_xxx")
 
 ## EXPECTED ENCODED AST
 

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -159,27 +159,42 @@ df = session.table_function(
     )
 )
 
+# Test artifact_repository parameters
+class ArtifactRepositoryUDTF:
+    def process(self) -> Iterable[Tuple[str]]:
+        import urllib3
+
+        return [(str(urllib3.exceptions.HTTPError("test")),)]
+
+ar_udtf = session.udtf.register(
+    ArtifactRepositoryUDTF,
+    output_schema=StructType([StructField("a", StringType())]),
+    artifact_repository="EXAMPLE_REPO",
+    artifact_repository_packages=["urllib3", "requests"],
+    resource_constraint={"architecture": "x86"},
+)
+
 ## EXPECTED UNPARSER OUTPUT
 
-prime_udtf = udtf("PrimeSieve", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+prime_udtf = udtf("PrimeSieve", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(prime_udtf(lit(20))).collect()
 
 df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
 
-df.with_column("total", udtf("sum_udtf", output_schema=StructType(fields=[StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
+df.with_column("total", udtf("sum_udtf", output_schema=StructType(fields=[StructField("number", LongType(), nullable=True)], structured=False), input_types=[LongType(), LongType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")(df["a"], df["b"])).sort(df["a"]).show()
 
-generator_udtf = udtf("GeneratorUDTF", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+generator_udtf = udtf("GeneratorUDTF", output_schema=StructType(fields=[StructField("number", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 session.table_function(generator_udtf(lit(3))).collect()
 
-foo = udtf("Foo", output_schema=StructType(fields=[StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", artifact_repository=None, artifact_repository_packages=None, copy_grants=False, force_inline_code=True, resource_constraint=None, _registered_object_name="foo")
+foo = udtf("Foo", output_schema=StructType(fields=[StructField("a", LongType(), nullable=True), StructField("b", LongType(), nullable=True)], structured=False), input_types=[IntegerType(), LongType()], name="foo", is_permanent=True, stage_location="@", imports=["numpy", ["seaborn", "sns"]], packages=["snowflake.snowpark"], replace=True, parallel=7, statement_params={"a": "b"}, strict=True, secure=True, external_access_integrations=["gs"], secrets={"test": "verysecret"}, immutable=True, comment="fufufufu", copy_grants=False, force_inline_code=True, _registered_object_name="foo")
 
 df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, "thirty three", 30)])
 
 df = df.to_df(["a", "b", "c"])
 
-twox_udtf = udtf("TwoXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twox_udtf = udtf("TwoXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select((twox_udtf("a"))).collect()
 
@@ -187,7 +202,7 @@ df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, 
 
 df = df.to_df(["a", "b", "c"])
 
-twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select(df["a"], (twoxsix_udtf(df["a"]))).collect()
 
@@ -195,17 +210,19 @@ df = session.create_dataframe([(1, "one o one", 10), (2, "twenty two", 20), (3, 
 
 df = df.to_df(["a", "b", "c"])
 
-twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+twoxsix_udtf = udtf("TwoXSixXUDTF", output_schema=StructType(fields=[StructField("two_x", IntegerType(), nullable=True), StructField("six_x", IntegerType(), nullable=True)], structured=False), input_types=[IntegerType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df.select("a", (twoxsix_udtf("a").alias("double", "six_x")), "c").collect()
 
-my_udtf = udtf("MyUDTFWithoutTypeHints", output_schema=StructType(fields=[StructField("int_", IntegerType(), nullable=True), StructField("float_", FloatType(), nullable=True), StructField("bool_", BooleanType(), nullable=True), StructField("decimal_", DecimalType(10, 2), nullable=True), StructField("str_", StringType(), nullable=True), StructField("bytes_", BinaryType(), nullable=True), StructField("bytearray_", BinaryType(), nullable=True)], structured=False), input_types=[IntegerType(), FloatType(), BooleanType(), DecimalType(10, 2), StringType(), BinaryType(), BinaryType()], immutable=True, artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+my_udtf = udtf("MyUDTFWithoutTypeHints", output_schema=StructType(fields=[StructField("int_", IntegerType(), nullable=True), StructField("float_", FloatType(), nullable=True), StructField("bool_", BooleanType(), nullable=True), StructField("decimal_", DecimalType(10, 2), nullable=True), StructField("str_", StringType(), nullable=True), StructField("bytes_", BinaryType(), nullable=True), StructField("bytearray_", BinaryType(), nullable=True)], structured=False), input_types=[IntegerType(), FloatType(), BooleanType(), DecimalType(10, 2), StringType(), BinaryType(), BinaryType()], immutable=True, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df = session.table_function(my_udtf(lit(1), lit(2.2), lit(True), lit(Decimal("3.33")).cast(DecimalType(10, 2)), lit("python"), lit(bytes("bytes", "utf-8")), lit(bytes("bytearray", "utf-8"))))
 
-my_udtf = udtf("MyUDTFWithTypeHints", output_schema=StructType(fields=[StructField("int_", LongType(), nullable=True), StructField("float_", FloatType(), nullable=True), StructField("bool_", BooleanType(), nullable=True), StructField("decimal_", DecimalType(38, 18), nullable=True), StructField("str_", StringType(), nullable=True), StructField("bytes_", BinaryType(), nullable=True), StructField("bytearray_", BinaryType(), nullable=True)], structured=False), input_types=[LongType(), FloatType(), BooleanType(), DecimalType(38, 18), StringType(), BinaryType(), BinaryType()], artifact_repository=None, artifact_repository_packages=None, copy_grants=False, resource_constraint=None, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+my_udtf = udtf("MyUDTFWithTypeHints", output_schema=StructType(fields=[StructField("int_", LongType(), nullable=True), StructField("float_", FloatType(), nullable=True), StructField("bool_", BooleanType(), nullable=True), StructField("decimal_", DecimalType(38, 18), nullable=True), StructField("str_", StringType(), nullable=True), StructField("bytes_", BinaryType(), nullable=True), StructField("bytearray_", BinaryType(), nullable=True)], structured=False), input_types=[LongType(), FloatType(), BooleanType(), DecimalType(38, 18), StringType(), BinaryType(), BinaryType()], copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 df = session.table_function(my_udtf(lit(1), lit(2.2), lit(True), lit(Decimal("3.33")), lit("python"), lit(bytes("bytes", "utf-8")), lit(bytes("bytearray", "utf-8"))))
+
+ar_udtf = udtf("ArtifactRepositoryUDTF", output_schema=StructType(fields=[StructField("a", StringType(), nullable=True)], structured=False), artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 ## EXPECTED ENCODED AST
 
@@ -236,51 +253,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 132
-                end_line: 48
-                file: 2
-                start_column: 21
-                start_line: 48
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 132
-                end_line: 48
-                file: 2
-                start_column: 21
-                start_line: 48
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 132
-                end_line: 48
-                file: 2
-                start_column: 21
-                start_line: 48
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 132
                 end_line: 48
@@ -473,51 +448,9 @@ body {
           long_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 39
-                end_line: 52
-                file: 2
-                start_column: 9
-                start_line: 52
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 39
-                end_line: 52
-                file: 2
-                start_column: 9
-                start_line: 52
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 39
-                end_line: 52
-                file: 2
-                start_column: 9
-                start_line: 52
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 39
                 end_line: 52
@@ -831,51 +764,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 139
-                end_line: 65
-                file: 2
-                start_column: 25
-                start_line: 65
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 139
-                end_line: 65
-                file: 2
-                start_column: 25
-                start_line: 65
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 139
-                end_line: 65
-                file: 2
-                start_column: 25
-                start_line: 65
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 139
                 end_line: 65
@@ -1089,34 +980,6 @@ body {
         }
         is_permanent: true
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 40
-                end_line: 91
-                file: 2
-                start_column: 14
-                start_line: 74
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 40
-                end_line: 91
-                file: 2
-                start_column: 14
-                start_line: 74
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
@@ -1142,20 +1005,6 @@ body {
                 start_line: 74
               }
               v: true
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
-              src {
-                end_column: 40
-                end_line: 91
-                file: 2
-                start_column: 14
-                start_line: 74
-              }
             }
           }
         }
@@ -1473,51 +1322,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 106
-                file: 2
-                start_column: 20
-                start_line: 102
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 106
-                file: 2
-                start_column: 20
-                start_line: 102
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 106
-                file: 2
-                start_column: 20
-                start_line: 102
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 106
@@ -1921,51 +1728,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 120
-                file: 2
-                start_column: 23
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 120
-                file: 2
-                start_column: 23
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 120
-                file: 2
-                start_column: 23
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 120
@@ -2402,51 +2167,9 @@ body {
           integer_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 120
-                file: 2
-                start_column: 23
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 120
-                file: 2
-                start_column: 23
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 120
-                file: 2
-                start_column: 23
-                start_line: 114
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 120
@@ -2720,51 +2443,9 @@ body {
           binary_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 152
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 152
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 152
-                file: 2
-                start_column: 18
-                start_line: 138
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 152
@@ -3242,51 +2923,9 @@ body {
           binary_type: true
         }
         kwargs {
-          _1: "artifact_repository"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 171
-                file: 2
-                start_column: 18
-                start_line: 167
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "artifact_repository_packages"
-          _2 {
-            null_val {
-              src {
-                end_column: 9
-                end_line: 171
-                file: 2
-                start_column: 18
-                start_line: 167
-              }
-            }
-          }
-        }
-        kwargs {
           _1: "copy_grants"
           _2 {
             bool_val {
-              src {
-                end_column: 9
-                end_line: 171
-                file: 2
-                start_column: 18
-                start_line: 167
-              }
-            }
-          }
-        }
-        kwargs {
-          _1: "resource_constraint"
-          _2 {
-            null_val {
               src {
                 end_column: 9
                 end_line: 171
@@ -3702,6 +3341,83 @@ body {
       value: "df"
     }
     uid: 33
+  }
+}
+body {
+  bind {
+    expr {
+      udtf {
+        artifact_repository {
+          value: "EXAMPLE_REPO"
+        }
+        artifact_repository_packages: "urllib3"
+        artifact_repository_packages: "requests"
+        handler {
+          id: 8
+          name: "ArtifactRepositoryUDTF"
+          object_name {
+            name {
+              name_flat {
+                name: "\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx"
+              }
+            }
+          }
+        }
+        kwargs {
+          _1: "copy_grants"
+          _2 {
+            bool_val {
+              src {
+                end_column: 9
+                end_line: 197
+                file: 2
+                start_column: 18
+                start_line: 191
+              }
+            }
+          }
+        }
+        output_schema {
+          udtf_schema__type {
+            return_type {
+              struct_type {
+                fields {
+                  column_identifier {
+                    column_name {
+                      name: "a"
+                    }
+                  }
+                  data_type {
+                    string_type {
+                      length {
+                      }
+                    }
+                  }
+                  nullable: true
+                }
+              }
+            }
+          }
+        }
+        parallel: 4
+        resource_constraint {
+          _1: "architecture"
+          _2: "x86"
+        }
+        src {
+          end_column: 9
+          end_line: 197
+          file: 2
+          start_column: 18
+          start_line: 191
+        }
+      }
+    }
+    first_request_id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"
+    symbol {
+      value: "ar_udtf"
+    }
+    uid: 34
   }
 }
 client_ast_version: 1

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -222,7 +222,7 @@ my_udtf = udtf("MyUDTFWithTypeHints", output_schema=StructType(fields=[StructFie
 
 df = session.table_function(my_udtf(lit(1), lit(2.2), lit(True), lit(Decimal("3.33")), lit("python"), lit(bytes("bytes", "utf-8")), lit(bytes("bytearray", "utf-8"))))
 
-ar_udtf = udtf("ArtifactRepositoryUDTF", output_schema=StructType(fields=[StructField("a", StringType(), nullable=True)], structured=False), artifactRepository="EXAMPLE_REPO", artifactRepositoryPackages=["urllib3", "requests"], resourceConstraint={"architecture": "x86"}, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
+ar_udtf = udtf("ArtifactRepositoryUDTF", output_schema=StructType(fields=[StructField("a", StringType(), nullable=True)], structured=False), artifact_repository="EXAMPLE_REPO", artifact_repository_packages=["urllib3", "requests"], resource_constraint={"architecture": "x86"}, copy_grants=False, _registered_object_name="\"MOCK_DATABASE\".\"MOCK_SCHEMA\".SNOWPARK_TEMP_TABLE_FUNCTION_xxx")
 
 ## EXPECTED ENCODED AST
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2036949

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This change updates the AST with new parameters for sprocs and udxfs to support artifact_repository parameters. Previously these parameters were being added via kwargs, but now they are named parameters. This results in quite a few expectation tests dropping them as parameters when unparsing. I've added examples with them included to maintain coverage.