### PR TITLE
SNOW-2110572: add mode verification for open

### DIFF
--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -88,6 +88,10 @@ class SnowflakeFile(RawIOBase):
             is_owner_file: (Deprecated) A boolean value, if True, the API is intended to access owner's files and all URI/URL are allowed. If False, the API is intended to access files passed into the function by the caller and only scoped URL is allowed.
             require_scoped_url: A boolean value, if True, file_location must be a scoped URL. A scoped URL ensures that the caller cannot access the UDF owners files that the caller does not have access to.
         """
+        if mode not in ("r", "rb"):
+            raise ValueError(
+                f"Invalid mode '{mode}' for SnowflakeFile.open. Supported modes are 'r' and 'rb'."
+            )
         return cls(
             file_location, mode, is_owner_file, require_scoped_url=require_scoped_url
         )

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -14,6 +14,16 @@ def test_create_snowflakefile():
         assert snowflake_file._file_location == "test_file_location"
         assert snowflake_file._mode == "r"
 
+    with SnowflakeFile.open("test_file_location", mode="rb") as snowflake_file:
+        assert snowflake_file._file_location == "test_file_location"
+        assert snowflake_file._mode == "rb"
+
+    with pytest.raises(
+        ValueError,
+        match="Invalid mode 'rw' for SnowflakeFile.open. Supported modes are 'r' and 'rb'.",
+    ):
+        snowflake_file = SnowflakeFile.open("test_file_location", mode="rw")
+
 
 def test_write_snowflakefile():
     with SnowflakeFile.open_new_result("w") as snowflake_file:


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Part of fixes for SNOW-2110572 (2/x)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

 SnowflakeFile.open() was missing verification that r and rb are the only acceptable modes.
