### PR TITLE
SNOW-2147878: Remove test-unsupported-py38 from github actions

### DIFF
--- a/.github/workflows/daily_modin_precommit_py39_py310.yml
+++ b/.github/workflows/daily_modin_precommit_py39_py310.yml
@@ -62,27 +62,6 @@ jobs:
           name: wheel
           path: dist/
 
-  test-unsupported-py38:
-    name: Test importing Snowpark pandas with Python 3.8 fails
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Install protoc
-        shell: bash
-        run: .github/scripts/install_protoc.sh
-      - name: Upgrade setuptools and pip
-        run: python -m pip install -U setuptools pip
-      - name: Install tox
-        run: python -m pip install tox
-      - name: Ensure importing Snowpark pandas fails on Python 3.8
-        run: tox -e snowpark_pandas_py38_import_error
-
   test-old-np:
     name: Tests that Snowpark pandas works with numpy 1.26
     needs: build

--- a/tox.ini
+++ b/tox.ini
@@ -211,11 +211,6 @@ usedevelop = True
 commands = python -m pip list --format=columns
            python -c "print(r'{envpython}')"
 
-[testenv:snowpark_pandas_py38_import_error]
-description = test RuntimeError when importing Snowpark pandas on Python 3.8
-basepython = python3.8
-commands = python -m pytest --noconftest tests/unit/modin/test_python_version.py
-
 [testenv:snowpark_pandas_old_np]
 description = test that Snowpark pandas works with numpy 1.26
 deps = .[modin-development]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2147878

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Remove test-unsupported-py38 from github actions since python 3.8 is not supported anymore.
