### PR TITLE
SNOW-2129001: Support `nullValue` option in XML reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Added support for specifying the prefix for the attribute column in the result table using `attributePrefix` option.
   - Added support for excluding attributes from the XML element using `excludeAttributes` option.
   - Added support for specifying the column name for the value when there are attributes in an element that has no child elements using `valueTag` option.
+  - Added support for specifying the value to treat as a ``null`` value using `nullValue` option.
 - Added support for parameter `return_dataframe` in `Session.call`, which can be used to set the return type of the functions to a `DataFrame` object.
 - Added a new argument to `Dataframe.describe` called `strings_include_math_stats` that triggers `stddev` and `mean` to be calculated for String columns.
 - Improved the error message for `Session.write_pandas()` and `Session.create_dataframe()` when the input pandas DataFrame does not have a column.

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1444,6 +1444,8 @@ class SnowflakePlanBuilder:
         attribute_prefix = options.get("ATTRIBUTEPREFIX", "_")
         exclude_attributes = options.get("EXCLUDEATTRIBUTES", False)
         value_tag = options.get("VALUETAG", "_VALUE")
+        # NULLVALUE will be mapped to NULL_IF in pre-defined mapping in `dataframe_writer.py`
+        null_value = options.get("NULL_IF", "")
 
         if mode not in {"PERMISSIVE", "DROPMALFORMED", "FAILFAST"}:
             raise ValueError(
@@ -1477,6 +1479,7 @@ class SnowflakePlanBuilder:
                 lit(attribute_prefix),
                 lit(exclude_attributes),
                 lit(value_tag),
+                lit(null_value),
             ),
         )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -895,6 +895,8 @@ class DataFrameReader:
 
               + ``valueTag``: The column name used for the value when there are attributes in an element that has no child elements.
                 The default value is ``_VALUE``.
+
+              + ``nullValue``: The value to treat as a null value. The default value is ``""``.
         """
         df = self._read_semi_structured_file(path, "XML")
 

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -34,6 +34,7 @@ test_file_malformed_not_self_closing_xml = "malformed_not_self_closing.xml"
 test_file_malformed_record_xml = "malformed_record.xml"
 test_file_xml_declared_namespace = "declared_namespace.xml"
 test_file_xml_undeclared_namespace = "undeclared_namespace.xml"
+test_file_null_value_xml = "null_value.xml"
 
 # Global stage name for uploading test files
 tmp_stage_name = Utils.random_stage_name()
@@ -92,6 +93,12 @@ def setup(session, resources_path, local_testing_mode):
         session,
         "@" + tmp_stage_name,
         test_files.test_xml_undeclared_namespace,
+        compress=False,
+    )
+    Utils.upload_to_stage(
+        session,
+        "@" + tmp_stage_name,
+        test_files.test_null_value_xml,
         compress=False,
     )
 
@@ -306,3 +313,42 @@ def test_read_xml_value_tag(session):
     assert len(result) == 12
     assert len(result[0]) == 1
     assert result[0]["'value'"] is not None
+
+    row_tag = "str3"
+    df = (
+        session.read.option("rowTag", row_tag)
+        .option("valueTag", "value")
+        .xml(f"@{tmp_stage_name}/{test_file_null_value_xml}")
+    )
+    result = df.collect()
+    print(result)
+    assert len(result) == 1
+    assert len(result[0]) == 2
+    assert result[0]["'value'"] == '"xxx"'
+
+
+@pytest.mark.parametrize(
+    "null_value, expected_row",
+    [
+        (
+            "",
+            Row('"1"', '"NULL"', "null", '{\n  "_VALUE": "xxx",\n  "_id": "empty"\n}'),
+        ),
+        (
+            "NULL",
+            Row('"1"', "null", "null", '{\n  "_VALUE": "xxx",\n  "_id": "empty"\n}'),
+        ),
+        (
+            "empty",
+            Row('"1"', '"NULL"', "null", '{\n  "_VALUE": "xxx",\n  "_id": null\n}'),
+        ),
+    ],
+)
+def test_read_xml_null_value(session, null_value, expected_row):
+    row_tag = "test"
+    df = (
+        session.read.option("rowTag", row_tag)
+        .option("nullValue", null_value)
+        .xml(f"@{tmp_stage_name}/{test_file_null_value_xml}")
+    )
+    Utils.check_answer(df, [expected_row])

--- a/tests/resources/nested.xml
+++ b/tests/resources/nested.xml
@@ -5,6 +5,6 @@
         <obj>
             <str>str2</str>
             <bool>true</bool>
-        </obj>>
+        </obj>
     </test>
 </tag>

--- a/tests/resources/null_value.xml
+++ b/tests/resources/null_value.xml
@@ -1,0 +1,8 @@
+<tag>
+    <test>
+        <num>1</num>
+        <str1>NULL</str1>
+        <str2></str2>
+        <str3 id="empty">xxx</str3>
+    </test>
+</tag>

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -289,6 +289,7 @@ def test_zip_file_or_directory_to_stream():
                 "resources/malformed_not_self_closing.xml",
                 "resources/malformed_record.xml",
                 "resources/nested.xml",
+                "resources/null_value.xml",
                 "resources/test.avro",
                 "resources/test.orc",
                 "resources/test.parquet",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1574,6 +1574,10 @@ class TestFiles:
         return os.path.join(self.resources_path, "undeclared_namespace.xml")
 
     @property
+    def test_null_value_xml(self):
+        return os.path.join(self.resources_path, "null_value.xml")
+
+    @property
     def test_dog_image(self):
         return os.path.join(self.resources_path, "dog.jpg")
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2129001

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Also found a related bug that for value_tag, if there are attributes available, we should use value_tag as column name too. 
