### PR TITLE
SNOW-1285387: add local testing and support for snowurl get/put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 #### New Features
 
-- Add support for snow urls (snow://) in local file testing
+- Added support for snow urls (snow://) in local file testing.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 ### Snowpark Local Testing Updates
 
+#### New Features
+
+- Add support for snow urls (snow://) in local file testing
+
 #### Bug Fixes
 
 - Fixed a bug in `Column.isin` that would cause incorrect filtering on joined or previously filtered data.

--- a/src/snowflake/snowpark/mock/_stage_registry.py
+++ b/src/snowflake/snowpark/mock/_stage_registry.py
@@ -739,6 +739,12 @@ class StageEntityRegistry:
         target_directory: str,
         options: Dict[str, str] = None,
     ):
+        if not stage_location.startswith("@") and not stage_location.startswith(
+            "snow://"
+        ):
+            raise SnowparkLocalTestingException(
+                f"Invalid stage {stage_location}, stage name should start with character '@' or snow://"
+            )
         stage_name, stage_prefix = extract_stage_name_and_prefix(stage_location)
         with self._lock:
             if stage_name not in self._stage_registry:
@@ -758,6 +764,12 @@ class StageEntityRegistry:
         analyzer: "MockAnalyzer",
         options: Dict[str, str],
     ):
+        if not stage_location.startswith("@") and not stage_location.startswith(
+            "snow://"
+        ):
+            raise SnowparkLocalTestingException(
+                f"Invalid stage {stage_location}, stage name should start with character '@' or snow://"
+            )
         stage_name, stage_prefix = extract_stage_name_and_prefix(stage_location)
         with self._lock:
             if stage_name not in self._stage_registry:

--- a/src/snowflake/snowpark/mock/_stage_registry.py
+++ b/src/snowflake/snowpark/mock/_stage_registry.py
@@ -736,10 +736,6 @@ class StageEntityRegistry:
         target_directory: str,
         options: Dict[str, str] = None,
     ):
-        if not stage_location.startswith("@"):
-            raise SnowparkLocalTestingException(
-                f"Invalid stage {stage_location}, stage name should start with character '@'"
-            )
         stage_name, stage_prefix = extract_stage_name_and_prefix(stage_location)
         with self._lock:
             if stage_name not in self._stage_registry:
@@ -759,10 +755,6 @@ class StageEntityRegistry:
         analyzer: "MockAnalyzer",
         options: Dict[str, str],
     ):
-        if not stage_location.startswith("@"):
-            raise SnowparkLocalTestingException(
-                f"Invalid stage {stage_location}, stage name should start with character '@'"
-            )
         stage_name, stage_prefix = extract_stage_name_and_prefix(stage_location)
         with self._lock:
             if stage_name not in self._stage_registry:

--- a/src/snowflake/snowpark/mock/_stage_registry.py
+++ b/src/snowflake/snowpark/mock/_stage_registry.py
@@ -126,7 +126,10 @@ def extract_stage_name_and_prefix(stage_location: str) -> Tuple[str, str]:
     if not normalized.endswith("/"):
         normalized = f"{normalized}/"
 
-    normalized = normalized[1:]  # remove the beginning '@'
+    if normalized.startswith("@"):
+        normalized = normalized[1:]  # remove the beginning '@'
+    elif normalized.startswith("snow://"):
+        normalized = "snow:/" + normalized[7:]  # remove one of the two slashes
 
     if normalized.startswith("~/"):
         return "~", normalized[3:]  # skip '/'

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -177,9 +177,7 @@ def test_put_with_snowurl_one_file(
     session, path1, temp_target_directory, local_testing_mode
 ):
     snowurl = f"snow://{temp_target_directory}"
-    result = session.file.put(
-        f"file://{path1}", snowurl, auto_compress=not local_testing_mode
-    )[0]
+    result = session.file.put(f"file://{path1}", snowurl, auto_compress=False)[0]
     file_name = os.path.basename(path1)
     assert result.source == file_name
     assert result.target == f"{file_name}.gz" if not local_testing_mode else file_name
@@ -517,7 +515,7 @@ def test_get_with_snowurl_one_file(
     session, path1, temp_target_directory, temp_source_directory, local_testing_mode
 ):
     snowurl = f"snow://{temp_target_directory}"
-    session.file.put(f"file://{path1}", snowurl, auto_compress=not local_testing_mode)
+    session.file.put(f"file://{path1}", snowurl, auto_compress=False)
     file_name = os.path.basename(path1)
     result = session.file.get(
         snowurl,

--- a/tests/integ/scala/test_file_operation_suite.py
+++ b/tests/integ/scala/test_file_operation_suite.py
@@ -169,26 +169,6 @@ def test_put_with_one_file(
     assert third_result.message == ""
 
 
-@pytest.mark.skipif(
-    "not config.getoption('local_testing_mode', default=False)",
-    reason="non local testing mode requires end-to-end test in snowfort",
-)
-def test_put_with_snowurl_one_file(
-    session, path1, temp_target_directory, local_testing_mode
-):
-    snowurl = f"snow://{temp_target_directory}"
-    result = session.file.put(f"file://{path1}", snowurl, auto_compress=False)[0]
-    file_name = os.path.basename(path1)
-    assert result.source == file_name
-    assert result.target == f"{file_name}.gz" if not local_testing_mode else file_name
-    assert result.source_size in (10, 11)
-    assert result.target_size in (64, 96) if not local_testing_mode else (10,)
-    assert result.source_compression == "NONE"
-    assert result.target_compression == "GZIP" if not local_testing_mode else "NONE"
-    assert result.status == "UPLOADED"
-    assert result.message == ""
-
-
 def test_put_with_one_file_twice(session, temp_stage, path1, local_testing_mode):
     stage_prefix = f"prefix_{random_alphanumeric_name()}"
     stage_with_prefix = f"@{temp_stage}/{stage_prefix}/"
@@ -505,27 +485,6 @@ def test_get_one_file(
         assert results[0].message == results_with_statement_params[0].message == ""
     finally:
         os.remove(f"{temp_target_directory}/{file_name}")
-
-
-@pytest.mark.skipif(
-    "not config.getoption('local_testing_mode', default=False)",
-    reason="non local testing mode requires end-to-end test in snowfort",
-)
-def test_get_with_snowurl_one_file(
-    session, path1, temp_target_directory, temp_source_directory, local_testing_mode
-):
-    snowurl = f"snow://{temp_target_directory}"
-    session.file.put(f"file://{path1}", snowurl, auto_compress=False)
-    file_name = os.path.basename(path1)
-    result = session.file.get(
-        snowurl,
-        str(temp_source_directory),
-    )[0]
-    assert result.file == file_name
-    assert result.size in ((54, 55) if not local_testing_mode else (10, 11))
-    assert result.target_size in (64, 96) if not local_testing_mode else (10,)
-    assert result.status == "DOWNLOADED"
-    assert result.message == ""
 
 
 def test_get_multiple_files(

--- a/tests/mock/test_file_operations.py
+++ b/tests/mock/test_file_operations.py
@@ -42,31 +42,14 @@ def test_get_and_put_snowurl(session):
                 content = f.read()
                 assert content == test_content
 
-    # Test put with a directory that hasn't been created
-    snowurl = "snow://test_file_1"
-    put_results = session.file.put(
-        normalize_local_file(test_file),
-        snowurl,
-        auto_compress=False,
-    )
-    assert len(put_results) == 1
-    put_result = put_results[0]
-    assert put_result.source == put_result.target == "test_file_1"
-    assert put_result.source_size is not None
-    assert put_result.target_size is not None
-    assert put_result.source_compression == "NONE"
-    assert put_result.target_compression == "NONE"
-    assert put_result.status == "UPLOADED"
-    assert put_result.message == ""
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Test that the file can be retrieved without a trailing slash
-        get_result = session.file.get(
-            snowurl,
-            temp_dir,
-        )
-        assert len(get_result) == 1
-        assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
-        with open(os.path.join(temp_dir, "test_file_1"), "rb") as f:
-            content = f.read()
-            assert content == test_content
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Test that the file can be retrieved without a trailing slash
+            get_result = session.file.get(
+                snowurl,
+                temp_dir,
+            )
+            assert len(get_result) == 1
+            assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
+            with open(os.path.join(temp_dir, "test_file_1"), "rb") as f:
+                content = f.read()
+                assert content == test_content

--- a/tests/mock/test_file_operations.py
+++ b/tests/mock/test_file_operations.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+import os
+import tempfile
+
+from snowflake.snowpark._internal.utils import normalize_local_file
+
+
+def test_get_and_put_snowurl(session):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        snowurl = f"snow://{temp_dir}"
+        result = session.file.put(
+            normalize_local_file(
+                f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
+            ),
+            snowurl,
+            auto_compress=False,
+        )
+
+        assert len(result) == 1
+        result = result[0]
+        assert result.source == result.target == "test_file_1"
+        assert result.source_size is not None
+        assert result.target_size is not None
+        assert result.source_compression == "NONE"
+        assert result.target_compression == "NONE"
+        assert result.status == "UPLOADED"
+        assert result.message == ""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Test that the file can be retrieved with a trailing slash
+            session.file.get(
+                f"{snowurl}/",
+                temp_dir,
+            )
+            assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
+
+    # Test put without tempdir
+    snowurl = "snow://test_file_1"
+    result = session.file.put(
+        normalize_local_file(
+            f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
+        ),
+        snowurl,
+        auto_compress=False,
+    )
+    assert len(result) == 1
+    result = result[0]
+    assert result.source == result.target == "test_file_1"
+    assert result.source_size is not None
+    assert result.target_size is not None
+    assert result.source_compression == "NONE"
+    assert result.target_compression == "NONE"
+    assert result.status == "UPLOADED"
+    assert result.message == ""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Test that the non-tempdir file can be retrieved without a trailing slash
+        session.file.get(
+            snowurl,
+            temp_dir,
+        )
+        assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))

--- a/tests/mock/test_file_operations.py
+++ b/tests/mock/test_file_operations.py
@@ -10,7 +10,7 @@ from snowflake.snowpark._internal.utils import normalize_local_file
 def test_get_and_put_snowurl(session):
     with tempfile.TemporaryDirectory() as temp_dir:
         snowurl = f"snow://{temp_dir}"
-        result = session.file.put(
+        put_results = session.file.put(
             normalize_local_file(
                 f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
             ),
@@ -18,47 +18,55 @@ def test_get_and_put_snowurl(session):
             auto_compress=False,
         )
 
-        assert len(result) == 1
-        result = result[0]
-        assert result.source == result.target == "test_file_1"
-        assert result.source_size is not None
-        assert result.target_size is not None
-        assert result.source_compression == "NONE"
-        assert result.target_compression == "NONE"
-        assert result.status == "UPLOADED"
-        assert result.message == ""
+        assert len(put_results) == 1
+        put_result = put_results[0]
+        assert put_result.source == put_result.target == "test_file_1"
+        assert put_result.source_size is not None
+        assert put_result.target_size is not None
+        assert put_result.source_compression == "NONE"
+        assert put_result.target_compression == "NONE"
+        assert put_result.status == "UPLOADED"
+        assert put_result.message == ""
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Test that the file can be retrieved with a trailing slash
-            session.file.get(
+            get_result = session.file.get(
                 f"{snowurl}/",
                 temp_dir,
             )
+            assert len(get_result) == 1
             assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
+            with open(os.path.join(temp_dir, "test_file_1"), "rb") as f:
+                content = f.read()
+                assert content == b"test data 1\n"
 
-    # Test put without tempdir
+    # Test put with a directory that hasn't been created
     snowurl = "snow://test_file_1"
-    result = session.file.put(
+    put_results = session.file.put(
         normalize_local_file(
             f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
         ),
         snowurl,
         auto_compress=False,
     )
-    assert len(result) == 1
-    result = result[0]
-    assert result.source == result.target == "test_file_1"
-    assert result.source_size is not None
-    assert result.target_size is not None
-    assert result.source_compression == "NONE"
-    assert result.target_compression == "NONE"
-    assert result.status == "UPLOADED"
-    assert result.message == ""
+    assert len(put_results) == 1
+    put_result = put_results[0]
+    assert put_result.source == put_result.target == "test_file_1"
+    assert put_result.source_size is not None
+    assert put_result.target_size is not None
+    assert put_result.source_compression == "NONE"
+    assert put_result.target_compression == "NONE"
+    assert put_result.status == "UPLOADED"
+    assert put_result.message == ""
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        # Test that the non-tempdir file can be retrieved without a trailing slash
-        session.file.get(
+        # Test that the file can be retrieved without a trailing slash
+        get_result = session.file.get(
             snowurl,
             temp_dir,
         )
+        assert len(get_result) == 1
         assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
+        with open(os.path.join(temp_dir, "test_file_1"), "rb") as f:
+            content = f.read()
+            assert content == b"test data 1\n"

--- a/tests/mock/test_file_operations.py
+++ b/tests/mock/test_file_operations.py
@@ -8,12 +8,14 @@ from snowflake.snowpark._internal.utils import normalize_local_file
 
 
 def test_get_and_put_snowurl(session):
+    test_file = f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
+    with open(test_file, "rb") as f:
+        test_content = f.read()
+
     with tempfile.TemporaryDirectory() as temp_dir:
         snowurl = f"snow://{temp_dir}"
         put_results = session.file.put(
-            normalize_local_file(
-                f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
-            ),
+            normalize_local_file(test_file),
             snowurl,
             auto_compress=False,
         )
@@ -38,14 +40,12 @@ def test_get_and_put_snowurl(session):
             assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
             with open(os.path.join(temp_dir, "test_file_1"), "rb") as f:
                 content = f.read()
-                assert content == b"test data 1\n"
+                assert content == test_content
 
     # Test put with a directory that hasn't been created
     snowurl = "snow://test_file_1"
     put_results = session.file.put(
-        normalize_local_file(
-            f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
-        ),
+        normalize_local_file(test_file),
         snowurl,
         auto_compress=False,
     )
@@ -69,4 +69,4 @@ def test_get_and_put_snowurl(session):
         assert os.path.isfile(os.path.join(temp_dir, "test_file_1"))
         with open(os.path.join(temp_dir, "test_file_1"), "rb") as f:
             content = f.read()
-            assert content == b"test data 1\n"
+            assert content == test_content


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-1285387

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

  Added tests to verify that snowurls work with session.file.get and .put in local testing. Removed unnecessary error check in stage_registry to allow for snowurls and make get and read_file consistent with put.
