### PR TITLE
SNOW-2012567: Skip describe for SYSTEM$ procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.32.0 (YYYY-MM-DD)
 
+### Snowpark Python API Updates
+
+#### Improvements
+
+- Invoking snowflake system procedures does not invoke an additional `describe procedure` call to check the return type of the procedure.
+
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -4072,7 +4072,7 @@ class Session:
     def _infer_is_return_table(
         self, sproc_name: str, *args: Any, log_on_exception: bool = False
     ) -> bool:
-        if sproc_name.upper().startswith("SYSTEM$"):
+        if sproc_name.strip().upper().startswith("SYSTEM$"):
             # Built-in stored procedures do not have schema and cannot be described
             # Currently all SYSTEM$ stored procedures are scalar so return false.
             return False

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -4072,7 +4072,7 @@ class Session:
     def _infer_is_return_table(
         self, sproc_name: str, *args: Any, log_on_exception: bool = False
     ) -> bool:
-        if "SYSTEM$" in sproc_name.upper():
+        if sproc_name.upper().startswith("SYSTEM$"):
             # Built-in stored procedures do not have schema and cannot be described
             # Currently all SYSTEM$ stored procedures are scalar so return false.
             return False

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -4072,6 +4072,10 @@ class Session:
     def _infer_is_return_table(
         self, sproc_name: str, *args: Any, log_on_exception: bool = False
     ) -> bool:
+        if "SYSTEM$" in sproc_name.upper():
+            # Built-in stored procedures do not have schema and cannot be described
+            # Currently all SYSTEM$ stored procedures are scalar so return false.
+            return False
         func_signature = ""
         try:
             arg_types = []

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -349,6 +349,13 @@ def test_call_named_stored_procedure(
             # restore active session
 
 
+def test_infer_table_type_is_skipped_for_system_procedures(session):
+    with session.query_history() as history:
+        session.call("system$wait", 1)
+
+    assert len(history.queries) == 1
+
+
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
     reason="system functions not supported by local testing",

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -349,6 +349,10 @@ def test_call_named_stored_procedure(
             # restore active session
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="system functions not supported by local testing",
+)
 def test_infer_table_type_is_skipped_for_system_procedures(session):
     with session.query_history() as history:
         session.call("system$wait", 1)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2012567

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [x] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

  For `session.call` snowpark client runs a `describe procedure` query on the given procedure to determine if the return type is scalar or a table. However, running a describe on `SYSTEM$` procedures shows up as a failed query in query history. In this PR, we skip submitting a describe for `SYSTEM$` procedures since all system procedure's return type is scalar.
