### PR TITLE
SNOW-2053921: Add support for dict values in Series.str[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added support for dict values in `Series.str.get`.
 - Added support for dict values in `Series.str.slice`.
+- Added support for dict values in `Series.str.__getitem__` (`Series.str[...]`).
 
 ## 1.31.0 (2025-04-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@
 
 #### New Features
 
-- Added support for dict values in `Series.str.get`.
-- Added support for dict values in `Series.str.slice`.
-- Added support for dict values in `Series.str.__getitem__` (`Series.str[...]`).
+- Added support for dict values in `Series.str.get`, `Series.str.slice`, and `Series.str.__getitem__` (`Series.str[...]`).
 
 ## 1.31.0 (2025-04-24)
 

--- a/docs/source/modin/supported/series_str_supported.rst
+++ b/docs/source/modin/supported/series_str_supported.rst
@@ -14,9 +14,8 @@ the method in the left column.
 | StringMethods               | Snowpark implemented? (Y/N/P/D) | Notes for current implementation                   |
 | (Series.str)                |                                 |                                                    |
 +-----------------------------+---------------------------------+----------------------------------------------------+
-| ``__getitem__``             | P                               | ``N`` if the `key` parameter is set to a non-int   |
-|                             |                                 | value. For the column data type, only string and   |
-|                             |                                 | list values are supported. All column values must  |
+| ``__getitem__``             | P                               | For the column data type, only string, list, and   |
+|                             |                                 | dict values are supported. All column values must  |
 |                             |                                 | be of the same type.                               |
 +-----------------------------+---------------------------------+----------------------------------------------------+
 | ``capitalize``              | Y                               |                                                    |

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -76,7 +76,7 @@ from pandas.io.formats.printing import PrettyDict
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
 )
-from snowflake.snowpark._internal.type_utils import ColumnOrName, NoneType
+from snowflake.snowpark._internal.type_utils import ColumnOrName
 from snowflake.snowpark._internal.utils import (
     generate_random_alphanumeric,
     parse_table_name,
@@ -16702,7 +16702,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
         return SnowflakeQueryCompiler(new_internal_frame)
 
-    def str_get(self, i: Union[NoneType, int, str]) -> "SnowflakeQueryCompiler":  # type: ignore
+    def str_get(self, i: Union[None, int, str]) -> "SnowflakeQueryCompiler":
         """
         Extract element from each component at specified position or with specified key.
 
@@ -16723,7 +16723,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
 
         def output_col_string(
-            column: SnowparkColumn, i: Union[NoneType, int]  # type: ignore
+            column: SnowparkColumn, i: Union[None, int]
         ) -> SnowparkColumn:
             col_len_exp = length(column)
             if i is None:
@@ -16753,7 +16753,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             return self._replace_non_str(column, new_col)
 
         def output_col_list(
-            column: SnowparkColumn, i: Union[NoneType, int]  # type: ignore
+            column: SnowparkColumn, i: Union[None, int]
         ) -> SnowparkColumn:
             col_len_exp = array_size(column)
             if i is None:

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -16536,11 +16536,14 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # Follow pandas behavior; all values will be None.
             key = None
         if is_scalar(key):
-            if key is not None and not isinstance(key, int):
+            if key is not None and not isinstance(key, (int, str)):
                 ErrorMessage.not_implemented(
-                    "Snowpark pandas string indexing doesn't yet support non-numeric keys"
+                    "Snowpark pandas string indexing doesn't yet support keys of types other than int or str"
                 )
-            return self.str_get(typing.cast(int, key))
+            if key is not None and isinstance(key, int):
+                key = typing.cast(int, key)
+            assert isinstance(key, (int, str))
+            return self.str_get(key)
         else:
             assert isinstance(key, slice), "key is expected to be slice here"
             if key.step == 0:

--- a/tests/integ/modin/series/test_str_accessor.py
+++ b/tests/integ/modin/series/test_str_accessor.py
@@ -316,6 +316,36 @@ def test_str___getitem___list_neg():
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        [{"a": "x", "b": "y"}, {"c": None}, {None: "z"}, None, {}],
+        [{"a": 1, "b": 2}, {"c": None}, {None: 3}, None, {}],
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        "a",
+        "b",
+        "c",
+        "d",
+        slice(None, None, None),
+        slice(0, -1, 1),
+        slice(-100, 100, 1),
+    ],
+)
+@sql_count_checker(query_count=1)
+def test_str___getitem___dict(data, key):
+    native_ser = native_pd.Series(data=data)
+    snow_ser = pd.Series(native_ser)
+    eval_snowpark_pandas_result(
+        snow_ser,
+        native_ser,
+        lambda ser: ser.str[key],
+    )
+
+
+@pytest.mark.parametrize(
     "pat",
     [
         "",

--- a/tests/integ/modin/series/test_str_accessor.py
+++ b/tests/integ/modin/series/test_str_accessor.py
@@ -269,7 +269,7 @@ def test_str___getitem___string_key():
     snow_ser = pd.Series(native_ser)
     with pytest.raises(
         NotImplementedError,
-        match="Snowpark pandas string indexing doesn't yet support non-numeric keys",
+        match="Snowpark pandas string indexing doesn't yet support keys of types other than int when the data column contains strings",
     ):
         snow_ser.str["a"]
 
@@ -343,6 +343,26 @@ def test_str___getitem___dict(data, key):
         native_ser,
         lambda ser: ser.str[key],
     )
+
+
+@pytest.mark.parametrize(
+    "data, key",
+    [
+        (["a", "b"], 1.2),
+        (["a", "b"], "a"),
+        ([[1, 2]], "a"),
+        ([{"a": "x"}], 1),
+    ],
+)
+@sql_count_checker(query_count=0)
+def test_str___getitem___neg(data, key):
+    native_ser = native_pd.Series(data=data)
+    snow_ser = pd.Series(native_ser)
+    with pytest.raises(
+        NotImplementedError,
+        match="Snowpark pandas string indexing doesn't yet support keys of types other than ",
+    ):
+        snow_ser.str[key]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2053921

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add support for dict values in Series.str[].
