### PR TITLE
SNOW-2116667: [Local Testing] Fix indexing issue in concat_ws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 #### Bug Fixes
 
 - Fixed a bug in `Column.isin` that would cause incorrect filtering on joined or previously filtered data.
+- Fixed a bug in `snowflake.snowpark.functions.concat_ws` that would cause results to have an incorrect index.
 
 ### Snowpark pandas API Updates
 

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -2118,7 +2118,7 @@ def mock_concat_ws(*columns: ColumnEmulator) -> ColumnEmulator:
                 "concat_ws expects a seperator column and one or more value column(s) to be passed in."
             )
         )
-    pdf = pandas.concat(columns, axis=1).reset_index(drop=True)
+    pdf = pandas.concat(columns, axis=1)
     result = pdf.T.apply(
         lambda c: None
         if c.isnull().values.any()

--- a/tests/mock/test_functions.py
+++ b/tests/mock/test_functions.py
@@ -16,6 +16,7 @@ from snowflake.snowpark.functions import (
     asc,
     call_function,
     col,
+    concat_ws,
     contains,
     count,
     current_date,
@@ -580,3 +581,10 @@ def test_array_construct_indexing(session):
         filtered = df.filter(col("a") == n)
         filtered = filtered.with_column("arr", array_construct(*["a", "b", "c"]))
         Utils.check_answer(filtered, result)
+
+
+def test_concat_ws_indexing(session):
+    df = session.create_dataframe([(1, "A"), (2, "B"), (3, "C")], schema=["A", "B"])
+    filtered = df.where(df.A > 1)
+    final = filtered.with_column("concat", concat_ws(lit("-"), "A", "B"))
+    Utils.check_answer(final, [Row(2, "B", "2-B"), Row(3, "C", "3-C")])


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2116667

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Dropping the index in concat_ws is not correct. This causes issues when the input df does not have a default index such as when some rows have been filtered out.