### PR TITLE
SNOW-2097586: Add Debug mode for eager evaluation

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import snowflake.snowpark
+import snowflake.snowpark.context
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 from snowflake.connector.options import installed_pandas, pandas, pyarrow
 
@@ -642,6 +643,9 @@ class DataFrame:
         self.replace = self._na.replace
 
         self._alias: Optional[str] = None
+
+        if session._debug_mode:
+            self._plan.attributes
 
     def _set_ast_ref(self, dataframe_expr_builder: Any) -> None:
         """

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -740,6 +740,7 @@ class Session:
         self._temp_table_auto_cleaner: TempTableAutoCleaner = TempTableAutoCleaner(self)
         self._sp_profiler = StoredProcedureProfiler(session=self)
         self._catalog = None
+        self._debug_mode = False
 
         self._ast_batch = AstBatch(self)
 
@@ -1126,6 +1127,15 @@ class Session:
             self._custom_package_usage_config = {
                 k.lower(): v for k, v in config.items()
             }
+
+    @experimental(version="1.32.0")
+    def enable_debug_mode(self, enabled=True):
+        """
+        Enables debug mode for this session.
+
+        When debug mode is enabled dataframe schemas are eagerly validated. This results in additional queries being executed.
+        """
+        self._debug_mode = enabled
 
     def cancel_all(self) -> None:
         """

--- a/tests/integ/test_debug_mode.py
+++ b/tests/integ/test_debug_mode.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+from copy import copy
+from unittest.mock import patch, Mock
+
+
+from snowflake.snowpark.functions import col, lit, max
+
+
+@pytest.mark.parametrize("debug_mode", [True, False])
+@pytest.mark.parametrize(
+    "transform",
+    [
+        pytest.param(lambda x: copy(x), id="copy"),
+        pytest.param(lambda x: x.to_df(["C", "D"]), id="to_df"),
+        pytest.param(lambda x: x.distinct(), id="distinct"),
+        pytest.param(lambda x: x.drop_duplicates(), id="drop_duplicates"),
+        pytest.param(lambda x: x.limit(1), id="limit"),
+        pytest.param(lambda x: x.union(x), id="union"),
+        pytest.param(lambda x: x.union_all(x), id="union_all"),
+        pytest.param(lambda x: x.union_by_name(x), id="union_by_name"),
+        pytest.param(lambda x: x.union_all_by_name(x), id="union_all_by_name"),
+        pytest.param(lambda x: x.intersect(x), id="intersect"),
+        pytest.param(lambda x: x.natural_join(x), id="natural_join"),
+        pytest.param(lambda x: x.cross_join(x), id="cross_join"),
+        pytest.param(lambda x: x.sample(n=1), id="sample"),
+        pytest.param(
+            lambda x: x.with_column_renamed(col("A"), "B"), id="with_column_renamed"
+        ),
+        # Unpivot already validates names
+        pytest.param(lambda x: x.unpivot("x", "y", ["A"]), id="unpivot"),
+        # The following functions do not error early because their schema_query do not contain
+        # information about the transformation being called.
+        pytest.param(lambda x: x.drop(col("A")), id="drop"),
+        pytest.param(lambda x: x.filter(col("A") == lit(1)), id="filter"),
+        pytest.param(lambda x: x.sort(col("A").desc()), id="sort"),
+    ],
+)
+def test_early_attributes(session, transform, debug_mode):
+    with patch.object(session, "_debug_mode", debug_mode):
+        df = session.create_dataframe([(1, "A"), (2, "B"), (3, "C")], ["A", "B"])
+
+        transformed = transform(df)
+
+        # When debug mode is enabled the dataframe plan attributes are populated early
+        if debug_mode:
+            assert transformed._plan._metadata.attributes is not None
+        else:
+            assert transformed._plan._metadata.attributes is None
+
+
+@pytest.mark.parametrize("debug_mode", [True, False])
+@pytest.mark.parametrize(
+    "transform",
+    [
+        pytest.param(lambda x: x.select("B"), id="select"),
+        pytest.param(lambda x: x.select_expr("cast(b as str)"), id="select_expr"),
+        pytest.param(lambda x: x.agg(max("B")), id="agg"),
+        pytest.param(lambda x: x.join(copy(x), on=(col("A") == col("B"))), id="join"),
+        pytest.param(
+            lambda x: x.join_table_function("flatten", col("B")),
+            id="join_table_function",
+        ),
+        pytest.param(lambda x: x.with_column("C", col("B")), id="with_column"),
+        pytest.param(lambda x: x.with_columns(["C"], [col("B")]), id="with_columns"),
+    ],
+)
+def test_early_error(session, transform, debug_mode):
+    with patch.object(session, "_debug_mode", debug_mode):
+        df = session.create_dataframe([1, 2, 3], ["A"])
+
+        show_mock = Mock()
+        show_mock.__qualname__ = "show"
+        show_mock.__name__ = "show"
+
+        with patch("snowflake.snowpark.dataframe.DataFrame.show", show_mock):
+            try:
+                transformed = transform(df)
+                transformed.show()
+            except Exception:
+                pass
+            # When debug mode is enabled the error is thrown before reaching show.
+            # Without debug mode the error only shows up once show is called.
+            if debug_mode:
+                show_mock.assert_not_called()
+                assert df._plan._metadata.attributes is not None
+            else:
+                show_mock.assert_called()
+                assert df._plan._metadata.attributes is None


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2097586

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR adds a new debug mode to sessions. Currently the only difference in debug mode is that dataframe attributes are populated on Dataframe creation instead of lazily, but in the future other features may be added. This change is done as a separate mode in order to avoid the additional describe queries for production pipelines.

The side effect of this change is that errors related to the dataframe schema become apparent on the line of code that caused them rather than on whatever line evaluates the dataframe. I've also modified the exception wrapper for column identifiers to not modify the error message if no additional context is available. 