### PR TITLE
SNOW-2125114 allow cast in in-values clause

### DIFF
--- a/src/snowflake/snowpark/column.py
+++ b/src/snowflake/snowpark/column.py
@@ -721,7 +721,9 @@ class Column:
 
             def validate_value(value_expr: Expression):
                 # literal and column
-                if isinstance(value_expr, (Literal, Attribute, UnresolvedAttribute)):
+                if isinstance(
+                    value_expr, (Literal, Attribute, UnresolvedAttribute, Cast)
+                ):
                     return
                 elif isinstance(value_expr, MultipleExpression):
                     for expr in value_expr.expressions:

--- a/tests/integ/scala/test_column_suite.py
+++ b/tests/integ/scala/test_column_suite.py
@@ -766,6 +766,13 @@ def test_in_expression_1_in_with_constant_value_list(session):
     df4 = df.select(~col("a").in_([lit(1), lit(2)]).as_("in_result"))
     Utils.check_answer(df4, [Row(False), Row(False), Row(True)], sort=False)
 
+    df5 = df.select(
+        ~col("a")
+        .in_([lit("1").cast(IntegerType()), lit("2").cast(IntegerType())])
+        .as_("in_result")
+    )
+    Utils.check_answer(df5, [Row(False), Row(False), Row(True)], sort=False)
+
 
 def test_in_expression_2_in_with_subquery(session):
     df0 = session.create_dataframe([[1], [2], [5]]).to_df(["a"])


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-2125114

2. Fill out the following pre-review checklist:

   - [s] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [s] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   In this PR I fix a bug where casted columns can be used in the values-clause of in functions.