### PR TITLE
TEST: Change all sproc to use Python 3.9 runtime

### DIFF
--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -223,7 +223,7 @@ def test_read_snowflake_query_cte_with_python_anonymous_sproc(
                 WITH filterByRole AS PROCEDURE (tableName VARCHAR, role VARCHAR)
                 RETURNS TABLE("id" NUMBER, "name" VARCHAR, "role" VARCHAR)
                 LANGUAGE PYTHON
-                RUNTIME_VERSION = '3.8'
+                RUNTIME_VERSION = '3.9'
                 PACKAGES = ('snowflake-snowpark-python')
                 HANDLER = 'filter_by_role'
                 AS $$from snowflake.snowpark.functions import col


### PR DESCRIPTION
This PR ensures that all sproc use the Python 3.9 runtime, other sprocs were updated in this PR here: https://github.com/snowflakedb/snowpark-python/pull/3349