### PR TITLE
SNOW-2123730: lookup Edge properties when getting lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added support for parameter `return_dataframe` in `Session.call`, which can be used to set the return type of the functions to a `DataFrame` object.
 - Added a new argument to `Dataframe.describe` called `strings_include_math_stats` that triggers `stddev` and `mean` to be calculated for String columns.
 - Improved the error message for `Session.write_pandas()` and `Session.create_dataframe()` when the input pandas DataFrame does not have a column.
+- Added support for retrieving `Edge.properties` when retrieving lineage from `DGQL` in `DataFrame.lineage.trace`.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/lineage.py
+++ b/src/snowflake/snowpark/lineage.py
@@ -145,7 +145,7 @@ class _DGQLQueryBuilder:
     Provides methods for building DGQL query.
     """
 
-    EDGE_TEMPLETE = "{direction}: {edge_key}(edgeType:[{edge_types}],direction:{dir}){{{source_key} {{{properties}}}, {target_key} {{{properties}}}}}"
+    EDGE_TEMPLETE = "{direction}: {edge_key}(edgeType:[{edge_types}],direction:{dir}){{{source_key} {{{properties}}}, {target_key} {{{properties}}}, properties}}"
     QUERY_TEMPLETE = '{{{nodeKey}({domainKey}: {domain}, {object_key}:"{query_object}"{parent_param}) {{{edges}}}}}'
     USER_TO_SYSTEM_DOMAIN_MAP = {
         _UserDomain.FEATURE_VIEW: _SnowflakeDomain.TABLE,

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -279,14 +279,14 @@ def test_get_feature_view_name():
 
 
 def test_build_query():
-    query = "select SYSTEM$DGQL('{V(domain: TABLE, name:\"db.sch.name1\") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}}}}')"
+    query = "select SYSTEM$DGQL('{V(domain: TABLE, name:\"db.sch.name1\") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, properties}}}')"
     assert query == _DGQLQueryBuilder.build_query(
         _SnowflakeDomain.TABLE,
         [LineageDirection.DOWNSTREAM],
         object_name="db.sch.name1",
     )
 
-    query = 'select SYSTEM$DGQL(\'{V(domain: MODULE, name:"v1", parentName:"db.sch.name1") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}}}}\')'
+    query = 'select SYSTEM$DGQL(\'{V(domain: MODULE, name:"v1", parentName:"db.sch.name1") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, properties}}}\')'
     assert query == _DGQLQueryBuilder.build_query(
         _UserDomain.MODEL,
         [LineageDirection.DOWNSTREAM],
@@ -294,7 +294,7 @@ def test_build_query():
         object_version="v1",
     )
 
-    query = 'select SYSTEM$DGQL(\'{V(domain: TABLE, name:"db.sch.\\\\"NAME1$v1\\\\"") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}}}}\')'
+    query = 'select SYSTEM$DGQL(\'{V(domain: TABLE, name:"db.sch.\\\\"NAME1$v1\\\\"") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, properties}}}\')'
     assert query == _DGQLQueryBuilder.build_query(
         _UserDomain.FEATURE_VIEW,
         [LineageDirection.DOWNSTREAM],
@@ -306,7 +306,7 @@ def test_build_query():
         'select SYSTEM$DGQL(\'{V(domain: MODULE, name:"\\\\"v1\\\\"", parentName:"\\\\"db\\\\".\\\\"sch\\\\".\\\\"name1\\\\""'
         ") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, "
         "properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, "
-        "status, createdOn, id}}}}')"
+        "status, createdOn, id}, properties}}}')"
     )
     assert query == _DGQLQueryBuilder.build_query(
         _UserDomain.MODEL,
@@ -319,7 +319,7 @@ def test_build_query():
         'select SYSTEM$DGQL(\'{V(domain: SNOWSERVICE_INSTANCE, name:"\\\\"db\\\\".\\\\"sch\\\\".\\\\"name1\\\\""'
         ") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, "
         "properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, "
-        "status, createdOn, id}}}}')"
+        "status, createdOn, id}, properties}}}')"
     )
     assert query == _DGQLQueryBuilder.build_query(
         _UserDomain.SERVICE,
@@ -327,12 +327,12 @@ def test_build_query():
         object_name='"db"."sch"."name1"',
     )
 
-    query = "select SYSTEM$DGQL('{V(domain: TABLE, id:\"12345\") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}}}}')"
+    query = "select SYSTEM$DGQL('{V(domain: TABLE, id:\"12345\") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, properties}}}')"
     assert query == _DGQLQueryBuilder.build_query(
         _SnowflakeDomain.TABLE, [LineageDirection.DOWNSTREAM], object_id="12345"
     )
 
-    query = 'select SYSTEM$DGQL(\'{V(domain: TABLE, id:"12345", parentId:"6789") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}}}}\')'
+    query = 'select SYSTEM$DGQL(\'{V(domain: TABLE, id:"12345", parentId:"6789") {downstream: E(edgeType:[DATA_LINEAGE, OBJECT_DEPENDENCY],direction:OUT){S {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, T {domain, refinedDomain, userDomain, name, properties, schema, db, status, createdOn, id}, properties}}}\')'
     assert query == _DGQLQueryBuilder.build_query(
         _SnowflakeDomain.TABLE,
         [LineageDirection.DOWNSTREAM],


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2123730

3. Fill out the following pre-review checklist:

i updated the unit tests to reflect the new dgql query, and have verified that the integration test continues to pass.

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

4. Please describe how your code solves the related issue.

   The Lineage API now requires providing a `properties` key if we want to retrieve Edge properties, this PR adds the `properties` key to the query
