### PR TITLE
NO-SNOW: Fix Snowfort failures

### DIFF
--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -114,12 +114,15 @@ def test_async_to_pandas_common(session):
         session.create_dataframe(res), session.create_dataframe(expected_res)
     )
 
-    # Non-select
-    non_select = session.sql("show regions")
-    expected = session.create_dataframe(non_select.to_pandas())
-    actual = session.create_dataframe(non_select.to_pandas(block=False).result())
-    assert non_select.columns == actual.columns
-    Utils.check_answer(expected, actual)
+    # Non-select cases
+
+    # show regions does not work in stored proc test
+    if not IS_IN_STORED_PROC:
+        non_select = session.sql("show regions")
+        expected = session.create_dataframe(non_select.to_pandas())
+        actual = session.create_dataframe(non_select.to_pandas(block=False).result())
+        assert non_select.columns == actual.columns
+        Utils.check_answer(expected, actual)
 
     try:
         table_name = Utils.random_table_name()

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1190,17 +1190,17 @@ def test_read_json_with_infer_schema(session, mode):
 )
 def test_read_json_quoted_names(session):
     stage_name = Utils.random_name_for_temp_object(TempObjectType.STAGE)
-    quoted_column_data = {'"A"': 1, '"B"': "2"}
+    quoted_column_data = {'"A"': 1, '"B"': 2.2}
     schema = StructType(
         [
             StructField('"A"', LongType(), True),
-            StructField('"B"', StringType(), False),
+            StructField('"B"', DoubleType(), False),
         ]
     )
     parsed_schema = StructType(
         [
             StructField('"""A"""', LongType(), True),
-            StructField('"""B"""', StringType(), False),
+            StructField('"""B"""', DoubleType(), False),
         ]
     )
 
@@ -1220,7 +1220,7 @@ def test_read_json_quoted_names(session):
         df_2 = reader.json(f"@{stage_name}/{put_result[0].target}")
         assert df_2.schema == parsed_schema
         result = df_1.union_all(df_2).collect()
-        Utils.check_answer(result, [Row(1, "2"), Row(1, "2")])
+        Utils.check_answer(result, [Row(1, 2.2), Row(1, 2.2)])
     finally:
         Utils.drop_stage(session, stage_name)
         if os.path.exists(file_path):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes NO-SNOW
2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   For `test_read_json_with_infer_schema` we could set a parameter on that Snowfort test suite that would fix the issue, but the test doesn't really need to be using StringType so I've replaced it with a different type.

  For the `test_async_to_pandas_common` failure I'm not sure why stored proc wouldn't be able to call that show function, but it should be ok to skip this test here. The next test case under it has similar coverage.