### PR TITLE
SNOW-2115026: Improve existing identifiers error message

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -561,6 +561,13 @@ class SelectableEntity(Selectable):
             self._schema_query = analyzer_utils.schema_value_statement(value)
 
 
+@SnowflakePlan.Decorator.wrap_exception
+def _analyze_attributes(
+    sql: str, session: "snowflake.snowpark.session.Session"
+) -> List[Attribute]:
+    return analyze_attributes(sql, session)
+
+
 class SelectSQL(Selectable):
     """Query from a SQL. Mainly used by session.sql()"""
 
@@ -587,7 +594,7 @@ class SelectSQL(Selectable):
                 self.pre_actions[0].query_id_place_holder
             )
             self._schema_query = analyzer_utils.schema_value_statement(
-                analyze_attributes(sql, self._session)
+                _analyze_attributes(sql, self._session)
             )  # Change to subqueryable schema query so downstream query plan can describe the SQL
             self._query_param = None
         else:

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -563,7 +563,7 @@ class SelectableEntity(Selectable):
 
 @SnowflakePlan.Decorator.wrap_exception
 def _analyze_attributes(
-    sql: str, session: "snowflake.snowpark.session.Session"
+    sql: str, session: "snowflake.snowpark.session.Session"  # type: ignore
 ) -> List[Attribute]:
     return analyze_attributes(sql, session)
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -237,6 +237,13 @@ class SnowflakePlan(LogicalPlan):
                                             node.quoted_identifiers
                                         )
 
+                            # No context available to enhance error message
+                            if not children:
+                                ne = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
+                                    e
+                                )
+                                raise ne.with_traceback(tb) from None
+
                             def add_single_quote(string: str) -> str:
                                 return f"'{string}'"
 
@@ -480,6 +487,10 @@ class SnowflakePlan(LogicalPlan):
         else:
             return [attr.name for attr in self.attributes]
 
+    @Decorator.wrap_exception
+    def _analyze_attributes(self) -> List[Attribute]:
+        return analyze_attributes(self.schema_query, self.session)
+
     @property
     def attributes(self) -> List[Attribute]:
         if self._metadata.attributes is not None:
@@ -487,7 +498,7 @@ class SnowflakePlan(LogicalPlan):
         assert (
             self.schema_query is not None
         ), "No schema query is available for the SnowflakePlan"
-        attributes = analyze_attributes(self.schema_query, self.session)
+        attributes = self._analyze_attributes()
         self._metadata = PlanMetadata(attributes=attributes, quoted_identifiers=None)
         # We need to cache attributes on SelectStatement too because df._plan is not
         # carried over to next SelectStatement (e.g., check the implementation of df.filter()).

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -489,6 +489,9 @@ class SnowflakePlan(LogicalPlan):
 
     @Decorator.wrap_exception
     def _analyze_attributes(self) -> List[Attribute]:
+        assert (
+            self.schema_query is not None
+        ), "No schema query is available for the SnowflakePlan"
         return analyze_attributes(self.schema_query, self.session)
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -238,7 +238,7 @@ class SnowflakePlan(LogicalPlan):
                                         )
 
                             # No context available to enhance error message
-                            if not children:
+                            if not quoted_identifiers:
                                 ne = SnowparkClientExceptionMessages.SQL_EXCEPTION_FROM_PROGRAMMING_ERROR(
                                     e
                                 )

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -267,7 +267,6 @@ class ServerConnection:
         rows = result_set_to_rows(self.run_query(query)["data"])
         return rows[0][0] if len(rows) > 0 else None
 
-    @SnowflakePlan.Decorator.wrap_exception
     def get_result_attributes(self, query: str) -> List[Attribute]:
         return convert_result_meta_to_attribute(
             self._run_new_describe(self._cursor, query), self.max_string_size

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2789,7 +2789,6 @@ class Session:
                 external_feature_name="Session.sql",
                 raise_error=NotImplementedError,
             )
-
         if self.sql_simplifier_enabled:
             d = DataFrame(
                 self,

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2789,6 +2789,7 @@ class Session:
                 external_feature_name="Session.sql",
                 raise_error=NotImplementedError,
             )
+
         if self.sql_simplifier_enabled:
             d = DataFrame(
                 self,

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -471,9 +471,17 @@ def test_invalid_identifier_error_message(session):
     ) as ex:
         df.select("20").collect()
 
+    # Describing an invalid schema has correct context
     df = session.create_dataframe([1, 2, 3], schema=["A"])
     with pytest.raises(
         SnowparkSQLException, match="There are existing quoted column identifiers:*..."
     ) as ex:
         df.select("B").schema
     assert "There are existing quoted column identifiers: ['\"A\"']" in str(ex.value)
+
+    # session.sql does not have schema query so no context is available
+    with pytest.raises(SnowparkSQLException, match="invalid identifier 'B'") as ex:
+        session.sql(
+            """SELECT "B" FROM ( SELECT $1 AS "A" FROM  VALUES (1 :: INT))"""
+        ).select("C")
+    assert "There are existing quoted column identifiers" not in str(ex.value)

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -470,3 +470,10 @@ def test_invalid_identifier_error_message(session):
         SnowparkSQLException, match="There are existing quoted column identifiers:*..."
     ) as ex:
         df.select("20").collect()
+
+    df = session.create_dataframe([1, 2, 3], schema=["A"])
+    with pytest.raises(
+        SnowparkSQLException, match="There are existing quoted column identifiers:*..."
+    ) as ex:
+        df.select("B").schema
+    assert "There are existing quoted column identifiers: ['\"A\"']" in str(ex.value)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2115026

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Previously when calling dataframe.schema or other functions that run a describe query it was possible to get back an error message along the lines of this even though the dataframe had some columns:
 ```
There are existing quoted column identifiers: []
```

This is because the get_result_attributes function does not have a SnowflakePlan available to look up the identifiers in. This change moves the wrapper further up the call stack so that the context is available in more cases. SelectSQL plans will still lack the context, but they also will no longer show the incorrect error message.