### PR TITLE
SNOW-2132902: Support `charset` option in XML reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   - Added support for excluding attributes from the XML element using `excludeAttributes` option.
   - Added support for specifying the column name for the value when there are attributes in an element that has no child elements using `valueTag` option.
   - Added support for specifying the value to treat as a ``null`` value using `nullValue` option.
+  - Added support for specifying the character encoding of the XML file using `charset` option.
 - Added support for parameter `return_dataframe` in `Session.call`, which can be used to set the return type of the functions to a `DataFrame` object.
 - Added a new argument to `Dataframe.describe` called `strings_include_math_stats` that triggers `stddev` and `mean` to be calculated for String columns.
 - Improved the error message for `Session.write_pandas()` and `Session.create_dataframe()` when the input pandas DataFrame does not have a column.

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1516,6 +1516,7 @@ class SnowflakePlanBuilder:
         value_tag = options.get("VALUETAG", "_VALUE")
         # NULLVALUE will be mapped to NULL_IF in pre-defined mapping in `dataframe_writer.py`
         null_value = options.get("NULL_IF", "")
+        charset = options.get("CHARSET", "utf-8")
 
         if mode not in {"PERMISSIVE", "DROPMALFORMED", "FAILFAST"}:
             raise ValueError(
@@ -1550,6 +1551,7 @@ class SnowflakePlanBuilder:
                 lit(exclude_attributes),
                 lit(value_tag),
                 lit(null_value),
+                lit(charset),
             ),
         )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -897,6 +897,8 @@ class DataFrameReader:
                 The default value is ``_VALUE``.
 
               + ``nullValue``: The value to treat as a null value. The default value is ``""``.
+
+              + ``charset``: The character encoding of the XML file. The default value is ``utf-8``.
         """
         df = self._read_semi_structured_file(path, "XML")
 

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -4,8 +4,11 @@
 
 import io
 import re
+import tempfile
+import os
 import lxml.etree as ET
 import html.entities
+from unittest.mock import patch
 import pytest
 
 from snowflake.snowpark._internal.xml_reader import (
@@ -15,6 +18,7 @@ from snowflake.snowpark._internal.xml_reader import (
     find_next_closing_tag_pos,
     find_next_opening_tag_pos,
     tag_is_self_closing,
+    process_xml_range,
     DEFAULT_CHUNK_SIZE,
 )
 
@@ -375,3 +379,98 @@ def test_find_next_opening_tag_pos_no_tag(chunk_size):
         find_next_opening_tag_pos(
             file_obj, tag_start_1, tag_start_2, end_limit, chunk_size=chunk_size
         )
+
+
+@pytest.mark.parametrize("charset", ["utf-8", "iso-8859-1", "ascii"])
+def test_process_xml_range_charset(charset):
+    """Test that process_xml_range handles different character encodings correctly."""
+    # Create test XML content with special characters
+    if charset == "utf-8":
+        xml_content = '<?xml version="1.0" encoding="UTF-8"?>\n<root><record>Café</record><record>Naïve</record></root>'
+        text_values = ["Café", "Naïve"]
+    elif charset == "iso-8859-1":
+        xml_content = '<?xml version="1.0" encoding="ISO-8859-1"?>\n<root><record>Café</record><record>résumé</record></root>'
+        text_values = ["Café", "résumé"]
+    else:  # ascii
+        xml_content = '<?xml version="1.0" encoding="ASCII"?>\n<root><record>test</record><record>data</record></root>'
+        text_values = ["test", "data"]
+
+    # Write XML content to a temporary file with the specified encoding
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding=charset, delete=False, suffix=".xml"
+    ) as f:
+        f.write(xml_content)
+        temp_file_path = f.name
+
+    try:
+        # Mock file operations for testing - create a BytesIO with the encoded content
+        xml_bytes = xml_content.encode(charset)
+
+        # Mock SnowflakeFile.open to return our test data
+        mock_file = io.BytesIO(xml_bytes)
+        with patch(
+            "snowflake.snowpark.files.SnowflakeFile.open", return_value=mock_file
+        ):
+            # Process the XML with the specified charset
+            results = list(
+                process_xml_range(
+                    file_path="test.xml",
+                    tag_name="record",
+                    approx_start=0,
+                    approx_end=len(xml_bytes),
+                    mode="PERMISSIVE",
+                    column_name_of_corrupt_record="_corrupt_record",
+                    strip_namespaces=True,
+                    attribute_prefix="_",
+                    exclude_attributes=False,
+                    value_tag="_VALUE",
+                    null_value="",
+                    charset=charset,
+                )
+            )
+
+        # Verify that the records were parsed correctly with the right charset
+        assert len(results) == 2
+        for i, result in enumerate(results):
+            assert result == {"_VALUE": text_values[i]}
+
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(temp_file_path):
+            os.unlink(temp_file_path)
+
+
+def test_process_xml_range_charset_decode_error():
+    """Test that process_xml_range handles encoding errors gracefully with errors='replace'."""
+    from unittest.mock import patch
+
+    # Create XML content with UTF-8 characters but try to decode as ASCII
+    xml_content = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n<root><record>Café</record></root>'
+    )
+    xml_bytes = xml_content.encode("utf-8")
+
+    mock_file = io.BytesIO(xml_bytes)
+    with patch("snowflake.snowpark.files.SnowflakeFile.open", return_value=mock_file):
+        # Process the XML with ASCII charset (should use errors='replace')
+        results = list(
+            process_xml_range(
+                file_path="test.xml",
+                tag_name="record",
+                approx_start=0,
+                approx_end=len(xml_bytes),
+                mode="PERMISSIVE",
+                column_name_of_corrupt_record="_corrupt_record",
+                strip_namespaces=True,
+                attribute_prefix="_",
+                exclude_attributes=False,
+                value_tag="_VALUE",
+                null_value="",
+                charset="ascii",  # This will cause decode errors
+            )
+        )
+
+    # Should still get a result, but with replacement characters
+    assert len(results) == 1
+    # The replacement character () should be present in the decoded text
+    assert "Caf" in str(results[0])  # Should get "Caf" or similar


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes [SNOW-2132902](https://snowflakecomputing.atlassian.net/browse/SNOW-2132902)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.


[SNOW-2132902]: https://snowflakecomputing.atlassian.net/browse/SNOW-2132902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ