### PR TITLE
SNOW-2096443: Add support for Variant to StructType.from_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added support for `Session.create_dataframe()` with the stage URL and FILE data type.
 - Added support for different modes for dealing with corrupt XML records when reading an XML file using `session.read.option('rowTag', <tag_name>).xml(<stage_file_path>)`. Currently `PERMISSIVE`, `DROPMALFORMED` and `FAILFAST` are supported.
 - Improved query generation for `Dataframe.drop` to use `SELECT * EXCLUDE ()` to exclude the dropped columns. To enable this feature, set `session.conf.set("use_simplified_query_generation", True)`.
+- Added support for `VariantType` to `StructType.from_json`
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -992,6 +992,8 @@ def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
             return TimestampType(timezone=_all_timestamp_types[json_value].tz)
         elif json_value == "decimal":
             return DecimalType()
+        elif json_value == "variant":
+            return VariantType()
         elif _FIXED_DECIMAL_PATTERN.match(json_value):
             m = _FIXED_DECIMAL_PATTERN.match(json_value)
             return DecimalType(int(m.group(1)), int(m.group(2)))  # type: ignore[union-attr]

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1099,6 +1099,7 @@ def test_snow_type_to_dtype_str():
         (LongType(), "bigint", '"long"', "long", "long"),
         (ShortType(), "smallint", '"short"', "short", "short"),
         (StringType(), "string", '"string"', "string", "string"),
+        (VariantType(), "variant", '"variant"', "variant", "variant"),
         (
             StructType(
                 [StructField("a", StringType()), StructField("b", IntegerType())]
@@ -1386,6 +1387,7 @@ def test_datatype(tpe, simple_string, json, type_name, json_value):
                 ]
             ),
         ),
+        (StructType, StructType([StructField("variant", VariantType())])),
         (
             StructField,
             StructField("AA", StringType()),


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2096443

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This pr adds support for VariantType to StructType.from_json. This fixes https://github.com/snowflakedb/snowpark-python/issues/3346