### PR TITLE
SNOW-2157718 - fillna attempts to fill incompatible columns with a value

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -11636,7 +11636,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # prepare label_to_value_map
             if is_scalar(value):
                 if isinstance(value, (int, float, complex)):
-                    label_to_value_map = {}
+                    label_to_value_map: dict[
+                        str, Union[Hashable, Mapping[Any, Any], Any, Any, None]
+                    ] = {}
                     for i, r in enumerate(self.dtypes):
                         if is_numeric_dtype(r):
                             label_to_value_map[self.columns[i]] = value

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -11635,7 +11635,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
             # prepare label_to_value_map
             if is_scalar(value):
-                label_to_value_map = {label: value for label in self.columns}
+                if isinstance(value, (int, float, complex)):
+                    label_to_value_map = {}
+                    for i, r in enumerate(self.dtypes):
+                        if is_numeric_dtype(r):
+                            label_to_value_map[self.columns[i]] = value
+                else:
+                    label_to_value_map = {label: value for label in self.columns}
             elif isinstance(value, dict):
                 label_to_value_map = fillna_label_to_value_map(value, self.columns)
             else:

--- a/tests/integ/modin/frame/test_fillna.py
+++ b/tests/integ/modin/frame/test_fillna.py
@@ -163,7 +163,6 @@ def test_timedelta_value_scalar(test_fillna_df):
     )
 
 
-
 @sql_count_checker(query_count=1)
 def test_value_scalar_none_index(test_fillna_df_none_index):
     # note: none in index should not be filled
@@ -709,7 +708,9 @@ def test_df_fillna_timestamp_no_numeric():
 # to fillna. Pandas will replace these with the value, and update the dtype for the
 # column.
 @sql_count_checker(query_count=1)
-@pytest.mark.xfail(reason="Pandas will replace the np.nan in a timestamp column with 0, and upcast the dtype")
+@pytest.mark.xfail(
+    reason="Pandas will replace the np.nan in a timestamp column with 0, and upcast the dtype"
+)
 def test_df_fillna_timestamp_no_numeric_with_nans():
     native_df = native_pd.DataFrame(
         [


### PR DESCRIPTION
Fixes 2157718

We currently defer to Snowflake for fillna behavior; and we generate incorrect SQL when fillna is used on a datetime column with a non-datetime value. This is unexpected. The semantics expressed in this change are not precisely the same as pandas, as we would need to actually support promoting column types to Object for this type of behavior, but it's a bit better when the non-numeric types have no NaNs.

Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
