### PR TITLE
SNOW-2157605 - Test Only - Providing more specific coverage for a customer-reported issue

### DIFF
--- a/tests/integ/modin/frame/test_setitem.py
+++ b/tests/integ/modin/frame/test_setitem.py
@@ -1606,3 +1606,30 @@ def test_df_setitem_2D_key_series_value(key_type):
         ValueError, match="setitem with a 2D key does not support Series values."
     ):
         snow_df[make_key([[True, True, True]] * 2, key_type, pd.DataFrame)] = snow_df[0]
+
+
+@sql_count_checker(query_count=2, join_count=1)
+def test_setitem_type_mismatch_SNOW_2157603():
+
+    # First possible failure, set item with a date range on top of an int
+    native_df = native_pd.DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+    expected_df = native_df
+    expected_df["A"] = native_pd.to_datetime(expected_df["A"])
+
+    snow_df = pd.DataFrame(native_df)
+    snow_df["A"] = pd.to_datetime(snow_df["A"])
+    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, expected_df)
+
+    # Second possible failure, set item with a date range using an index
+    native_index = native_pd.date_range(
+        native_pd.to_datetime(0), native_pd.to_datetime(9999999999999), freq="5min"
+    )
+    native_df = native_pd.DataFrame(native_index)
+    native_df[0] = native_pd.DataFrame(native_df[0])
+
+    snow_index = pd.date_range(
+        pd.to_datetime(0), pd.to_datetime(9999999999999), freq="5min"
+    )
+    snow_df = pd.DataFrame(snow_index)
+    snow_df[0] = pd.DataFrame(native_df[0])
+    assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(snow_df, native_df)


### PR DESCRIPTION
Ultimately no issue was found, and the culprit was/is being fixed by another change, but this test-only change just validates that approach.

   Fixes SNOW-2157605

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
