### PR TITLE
NO-SNOW: Use correct modin version in CI

### DIFF
--- a/.github/workflows/daily_modin_precommit_py39_py310.yml
+++ b/.github/workflows/daily_modin_precommit_py39_py310.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Run tests
-        run: tox -e modin_last_version-snowparkpandasdailynotdoctest
+        run: tox -e modin_previous_version-snowparkpandasdailynotdoctest-ci
 
   test:
     name: Test modin-${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}

--- a/tox.ini
+++ b/tox.ini
@@ -77,10 +77,8 @@ setenv =
     SNOWFLAKE_PYTEST_DAILY_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_DAILY_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources {env:SNOWFLAKE_PYTEST_IGNORE_MODIN_CMD}
     # This configures the extra dependency required by modin test
     modin: SNOWFLAKE_PYTEST_MODIN_DEPS = [modin-development]
-    modin_last_version:
-        SNOWFLAKE_PYTEST_MODIN_PIN = modin==0.32.0
-        SNOWFLAKE_PYTEST_MODIN_DEPS = [modin-development]
     modin_pandas_version: SNOWFLAKE_PYTEST_PANDAS_DEPS = pandas=={env:MODIN_PANDAS_PATCH_VERSION}
+    modin_previous_version: SNOWFLAKE_PYTEST_MODIN_PIN = modin==0.32.0
     SNOW_1314507_WORKAROUND_RERUN_FLAGS = --reruns 5 --reruns-delay 5 --only-rerun "Insufficient resource during interleaved execution."
     MODIN_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources
     MODIN_PYTEST_DAILY_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_DAILY_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

I made some configuration mistakes in #3394 that slipped through PR review. This PR fixes the tox configuration to correctly use the newest version of modin (0.33.1) by default in testing environments (tested locally with doctests).