### PR TITLE
SNOW-2127344: Add `valueTag` option for xml reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@
 
 #### Improvements
 
-- Added support for reading XML files with namespaces using `rowTag` and `stripNamespaces` options.
-- Added support for specifying the prefix for the attribute column in the result table when reading XML files using `rowTag` and  `attributePrefix` option.
-- Added support for excluding attributes from the XML element when reading XML files using `rowTag` and `excludeAttributes` option.
+- Added support for more options when reading XML files with a row tag using `rowTag` option:
+  - Added support for removing namespace prefixes from col names using `stripNamespaces` option.
+  - Added support for specifying the prefix for the attribute column in the result table using `attributePrefix` option.
+  - Added support for excluding attributes from the XML element using `excludeAttributes` option.
+  - Added support for specifying the column name for the value when there are attributes in an element that has no child elements using `valueTag` option.
 - Added support for parameter `return_dataframe` in `Session.call`, which can be used to set the return type of the functions to a `DataFrame` object.
 - Added a new argument to `Dataframe.describe` called `strings_include_math_stats` that triggers `stddev` and `mean` to be calculated for String columns.
 - Improved the error message for `Session.write_pandas()` and `Session.create_dataframe()` when the input pandas DataFrame does not have a column.

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1443,6 +1443,7 @@ class SnowflakePlanBuilder:
         strip_namespaces = options.get("STRIPNAMESPACES", True)
         attribute_prefix = options.get("ATTRIBUTEPREFIX", "_")
         exclude_attributes = options.get("EXCLUDEATTRIBUTES", False)
+        value_tag = options.get("VALUETAG", "_VALUE")
 
         if mode not in {"PERMISSIVE", "DROPMALFORMED", "FAILFAST"}:
             raise ValueError(
@@ -1475,6 +1476,7 @@ class SnowflakePlanBuilder:
                 lit(strip_namespaces),
                 lit(attribute_prefix),
                 lit(exclude_attributes),
+                lit(value_tag),
             ),
         )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -892,6 +892,9 @@ class DataFrameReader:
               + ``attributePrefix``: The prefix to add to the attribute names. The default value is ``_``.
 
               + ``excludeAttributes``: Whether to exclude attributes from the XML element. The default value is ``False``.
+
+              + ``valueTag``: The column name used for the value when there are attributes in an element that has no child elements.
+                The default value is ``_VALUE``.
         """
         df = self._read_semi_structured_file(path, "XML")
 

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -293,3 +293,16 @@ def test_read_xml_exclude_attributes(session):
     assert len(result[0]) == 6
     with pytest.raises(KeyError):
         _ = result[0]["'_id'"]
+
+
+def test_read_xml_value_tag(session):
+    row_tag = "author"
+    df = (
+        session.read.option("rowTag", row_tag)
+        .option("valueTag", "value")
+        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+    )
+    result = df.collect()
+    assert len(result) == 12
+    assert len(result[0]) == 1
+    assert result[0]["'value'"] is not None

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -10,7 +10,7 @@ import pytest
 
 from snowflake.snowpark._internal.xml_reader import (
     replace_entity,
-    element_to_dict,
+    element_to_dict_or_str,
     strip_xml_namespaces,
     find_next_closing_tag_pos,
     find_next_opening_tag_pos,
@@ -38,32 +38,34 @@ def test_replace_entity_unknown():
     assert replace_entity(match) == "&foo;"
 
 
-def test_element_to_dict_text():
+def test_element_to_dict_or_str_text():
     # Element with only text.
     element = ET.Element("greeting")
     element.text = "  hello world  "
-    result = element_to_dict(element)
+    result = element_to_dict_or_str(element)
     assert result == "hello world"
 
 
 @pytest.mark.parametrize("attribute_prefix", ["_", ""])
-def test_element_to_dict_attributes(attribute_prefix):
+def test_element_to_dict_or_str_attributes(attribute_prefix):
     # Element with attributes only.
     element = ET.Element("person", attrib={"name": "Alice", "age": "30"})
-    result = element_to_dict(element, attribute_prefix=attribute_prefix)
+    result = element_to_dict_or_str(element, attribute_prefix=attribute_prefix)
     expected = {f"{attribute_prefix}name": "Alice", f"{attribute_prefix}age": "30"}
     assert result == expected
 
 
-def test_element_to_dict_exclude_attributes():
+def test_element_to_dict_or_str_exclude_attributes():
     # Element with attributes only.
     element = ET.Element("person", attrib={"name": "Alice", "age": "30"})
-    result = element_to_dict(element, attribute_prefix="_", exclude_attributes=True)
+    result = element_to_dict_or_str(
+        element, attribute_prefix="_", exclude_attributes=True
+    )
     expected = {}
     assert result == expected
 
 
-def test_element_to_dict_children():
+def test_element_to_dict_or_str_children():
     # Element with children including repeated tags.
     root = ET.Element("data")
     child1 = ET.SubElement(root, "item")
@@ -72,7 +74,7 @@ def test_element_to_dict_children():
     child2.text = "value2"
     child3 = ET.SubElement(root, "note")
     child3.text = "note1"
-    result = element_to_dict(root)
+    result = element_to_dict_or_str(root)
     expected = {"item": ["value1", "value2"], "note": "note1"}
     assert result == expected
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2127344

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
