### PR TITLE
SNOW-2147180: Fix test_switch_operations.py::test_filtered_data on jenkins and test_df_creation.py::test_read_csv_local on windows

### DIFF
--- a/tests/integ/modin/hybrid/conftest.py
+++ b/tests/integ/modin/hybrid/conftest.py
@@ -31,13 +31,10 @@ def init_transaction_tables():
         );"""
         ).collect()
         session.sql(
-            """SET num_days = (SELECT DATEDIFF(DAY, '2024-01-01', CURRENT_DATE));"""
-        ).collect()
-        session.sql(
             """INSERT INTO revenue_transactions (Transaction_ID, Date, Revenue)
         SELECT
             UUID_STRING() AS Transaction_ID,
-            DATEADD(DAY, UNIFORM(0, $num_days, RANDOM(0)), '2024-01-01') AS Date,
+            DATEADD(DAY, UNIFORM(0, 800, RANDOM(0)), '2024-01-01') AS Date,
             UNIFORM(10, 1000, RANDOM(0)) AS Revenue
         FROM TABLE(GENERATOR(ROWCOUNT => 10000000));
         """

--- a/tests/integ/modin/hybrid/test_df_creation_backend.py
+++ b/tests/integ/modin/hybrid/test_df_creation_backend.py
@@ -39,9 +39,10 @@ raisin,-1
 # When automatic backend switching is enabled, read_csv should end up in native pandas.
 @sql_count_checker(query_count=0)
 def test_read_csv_local():
-    with tempfile.NamedTemporaryFile(mode="w") as f:
+    # delete=False is necessary to allow re-opening the file for reading on windows
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         f.write(CSV_CONTENT)
-        f.flush()
+        f.close()
         fruits = pd.read_csv(f.name)
         assert fruits.get_backend() == "Pandas"
 

--- a/tests/integ/modin/hybrid/test_switch_operations.py
+++ b/tests/integ/modin/hybrid/test_switch_operations.py
@@ -44,19 +44,17 @@ def test_filtered_data(init_transaction_tables):
     # in-place operations that do not change the backend
     df_transactions["DATE"] = pd.to_datetime(df_transactions["DATE"])
     assert df_transactions.get_backend() == "Snowflake"
+    base_date = pd.Timestamp("2025-06-09").date()
     df_transactions_filter1 = df_transactions[
-        (
-            df_transactions["DATE"]
-            >= pd.Timestamp.today().date() - pd.Timedelta("7 days")
-        )
-        & (df_transactions["DATE"] < pd.Timestamp.today().date())
+        (df_transactions["DATE"] >= base_date - pd.Timedelta("7 days"))
+        & (df_transactions["DATE"] < base_date)
     ]
     assert df_transactions_filter1.get_backend() == "Snowflake"
     # The smaller dataframe does operations in pandas
     df_transactions_filter1 = df_transactions_filter1.groupby("DATE").sum()["REVENUE"]
     assert df_transactions_filter1.get_backend() == "Pandas"
     df_transactions_filter2 = pd.read_snowflake(
-        "SELECT * FROM revenue_transactions WHERE Date >= DATEADD( 'days', -7, current_date ) and Date < current_date"
+        "SELECT * FROM revenue_transactions WHERE Date >= DATEADD( 'days', -7, '2025-06-09' ) and Date < '2025-06-09'"
     )
     assert df_transactions_filter2.get_backend() == "Pandas"
     assert_array_equal(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2147180

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

This fixes 2 test issues detected in Jenkins and GH.

1. Jenkins failure from tests/integ/modin/hybrid/test_switch_operations.py::test_filtered_data: https://snowpark-python-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/SnowparkPythonSnowPandasDailyRegressRunner/197901/consoleFull

Based on the output, `pd.Timestamp().today()` reports a different value from SQL `current_date`. This PR changes the test to be deterministic and use a fixed date instead.

2. GH actions failure on Windows in tests/integ/modin/hybrid/test_df_creation_backend.py: https://github.com/snowflakedb/snowpark-python/actions/runs/15546698782/job/43769617370

Per [official docs](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile), tempfiles cannot be re-opened for reading in the middle of a write on Windows. Setting `delete=True` and closing the file before calling read_csv should fix this.