### PR TITLE
SNOW-2043855: [Local Testing] Fix rank order bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 - Invoking snowflake system procedures does not invoke an additional `describe procedure` call to check the return type of the procedure.
 
+### Snowpark Local Testing Updates
+
+#### Bug Fixes
+
+- Fixed a bug in `snowflake.snowpark.functions.rank` that would cause sort direction to not be respected.
+
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -2211,7 +2211,16 @@ def _rank(raw_input, dense=False):
     Returns a series containing the rank of a row within an ordered TableEmulator.
     Args:
         raw_input: The TableEmulator to apply the rank to.
-        dense: When set no index is set when ranked values contain repeats.
+        dense: When dense is false ranks are skipped when there are repeated values. When set to true
+            ranks are not skipped. eg.
+            -----------------------------------
+            |"VALUE"  |"RANK"  |"DENSE_RANK"  |
+            -----------------------------------
+            |1        |1       |1             |
+            |1        |1       |1             |
+            |2        |3       |2             |
+            |3        |4       |3             |
+            -----------------------------------
     """
     final_values = []
     rank = 0

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -2207,10 +2207,27 @@ def mock_random(seed: Optional[int] = None, column_index=None) -> ColumnEmulator
 
 
 def _rank(raw_input, dense=False):
-    method = "dense" if dense else "min"
-    return (
-        raw_input[raw_input.sorted_by].apply(tuple, 1).rank(method=method).astype(int)
-    )
+    """
+    Returns a series containing the rank of a row within an ordered TableEmulator.
+    Args:
+        raw_input: The TableEmulator to apply the rank to.
+        dense: When set no index is set when ranked values contain repeats.
+    """
+    final_values = []
+    rank = 0
+    index = 0
+    previous = None
+    for value in raw_input[raw_input.sorted_by].apply(tuple, 1):
+        index += 1
+        if value != previous:
+            if dense:
+                rank = rank + 1
+            else:
+                rank = index
+        previous = value
+        final_values.append(rank)
+
+    return pandas.Series(final_values, index=raw_input.index)
 
 
 @patch("rank", pass_input_data=True, pass_row_index=True)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2043855

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR changes the mock implementation of rank to respect the order_by clause for each column in the window specification.

Previously pandas would recalculate the order of the input data and apply the rank to that ordering. This works correctly when the order_by clause on the window uses the default ordering, but is incorrect when one or more order_by columns are set to descending. 

With this change the rank function takes advantage of the fact that the data has already been ordered and manually calculates the order rather than use the pandas function.

This addresses the issue raised in https://github.com/snowflakedb/snowpark-python/issues/3270