### PR TITLE
SNOW-2084165: Update str(ex_info) to str(ex_info.value) for better string checks

### DIFF
--- a/tests/integ/modin/test_session_write_pandas.py
+++ b/tests/integ/modin/test_session_write_pandas.py
@@ -110,7 +110,9 @@ def test_write_pandas_with_overwrite(
                         auto_create_table=auto_create_table,
                         use_logical_type=use_logical_type,
                     )
-                assert "Insert value list does not match column list" in str(ex_info)
+                assert "Insert value list does not match column list" in str(
+                    ex_info.value
+                )
 
         with SqlCounter(query_count=1):
             with pytest.raises(SnowparkClientException) as ex_info:

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -556,15 +556,15 @@ def test_errors_for_aliased_columns(session, local_testing_mode):
     with pytest.raises(exc) as ex_info:
         df.select(col("a").as_("b") + 10).collect()
     if not local_testing_mode:
-        assert "You can only define aliases for the root" in str(ex_info)
+        assert "You can only define aliases for the root" in str(ex_info.value)
     else:
-        assert "invalid identifier" in str(ex_info)
+        assert "invalid identifier" in str(ex_info.value)
     with pytest.raises(exc) as ex_info:
         df.group_by(col("a")).agg(avg(col("a").as_("b"))).collect()
     if not local_testing_mode:
-        assert "You can only define aliases for the root" in str(ex_info)
+        assert "You can only define aliases for the root" in str(ex_info.value)
     else:
-        assert "invalid identifier" in str(ex_info)
+        assert "invalid identifier" in str(ex_info.value)
 
 
 def test_like(session):

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -488,13 +488,13 @@ def test_column_constructors_col(session):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(col('"Col"')).collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(col("COL .")).collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(col('"CoL"')).collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
 
 
 def test_column_constructors_select(session):
@@ -508,10 +508,10 @@ def test_column_constructors_select(session):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select('"Col"').collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select("COL .").collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
 
 
 @pytest.mark.xfail(
@@ -533,16 +533,16 @@ def test_sql_expr_column(session):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(sql_expr('"Col"')).collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(sql_expr("COL .")).collect()
-    assert "syntax error" in str(ex_info)
+    assert "syntax error" in str(ex_info.value)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(sql_expr('"CoL"')).collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(sql_expr("col .")).collect()
-    assert "syntax error" in str(ex_info)
+    assert "syntax error" in str(ex_info.value)
 
 
 def test_errors_for_aliased_columns(session, local_testing_mode):
@@ -668,7 +668,7 @@ def test_regexp(session):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.string4(session).where(col("A").regexp("+*")).collect()
-    assert "Invalid regular expression" in str(ex_info)
+    assert "Invalid regular expression" in str(ex_info.value)
 
     # Test when pattern is a column of literal strings
     df = session.create_dataframe(
@@ -728,7 +728,7 @@ def test_when_case(session, local_testing_mode):
             when(col("a").is_null(), lit("a")).when(col("a") == 1, lit(6)).as_("a")
         ).collect()
     if not local_testing_mode:
-        assert "Numeric value 'a' is not recognized" in str(ex_info)
+        assert "Numeric value 'a' is not recognized" in str(ex_info.value)
 
 
 def test_lit_contains_single_quote(session):

--- a/tests/integ/scala/test_dataframe_aggregate_suite.py
+++ b/tests/integ/scala/test_dataframe_aggregate_suite.py
@@ -388,7 +388,9 @@ def test_pivot_dynamic_subquery_with_bad_subquery(session):
             "month", subquery_df.select("month").sort("month")
         ).agg(sum(col("amount"))).collect()
 
-    assert "Invalid subquery pivot order by must be distinct query" in str(ex_info)
+    assert "Invalid subquery pivot order by must be distinct query" in str(
+        ex_info.value
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.monthly_sales(session).pivot(
@@ -1137,7 +1139,7 @@ def test_decimal_sum_over_window_should_work(session):
 def test_aggregate_function_in_groupby(session):
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data4(session).group_by(sum(col('"KEY"'))).count().collect()
-    assert "is not a valid group by expression" in str(ex_info)
+    assert "is not a valid group by expression" in str(ex_info.value)
 
 
 def test_ints_in_agg_exprs_are_taken_as_groupby_ordinal(session):

--- a/tests/integ/scala/test_dataframe_copy_into.py
+++ b/tests/integ/scala/test_dataframe_copy_into.py
@@ -405,7 +405,7 @@ def test_copy_csv_negative(session, tmp_stage_name1, tmp_table_name):
     with pytest.raises(SnowparkSQLException) as exec_info:
         df.copy_into_table(tmp_table_name, transformations=[col("$s1").as_("c1_alias")])
     assert "Insert value list does not match column list expecting 3 but got 1" in str(
-        exec_info
+        exec_info.value
     )
 
 
@@ -678,7 +678,7 @@ def test_copy_csv_negative_test_with_column_names(session, tmp_stage_name1):
                 target_columns=["c1", "c2", "c3", "c4"],
                 transformations=[col("$1"), col("$2"), col("$3"), col("$4")],
             )
-        assert "invalid identifier 'C4'" in str(exec_info)
+        assert "invalid identifier 'C4'" in str(exec_info.value)
     finally:
         Utils.drop_table(session, table_name)
 
@@ -1121,7 +1121,7 @@ def test_copy_non_csv_negative_test(
             )
         assert (
             "Insert value list does not match column list expecting 1 but got 2"
-            in str(exec_info)
+            in str(exec_info.value)
         )
     finally:
         Utils.drop_table(session, table_name)

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -402,7 +402,7 @@ def test_read_csv(session, mode):
     )
     with pytest.raises(SnowparkSQLException) as ex_info:
         df3.collect()
-    assert "is out of range" in str(ex_info)
+    assert "is out of range" in str(ex_info.value)
 
 
 @pytest.mark.xfail(
@@ -593,7 +593,7 @@ def test_read_csv_incorrect_schema(session, mode):
     df = reader.option("purge", False).schema(incorrect_schema).csv(test_file_on_stage)
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.collect()
-    assert "Number of columns in file (3) does not match" in str(ex_info)
+    assert "Number of columns in file (3) does not match" in str(ex_info.value)
 
 
 @pytest.mark.skipif(

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -567,7 +567,7 @@ def test_joins_on_result_scan(session):
 def test_df_stat_corr(session):
     with pytest.raises(SnowparkSQLException) as exec_info:
         TestData.string1(session).stat.corr("a", "b")
-    assert "Numeric value 'a' is not recognized" in str(exec_info)
+    assert "Numeric value 'a' is not recognized" in str(exec_info.value)
 
     assert TestData.null_data2(session).stat.corr("a", "b") is None
     assert (
@@ -588,7 +588,7 @@ def test_df_stat_corr(session):
 def test_df_stat_cov(session):
     with pytest.raises(SnowparkSQLException) as exec_info:
         TestData.string1(session).stat.cov("a", "b")
-    assert "Numeric value 'a' is not recognized" in str(exec_info)
+    assert "Numeric value 'a' is not recognized" in str(exec_info.value)
 
     assert TestData.null_data2(session).stat.cov("a", "b") == 0
     assert (
@@ -622,12 +622,12 @@ def test_df_stat_approx_quantile(session):
     with pytest.raises(SnowparkSQLException) as exec_info:
         TestData.approx_numbers(session).stat.approx_quantile("a", [-1])
     assert "Invalid value [-1.0] for function 'APPROX_PERCENTILE_ESTIMATE'" in str(
-        exec_info
+        exec_info.value
     )
 
     with pytest.raises(SnowparkSQLException) as exec_info:
         TestData.string1(session).stat.approx_quantile("a", [0.5])
-    assert "Numeric value 'test1' is not recognized" in str(exec_info)
+    assert "Numeric value 'test1' is not recognized" in str(exec_info.value)
 
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(session, table_name, "num int")
@@ -1277,19 +1277,19 @@ def test_select_negative_select(session):
     # select columns which don't exist
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select("not_exists_column").collect()
-    assert "SQL compilation error" in str(ex_info)
+    assert "SQL compilation error" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(["not_exists_column"]).collect()
-    assert "SQL compilation error" in str(ex_info)
+    assert "SQL compilation error" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(col("not_exists_column")).collect()
-    assert "SQL compilation error" in str(ex_info)
+    assert "SQL compilation error" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select([col("not_exists_column")]).collect()
-    assert "SQL compilation error" in str(ex_info)
+    assert "SQL compilation error" in str(ex_info.value)
 
 
 def test_drop_and_dropcolumns(session):
@@ -1392,8 +1392,8 @@ def test_rollup(session):
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.rollup(list()).agg(sum_(col("value"))).show()
 
-    assert "001003 (42000): " in str(ex_info) and "SQL compilation error" in str(
-        ex_info
+    assert "001003 (42000): " in str(ex_info.value) and "SQL compilation error" in str(
+        ex_info.value
     )
 
     # rollup() on 1 column
@@ -1518,8 +1518,8 @@ def test_cube(session):
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.cube(list()).agg(sum_(col("value"))).show()
 
-    assert "001003 (42000): " in str(ex_info) and "SQL compilation error" in str(
-        ex_info
+    assert "001003 (42000): " in str(ex_info.value) and "SQL compilation error" in str(
+        ex_info.value
     )
 
     # cube() on 1 column
@@ -2112,7 +2112,7 @@ def test_create_or_replace_temporary_view(session, db_parameters, local_testing_
             assert session is not session2
             with pytest.raises(SnowparkSQLException) as ex_info:
                 session2.table(view_name).collect()
-                assert "does not exist or not authorized" in str(ex_info)
+            assert "does not exist or not authorized" in str(ex_info.value)
 
 
 def test_create_temp_view(session):

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -274,13 +274,13 @@ def test_put_negative(
             stage_with_prefix,
             auto_compress=not local_testing_mode,
         )
-    assert "File doesn't exist" in str(file_not_exist_info)
+    assert "File doesn't exist" in str(file_not_exist_info.value)
 
     if not local_testing_mode:
         # local testing currently doesn't support stage CRUD
         with pytest.raises(SnowparkSQLException) as stage_not_exist_info:
             session.file.put(f"file://{path1}", "@NOT_EXIST_STAGE_NAME_TEST")
-        assert "does not exist or not authorized." in str(stage_not_exist_info)
+        assert "does not exist or not authorized." in str(stage_not_exist_info.value)
 
 
 def test_put_stream_with_one_file(
@@ -574,7 +574,7 @@ def test_get_negative_test(
     # Stage name doesn't exist, raise exception.
     with pytest.raises(SnowparkSQLException) as exec_info:
         session.file.get("@NOT_EXIST_STAGE_NAME_TEST", str(temp_target_directory))
-    assert "does not exist or not authorized." in str(exec_info)
+    assert "does not exist or not authorized." in str(exec_info.value)
 
     # If stage name exists but prefix doesn't exist, download nothing
     get_results = session.file.get(
@@ -662,7 +662,7 @@ def test_get_stream_negative(session, temp_stage):
         pytest.skip("Skip in stored-proc to prevent XP failing whole test")
     with pytest.raises(SnowparkSQLException) as ex_info:
         session.file.get_stream(f"{stage_with_prefix}non_existing_file")
-    assert "the file does not exist" in str(ex_info)
+    assert "the file does not exist" in str(ex_info.value)
 
 
 def test_quoted_local_file_name(

--- a/tests/integ/scala/test_permanent_udf_suite.py
+++ b/tests/integ/scala/test_permanent_udf_suite.py
@@ -67,7 +67,7 @@ def test_mix_temporary_and_permanent_udf(session, new_session):
             Utils.check_answer(
                 df2.select(call_udf(temp_func_name, col("a"))), [Row(2), Row(3)]
             )
-        assert "SQL compilation error" in str(ex_info)
+        assert "SQL compilation error" in str(ex_info.value)
     finally:
         session._run_query(f"drop function if exists {temp_func_name}(int)")
         session._run_query(f"drop function if exists {perm_func_name}(int)")
@@ -150,7 +150,7 @@ def test_support_fully_qualified_udf_name(session, new_session):
             Utils.check_answer(
                 df2.select(call_udf(temp_func_name, col("a"))), [Row(2), Row(3)]
             )
-        assert "SQL compilation error" in str(ex_info)
+        assert "SQL compilation error" in str(ex_info.value)
     finally:
         session._run_query(f"drop function if exists {temp_func_name}(int)")
         session._run_query(f"drop function if exists {perm_func_name}(int)")
@@ -195,7 +195,7 @@ def test_clean_up_files_if_udf_registration_fails(session):
                 is_permanent=True,
                 stage_location=stage_name,
             )
-        assert "SQL compilation error" in str(ex_info)
+        assert "SQL compilation error" in str(ex_info.value)
         # without clean up, below LIST gets 2 files
         assert len(session.sql(f"ls @{stage_name}/{perm_func_name}").collect()) == 1
     finally:

--- a/tests/integ/scala/test_window_frame_suite.py
+++ b/tests/integ/scala/test_window_frame_suite.py
@@ -271,7 +271,7 @@ def test_range_between_should_accept_at_most_one_order_by_expression_when_bounde
         ).collect()
         if not local_testing_mode:
             assert "Cumulative window frame unsupported for function MIN" in str(
-                ex_info
+                ex_info.value
             )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
@@ -280,13 +280,15 @@ def test_range_between_should_accept_at_most_one_order_by_expression_when_bounde
         ).collect()
         if not local_testing_mode:
             assert "Cumulative window frame unsupported for function MIN" in str(
-                ex_info
+                ex_info.value
             )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(min_("key").over(window.range_between(-1, 1))).collect()
         if not local_testing_mode:
-            assert "Sliding window frame unsupported for function MIN" in str(ex_info)
+            assert "Sliding window frame unsupported for function MIN" in str(
+                ex_info.value
+            )
 
 
 def test_range_between_should_accept_non_numeric_values_only_when_unbounded(
@@ -312,7 +314,7 @@ def test_range_between_should_accept_non_numeric_values_only_when_unbounded(
         ).collect()
         if not local_testing_mode:
             assert "Cumulative window frame unsupported for function MIN" in str(
-                ex_info
+                ex_info.value
             )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
@@ -321,13 +323,15 @@ def test_range_between_should_accept_non_numeric_values_only_when_unbounded(
         ).collect()
         if not local_testing_mode:
             assert "Cumulative window frame unsupported for function MIN" in str(
-                ex_info
+                ex_info.value
             )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(min_("value").over(window.range_between(-1, 1))).collect()
         if not local_testing_mode:
-            assert "Sliding window frame unsupported for function MIN" in str(ex_info)
+            assert "Sliding window frame unsupported for function MIN" in str(
+                ex_info.value
+            )
 
 
 @pytest.mark.skipif(

--- a/tests/integ/scala/test_window_spec_suite.py
+++ b/tests/integ/scala/test_window_spec_suite.py
@@ -129,33 +129,33 @@ def test_window_function_inside_where_and_having_clauses(session):
     if session.sql_simplifier_enabled:
         # The SQL has two errors - invalid identifier and using window function in where clause.
         # After sql is simplified, the SQL error reports using window function first.
-        assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info)
+        assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info.value)
     else:
-        assert "invalid identifier" in str(ex_info)
+        assert "invalid identifier" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data2(session).where(
             (col("b") == 2) & rank().over(Window.order_by("b")) == 1
         ).collect()
-    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info)
+    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data2(session).group_by("a").agg(avg("b").as_("avgb")).where(
             (col("a") > col("avgb")) & rank().over(Window.order_by("a")) == 1
         ).collect()
-    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info)
+    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data2(session).group_by("a").agg(
             [max_("b").as_("avgb"), sum_("b").as_("sumb")]
         ).where(rank().over(Window.order_by("a")) == 1).collect()
-    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info)
+    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data2(session).group_by("a").agg(
             [max_("b").as_("avgb"), sum_("b").as_("sumb")]
         ).where((col("sumb") == 5) & rank().over(Window.order_by("a")) == 1).collect()
-    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info)
+    assert "outside of SELECT, QUALIFY, and ORDER BY clauses" in str(ex_info.value)
 
 
 def test_reuse_window_partition_by(session):
@@ -272,7 +272,7 @@ def test_window_function_should_fail_if_order_by_clause_is_not_specified(session
     # Here we missed .order_by("key")!
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(row_number().over(Window.partition_by("value"))).collect()
-    assert "requires ORDER BY in window specification" in str(ex_info)
+    assert "requires ORDER BY in window specification" in str(ex_info.value)
 
 
 def test_snow_1360263_repro(session):
@@ -430,7 +430,7 @@ def test_aggregation_function_on_invalid_column(session):
     df = session.create_dataframe([(1, "1")]).to_df("key", "value")
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select("key", count("invalid").over()).collect()
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
 
 
 @pytest.mark.skipif(

--- a/tests/integ/test_column.py
+++ b/tests/integ/test_column.py
@@ -76,7 +76,7 @@ def test_try_cast_work_cast_not_work(session, local_testing_mode):
     with pytest.raises(SnowparkSQLException) as execinfo:
         df.select(df["a"].cast("date")).collect()
     if not local_testing_mode:
-        assert "Date 'aaa' is not recognized" in str(execinfo)
+        assert "Date 'aaa' is not recognized" in str(execinfo.value)
 
     Utils.check_answer(
         df.select(df["a"].try_cast("date")), [Row(None)]

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2230,8 +2230,8 @@ def test_create_dataframe_large_without_batch_insert(session):
         analyzer.ARRAY_BIND_THRESHOLD = 400_000
         with pytest.raises(SnowparkSQLException) as ex_info:
             session.create_dataframe([1] * 200_001).collect()
-        assert "SQL compilation error" in str(ex_info)
-        assert "maximum number of expressions in a list exceeded" in str(ex_info)
+        assert "SQL compilation error" in str(ex_info.value)
+        assert "maximum number of expressions in a list exceeded" in str(ex_info.value)
     finally:
         analyzer.ARRAY_BIND_THRESHOLD = original_value
 
@@ -2365,7 +2365,7 @@ def test_dataframe_duplicated_column_names(session, local_testing_mode):
             df.create_or_replace_view(
                 Utils.random_name_for_temp_object(TempObjectType.VIEW)
             )
-        assert "duplicate column name 'A'" in str(ex_info)
+        assert "duplicate column name 'A'" in str(ex_info.value)
 
 
 @pytest.mark.skipif(
@@ -2931,7 +2931,7 @@ def test_describe(session):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.test_data2(session).describe("c")
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
 
 
 def test_truncate_preserves_schema(session, local_testing_mode):
@@ -3784,7 +3784,7 @@ def test_call_with_statement_params(session):
     # collect
     with pytest.raises(SnowparkSQLException) as exc:
         df.collect(statement_params=statement_params_wrong_date_format.copy())
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
     assert (
         df.collect(statement_params=statement_params_correct_date_format)
         == expected_rows
@@ -3797,7 +3797,7 @@ def test_call_with_statement_params(session):
                 statement_params=statement_params_wrong_date_format.copy()
             )
         )
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
     assert (
         list(
             df.to_local_iterator(
@@ -3810,7 +3810,7 @@ def test_call_with_statement_params(session):
     # to_pandas
     with pytest.raises(SnowparkSQLException) as exc:
         df.to_pandas(statement_params=statement_params_wrong_date_format.copy())
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
     assert_frame_equal(
         df.to_pandas(statement_params=statement_params_correct_date_format.copy()),
         pandas_df,
@@ -3827,7 +3827,7 @@ def test_call_with_statement_params(session):
             ),
             ignore_index=True,
         )
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
     assert_frame_equal(
         pd.concat(
             list(
@@ -3849,7 +3849,7 @@ def test_call_with_statement_params(session):
     # show
     with pytest.raises(SnowparkSQLException) as exc:
         df.show(statement_params=statement_params_wrong_date_format.copy())
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
     df.show(statement_params=statement_params_correct_date_format.copy())
 
     # create_or_replace_view
@@ -3875,7 +3875,7 @@ def test_call_with_statement_params(session):
     # first
     with pytest.raises(SnowparkSQLException) as exc:
         df.first(statement_params=statement_params_wrong_date_format.copy())
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
 
     assert (
         df.first(statement_params=statement_params_correct_date_format.copy())
@@ -3887,7 +3887,7 @@ def test_call_with_statement_params(session):
         df.cache_result(
             statement_params=statement_params_wrong_date_format.copy()
         ).collect()
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
 
     assert (
         df.cache_result(
@@ -3902,7 +3902,7 @@ def test_call_with_statement_params(session):
             weights=[0.5, 0.5],
             statement_params=statement_params_wrong_date_format.copy(),
         )
-    assert "is not recognized" in str(exc)
+    assert "is not recognized" in str(exc.value)
     assert (
         len(
             df.random_split(

--- a/tests/integ/test_df_analytics.py
+++ b/tests/integ/test_df_analytics.py
@@ -217,7 +217,7 @@ def test_moving_agg_invalid_inputs(session, local_testing_mode):
                 order_by=["ORDERDATE"],
                 group_by=["PRODUCTKEY"],
             ).collect()
-        assert "Sliding window frame unsupported for function" in str(exc)
+        assert "Sliding window frame unsupported for function" in str(exc.value)
 
     def bad_formatter(input_col, agg):
         return f"{agg}_{input_col}"

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -792,7 +792,7 @@ def test_basic_numerical_operations_negative(session, local_testing_mode):
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(sqrt(lit(-1))).collect()
     if not local_testing_mode:
-        assert "Invalid floating point operation: sqrt(-1)" in str(ex_info)
+        assert "Invalid floating point operation: sqrt(-1)" in str(ex_info.value)
 
     # abs
     with pytest.raises(TypeError) as ex_info:
@@ -838,7 +838,9 @@ def test_basic_string_operations(session, local_testing_mode):
     df = session.create_dataframe(["a not that long string"], schema=["a"])
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(substring("a", "b", 1)).collect()
-    assert local_testing_mode or "Numeric value 'b' is not recognized" in str(ex_info)
+    assert local_testing_mode or "Numeric value 'b' is not recognized" in str(
+        ex_info.value
+    )
 
     # substring - negative length yields empty string
     res = df.select(substring("a", 6, -1)).collect()
@@ -848,7 +850,9 @@ def test_basic_string_operations(session, local_testing_mode):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(substring("a", 1, "c")).collect()
-    assert local_testing_mode or "Numeric value 'c' is not recognized" in str(ex_info)
+    assert local_testing_mode or "Numeric value 'c' is not recognized" in str(
+        ex_info.value
+    )
 
     # Split is not yet supported by local testing mode
     if not local_testing_mode:
@@ -1167,63 +1171,67 @@ def test_is_negative(session):
     # Test that we can only use these with variants
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_array("a")).collect()
-    assert "Invalid argument types for function 'IS_ARRAY'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_ARRAY'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_binary("a")).collect()
-    assert "Invalid argument types for function 'IS_BINARY'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_BINARY'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_char("a")).collect()
-    assert "Invalid argument types for function 'IS_CHAR'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_CHAR'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_varchar("a")).collect()
-    assert "Invalid argument types for function 'IS_CHAR'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_CHAR'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_date("a")).collect()
-    assert "Invalid argument types for function 'IS_DATE'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_DATE'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_decimal("a")).collect()
-    assert "Invalid argument types for function 'IS_DECIMAL'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_DECIMAL'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_double("a")).collect()
-    assert "Invalid argument types for function 'IS_DOUBLE'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_DOUBLE'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_real("a")).collect()
-    assert "Invalid argument types for function 'IS_REAL'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_REAL'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_integer("a")).collect()
-    assert "Invalid argument types for function 'IS_INTEGER'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_INTEGER'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_null_value("a")).collect()
-    assert "Invalid argument types for function 'IS_NULL_VALUE'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_NULL_VALUE'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_object("a")).collect()
-    assert "Invalid argument types for function 'IS_OBJECT'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_OBJECT'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_time("a")).collect()
-    assert "Invalid argument types for function 'IS_TIME'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_TIME'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_timestamp_ltz("a")).collect()
-    assert "Invalid argument types for function 'IS_TIMESTAMP_LTZ'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_TIMESTAMP_LTZ'" in str(
+        ex_info.value
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_timestamp_ntz("a")).collect()
-    assert "Invalid argument types for function 'IS_TIMESTAMP_NTZ'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_TIMESTAMP_NTZ'" in str(
+        ex_info.value
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(is_timestamp_tz("a")).collect()
-    assert "Invalid argument types for function 'IS_TIMESTAMP_TZ'" in str(ex_info)
+    assert "Invalid argument types for function 'IS_TIMESTAMP_TZ'" in str(ex_info.value)
 
 
 def test_parse_json(session):
@@ -1319,29 +1327,29 @@ def test_as_negative(session):
     # Test that we can only use these with variants
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_array("a")).collect()
-    assert "Invalid argument types for function 'AS_ARRAY'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_ARRAY'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_binary("a")).collect()
-    assert "Invalid argument types for function 'AS_BINARY'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_BINARY'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_char("a")).collect()
-    assert "Invalid argument types for function 'AS_CHAR'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_CHAR'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_varchar("a")).collect()
-    assert "Invalid argument types for function 'AS_VARCHAR'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_VARCHAR'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_date("a")).collect()
-    assert "Invalid argument types for function 'AS_DATE'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_DATE'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_decimal("a")).collect()
     assert (
         "invalid type [VARCHAR(5)] for parameter 'AS_DECIMAL(variantValue...)'"
-        in str(ex_info)
+        in str(ex_info.value)
     )
 
     with pytest.raises(ValueError) as ex_info:
@@ -1351,18 +1359,20 @@ def test_as_negative(session):
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.variant1(session).select(as_decimal(col("decimal1"), -1)).collect()
     assert "invalid value [-1] for parameter 'AS_DECIMAL(?, precision...)'" in str(
-        ex_info
+        ex_info.value
     )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.variant1(session).select(as_decimal(col("decimal1"), 6, -1)).collect()
-    assert "invalid value [-1] for parameter 'AS_DECIMAL(?, ?, scale)'" in str(ex_info)
+    assert "invalid value [-1] for parameter 'AS_DECIMAL(?, ?, scale)'" in str(
+        ex_info.value
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_number("a")).collect()
     assert (
         "invalid type [VARCHAR(5)] for parameter 'AS_DECIMAL(variantValue...)'"
-        in str(ex_info)
+        in str(ex_info.value)
     )
 
     with pytest.raises(ValueError) as ex_info:
@@ -1372,55 +1382,57 @@ def test_as_negative(session):
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.variant1(session).select(as_number(col("decimal1"), -1)).collect()
     assert "invalid value [-1] for parameter 'AS_DECIMAL(?, precision...)'" in str(
-        ex_info
+        ex_info.value
     )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.variant1(session).select(as_number(col("decimal1"), 6, -1)).collect()
-    assert "invalid value [-1] for parameter 'AS_DECIMAL(?, ?, scale)'" in str(ex_info)
+    assert "invalid value [-1] for parameter 'AS_DECIMAL(?, ?, scale)'" in str(
+        ex_info.value
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_double("a")).collect()
-    assert "Invalid argument types for function 'AS_DOUBLE'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_DOUBLE'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_real("a")).collect()
-    assert "Invalid argument types for function 'AS_REAL'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_REAL'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_integer("a")).collect()
     assert (
         "invalid type [VARCHAR(5)] for parameter 'AS_INTEGER(variantValue...)'"
-        in str(ex_info)
+        in str(ex_info.value)
     )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_object("a")).collect()
-    assert "Invalid argument types for function 'AS_OBJECT'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_OBJECT'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_time("a")).collect()
-    assert "Invalid argument types for function 'AS_TIME'" in str(ex_info)
+    assert "Invalid argument types for function 'AS_TIME'" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_timestamp_ltz("a")).collect()
     assert (
         "invalid type [VARCHAR(5)] for parameter 'AS_TIMESTAMP_LTZ(variantValue...)'"
-        in str(ex_info)
+        in str(ex_info.value)
     )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_timestamp_ntz("a")).collect()
     assert (
         "invalid type [VARCHAR(5)] for parameter 'AS_TIMESTAMP_NTZ(variantValue...)'"
-        in str(ex_info)
+        in str(ex_info.value)
     )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         td.select(as_timestamp_tz("a")).collect()
     assert (
         "invalid type [VARCHAR(5)] for parameter 'AS_TIMESTAMP_TZ(variantValue...)'"
-        in str(ex_info)
+        in str(ex_info.value)
     )
 
 
@@ -1686,7 +1698,7 @@ def test_coalesce(session):
     # single input column
     with pytest.raises(SnowparkSQLException) as ex_info:
         TestData.null_data2(session).select(coalesce(col("A"))).collect()
-    assert "not enough arguments for function [COALESCE" in str(ex_info)
+    assert "not enough arguments for function [COALESCE" in str(ex_info.value)
 
     with pytest.raises(TypeError) as ex_info:
         TestData.null_data2(session).select(coalesce(["A", "B", "C"]))
@@ -1739,7 +1751,7 @@ def test_uniform_negative(session):
     df = session.create_dataframe([1], schema=["a"])
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(uniform(lit("z"), 11, random())).collect()
-    assert "Numeric value 'z' is not recognized" in str(ex_info)
+    assert "Numeric value 'z' is not recognized" in str(ex_info.value)
 
 
 def test_negate_and_not_negative(session):
@@ -1762,7 +1774,7 @@ def test_random_negative(session, local_testing_mode):
         if local_testing_mode
         else "Numeric value 'abc' is not recognized"
     )
-    assert err_str in str(ex_info)
+    assert err_str in str(ex_info.value)
 
 
 def test_check_functions_negative(session):
@@ -2417,7 +2429,7 @@ def test_negative_function_call(session):
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df.select(sum_(col("a"))).collect()
-        assert "is not recognized" in str(ex_info)
+    assert "is not recognized" in str(ex_info.value)
 
 
 def test_ln(session):

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1062,7 +1062,7 @@ def test_sp_negative(session, local_testing_mode):
     with pytest.raises(SnowparkSQLException) as ex_info:
         session.call("f", 1).collect()
 
-    assert "Unknown function" in str(ex_info)
+    assert "Unknown function" in str(ex_info.value)
 
     with pytest.raises(SnowparkInvalidObjectNameException) as ex_info:
         sproc(
@@ -1071,7 +1071,7 @@ def test_sp_negative(session, local_testing_mode):
             input_types=[IntegerType()],
             name="invalid name",
         )
-    assert "The object name 'invalid name' is invalid" in str(ex_info)
+    assert "The object name 'invalid name' is invalid" in str(ex_info.value)
 
     # incorrect data type
     int_sp = sproc(
@@ -1079,11 +1079,13 @@ def test_sp_negative(session, local_testing_mode):
     )
     with pytest.raises(SnowparkSQLException) as ex_info:
         int_sp("x")
-    assert "is not recognized" in str(ex_info) or "Unexpected type" in str(ex_info)
+    assert "is not recognized" in str(ex_info.value) or "Unexpected type" in str(
+        ex_info.value
+    )
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         int_sp(None)
-    assert "Python Interpreter Error" in str(ex_info)
+    assert "Python Interpreter Error" in str(ex_info.value)
 
     with pytest.raises(TypeError) as ex_info:
 
@@ -1502,7 +1504,7 @@ def test_sp_replace(session):
             return_type=IntegerType(),
             input_types=[IntegerType(), IntegerType()],
         )
-    assert "SQL compilation error" in str(ex_info)
+    assert "SQL compilation error" in str(ex_info.value)
 
     # Expect second sp version to still be there.
     assert add_sp(1, 2) == 4

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -251,17 +251,19 @@ def test_stored_procedure_with_basic_column_datatype(session, local_testing_mode
 
     with pytest.raises(expected_err) as ex_info:
         plus1_sp(col("a"))
-    assert "invalid identifier" in str(ex_info)
+    assert "invalid identifier" in str(ex_info.value)
 
     with pytest.raises(expected_err) as ex_info:
         plus1_sp(current_date())
     assert "Invalid argument types for function" in str(
-        ex_info
-    ) or "Unexpected type" in str(ex_info)
+        ex_info.value
+    ) or "Unexpected type" in str(ex_info.value)
 
     with pytest.raises(expected_err) as ex_info:
         plus1_sp(lit(""))
-    assert "not recognized" in str(ex_info) or "Unexpected type" in str(ex_info)
+    assert "not recognized" in str(ex_info.value) or "Unexpected type" in str(
+        ex_info.value
+    )
 
 
 def test_stored_procedure_with_column_datatype(session, local_testing_mode):

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -647,7 +647,7 @@ def test_udaf_artifact_repository(session):
     except SnowparkSQLException as ex:
         assert (
             "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse."
-            in str(ex)
+            in str(ex.value)
         )
 
 

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1297,11 +1297,11 @@ def test_udf_negative(session, local_testing_mode):
     if not local_testing_mode:
         with pytest.raises(SnowparkSQLException) as ex_info:
             session.sql("select f(1)").collect()
-        assert "Unknown function" in str(ex_info)
+        assert "Unknown function" in str(ex_info.value)
 
     with pytest.raises(SnowparkSQLException) as ex_info:
         df1.select(call_udf("f", "x")).collect()
-    assert "Unknown function" in str(ex_info)
+    assert "Unknown function" in str(ex_info.value)
 
     with pytest.raises(SnowparkInvalidObjectNameException) as ex_info:
         udf(
@@ -1310,7 +1310,7 @@ def test_udf_negative(session, local_testing_mode):
             input_types=[IntegerType()],
             name="invalid name",
         )
-    assert "The object name 'invalid name' is invalid" in str(ex_info)
+    assert "The object name 'invalid name' is invalid" in str(ex_info.value)
 
     # incorrect data type
     udf2 = udf(lambda x: int(x), return_type=IntegerType(), input_types=[IntegerType()])
@@ -1318,13 +1318,13 @@ def test_udf_negative(session, local_testing_mode):
         df1.select(udf2("x")).collect()
     assert (
         local_testing_mode
-        or "Numeric value" in str(ex_info)
-        and "is not recognized" in str(ex_info)
+        or "Numeric value" in str(ex_info.value)
+        and "is not recognized" in str(ex_info.value)
     )
     df2 = session.create_dataframe([1, None]).to_df("x")
     with pytest.raises(SnowparkSQLException) as ex_info:
         df2.select(udf2("x")).collect()
-    assert "Python Interpreter Error" in str(ex_info)
+    assert "Python Interpreter Error" in str(ex_info.value)
 
     with pytest.raises(TypeError) as ex_info:
 
@@ -1644,7 +1644,7 @@ def test_udf_replace(session):
             input_types=[IntegerType(), IntegerType()],
             replace=False,
         )
-    assert "SQL compilation error" in str(ex_info)
+    assert "SQL compilation error" in str(ex_info.value)
 
     # Expect second UDF version to still be there.
     Utils.check_answer(

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2908,7 +2908,7 @@ def test_register_artifact_repository_negative(session):
     except SnowparkSQLException as ex:
         assert (
             "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse."
-            in str(ex)
+            in str(ex.value)
         )
 
 

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -1400,7 +1400,7 @@ def test_udtf_artifact_repository(session, resources_path):
     except SnowparkSQLException as ex:
         assert (
             "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse."
-            in str(ex)
+            in str(ex.value)
         )
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2084165

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR is split up from https://github.com/snowflakedb/snowpark-python/pull/3339

   str(ex_info) compresses the error using `...` and some of the expected string in string matching gets hidden into the `...`. We make these updates to find the expected string in the full error string.

example str(ex_info) output
```
<ExceptionInfo SnowparkSQLException('snowflake.snowpark.exceptions.SnowparkSQLException: (1304): 01bc4ee1-0a10-0849-000c-a909c7a27113...s/snowpark-python/tests/integ/test_function.py|787:9-787:52:  session.create_dataframe([4], schema=["a"])', None, None) tblen=2>
```

example str(ex_info.value) output
```
snowflake.snowpark.exceptions.SnowparkSQLException: (1304): 01bc4ee1-0a10-0849-000c-a909c7a27113: 100044 (22P01): Invalid floating point operation: sqrt(-1)


--- Additional Debug Information ---


Trace of the dataframe operations that could have caused the error (total 2):

/Users/aalam/Projects/snowpark-python/tests/integ/test_function.py|793:8-793:32:  df.select(sqrt(lit(-1))).collec
/Users/aalam/Projects/snowpark-python/tests/integ/test_function.py|787:9-787:52:  session.create_dataframe([4], schema=["a"])
```