### PR TITLE
SNOW-2133976: Support `ignoreSurroundingWhitespace` option in XML reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   - Added support for specifying the column name for the value when there are attributes in an element that has no child elements using `valueTag` option.
   - Added support for specifying the value to treat as a ``null`` value using `nullValue` option.
   - Added support for specifying the character encoding of the XML file using `charset` option.
+  - Added support for ignoring surrounding whitespace in the XML element using `ignoreSurroundingWhitespace` option.
 - Added support for parameter `return_dataframe` in `Session.call`, which can be used to set the return type of the functions to a `DataFrame` object.
 - Added a new argument to `Dataframe.describe` called `strings_include_math_stats` that triggers `stddev` and `mean` to be calculated for String columns.
 - Improved the error message for `Session.write_pandas()` and `Session.create_dataframe()` when the input pandas DataFrame does not have a column.

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1517,6 +1517,9 @@ class SnowflakePlanBuilder:
         # NULLVALUE will be mapped to NULL_IF in pre-defined mapping in `dataframe_writer.py`
         null_value = options.get("NULL_IF", "")
         charset = options.get("CHARSET", "utf-8")
+        ignore_surrounding_whitespace = options.get(
+            "IGNORESURROUNDINGWHITESPACE", False
+        )
 
         if mode not in {"PERMISSIVE", "DROPMALFORMED", "FAILFAST"}:
             raise ValueError(
@@ -1552,6 +1555,7 @@ class SnowflakePlanBuilder:
                 lit(value_tag),
                 lit(null_value),
                 lit(charset),
+                lit(ignore_surrounding_whitespace),
             ),
         )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -899,6 +899,9 @@ class DataFrameReader:
               + ``nullValue``: The value to treat as a null value. The default value is ``""``.
 
               + ``charset``: The character encoding of the XML file. The default value is ``utf-8``.
+
+              + ``ignoreSurroundingWhitespace``: Whether or not whitespaces surrounding values should be skipped.
+                The default value is ``False``.
         """
         df = self._read_semi_structured_file(path, "XML")
 

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -352,3 +352,29 @@ def test_read_xml_null_value(session, null_value, expected_row):
         .xml(f"@{tmp_stage_name}/{test_file_null_value_xml}")
     )
     Utils.check_answer(df, [expected_row])
+
+
+@pytest.mark.parametrize(
+    "ignore_surrounding_whitespace, expected_row",
+    [
+        (
+            True,
+            Row('{\n  "_VALUE": "xxx",\n  "_id": null\n}'),
+        ),
+        (
+            False,
+            Row('{\n  "_VALUE": " xxx  ",\n  "_id": "  empty"\n}'),
+        ),
+    ],
+)
+def test_read_xml_ignore_surrounding_whitespace(
+    session, ignore_surrounding_whitespace, expected_row
+):
+    row_tag = "test2"
+    df = (
+        session.read.option("rowTag", row_tag)
+        .option("nullValue", "empty")
+        .option("ignoreSurroundingWhitespace", ignore_surrounding_whitespace)
+        .xml(f"@{tmp_stage_name}/{test_file_null_value_xml}")
+    )
+    Utils.check_answer(df, [expected_row])

--- a/tests/resources/null_value.xml
+++ b/tests/resources/null_value.xml
@@ -5,4 +5,7 @@
         <str2></str2>
         <str3 id="empty">xxx</str3>
     </test>
+    <test2>
+        <str4 id="  empty"> xxx  </str4>
+    </test2>
 </tag>


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2133976

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
