### PR TITLE
SNOW-2096094: Add associated df ast id to SnowflakePlan and Selectable

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -372,7 +372,7 @@ class Selectable(LogicalPlan, ABC):
             if self.df_ast_ids is not None:
                 # Add the last df ast id to the snowflake plan as the most recent
                 # dataframe operation to create this plan.
-                self._snowflake_plan._df_ast_id = self.df_ast_ids[-1]
+                self._snowflake_plan.df_ast_id = self.df_ast_ids[-1]
         return self._snowflake_plan
 
     @property
@@ -674,7 +674,7 @@ class SelectSnowflakePlan(Selectable):
                 self._query_params.extend(query.params)
 
         # Copy the df ast ids from the snowflake plan.
-        if (df_ast_id := self._snowflake_plan._df_ast_id) is not None:
+        if (df_ast_id := self._snowflake_plan.df_ast_id) is not None:
             self.df_ast_ids = [df_ast_id]
 
     def __deepcopy__(self, memodict={}) -> "SelectSnowflakePlan":  # noqa: B006

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -399,7 +399,7 @@ class SnowflakePlan(LogicalPlan):
         self._plan_state: Optional[Dict[PlanState, Any]] = None
         # If the plan has an associated DataFrame, and this Dataframe has an ast_id,
         # we will store the ast_id here.
-        self._df_ast_id: Optional[int] = None
+        self.df_ast_id: Optional[int] = None
 
     @property
     def uuid(self) -> str:
@@ -613,7 +613,7 @@ class SnowflakePlan(LogicalPlan):
                 session=self.session,
                 referenced_ctes=self.referenced_ctes,
             )
-        plan._df_ast_id = self._df_ast_id
+        plan.df_ast_id = self.df_ast_id
         return plan
 
     def __deepcopy__(self, memodict={}) -> "SnowflakePlan":  # noqa: B006
@@ -647,7 +647,7 @@ class SnowflakePlan(LogicalPlan):
         copied_plan._is_valid_for_replacement = True
         if copied_source_plan:
             copied_source_plan._is_valid_for_replacement = True
-        copied_plan._df_ast_id = self._df_ast_id
+        copied_plan.df_ast_id = self.df_ast_id
 
         return copied_plan
 

--- a/src/snowflake/snowpark/_internal/error_message.py
+++ b/src/snowflake/snowpark/_internal/error_message.py
@@ -298,23 +298,26 @@ class SnowparkClientExceptionMessages:
     @staticmethod
     def SQL_PYTHON_REPORT_UNEXPECTED_ALIAS(
         query: Optional[str] = None,
+        debug_context: Optional[str] = None,
     ) -> SnowparkSQLUnexpectedAliasException:
         return SnowparkSQLUnexpectedAliasException(
             "You can only define aliases for the root Columns in a DataFrame returned by "
             "select() and agg(). You cannot use aliases for Columns in expressions.",
             error_code="1301",
             query=query,
+            debug_context=debug_context,
         )
 
     @staticmethod
     def SQL_PYTHON_REPORT_INVALID_ID(
-        name: str, query: Optional[str] = None
+        name: str, query: Optional[str] = None, debug_context: Optional[str] = None
     ) -> SnowparkSQLInvalidIdException:
         return SnowparkSQLInvalidIdException(
             f'The column specified in df("{name}") '
             f"is not present in the output of the DataFrame.",
             error_code="1302",
             query=query,
+            debug_context=debug_context,
         )
 
     @staticmethod
@@ -322,6 +325,7 @@ class SnowparkClientExceptionMessages:
         c1: str,
         c2: str,
         query: Optional[str] = None,
+        debug_context: Optional[str] = None,
     ) -> SnowparkSQLAmbiguousJoinException:
         return SnowparkSQLAmbiguousJoinException(
             f"The reference to the column '{c1}' is ambiguous. The column is "
@@ -333,13 +337,17 @@ class SnowparkClientExceptionMessages:
             f"the DataFrame.join() method for more details.",
             error_code="1303",
             query=query,
+            debug_context=debug_context,
         )
 
     @staticmethod
     def SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
         pe: ProgrammingError,
+        debug_context: Optional[str] = None,
     ) -> SnowparkSQLException:
-        return SnowparkSQLException(pe.msg, error_code="1304", conn_error=pe)
+        return SnowparkSQLException(
+            pe.msg, error_code="1304", conn_error=pe, debug_context=debug_context
+        )
 
     @staticmethod
     def SQL_EXCEPTION_FROM_OPERATIONAL_ERROR(

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -668,7 +668,8 @@ class DataFrame:
     @_ast_id.setter
     def _ast_id(self, value: Optional[int]) -> None:
         self.__ast_id = value
-        self._plan._df_ast_id = value
+        if self._plan is not None:
+            self._plan._df_ast_id = value
         if self._select_statement is not None:
             self._select_statement.add_df_ast_id(value)
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -591,10 +591,6 @@ class DataFrame:
                              referenced in subsequent dataframe expressions.
         """
         self._session = session
-        self._ast_id = None
-        if _emit_ast:
-            self._ast_id = _ast_stmt.uid if _ast_stmt is not None else None
-
         if plan is not None:
             self._plan = self._session._analyzer.resolve(plan)
         else:
@@ -608,6 +604,12 @@ class DataFrame:
             )
         else:
             self._select_statement = None
+
+        # Setup the ast id for the dataframe.
+        self.__ast_id = None
+        if _emit_ast:
+            self._ast_id = _ast_stmt.uid if _ast_stmt is not None else None
+
         self._statement_params = None
         self.is_cached: bool = is_cached  #: Whether the dataframe is cached.
 
@@ -658,6 +660,17 @@ class DataFrame:
     @property
     def analytics(self) -> DataFrameAnalyticsFunctions:
         return self._analytics
+
+    @property
+    def _ast_id(self) -> Optional[int]:
+        return self.__ast_id
+
+    @_ast_id.setter
+    def _ast_id(self, value: Optional[int]) -> None:
+        self.__ast_id = value
+        self._plan._df_ast_id = value
+        if self._select_statement is not None:
+            self._select_statement.add_df_ast_id(value)
 
     @publicapi
     @overload

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -669,7 +669,7 @@ class DataFrame:
     def _ast_id(self, value: Optional[int]) -> None:
         self.__ast_id = value
         if self._plan is not None:
-            self._plan._df_ast_id = value
+            self._plan.df_ast_id = value
         if self._select_statement is not None:
             self._select_statement.add_df_ast_id(value)
 

--- a/src/snowflake/snowpark/exceptions.py
+++ b/src/snowflake/snowpark/exceptions.py
@@ -89,6 +89,7 @@ class SnowparkSQLException(SnowparkClientException):
         query: Optional[str] = None,
         sql_error_code: Optional[int] = None,
         raw_message: Optional[str] = None,
+        debug_context: Optional[str] = None,
     ) -> None:
         super().__init__(message, error_code=error_code)
 
@@ -97,10 +98,13 @@ class SnowparkSQLException(SnowparkClientException):
         self.query = query or getattr(self.conn_error, "query", None)
         self.sql_error_code = sql_error_code or getattr(self.conn_error, "errno", None)
         self.raw_message = raw_message or getattr(self.conn_error, "raw_msg", None)
+        self.debug_context = debug_context
 
         pretty_error_code = f"({self.error_code}): " if self.error_code else ""
         pretty_sfqid = f"{self.sfqid}: " if self.sfqid else ""
-        self._pretty_msg = f"{pretty_error_code}{pretty_sfqid}{self.message}"
+        self._pretty_msg = (
+            f"{pretty_error_code}{pretty_sfqid}{self.message}{self.debug_context or ''}"
+        )
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.message!r}, {self.error_code!r}, {self.sfqid!r})"

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -208,7 +208,7 @@ class MockExecutionPlan(LogicalPlan):
         )
         self.api_calls = []
         self._attributes = None
-        self._df_ast_id = None
+        self.df_ast_id = None
 
     @property
     def attributes(self) -> List[Attribute]:

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -208,6 +208,7 @@ class MockExecutionPlan(LogicalPlan):
         )
         self.api_calls = []
         self._attributes = None
+        self._df_ast_id = None
 
     @property
     def attributes(self) -> List[Attribute]:

--- a/src/snowflake/snowpark/mock/_select_statement.py
+++ b/src/snowflake/snowpark/mock/_select_statement.py
@@ -76,6 +76,7 @@ class MockSelectable(LogicalPlan, ABC):
         self.df_aliased_col_name_to_real_col_name: DefaultDict[
             str, Dict[str, str]
         ] = defaultdict(dict)
+        self.df_ast_ids = None
 
     @property
     def analyzer(self) -> "Analyzer":

--- a/src/snowflake/snowpark/mock/_select_statement.py
+++ b/src/snowflake/snowpark/mock/_select_statement.py
@@ -123,6 +123,12 @@ class MockSelectable(LogicalPlan, ABC):
             )
         return self._column_states
 
+    def add_df_ast_id(self, df_ast_id: int):
+        if self.df_ast_ids is None:
+            self.df_ast_ids = [df_ast_id]
+        elif self.df_ast_ids[-1] != df_ast_id:
+            self.df_ast_ids.append(df_ast_id)
+
     def to_subqueryable(self) -> "Selectable":
         """Some queries can be used in a subquery. Some can't. For details, refer to class SelectSQL."""
         return self

--- a/tests/integ/test_df_ast_id_map.py
+++ b/tests/integ/test_df_ast_id_map.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+from snowflake.snowpark._internal.utils import set_ast_state, AstFlagSource
+from snowflake.snowpark.functions import col, explode, sum as sum_, split
+from tests.utils import Utils
+
+# pytestmark = [
+#     pytest.mark.skipif(
+#         "config.getoption('local_testing_mode', default=False)",
+#         reason="CTE is a SQL feature",
+#         run=False,
+#     ),
+# ]
+
+
+@pytest.fixture(autouse=True)
+def setup(request, session):
+    original = session.ast_enabled
+    set_ast_state(AstFlagSource.TEST, True)
+    yield
+    set_ast_state(AstFlagSource.TEST, original)
+
+
+@pytest.fixture(scope="module")
+def test_table(session):
+    table_name = Utils.random_table_name()
+    df = session.create_dataframe(
+        [[":", "colon:separated:values", 3], [":", "more:colon:separated:values", 6]],
+        schema=["a", "b", "c"],
+    )
+    df.write.mode("overwrite").save_as_table(table_name, table_type="temp")
+
+    yield table_name
+
+    Utils.drop_table(session, table_name)
+
+
+def verify_ast_id_consistency(df):
+    assert df._ast_id is not None
+    assert df._ast_id == df._plan._df_ast_id
+    assert df._select_statement.df_ast_ids is not None
+    assert df._select_statement.df_ast_ids[-1] == df._ast_id
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        lambda df, _: df.select("a", "b"),
+        lambda df, _: df.filter("a > 1"),
+        lambda df, _: df.sort("a"),
+        lambda df, _: df.limit(10),
+        lambda df, _: df.distinct(),
+        lambda df, _: df.to_df("a1", "b1", "c1"),
+        lambda df, _: df.group_by("a", "b").agg(sum_("c")),
+        lambda df, _: df.with_column("a1", col("a") + 1),
+        lambda df, df2: df.join(df2, on="a", how="left"),
+        lambda df, df2: df.union(df2),
+        lambda df, df2: df.intersect(df2),
+        lambda df, df2: df.except_(df2),
+    ],
+)
+def test_df_ast_id(session, op, test_table):
+    if not session.sql_simplifier_enabled:
+        pytest.skip("sql simplifier is not enabled")
+    df1 = session.table(test_table)
+    df2 = session.create_dataframe(
+        [
+            [",", "some,comma,separated,values", 33],
+            [",", "some,more,comma,separated,values", 66],
+        ],
+        schema=["a", "b", "c"],
+    )
+
+    verify_ast_id_consistency(df1)
+    verify_ast_id_consistency(df2)
+
+    df = op(df1, df2)
+
+    verify_ast_id_consistency(df)
+
+    df = df.select(col("$1").as_("a1"), col("$2").as_("b1")).filter(col("a1") > 1)
+    verify_ast_id_consistency(df)
+
+    df = df.select(col("a1"), split(col("b1"), col("a1")).alias("array_col")).select(
+        "a1", explode(col("array_col")).alias("exploded_col")
+    )
+    verify_ast_id_consistency(df)

--- a/tests/integ/test_df_ast_id_map.py
+++ b/tests/integ/test_df_ast_id_map.py
@@ -41,7 +41,7 @@ def test_table(session):
 
 def verify_ast_id_consistency(df):
     assert df._ast_id is not None
-    assert df._ast_id == df._plan._df_ast_id
+    assert df._ast_id == df._plan.df_ast_id
     assert df._select_statement.df_ast_ids is not None
     assert df._select_statement.df_ast_ids[-1] == df._ast_id
 

--- a/tests/unit/compiler/test_replace_child_and_update_node.py
+++ b/tests/unit/compiler/test_replace_child_and_update_node.py
@@ -80,7 +80,7 @@ def mock_query_generator(mock_session) -> QueryGenerator:
     def mock_resolve(x):
         snowflake_plan = mock_snowflake_plan()
         snowflake_plan.source_plan = x
-        snowflake_plan._df_ast_id = None
+        snowflake_plan.df_ast_id = None
         if hasattr(x, "post_actions"):
             snowflake_plan.post_actions = x.post_actions
         return snowflake_plan

--- a/tests/unit/compiler/test_replace_child_and_update_node.py
+++ b/tests/unit/compiler/test_replace_child_and_update_node.py
@@ -80,6 +80,7 @@ def mock_query_generator(mock_session) -> QueryGenerator:
     def mock_resolve(x):
         snowflake_plan = mock_snowflake_plan()
         snowflake_plan.source_plan = x
+        snowflake_plan._df_ast_id = None
         if hasattr(x, "post_actions"):
             snowflake_plan.post_actions = x.post_actions
         return snowflake_plan

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -65,7 +65,7 @@ def mock_snowflake_plan(mock_query) -> Analyzer:
 def mock_analyzer(mock_snowflake_plan) -> Analyzer:
     def mock_resolve(x):
         mock_snowflake_plan.source_plan = x
-        mock_snowflake_plan._df_ast_id = None
+        mock_snowflake_plan.df_ast_id = None
         return mock_snowflake_plan
 
     fake_analyzer = mock.create_autospec(Analyzer)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -65,6 +65,7 @@ def mock_snowflake_plan(mock_query) -> Analyzer:
 def mock_analyzer(mock_snowflake_plan) -> Analyzer:
     def mock_resolve(x):
         mock_snowflake_plan.source_plan = x
+        mock_snowflake_plan._df_ast_id = None
         return mock_snowflake_plan
 
     fake_analyzer = mock.create_autospec(Analyzer)

--- a/tests/unit/scala/test_error_message.py
+++ b/tests/unit/scala/test_error_message.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import pytest
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark.exceptions import (
     SnowparkColumnException,
@@ -274,9 +275,10 @@ def test_sql_last_query_return_resultset():
     )
 
 
-def test_sql_python_report_unexpected_alias():
+@pytest.mark.parametrize("debug_context", [None, "debug_context"])
+def test_sql_python_report_unexpected_alias(debug_context):
     ex = SnowparkClientExceptionMessages.SQL_PYTHON_REPORT_UNEXPECTED_ALIAS(
-        "test query"
+        "test query", debug_context
     )
     assert type(ex) == SnowparkSQLUnexpectedAliasException
     assert ex.error_code == "1301"
@@ -286,12 +288,16 @@ def test_sql_python_report_unexpected_alias():
         "select() and agg(). You cannot use aliases for Columns in expressions."
     )
     assert ex.query == "test query"
+    assert ex.debug_context == debug_context
 
 
-def test_sql_python_report_invalid_id():
+@pytest.mark.parametrize("debug_context", [None, "debug_context"])
+def test_sql_python_report_invalid_id(debug_context):
     name = "C1"
     query = "test query"
-    ex = SnowparkClientExceptionMessages.SQL_PYTHON_REPORT_INVALID_ID(name, query)
+    ex = SnowparkClientExceptionMessages.SQL_PYTHON_REPORT_INVALID_ID(
+        name, query, debug_context
+    )
     assert type(ex) == SnowparkSQLInvalidIdException
     assert ex.error_code == "1302"
     assert (
@@ -299,14 +305,18 @@ def test_sql_python_report_invalid_id():
         == f'The column specified in df("{name}") is not present in the output of the DataFrame.'
     )
     assert ex.query == query
+    assert ex.debug_context == debug_context
 
 
-def test_sql_report_join_ambiguous():
+@pytest.mark.parametrize("debug_context", [None, "debug_context"])
+def test_sql_report_join_ambiguous(debug_context):
     column = "A"
     c1 = column
     c2 = column
     query = "test query"
-    ex = SnowparkClientExceptionMessages.SQL_PYTHON_REPORT_JOIN_AMBIGUOUS(c1, c2, query)
+    ex = SnowparkClientExceptionMessages.SQL_PYTHON_REPORT_JOIN_AMBIGUOUS(
+        c1, c2, query, debug_context
+    )
     assert type(ex) == SnowparkSQLAmbiguousJoinException
     assert ex.error_code == "1303"
     assert (
@@ -319,6 +329,7 @@ def test_sql_report_join_ambiguous():
         f"the DataFrame.join() method for more details."
     )
     assert ex.query == query
+    assert ex.debug_context == debug_context
 
 
 def test_server_cannot_find_current_db_or_schema():

--- a/tests/unit/test_error_message.py
+++ b/tests/unit/test_error_message.py
@@ -2,19 +2,23 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import pytest
 from snowflake.connector import OperationalError, ProgrammingError
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark.exceptions import SnowparkSQLException
 
 
-def test_sql_exception_from_programming_error():
+@pytest.mark.parametrize("debug_context", [None, " debug_context"])
+def test_sql_exception_from_programming_error(debug_context):
     pe = ProgrammingError(
         msg="test message",
         errno=123,
         sfqid="0000-1111",
         query="SELECT CURRENT_USER()",
     )
-    ex = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(pe)
+    ex = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
+        pe, debug_context
+    )
     assert type(ex) == SnowparkSQLException
     assert ex.error_code == "1304"
     assert ex.conn_error == pe
@@ -23,6 +27,9 @@ def test_sql_exception_from_programming_error():
     assert ex.message == "000123: test message"
     assert ex.sql_error_code == 123
     assert ex.raw_message == "test message"
+    assert ex.debug_context == debug_context
+
+    assert str(ex) == f"(1304): 0000-1111: 000123: test message{debug_context or ''}"
 
 
 def test_sql_exception_from_operational_error():

--- a/tests/unit/test_query_plan_analysis.py
+++ b/tests/unit/test_query_plan_analysis.py
@@ -167,6 +167,7 @@ def test_select_statement_individual_node_complexity(
     from_.post_actions = None
     from_.expr_to_alias = {}
     from_.df_aliased_col_name_to_real_col_name = {}
+    from_.df_ast_ids = None
 
     plan_node = SelectStatement(from_=from_, analyzer=mock_analyzer)
     setattr(plan_node, attribute, value)
@@ -399,6 +400,7 @@ def test_select_statement_get_complexity_map_no_column_state(
     mock_from.post_actions = None
     mock_from.expr_to_alias = {}
     mock_from.df_aliased_col_name_to_real_col_name = {}
+    mock_from.df_ast_ids = None
     select_statement = SelectStatement(analyzer=mock_analyzer, from_=mock_from)
 
     assert select_statement.get_projection_name_complexity_map() is None
@@ -419,6 +421,7 @@ def test_select_statement_get_complexity_map_mismatch_projection_length(
     mock_from.post_actions = None
     mock_from.expr_to_alias = {}
     mock_from.df_aliased_col_name_to_real_col_name = {}
+    mock_from.df_ast_ids = None
 
     # create a select_statement with 2 projections
     select_statement = SelectStatement(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2096094

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This change updates `SnowflakePlan` and `Selectable` to have their generating `Dataframe` object's `_ast_id` linked to them. We add `df_ast_id` field to `SnowflakePlan` and `df_ast_ids` to Selectable to keep maintain the list.
