### PR TITLE
SNOW-2096094: Maintaining list of ast_ids for SnowflakePlan

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -429,7 +429,7 @@ class Selectable(LogicalPlan, ABC):
             if self.df_ast_ids is not None:
                 # Add the last df ast id to the snowflake plan as the most recent
                 # dataframe operation to create this plan.
-                self._snowflake_plan.df_ast_id = self.df_ast_ids[-1]
+                self._snowflake_plan.df_ast_ids = self.df_ast_ids
         return self._snowflake_plan
 
     @property
@@ -775,8 +775,8 @@ class SelectSnowflakePlan(Selectable):
                 self._query_params.extend(query.params)
 
         # Copy the df ast ids from the snowflake plan.
-        if (df_ast_id := self._snowflake_plan.df_ast_id) is not None:
-            self.df_ast_ids = [df_ast_id]
+        if (df_ast_ids := self._snowflake_plan.df_ast_ids) is not None:
+            self.df_ast_ids = df_ast_ids
 
     def __deepcopy__(self, memodict={}) -> "SelectSnowflakePlan":  # noqa: B006
         copied = SelectSnowflakePlan(

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -775,8 +775,7 @@ class SelectSnowflakePlan(Selectable):
                 self._query_params.extend(query.params)
 
         # Copy the df ast ids from the snowflake plan.
-        if (df_ast_ids := self._snowflake_plan.df_ast_ids) is not None:
-            self.df_ast_ids = df_ast_ids
+        self.df_ast_ids = self._snowflake_plan.df_ast_ids
 
     def __deepcopy__(self, memodict={}) -> "SelectSnowflakePlan":  # noqa: B006
         copied = SelectSnowflakePlan(

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -757,7 +757,7 @@ class SnowflakePlan(LogicalPlan):
         else:
             self.expr_to_alias = {**self.expr_to_alias, **to_add}
 
-    def _propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
+    def propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
         """Propagate df_ast_id to associated SelectSQL instances."""
         from snowflake.snowpark._internal.analyzer.select_statement import SelectSQL
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -774,6 +774,7 @@ class SnowflakePlan(LogicalPlan):
             self.df_ast_ids = [ast_id]
         elif self.df_ast_ids[-1] != ast_id:
             self.df_ast_ids.append(ast_id)
+        self.propagate_ast_id_to_select_sql(ast_id)
 
 
 class SnowflakePlanBuilder:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -183,8 +183,8 @@ class SnowflakePlan(LogicalPlan):
                     # extract df_ast_id, stmt_cache from args
                     df_ast_id, stmt_cache = None, None
                     for arg in args:
-                        if isinstance(arg, SnowflakePlan):
-                            df_ast_id = arg.df_ast_id
+                        if isinstance(arg, SnowflakePlan) and arg.df_ast_ids:
+                            df_ast_id = arg.df_ast_ids[-1]
                             stmt_cache = arg.session._ast_batch._bind_stmt_cache
                             break
                     df_transform_debug_trace = None
@@ -459,7 +459,7 @@ class SnowflakePlan(LogicalPlan):
         self._plan_state: Optional[Dict[PlanState, Any]] = None
         # If the plan has an associated DataFrame, and this Dataframe has an ast_id,
         # we will store the ast_id here.
-        self.df_ast_id: Optional[int] = None
+        self.df_ast_ids: Optional[List[int]] = None
 
     @property
     def uuid(self) -> str:
@@ -713,7 +713,7 @@ class SnowflakePlan(LogicalPlan):
                 session=self.session,
                 referenced_ctes=self.referenced_ctes,
             )
-        plan.df_ast_id = self.df_ast_id
+        plan.df_ast_ids = self.df_ast_ids
         return plan
 
     def __deepcopy__(self, memodict={}) -> "SnowflakePlan":  # noqa: B006
@@ -747,7 +747,7 @@ class SnowflakePlan(LogicalPlan):
         copied_plan._is_valid_for_replacement = True
         if copied_source_plan:
             copied_source_plan._is_valid_for_replacement = True
-        copied_plan.df_ast_id = self.df_ast_id
+        copied_plan.df_ast_ids = self.df_ast_ids
 
         return copied_plan
 
@@ -756,6 +756,14 @@ class SnowflakePlan(LogicalPlan):
             self.expr_to_alias.update(to_add)
         else:
             self.expr_to_alias = {**self.expr_to_alias, **to_add}
+
+    def _propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
+        """Propagate df_ast_id to associated SelectSQL instances."""
+        from snowflake.snowpark._internal.analyzer.select_statement import SelectSQL
+
+        for child in self.children_plan_nodes:
+            if isinstance(child, SelectSQL):
+                child.add_df_ast_id(ast_id)
 
 
 class SnowflakePlanBuilder:

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -765,6 +765,16 @@ class SnowflakePlan(LogicalPlan):
             if isinstance(child, SelectSQL):
                 child.add_df_ast_id(ast_id)
 
+    def add_df_ast_id(self, ast_id: int) -> None:
+        """Method to add a df ast id to SnowflakePlan.
+        This is used to track the df ast ids that are used in creating the
+        sql for this SnowflakePlan.
+        """
+        if self.df_ast_ids is None:
+            self.df_ast_ids = [ast_id]
+        elif self.df_ast_ids[-1] != ast_id:
+            self.df_ast_ids.append(ast_id)
+
 
 class SnowflakePlanBuilder:
     def __init__(

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -669,7 +669,8 @@ class DataFrame:
     def _ast_id(self, value: Optional[int]) -> None:
         self.__ast_id = value
         if self._plan is not None:
-            self._plan.df_ast_id = value
+            self._plan.df_ast_ids = [value]
+            self._plan._propagate_ast_id_to_select_sql(value)
         if self._select_statement is not None:
             self._select_statement.add_df_ast_id(value)
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -670,7 +670,7 @@ class DataFrame:
         self.__ast_id = value
         if self._plan is not None:
             self._plan.df_ast_ids = [value]
-            self._plan._propagate_ast_id_to_select_sql(value)
+            self._plan.propagate_ast_id_to_select_sql(value)
         if self._select_statement is not None:
             self._select_statement.add_df_ast_id(value)
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -670,7 +670,6 @@ class DataFrame:
         self.__ast_id = value
         if self._plan is not None:
             self._plan.add_df_ast_id(value)
-            self._plan.propagate_ast_id_to_select_sql(value)
         if self._select_statement is not None:
             self._select_statement.add_df_ast_id(value)
 

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -669,7 +669,7 @@ class DataFrame:
     def _ast_id(self, value: Optional[int]) -> None:
         self.__ast_id = value
         if self._plan is not None:
-            self._plan.df_ast_ids = [value]
+            self._plan.add_df_ast_id(value)
             self._plan.propagate_ast_id_to_select_sql(value)
         if self._select_statement is not None:
             self._select_statement.add_df_ast_id(value)

--- a/src/snowflake/snowpark/mock/_nop_plan.py
+++ b/src/snowflake/snowpark/mock/_nop_plan.py
@@ -231,3 +231,6 @@ class NopExecutionPlan(MockExecutionPlan):
             attr.name: (attr.datatype, attr.nullable) for attr in self.output
         }
         return output_dict
+
+    def propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
+        pass

--- a/src/snowflake/snowpark/mock/_nop_plan.py
+++ b/src/snowflake/snowpark/mock/_nop_plan.py
@@ -231,6 +231,3 @@ class NopExecutionPlan(MockExecutionPlan):
             attr.name: (attr.datatype, attr.nullable) for attr in self.output
         }
         return output_dict
-
-    def propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
-        pass

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -245,6 +245,12 @@ class MockExecutionPlan(LogicalPlan):
     def add_aliases(self, to_add: Dict) -> None:
         self.expr_to_alias.update(to_add)
 
+    def add_df_ast_id(self, ast_id: int) -> None:
+        if self.df_ast_ids is None:
+            self.df_ast_ids = [ast_id]
+        elif self.df_ast_ids[-1] != ast_id:
+            self.df_ast_ids.append(ast_id)
+
     def propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
         pass
 

--- a/src/snowflake/snowpark/mock/_plan.py
+++ b/src/snowflake/snowpark/mock/_plan.py
@@ -211,7 +211,7 @@ class MockExecutionPlan(LogicalPlan):
         )
         self.api_calls = []
         self._attributes = None
-        self.df_ast_id = None
+        self.df_ast_ids = None
 
     @property
     def attributes(self) -> List[Attribute]:
@@ -244,6 +244,9 @@ class MockExecutionPlan(LogicalPlan):
 
     def add_aliases(self, to_add: Dict) -> None:
         self.expr_to_alias.update(to_add)
+
+    def propagate_ast_id_to_select_sql(self, ast_id: int) -> None:
+        pass
 
 
 class MockFileOperation(MockExecutionPlan):

--- a/tests/integ/test_df_ast_id_map.py
+++ b/tests/integ/test_df_ast_id_map.py
@@ -33,7 +33,8 @@ def test_table(session):
 
 def verify_ast_id_consistency(df):
     assert df._ast_id is not None
-    assert df._ast_id == df._plan.df_ast_id
+    assert df._plan.df_ast_ids
+    assert df._ast_id == df._plan.df_ast_ids[-1]
     assert df._select_statement.df_ast_ids is not None
     assert df._select_statement.df_ast_ids[-1] == df._ast_id
 

--- a/tests/unit/compiler/test_replace_child_and_update_node.py
+++ b/tests/unit/compiler/test_replace_child_and_update_node.py
@@ -81,7 +81,7 @@ def mock_query_generator(mock_session) -> QueryGenerator:
     def mock_resolve(x):
         snowflake_plan = mock_snowflake_plan()
         snowflake_plan.source_plan = x
-        snowflake_plan.df_ast_id = None
+        snowflake_plan.df_ast_ids = None
         if hasattr(x, "post_actions"):
             snowflake_plan.post_actions = x.post_actions
         return snowflake_plan

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -71,7 +71,7 @@ def mock_snowflake_plan(mock_query) -> Analyzer:
 def mock_analyzer(mock_snowflake_plan) -> Analyzer:
     def mock_resolve(x):
         mock_snowflake_plan.source_plan = x
-        mock_snowflake_plan.df_ast_id = None
+        mock_snowflake_plan.df_ast_ids = None
         return mock_snowflake_plan
 
     fake_analyzer = mock.create_autospec(Analyzer)

--- a/tests/unit/test_selectable_queries.py
+++ b/tests/unit/test_selectable_queries.py
@@ -166,7 +166,7 @@ def test_select_snowflake_plan_commented_sql(mock_session, mock_analyzer):
     mock_snowflake_plan.schema_query = "SELECT A, B FROM test_table WHERE A > 10"
     mock_snowflake_plan.expr_to_alias = {}
     mock_snowflake_plan.df_aliased_col_name_to_real_col_name = {}
-    mock_snowflake_plan.df_ast_id = None
+    mock_snowflake_plan.df_ast_ids = None
     select_snowflake_plan = SelectSnowflakePlan(
         snowflake_plan=mock_snowflake_plan,
         analyzer=mock_analyzer,


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Bug fixes associated with SNOW-2096094

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.
Added code to maintain a list of ast ids for SnowflakePlan rather than a single int for cases when multiple dfs are responsible for a SnowflakePlan. This case mainly arises when we create a SnowflakePlan from a Selectable object, as we previously just took the last ast_id. 
