### PR TITLE
NO-SNOW: Fix dependency setup issues in modin daily tests

### DIFF
--- a/.github/workflows/daily_modin_precommit_py39_py310.yml
+++ b/.github/workflows/daily_modin_precommit_py39_py310.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Run tests
-        run: tox -e modin_previous_version-snowparkpandasdailynotdoctest-ci
+        run: tox -e modin_previous_version-snowparkpandasdailynotdoctest-modin-ci
 
   test:
     name: Test modin-${{ matrix.os.download_name }}-${{ matrix.python-version }}-${{ matrix.cloud-provider }}

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
             # TODO(SNOW-1938831): Test snowflake-ml-python on python 3.12 once
             # snowflake-ml-python is available on python 3.12.
             "snowflake-ml-python>=1.8.0; python_version<'3.12'",
+            "s3fs",  # Used in tests that read CSV files from s3
         ],
         "localtest": [
             "pandas",


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Fixes some more test failures.

1. Failure on Python 3.12 runners: `tests/integ/modin/hybrid/test_df_creation_backend.py::test_read_csv_remote_backend[0m - ImportError: Install s3fs to access S3`

https://github.com/snowflakedb/snowpark-python/actions/runs/15614263026/job/43983100430

`s3fs` is imported implicitly by the `snowflake-ml-python` dependency, but we exclude this dependency in Python 3.12 due to dependency version conflicts. Adding `s3fs` as an explicit dev dependency addresses this.

2. Failure on old modin version tests with `ModuleNotFoundError: No module named 'scipy'`

https://github.com/snowflakedb/snowpark-python/actions/runs/15610057149/job/43968818500

The tox environment was specified incorrectly, and `modin-development` was not specified as a dependency.