### PR TITLE
NO-SNOW: Fix misc test failures

### DIFF
--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -348,7 +348,7 @@ df327 = df.select(ai_filter("A", "B"))
 
 df328 = df.select(ai_agg("A", "B"))
 
-df329 = df.select(summarize_agg("A"))
+df329 = df.select(ai_summarize_agg("A"))
 
 df330 = df.select(to_file("A/B"))
 
@@ -796,7 +796,7 @@ df327 = df.select(ai_filter("A", "B"))
 
 df328 = df.select(ai_agg("A", "B"))
 
-df329 = df.select(summarize_agg("A"))
+df329 = df.select(ai_summarize_agg("A"))
 
 df330 = df.select(to_file("A/B"))
 
@@ -23439,7 +23439,7 @@ body {
                   name {
                     name {
                       name_flat {
-                        name: "summarize_agg"
+                        name: "ai_summarize_agg"
                       }
                     }
                   }
@@ -23448,7 +23448,7 @@ body {
               pos_args {
                 string_val {
                   src {
-                    end_column: 44
+                    end_column: 47
                     end_line: 373
                     file: 2
                     start_column: 26
@@ -23458,7 +23458,7 @@ body {
                 }
               }
               src {
-                end_column: 44
+                end_column: 47
                 end_line: 373
                 file: 2
                 start_column: 26
@@ -23474,7 +23474,7 @@ body {
           }
         }
         src {
-          end_column: 45
+          end_column: 48
           end_line: 373
           file: 2
           start_column: 16

--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -484,5 +484,5 @@ def test_invalid_identifier_error_message(session):
     with pytest.raises(SnowparkSQLException, match="invalid identifier 'B'") as ex:
         session.sql(
             """SELECT "B" FROM ( SELECT $1 AS "A" FROM  VALUES (1 :: INT))"""
-        ).select("C")
+        ).select("C").collect()
     assert "There are existing quoted column identifiers" not in str(ex.value)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

This [change](https://github.com/snowflakedb/snowpark-python/pull/3382) introduced a new test case that was failing in the snowflake_plan_suite.py file when the sql simplifier is disabled. By collecting the result  of the select the error is raised even without the simplifier.

This [change](https://github.com/snowflakedb/snowpark-python/pull/3443) renamed summarize_agg to ai_summarize_agg. I've updated the ast test file to reflect this change which should fix the test failure there.