### PR TITLE
SNOW-1952256: Add support for `create_dataframe` with FILE data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Improvements
 
 - Invoking snowflake system procedures does not invoke an additional `describe procedure` call to check the return type of the procedure.
-- Added support for `Session.create_dataframe()` with FILE data type support.
+- Added support for `Session.create_dataframe()` with the stage URL and FILE data type support.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Improvements
 
 - Invoking snowflake system procedures does not invoke an additional `describe procedure` call to check the return type of the procedure.
-- Added support for `Session.create_dataframe()` with the stage URL and FILE data type support.
+- Added support for `Session.create_dataframe()` with the stage URL and FILE data type.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Improvements
 
 - Invoking snowflake system procedures does not invoke an additional `describe procedure` call to check the return type of the procedure.
+- Added support for `Session.create_dataframe()` with FILE data type support.
 
 #### Bug Fixes
 

--- a/docs/source/snowpark/types.rst
+++ b/docs/source/snowpark/types.rst
@@ -20,6 +20,7 @@ This package contains all Snowpark logical types.
     DateType
     DecimalType
     DoubleType
+    FileType
     FloatType
     Geography
     GeographyType

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -3549,6 +3549,7 @@ class Session:
                         TimestampType,
                         VariantType,
                         VectorType,
+                        FileType,
                     ),
                 )
                 else field.datatype
@@ -3675,7 +3676,6 @@ class Session:
                 project_columns.append(
                     parse_json(column(name)).cast(field.datatype).as_(name)
                 )
-            # TODO SNOW-1952256: Test file type in create_dataframe once it accepts full path
             elif isinstance(field.datatype, FileType):
                 project_columns.append(to_file(column(name)).as_(name))
             else:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -5189,12 +5189,12 @@ def test_create_dataframe_x_string_y_integer(session):
 )
 def test_create_dataframe_file_type(session, resources_path):
     stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
-    _ = session.sql(f"create or replace temp stage {stage_name}").collect()
+    session.sql(f"create or replace temp stage {stage_name}").collect()
     test_files = TestFiles(resources_path)
-    _ = session.file.put(
+    session.file.put(
         test_files.test_file_csv, f"@{stage_name}", auto_compress=False, overwrite=True
     )
-    _ = session.file.put(
+    session.file.put(
         test_files.test_dog_image, f"@{stage_name}", auto_compress=False, overwrite=True
     )
     csv_url = f"@{stage_name}/testCSV.csv"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1553,6 +1553,10 @@ class TestFiles:
     def test_nested_xml(self):
         return os.path.join(self.resources_path, "nested.xml")
 
+    @property
+    def test_dog_image(self):
+        return os.path.join(self.resources_path, "dog.jpg")
+
 
 class TypeMap(NamedTuple):
     col_name: str


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1952256

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Now we can create a dataframe with the stage url and file data type directly 
