### PR TITLE
SNOW-2145168: Support `rowValidationXSDPath` option in XML reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.34.0 (YYYY-MM-DD)
+
+### Snowpark Python API Updates
+
+#### Improvements
+
+- Added support for row validation using XSD schema using `rowValidationXSDPath` option when reading XML files with a row tag using `rowTag` option.
+
 ## 1.33.0 (YYYY-MM-DD)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1524,6 +1524,7 @@ class SnowflakePlanBuilder:
         ignore_surrounding_whitespace = options.get(
             "IGNORESURROUNDINGWHITESPACE", False
         )
+        row_validation_xsd_path = options.get("ROWVALIDATIONXSDPATH", "")
 
         if mode not in {"PERMISSIVE", "DROPMALFORMED", "FAILFAST"}:
             raise ValueError(
@@ -1560,6 +1561,7 @@ class SnowflakePlanBuilder:
                 lit(null_value),
                 lit(charset),
                 lit(ignore_surrounding_whitespace),
+                lit(row_validation_xsd_path),
             ),
         )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -858,6 +858,8 @@ class DataFrameReader:
             - To parse the nested XML under a row tag, you can use dot notation ``.`` to query the nested fields in
               a DataFrame. See Example 13 in :class:`DataFrameReader`.
 
+            - ``compression`` is not supported for XML files when ``rowTag`` is specified.
+
             - When ``rowTag`` is specified, the following options are supported for reading XML files
               via :meth:`option()` or :meth:`options()`:
 
@@ -894,9 +896,12 @@ class DataFrameReader:
 
               + ``ignoreSurroundingWhitespace``: Whether or not whitespaces surrounding values should be skipped.
                 The default value is ``False``.
+
+              + ``rowValidationXSDPath``: The Snowflake stage path to the XSD file used for row validation.
+                Rows that do not match the XSD schema will be considered corrupt records and handled according to
+                the specified ``mode`` option.
         """
         df = self._read_semi_structured_file(path, "XML")
-
         # AST.
         if _emit_ast and self._ast is not None:
             stmt = self._session._ast_batch.bind()

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -35,6 +35,7 @@ test_file_malformed_record_xml = "malformed_record.xml"
 test_file_xml_declared_namespace = "declared_namespace.xml"
 test_file_xml_undeclared_namespace = "undeclared_namespace.xml"
 test_file_null_value_xml = "null_value.xml"
+test_file_books_xsd = "books.xsd"
 
 # Global stage name for uploading test files
 tmp_stage_name = Utils.random_stage_name()
@@ -99,6 +100,12 @@ def setup(session, resources_path, local_testing_mode):
         session,
         "@" + tmp_stage_name,
         test_files.test_null_value_xml,
+        compress=False,
+    )
+    Utils.upload_to_stage(
+        session,
+        "@" + tmp_stage_name,
+        test_files.test_books_xsd,
         compress=False,
     )
 
@@ -378,3 +385,23 @@ def test_read_xml_ignore_surrounding_whitespace(
         .xml(f"@{tmp_stage_name}/{test_file_null_value_xml}")
     )
     Utils.check_answer(df, [expected_row])
+
+
+def test_read_xml_row_validation_xsd_path(session):
+    row_tag = "book"
+    df = (
+        session.read.option("rowTag", row_tag)
+        .option("rowValidationXSDPath", f"@{tmp_stage_name}/{test_file_books_xsd}")
+        .option("mode", "dropmalformed")
+        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+    )
+
+    # Only bk101 should pass XSD validation (author must be "Gambardella, Matthew")
+    result = df.collect()
+    assert len(result) == 1
+    assert result[0]["'author'"] == '"Gambardella, Matthew"'
+    assert result[0]["'title'"] == '"XML Developer\'s Guide"'
+    assert result[0]["'genre'"] == '"Computer"'
+    assert result[0]["'price'"] == '"44.95"'
+    assert result[0]["'publish_date'"] == '"2000-10-01"'
+    assert result[0]["'_id'"] == '"bk101"'

--- a/tests/resources/books.xsd
+++ b/tests/resources/books.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Global book element declaration for individual book validation -->
+  <xs:element name="book">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="author" type="restrictiveAuthorType"/>
+        <xs:element name="title" type="xs:string"/>
+        <xs:element name="genre" type="xs:string"/>
+        <xs:element name="price" type="xs:decimal"/>
+        <xs:element name="publish_date" type="xs:date"/>
+        <xs:element name="description" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Root element definition -->
+  <xs:element name="catalog">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="book" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Only allow one specific author - only bk101 will be valid -->
+  <xs:simpleType name="restrictiveAuthorType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Gambardella, Matthew"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -278,6 +278,7 @@ def test_zip_file_or_directory_to_stream():
             [
                 "resources/",
                 "resources/books.xml",
+                "resources/books.xsd",
                 "resources/books2.xml",
                 "resources/broken.csv",
                 "resources/cat.jpeg",

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -482,6 +482,7 @@ def test_process_xml_range_charset(charset):
                     null_value="",
                     charset=charset,
                     ignore_surrounding_whitespace=True,
+                    row_validation_xsd_path="",
                 )
             )
 
@@ -524,6 +525,7 @@ def test_process_xml_range_charset_decode_error():
                 null_value="",
                 charset="ascii",  # This will cause decode errors
                 ignore_surrounding_whitespace=True,
+                row_validation_xsd_path="",
             )
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1592,6 +1592,10 @@ class TestFiles:
     def test_dog_image(self):
         return os.path.join(self.resources_path, "dog.jpg")
 
+    @property
+    def test_books_xsd(self):
+        return os.path.join(self.resources_path, "books.xsd")
+
 
 class TypeMap(NamedTuple):
     col_name: str


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2145168

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
