### PR TITLE
SNOW-2111933: Add local testing for sproc put and get 

### DIFF
--- a/tests/mock/conftest.py
+++ b/tests/mock/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from snowflake.snowpark import Session
 from snowflake.snowpark.mock._connection import MockServerConnection
+from snowflake.snowpark.session import _add_session, _remove_session
 
 
 @pytest.fixture(scope="function")
@@ -19,7 +20,9 @@ def mock_server_connection():
 @pytest.fixture(scope="function")
 def session(mock_server_connection):
     with Session(mock_server_connection) as s:
+        _add_session(s)
         yield s
+        _remove_session(s)
 
 
 def pytest_sessionstart(session):

--- a/tests/mock/conftest.py
+++ b/tests/mock/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 from snowflake.snowpark import Session
 from snowflake.snowpark.mock._connection import MockServerConnection
-from snowflake.snowpark.session import _add_session, _remove_session
 
 
 @pytest.fixture(scope="function")
@@ -19,10 +18,8 @@ def mock_server_connection():
 
 @pytest.fixture(scope="function")
 def session(mock_server_connection):
-    with Session(mock_server_connection) as s:
-        _add_session(s)
+    with Session.builder.config("local_testing", True).create() as s:
         yield s
-        _remove_session(s)
 
 
 def pytest_sessionstart(session):

--- a/tests/mock/test_stage_registry.py
+++ b/tests/mock/test_stage_registry.py
@@ -228,12 +228,13 @@ def test_stage_get_and_put_sproc(session):
 
     @sproc
     def read_and_write_file(session_: Session) -> str:
-        put_result = stage_registry.put(
+        put_result = session_.file.put(
             normalize_local_file(test_file),
             "@test_output_stage/test_parent_dir/test_child_dir",
+            auto_compress=False,
         )
         assert len(put_result) == 1
-        put_result = put_result.iloc[0]
+        put_result = put_result[0]
         assert put_result.source == put_result.target == "test_file_1"
         assert put_result.source_size is not None
         assert put_result.target_size is not None
@@ -243,12 +244,12 @@ def test_stage_get_and_put_sproc(session):
         assert put_result.message == ""
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            get_results = stage_registry.get(
+            get_results = session_.file.get(
                 "@test_output_stage/test_parent_dir/test_child_dir/test_file_1",
                 f"'file://{temp_dir}'",
             )
             assert len(get_results) == 1
-            get_result = get_results.iloc[0]
+            get_result = get_results[0]
             assert get_result.file == "test_file_1"
             assert get_result.size is not None
             assert get_result.status == "DOWNLOADED"

--- a/tests/mock/test_stage_registry.py
+++ b/tests/mock/test_stage_registry.py
@@ -219,9 +219,6 @@ def test_stage_get_file():
 
 
 def test_stage_get_and_put_sproc(session):
-    stage_registry = StageEntityRegistry(MockServerConnection())
-    stage_registry.create_or_replace_stage("test_stage")
-
     test_file = f"{os.path.dirname(os.path.abspath(__file__))}/files/test_file_1"
     with open(test_file, "rb") as f:
         test_content = f.read()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2111933

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Added tests that leverages put/get/readfile APIs inside of a mocked sproc. Made it so that the conftest session fixture is registered as the default session.