### PR TITLE
SNOW-2070070: Make iceberg_config a required parameter for DataFrame/Series.to_iceberg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Added support for dict values in `Series.str.get`.
 - Added support for dict values in `Series.str.slice`.
 
+#### Improvements
+
+- Make `iceberg_config` a required parameter for `DataFrame.to_iceberg` and `Series.to_iceberg`.
+
 ## 1.31.0 (2025-04-24)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -20326,6 +20326,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         self,
         table_name: Union[str, Iterable[str]],
         *,
+        iceberg_config: Optional[dict],
         mode: Optional[str] = None,
         column_order: str = "index",
         clustering_keys: Optional[Iterable[ColumnOrName]] = None,
@@ -20336,7 +20337,6 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         max_data_extension_time: Optional[int] = None,
         change_tracking: Optional[bool] = None,
         copy_grants: bool = False,
-        iceberg_config: Optional[dict] = None,
         index: bool = True,
         index_label: Optional[IndexLabel] = None,
     ) -> List[Row]:

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -20356,7 +20356,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         self,
         table_name: Union[str, Iterable[str]],
         *,
-        iceberg_config: Optional[dict],
+        iceberg_config: dict,
         mode: Optional[str] = None,
         column_order: str = "index",
         clustering_keys: Optional[Iterable[ColumnOrName]] = None,

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -514,6 +514,7 @@ def to_iceberg(
     self,
     table_name: Union[str, Iterable[str]],
     *,
+    iceberg_config: Optional[dict],
     mode: Optional[str] = None,
     column_order: str = "index",
     clustering_keys: Optional[Iterable[ColumnOrName]] = None,
@@ -524,7 +525,6 @@ def to_iceberg(
     max_data_extension_time: Optional[int] = None,
     change_tracking: Optional[bool] = None,
     copy_grants: bool = False,
-    iceberg_config: Optional[dict] = None,
     index: bool = True,
     index_label: Optional[IndexLabel] = None,
 ) -> Optional[AsyncJob]:
@@ -535,6 +535,18 @@ def to_iceberg(
         table_name: A string or list of strings representing table name.
             If input is a string, it represents the table name; if input is of type iterable of strings,
             it represents the fully-qualified object identifier (database name, schema name, and table name).
+        iceberg_config: A dictionary that can contain the following iceberg configuration values:
+
+            * external_volume: specifies the identifier for the external volume where
+                the Iceberg table stores its metadata files and data in Parquet format
+
+            * catalog: specifies either Snowflake or a catalog integration to use for this table
+
+            * base_location: the base directory that snowflake can write iceberg metadata and files to
+
+            * catalog_sync: optionally sets the catalog integration configured for Polaris Catalog
+
+            * storage_serialization_policy: specifies the storage serialization policy for the table
         mode: One of the following values. When it's ``None`` or not provided,
             the save mode set by :meth:`mode` is used.
 
@@ -570,18 +582,6 @@ def to_iceberg(
             streams on the table from becoming stale.
         change_tracking: Specifies whether to enable change tracking for the table. If not set, the default behavior is used.
         copy_grants: When true, retain the access privileges from the original table when a new table is created with "overwrite" mode.
-        iceberg_config: A dictionary that can contain the following iceberg configuration values:
-
-            * external_volume: specifies the identifier for the external volume where
-                the Iceberg table stores its metadata files and data in Parquet format
-
-            * catalog: specifies either Snowflake or a catalog integration to use for this table
-
-            * base_location: the base directory that snowflake can write iceberg metadata and files to
-
-            * catalog_sync: optionally sets the catalog integration configured for Polaris Catalog
-
-            * storage_serialization_policy: specifies the storage serialization policy for the table
         index: default True
             If true, save DataFrame index columns as table columns.
         index_label:
@@ -601,10 +601,11 @@ def to_iceberg(
         ...     "base_location": "/iceberg_root",
         ...     "storage_serialization_policy": "OPTIMIZED",
         ... }
-        >>> df.to_snowpark_pandas().to_iceberg("my_table", mode="overwrite", iceberg_config=iceberg_config) # doctest: +SKIP
+        >>> df.to_snowpark_pandas().to_iceberg("my_table", iceberg_config=iceberg_config, mode="overwrite") # doctest: +SKIP
     """
     return self._query_compiler.to_iceberg(
         table_name=table_name,
+        iceberg_config=iceberg_config,
         mode=mode,
         column_order=column_order,
         clustering_keys=clustering_keys,
@@ -615,7 +616,6 @@ def to_iceberg(
         max_data_extension_time=max_data_extension_time,
         change_tracking=change_tracking,
         copy_grants=copy_grants,
-        iceberg_config=iceberg_config,
         index=index,
         index_label=index_label,
     )

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -514,7 +514,7 @@ def to_iceberg(
     self,
     table_name: Union[str, Iterable[str]],
     *,
-    iceberg_config: Optional[dict],
+    iceberg_config: dict,
     mode: Optional[str] = None,
     column_order: str = "index",
     clustering_keys: Optional[Iterable[ColumnOrName]] = None,

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -504,6 +504,7 @@ def to_iceberg(
     self,
     table_name: Union[str, Iterable[str]],
     *,
+    iceberg_config: Optional[dict],
     mode: Optional[str] = None,
     column_order: str = "index",
     clustering_keys: Optional[Iterable[ColumnOrName]] = None,
@@ -514,7 +515,6 @@ def to_iceberg(
     max_data_extension_time: Optional[int] = None,
     change_tracking: Optional[bool] = None,
     copy_grants: bool = False,
-    iceberg_config: Optional[dict] = None,
     index: bool = True,
     index_label: Optional[IndexLabel] = None,
 ) -> Optional[AsyncJob]:
@@ -525,6 +525,18 @@ def to_iceberg(
         table_name: A string or list of strings representing table name.
             If input is a string, it represents the table name; if input is of type iterable of strings,
             it represents the fully-qualified object identifier (database name, schema name, and table name).
+        iceberg_config: A dictionary that can contain the following iceberg configuration values:
+
+            * external_volume: specifies the identifier for the external volume where
+                the Iceberg table stores its metadata files and data in Parquet format
+
+            * catalog: specifies either Snowflake or a catalog integration to use for this table
+
+            * base_location: the base directory that snowflake can write iceberg metadata and files to
+
+            * catalog_sync: optionally sets the catalog integration configured for Polaris Catalog
+
+            * storage_serialization_policy: specifies the storage serialization policy for the table
         mode: One of the following values. When it's ``None`` or not provided,
             the save mode set by :meth:`mode` is used.
 
@@ -560,18 +572,6 @@ def to_iceberg(
             streams on the table from becoming stale.
         change_tracking: Specifies whether to enable change tracking for the table. If not set, the default behavior is used.
         copy_grants: When true, retain the access privileges from the original table when a new table is created with "overwrite" mode.
-        iceberg_config: A dictionary that can contain the following iceberg configuration values:
-
-            * external_volume: specifies the identifier for the external volume where
-                the Iceberg table stores its metadata files and data in Parquet format
-
-            * catalog: specifies either Snowflake or a catalog integration to use for this table
-
-            * base_location: the base directory that snowflake can write iceberg metadata and files to
-
-            * catalog_sync: optionally sets the catalog integration configured for Polaris Catalog
-
-            * storage_serialization_policy: specifies the storage serialization policy for the table
         index: default True
             If true, save Series index columns as table columns.
         index_label:
@@ -591,10 +591,11 @@ def to_iceberg(
         ...     "base_location": "/iceberg_root",
         ...     "storage_serialization_policy": "OPTIMIZED",
         ... }
-        >>> df.to_snowpark_pandas()["a"].to_iceberg("my_table", mode="overwrite", iceberg_config=iceberg_config) # doctest: +SKIP
+        >>> df.to_snowpark_pandas()["a"].to_iceberg("my_table", iceberg_config=iceberg_config, mode="overwrite") # doctest: +SKIP
     """
     return self._query_compiler.to_iceberg(
         table_name=table_name,
+        iceberg_config=iceberg_config,
         mode=mode,
         column_order=column_order,
         clustering_keys=clustering_keys,
@@ -605,7 +606,6 @@ def to_iceberg(
         max_data_extension_time=max_data_extension_time,
         change_tracking=change_tracking,
         copy_grants=copy_grants,
-        iceberg_config=iceberg_config,
         index=index,
         index_label=index_label,
     )

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -504,7 +504,7 @@ def to_iceberg(
     self,
     table_name: Union[str, Iterable[str]],
     *,
-    iceberg_config: Optional[dict],
+    iceberg_config: dict,
     mode: Optional[str] = None,
     column_order: str = "index",
     clustering_keys: Optional[Iterable[ColumnOrName]] = None,

--- a/tests/integ/modin/frame/test_to_iceberg.py
+++ b/tests/integ/modin/frame/test_to_iceberg.py
@@ -56,3 +56,14 @@ def test_to_iceberg(session, native_pandas_df_basic, local_testing_mode):
         )
     finally:
         Utils.drop_table(session, table_name)
+
+
+@sql_count_checker(query_count=0)
+def test_to_iceberg_config_required(native_pandas_df_basic):
+    snow_dataframe = pd.DataFrame(native_pandas_df_basic)
+
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    with pytest.raises(
+        TypeError, match="missing 1 required keyword-only argument: 'iceberg_config'"
+    ):
+        snow_dataframe.to_iceberg(table_name=table_name, mode="overwrite")

--- a/tests/integ/modin/series/test_to_iceberg.py
+++ b/tests/integ/modin/series/test_to_iceberg.py
@@ -49,3 +49,14 @@ def test_to_iceberg(session, native_pandas_ser_basic, local_testing_mode):
         )
     finally:
         Utils.drop_table(session, table_name)
+
+
+@sql_count_checker(query_count=0)
+def test_to_iceberg_config_required(native_pandas_ser_basic):
+    snow_series = pd.Series(native_pandas_ser_basic)
+
+    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+    with pytest.raises(
+        TypeError, match="missing 1 required keyword-only argument: 'iceberg_config'"
+    ):
+        snow_series.to_iceberg(table_name=table_name, mode="overwrite")


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2070070

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Make iceberg_config a required parameter for DataFrame/Series.to_iceberg. Before this change, when iceberg_config was not provided, a non-iceberg table would get created. By making it a required parameter, we guarantee that the method will only create iceberg tables.