### PR TITLE
NO-SNOW: Skip failing tests in stored procs

### DIFF
--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1948,12 +1948,15 @@ def test_register_sproc_after_switch_schema(session):
         session.use_schema(current_schema)
 
 
-@pytest.mark.xfail(reason="SNOW-2041110: flaky test", strict=False)
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
     reason="artifact repository not supported in local testing",
 )
 @pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Stored proc env does not have permissions to look up warehouse details",
+)
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="artifact repository requires Python 3.9+"
 )

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -1992,13 +1992,14 @@ def test_sproc_artifact_repository(session):
                 session=session,
                 return_type=StringType(),
                 artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
-                packages=["urllib3", "requests"],
+                packages=["urllib3", "requests", "cloudpickle"],
                 resource_constraint={"architecture": "x86"},
             )
         except SnowparkSQLException as ex:
-            assert (
-                "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse."
-                in str(ex)
+            assert "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse." in str(
+                ex
+            ) or "Cannot create or execute a function with resource_constraint annotation on a standard warehouse." in str(
+                ex
             )
 
 

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -634,7 +634,7 @@ def test_udaf_artifact_repository(session):
         return_type=StringType(),
         input_types=[IntegerType()],
         artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
-        packages=["urllib3", "requests"],
+        packages=["urllib3", "requests", "cloudpickle"],
     )
     df = session.create_dataframe([(1,)], schema=["a"])
     Utils.check_answer(df.agg(ar_udaf("a")), [Row("test")])

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -597,12 +597,15 @@ def test_udaf_external_access_integration(session, db_parameters):
         pytest.skip("External Access Integration is not supported on the deployment.")
 
 
-@pytest.mark.xfail(reason="SNOW-2041110: flaky test", strict=False)
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
     reason="artifact repository not supported in local testing",
 )
 @pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Stored proc env does not have permissions to look up warehouse details",
+)
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="artifact repository requires Python 3.9+"
 )

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -656,13 +656,14 @@ def test_udaf_artifact_repository(session):
                 return_type=StringType(),
                 input_types=[IntegerType()],
                 artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
-                packages=["urllib3", "requests"],
+                packages=["urllib3", "requests", "cloudpickle"],
                 resource_constraint={"architecture": "x86"},
             )
         except SnowparkSQLException as ex:
-            assert (
-                "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse."
-                in str(ex)
+            assert "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse." in str(
+                ex
+            ) or "Cannot create or execute a function with resource_constraint annotation on a standard warehouse." in str(
+                ex
             )
 
 

--- a/tests/integ/test_udaf.py
+++ b/tests/integ/test_udaf.py
@@ -710,7 +710,7 @@ def test_udaf_artifact_repository_from_file(session, tmpdir):
         return_type=StringType(),
         input_types=[IntegerType()],
         artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
-        packages=["urllib3", "requests"],
+        packages=["urllib3", "requests", "cloudpickle"],
     )
     df = session.create_dataframe([(1,)], schema=["a"])
     Utils.check_answer(df.agg(ar_udaf("a")), [Row("test")])

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2898,9 +2898,10 @@ def test_register_artifact_repository_negative(session):
                 resource_constraint={"architecture": "x86"},
             )
         except SnowparkSQLException as ex:
-            assert (
-                "Cannot create or execute a function with resource_constraint annotation on a standard warehouse."
-                in str(ex)
+            assert "Cannot create or execute a function with resource_constraint annotation on a standard warehouse." in str(
+                ex
+            ) or "Cannot create or execute a function with resource_constraint annotation on a standard warehouse." in str(
+                ex
             )
 
 

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -2847,6 +2847,10 @@ def test_register_artifact_repository(session):
     reason="artifact repository not supported in local testing",
 )
 @pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Stored proc env does not have permissions to look up warehouse details",
+)
+@pytest.mark.skipif(
     sys.version_info < (3, 9), reason="artifact repository requires Python 3.9+"
 )
 def test_register_artifact_repository_negative(session):

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -1358,12 +1358,15 @@ def test_udtf_external_access_integration(session, db_parameters):
         pytest.skip("External Access Integration is not supported on the deployment.")
 
 
-@pytest.mark.xfail(reason="SNOW-2041110: flaky test", strict=False)
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
     reason="artifact repository not supported in local testing",
 )
 @pytest.mark.skipif(IS_NOT_ON_GITHUB, reason="need resources")
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="Stored proc env does not have permissions to look up warehouse details",
+)
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="artifact repository requires Python 3.9+"
 )

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -1381,7 +1381,7 @@ def test_udtf_artifact_repository(session, resources_path):
         ArtifactRepositoryUDTF,
         output_schema=StructType([StructField("a", StringType())]),
         artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
-        packages=["urllib3", "requests"],
+        packages=["urllib3", "requests", "cloudpickle"],
     )
 
     Utils.check_answer(
@@ -1413,9 +1413,10 @@ def test_udtf_artifact_repository(session, resources_path):
                 resource_constraint={"architecture": "x86"},
             )
         except SnowparkSQLException as ex:
-            assert (
-                "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse."
-                in str(ex)
+            assert "Cannot create on a Python function with 'X86' architecture annotation using an 'ARM' warehouse." in str(
+                ex
+            ) or "Cannot create or execute a function with resource_constraint annotation on a standard warehouse." in str(
+                ex
             )
 
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   The stored proc env does not have permissions to run `show warehouses`. Depending on the deployment the error can be different so I've added both cases. The UDxF objects also need cloudpickle to run.