### PR TITLE
SNOW-2090084: Add support for reading files from S3 buckets using pd.read_csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added support for dict values in `Series.str.get`, `Series.str.slice`, and `Series.str.__getitem__` (`Series.str[...]`).
 - Added support for `DataFrame.to_html`.
 - Added support for `DataFrame.to_string` and `Series.to_string`.
+- Added support for reading files from S3 buckets using `pd.read_csv`.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -399,7 +399,10 @@ class PandasOnSnowflakeIO(BaseIO):
         if (
             filepath_or_buffer is not None
             and isinstance(filepath_or_buffer, str)
-            and filepath_or_buffer.lower().startswith("s3")
+            and any(
+                filepath_or_buffer.lower().startswith(prefix)
+                for prefix in ["s3://", "s3china://", "s3gov://"]
+            )
         ):
             session = get_active_session()
             temp_stage_name = random_name_for_temp_object(TempObjectType.STAGE)

--- a/tests/integ/modin/io/test_read_csv.py
+++ b/tests/integ/modin/io/test_read_csv.py
@@ -840,6 +840,9 @@ def test_read_csv_dateparse_multiple_columns():
 
 
 def test_read_csv_s3():
+    host = pd.session.connection.host
+    if any(platform in host.split(".") for platform in ["gcp", "azure"]):
+        pytest.mark.skip(reason="Skipping test for Azure and GCP deployment")
     with SqlCounter(query_count=9):
         df = pd.read_csv(
             "s3://sfquickstarts/frostbyte_tastybytes/analytics/menu_item_aggregate_v.csv"

--- a/tests/integ/modin/io/test_read_csv.py
+++ b/tests/integ/modin/io/test_read_csv.py
@@ -837,3 +837,11 @@ def test_read_csv_dateparse_multiple_columns():
     assert_frame_equal(expected_df, got_df, check_dtype=False, check_index_type=False)
 
     os.remove(temp_file_name)
+
+
+def test_read_csv_s3():
+    with SqlCounter(query_count=9):
+        df = pd.read_csv(
+            "s3://sfquickstarts/frostbyte_tastybytes/analytics/menu_item_aggregate_v.csv"
+        )
+    assert len(df.columns) == 12

--- a/tests/integ/modin/io/test_read_csv.py
+++ b/tests/integ/modin/io/test_read_csv.py
@@ -842,7 +842,7 @@ def test_read_csv_dateparse_multiple_columns():
 def test_read_csv_s3():
     host = pd.session.connection.host
     if any(platform in host.split(".") for platform in ["gcp", "azure"]):
-        pytest.mark.skip(reason="Skipping test for Azure and GCP deployment")
+        pytest.skip(reason="Skipping test for Azure and GCP deployment")
     with SqlCounter(query_count=9):
         df = pd.read_csv(
             "s3://sfquickstarts/frostbyte_tastybytes/analytics/menu_item_aggregate_v.csv"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2090084

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add support for reading files from S3 buckets using pd.read_csv.
