### PR TITLE
SNOW-2128261: Allow PATTERN when INFER_SCHEMA is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for MySQL in `DataFrameWriter.dbapi` (PrPr) for both Parquet and UDTF-based ingestion.
 - Added support for PostgreSQL in `DataFrameReader.dbapi` (PrPr) for both Parquet and UDTF-based ingestion.
 - Added support for Databricks in `DataFrameWriter.dbapi` (PrPr) for UDTF-based ingestion.
+- Added support to `DataFrameReader` to enable use of `PATTERN` when reading files with `INFER_SCHEMA` enabled.
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1130,7 +1130,9 @@ def file_operation_statement(
     raise ValueError(f"Unsupported file operation type {command}")
 
 
-def convert_value_to_sql_option(value: Optional[Union[str, bool, int, float]]) -> str:
+def convert_value_to_sql_option(
+    value: Optional[Union[str, bool, int, float, list, tuple]]
+) -> str:
     if isinstance(value, str):
         if len(value) > 1 and is_single_quoted(value):
             return value

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -1038,7 +1038,10 @@ def infer_schema_statement(
         + file_format_name
         + SINGLE_QUOTE
         + (
-            ", " + ", ".join(f"{k} => {v}" for k, v in options.items())
+            ", "
+            + ", ".join(
+                f"{k} => {convert_value_to_sql_option(v)}" for k, v in options.items()
+            )
             if options
             else ""
         )
@@ -1067,9 +1070,9 @@ def convert_value_to_sql_option(value: Optional[Union[str, bool, int, float]]) -
             )  # escape single quotes before adding a pair of quotes
             return f"'{value}'"
     else:
-        if isinstance(value, list):
+        if isinstance(value, (list, tuple)):
             # Snowflake sql uses round brackets for options that are lists
-            return str(tuple(value))
+            return f"({', '.join(convert_value_to_sql_option(val) for val in value)})"
         return str(value)
 
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -978,7 +978,7 @@ class DataFrameReader:
         # Client side has no context for if the path is a directory or a file
         # It should be safe to assume it is a file if there is a parent directory which means that it's
         # not the top level stage and there's a suffix which means it has a file extension.
-        parsed_path = pathlib.PurePosixPath(path)
+        parsed_path = pathlib.Path(path)
         path_is_file = parsed_path.parent and parsed_path.suffix
 
         # When pattern is set we should only consider files that match the pattern during schema inference

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -989,7 +989,7 @@ class DataFrameReader:
 
                 # Reconstruct path using just stage and any qualifiers
                 stage, _ = get_stage_parts(path)
-                infer_path = path[: path.find(stage)] + stage
+                infer_path = path.partition(stage)[0] + stage
 
         infer_schema_query = infer_schema_statement(
             infer_path, file_format_name, infer_schema_options or None

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -979,7 +979,7 @@ class DataFrameReader:
         # It should be safe to assume it is a file if there is a parent directory which means that it's
         # not the top level stage and there's a suffix which means it has a file extension.
         parsed_path = pathlib.Path(path)
-        path_is_file = parsed_path.parent and parsed_path.suffix
+        path_is_file = bool(parsed_path.parent and parsed_path.suffix)
 
         # When pattern is set we should only consider files that match the pattern during schema inference
         # If no files match fallback to trying to read all files.

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -978,7 +978,7 @@ class DataFrameReader:
         # Client side has no context for if the path is a directory or a file
         # It should be safe to assume it is a file if there is a parent directory which means that it's
         # not the top level stage and there's a suffix which means it has a file extension.
-        parsed_path = pathlib.Path(path)
+        parsed_path = pathlib.PurePosixPath(path)
         path_is_file = parsed_path.parent and parsed_path.suffix
 
         # When pattern is set we should only consider files that match the pattern during schema inference

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -3,7 +3,6 @@
 #
 
 import csv
-import os
 import datetime
 import json
 import logging
@@ -1736,11 +1735,11 @@ def test_pattern_with_infer(session, mode):
                 good_file_path = os.path.join(temp_dir, f"good{i}.csv")
                 bad_file_path = os.path.join(temp_dir, f"bad{i}.csv")
 
-                with open(good_file_path, "w+") as ofile:
+                with open(good_file_path, "w+", newline="") as ofile:
                     csv_writer = csv.writer(ofile)
                     csv_writer.writerows(example_data)
 
-                with open(bad_file_path, "w+") as ofile:
+                with open(bad_file_path, "w+", newline="") as ofile:
                     csv_writer = csv.writer(ofile)
                     csv_writer.writerows(incompatible_data)
 
@@ -1755,10 +1754,7 @@ def test_pattern_with_infer(session, mode):
         )
 
         single_file_df = reader.csv(f"@{stage_name}/path/good1.csv")
-        try:
-            Utils.check_answer(single_file_df, expected_rows)
-        except Exception:
-            raise ValueError(single_file_df.collect())
+        Utils.check_answer(single_file_df, expected_rows)
 
         reader = reader.option("PATTERN", ".*good.*")
         single_file_with_pattern_df = reader.csv(f"@{stage_name}/path/good1.csv")

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1710,7 +1710,10 @@ def test_pattern_with_infer(session, mode):
         )
 
         single_file_df = reader.csv(f"@{stage_name}/path/good1.csv")
-        Utils.check_answer(single_file_df, expected_rows)
+        try:
+            Utils.check_answer(single_file_df, expected_rows)
+        except Exception:
+            raise ValueError(single_file_df.collect())
 
         reader = reader.option("PATTERN", ".*good.*")
         single_file_with_pattern_df = reader.csv(f"@{stage_name}/path/good1.csv")

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1779,6 +1779,14 @@ def test_pattern_with_infer(session, mode):
         assert df.schema == expected_schema
         Utils.check_answer(df, expected_rows * 3)
 
+        # Test using fully qualified stage name
+        reader = base_reader()
+        df = reader.csv(
+            f"@{session.get_current_database()}.{session.get_current_schema()}.{stage_name}"
+        )
+        assert df.schema == expected_schema
+        Utils.check_answer(df, expected_rows * 3)
+
     finally:
         Utils.drop_stage(session, stage_name)
 

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1663,6 +1663,10 @@ def test_pattern(session, mode):
     )
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="Local testing does not support file.put",
+)
 @pytest.mark.parametrize("mode", ["select", "copy"])
 def test_pattern_with_infer(session, mode):
     stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -16,6 +16,7 @@ from snowflake.snowpark._internal.utils import (
     deprecated,
     experimental,
     get_stage_file_prefix_length,
+    get_stage_parts,
     get_temp_type_for_object,
     get_udf_upload_prefix,
     is_snowflake_quoted_id_case_insensitive,
@@ -354,97 +355,133 @@ def test_zip_file_or_directory_to_stream():
 
 def test_get_stage_file_prefix_length():
     stageName = "@stage"  # stage/
+    assert get_stage_parts(stageName) == ("stage", "")
     assert get_stage_file_prefix_length(stageName) == 6
 
     stageName2 = "@stage/"  # stage/
+    assert get_stage_parts(stageName2) == ("stage", "")
     assert get_stage_file_prefix_length(stageName2) == 6
 
     stageName3 = '@"sta/ge"/'  # sta/ge/
+    assert get_stage_parts(stageName3) == ('"sta/ge"', "")
     assert get_stage_file_prefix_length(stageName3) == 7
 
     stageName4 = '@"stage.1"/dir'  # stage.1/dir/
+    assert get_stage_parts(stageName4) == ('"stage.1"', "dir/")
     assert get_stage_file_prefix_length(stageName4) == 12
 
     stageName5 = '@" stage.\'1"/dir'  # [whitespace]stage.'1/dir/
+    assert get_stage_parts(stageName5) == ('" stage.\'1"', "dir/")
     assert get_stage_file_prefix_length(stageName5) == 14
 
     stageName6 = "'@\" stage.'1\"/dir'"  # [whitespace]stage.'1/dir/
+    assert get_stage_parts(stageName6) == ('" stage.\'1"', "dir/")
     assert get_stage_file_prefix_length(stageName6) == 14
 
     stageName7 = "'@\" stage.\\'1\"/dir'"  # [whitespace]stage.'1/dir/
+    assert get_stage_parts(stageName7) == ('" stage.\'1"', "dir/")
     assert get_stage_file_prefix_length(stageName7) == 14
 
     quotedStageName = '@"stage"'  # stage/
+    assert get_stage_parts(quotedStageName) == ('"stage"', "")
     assert get_stage_file_prefix_length(quotedStageName) == 6
 
     quotedStageName2 = '@"stage"/'  # stage/
+    assert get_stage_parts(quotedStageName2) == ('"stage"', "")
     assert get_stage_file_prefix_length(quotedStageName2) == 6
 
     stagePrefix = "@stage/dir"  # stage/dir/
+    assert get_stage_parts(stagePrefix) == ("stage", "dir/")
     assert get_stage_file_prefix_length(stagePrefix) == 10
 
     stagePrefix2 = '@"stage"/dir'  # stage/dir/
+    assert get_stage_parts(stagePrefix2) == ('"stage"', "dir/")
     assert get_stage_file_prefix_length(stagePrefix2) == 10
 
     schemaStage = "@schema.stage"  # stage/
+    assert get_stage_parts(schemaStage) == ("stage", "")
     assert get_stage_file_prefix_length(schemaStage) == 6
 
     schemaStage2 = "@schema.stage/"  # stage/
+    assert get_stage_parts(schemaStage2) == ("stage", "")
     assert get_stage_file_prefix_length(schemaStage2) == 6
 
     schemaStage3 = '@"schema".stage'  # stage/
+    assert get_stage_parts(schemaStage3) == ("stage", "")
     assert get_stage_file_prefix_length(schemaStage3) == 6
 
     schemaStage4 = '@"schema".stage/'  # stage/
+    assert get_stage_parts(schemaStage4) == ("stage", "")
     assert get_stage_file_prefix_length(schemaStage4) == 6
 
     schemaStage5 = '@"schema"."stage"'  # stage/
+    assert get_stage_parts(schemaStage5) == ('"stage"', "")
     assert get_stage_file_prefix_length(schemaStage5) == 6
 
     schemaStage6 = '@"schema"."sta/ge"/'  # sta/ge/
+    assert get_stage_parts(schemaStage6) == ('"sta/ge"', "")
     assert get_stage_file_prefix_length(schemaStage6) == 7
 
     schemaStage7 = '@"schema.1".stage/dir'  # stage/dir/
+    assert get_stage_parts(schemaStage7) == ("stage", "dir/")
     assert get_stage_file_prefix_length(schemaStage7) == 10
 
     dbStage = "@db.schema.stage"  # stage/
+    assert get_stage_parts(dbStage) == ("stage", "")
     assert get_stage_file_prefix_length(dbStage) == 6
 
     dbStage1 = "@db..stage"  # stage/
+    assert get_stage_parts(dbStage1) == ("stage", "")
     assert get_stage_file_prefix_length(dbStage1) == 6
 
     dbStage2 = "@db.schema.stage/"  # stage/
+    assert get_stage_parts(dbStage2) == ("stage", "")
     assert get_stage_file_prefix_length(dbStage2) == 6
 
     dbStage3 = "@db..stage/"  # stage/
+    assert get_stage_parts(dbStage3) == ("stage", "")
     assert get_stage_file_prefix_length(dbStage3) == 6
 
     dbStage4 = '@"db"."schema"."stage"'  # stage/
+    assert get_stage_parts(dbStage4) == ('"stage"', "")
     assert get_stage_file_prefix_length(dbStage4) == 6
 
     dbStage5 = '@"db".."stage"/'  # stage/
+    assert get_stage_parts(dbStage5) == ('"stage"', "")
     assert get_stage_file_prefix_length(dbStage5) == 6
 
     dbStage6 = '@"db.1"."schema.1"."stage.1"/dir'  # stage.1/dir/
+    assert get_stage_parts(dbStage6) == ('"stage.1"', "dir/")
     assert get_stage_file_prefix_length(dbStage6) == 12
 
     dbStage7 = '\'@"db.1"."schema.1"."\'stage.1"/dir\''  # 'stage.1/dir/
+    assert get_stage_parts(dbStage7) == ('"\'stage.1"', "dir/")
     assert get_stage_file_prefix_length(dbStage7) == 13
 
     tempStage = '@"TESTDB_SNOWPARK"."SN_TEST_OBJECT_1509309849".SNOWPARK_TEMP_STAGE_AS0HRUKQIZH0JOL'
+    assert get_stage_parts(tempStage) == ("SNOWPARK_TEMP_STAGE_AS0HRUKQIZH0JOL", "")
     assert get_stage_file_prefix_length(tempStage) == 36
 
     tempStage2 = '@"TESTDB_SNOWPARK"."SN_TEST_OBJECT_1509309849".SNOWPARK_TEMP_STAGE_AS0HRUKQIZH0JOL/'
+    assert get_stage_parts(tempStage2) == ("SNOWPARK_TEMP_STAGE_AS0HRUKQIZH0JOL", "")
     assert get_stage_file_prefix_length(tempStage2) == 36
 
     tempStage3 = '@"TESTDB_SNOWPARK"."SN_TEST_OBJECT_1509309849"."SNOWPARK_TEMP_STAGE_AS0HRUKQIZH0JOL"/'
+    assert get_stage_parts(tempStage3) == ('"SNOWPARK_TEMP_STAGE_AS0HRUKQIZH0JOL"', "")
     assert get_stage_file_prefix_length(tempStage3) == 36
 
     userStage = "@~/dir"  # dir/
+    assert get_stage_parts(userStage) == ("~", "dir/")
     assert get_stage_file_prefix_length(userStage) == 4
 
     tableStage = "db.schema.%table/dir"  # dir/
+    assert get_stage_parts(tableStage) == ("%table", "dir/")
     assert get_stage_file_prefix_length(tableStage) == 4
+
+    with pytest.raises(ValueError, match="Invalid stage"):
+        invalid_stage = "@!/dir"
+        assert get_stage_parts(invalid_stage) == (None, None)
+        get_stage_file_prefix_length(invalid_stage)
 
 
 def test_use_scoped_temporary():

--- a/tests/unit/test_analyzer_util_suite.py
+++ b/tests/unit/test_analyzer_util_suite.py
@@ -345,6 +345,8 @@ def test_convert_value_to_sql_option():
     assert convert_value_to_sql_option("") == "''"
     assert convert_value_to_sql_option(1) == "1"
     assert convert_value_to_sql_option(None) == "None"
+    assert convert_value_to_sql_option((1,)) == "(1)"
+    assert convert_value_to_sql_option((1, 2)) == "(1, 2)"
 
 
 def test_file_operation_negative():


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2128261

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR fixes an issue that DataFrameReader can run into when inferring schema. Before this change the `_infer_schema_for_file_format` would generate a query that used all files in the stage location in order to infer the schema. This is brittle because a stage location could contain files of different types or structures.

We already provide support for specifying `PATTERN` when loading files with a predefined schema. This change ensures that the same `PATTERN` is used to filter out files that should not affect the inferred schema. It does this by running a `list @stage_location pattern='PATTERN'` query and using the list of files returned to infer the schema. 

While writing the tests for this change I found that the `convert_value_to_sql_option` helper function was not correctly handling tuples of size 1. The SQL generated for tuples of size 1 would have an incorrect trailing comma. This hasn't been an issue in the past because every example I can find has two or more items in the tuple, but the FILES parameter can have just one.