### PR TITLE
SNOW-2174093: improve error handling when closing cursor and connection in dbapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 #### Bug Fixes
 
 - Fixed a bug caused by redundant validation when creating an iceberg table.
+- Fixed a bug in `DataFrameReader.dbapi` (PrPr) where closing the cursor or connection could unexpectedly raise an error and terminate the program.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
+++ b/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
@@ -83,8 +83,18 @@ class DataSourceReader:
             else:
                 raise ValueError("fetch size cannot be smaller than 0")
         finally:
-            cursor.close()
-            conn.close()
+            try:
+                cursor.close()
+            except BaseException as exc:
+                logger.debug(
+                    f"Failed to close cursor after reading data due to error: {exc!r}"
+                )
+            try:
+                conn.close()
+            except BaseException as exc:
+                logger.debug(
+                    f"Failed to close connection after reading data due to error: {exc!r}"
+                )
 
     def data_source_data_to_pandas_df(self, data: List[Any]) -> "pd.DataFrame":
         # self.driver is guaranteed to be initialized in self.read() which is called prior to this method

--- a/src/snowflake/snowpark/_internal/data_source/drivers/base_driver.py
+++ b/src/snowflake/snowpark/_internal/data_source/drivers/base_driver.py
@@ -82,8 +82,20 @@ class BaseDriver:
                 f" Please check the stack trace for more details."
             ) from exc
         finally:
-            cursor.close()
-            conn.close()
+            # Best effort to close cursor and connection; failures are non-critical and can be ignored.
+            try:
+                cursor.close()
+            except BaseException as exc:
+                logger.debug(
+                    f"Failed to close cursor after inferring schema from description due to error: {exc!r}"
+                )
+
+            try:
+                conn.close()
+            except BaseException as exc:
+                logger.debug(
+                    f"Failed to close connection after inferring schema from description due to error: {exc!r}"
+                )
 
     def udtf_ingestion(
         self,

--- a/tests/unit/test_data_source.py
+++ b/tests/unit/test_data_source.py
@@ -6,6 +6,7 @@ import pytest
 import re
 from unittest.mock import Mock, patch
 from snowflake.snowpark._internal.data_source.drivers.base_driver import BaseDriver
+from snowflake.snowpark._internal.data_source.datasource_reader import DataSourceReader
 from snowflake.snowpark._internal.data_source.utils import DBMS_TYPE
 from snowflake.snowpark.types import StructType, StructField, StringType
 
@@ -52,6 +53,64 @@ def test_close_error_handling(cursor_fails, conn_fails):
         assert result == expected_schema
 
         # Use regex to match the log message flexibly
+        mock_logger.debug.assert_called()
+        args, kwargs = mock_logger.debug.call_args
+        assert re.search(r"Failed to close", args[0])
+
+
+@pytest.mark.parametrize(
+    "cursor_fails,conn_fails",
+    [
+        (True, False),  # cursor.close() fails
+        (False, True),  # connection.close() fails
+        (True, True),  # both fail
+    ],
+)
+def test_datasource_reader_close_error_handling(cursor_fails, conn_fails):
+    """Test that DataSourceReader handles cursor/connection close errors gracefully."""
+    # Setup mocks
+    mock_create_connection = Mock()
+    expected_schema = StructType([StructField("test_col", StringType())])
+
+    # Mock driver, connection, and cursor
+    mock_driver = Mock()
+    mock_conn = Mock()
+    mock_cursor = Mock()
+
+    # Configure the mock chain
+    mock_driver.prepare_connection.return_value = mock_conn
+    mock_driver.create_connection.return_value = mock_conn
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.fetchall.return_value = [("test_data",)]
+
+    # Configure failures
+    if cursor_fails:
+        mock_cursor.close.side_effect = Exception("Cursor close failed")
+    if conn_fails:
+        mock_conn.close.side_effect = Exception("Connection close failed")
+
+    # Create mock driver class that returns our mock driver
+    mock_driver_class = Mock(return_value=mock_driver)
+
+    # Create reader with the mock driver class
+    reader = DataSourceReader(
+        driver_class=mock_driver_class,
+        create_connection=mock_create_connection,
+        schema=expected_schema,
+        dbms_type=DBMS_TYPE.UNKNOWN,
+        fetch_size=0,  # Use 0 to trigger fetchall() path
+        query_timeout=0,
+        session_init_statement=None,
+        fetch_merge_count=1,
+    )
+
+    # Test - should succeed despite close errors and log the failure
+    with patch(
+        "snowflake.snowpark._internal.data_source.datasource_reader.logger"
+    ) as mock_logger:
+        # Consume the generator to trigger execution of the finally block
+        list(reader.read("SELECT * FROM test"))
+
         mock_logger.debug.assert_called()
         args, kwargs = mock_logger.debug.call_args
         assert re.search(r"Failed to close", args[0])

--- a/tests/unit/test_data_source.py
+++ b/tests/unit/test_data_source.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+import re
+from unittest.mock import Mock, patch
+from snowflake.snowpark._internal.data_source.drivers.base_driver import BaseDriver
+from snowflake.snowpark._internal.data_source.utils import DBMS_TYPE
+from snowflake.snowpark.types import StructType, StructField, StringType
+
+
+@pytest.mark.parametrize(
+    "cursor_fails,conn_fails",
+    [
+        (True, False),  # cursor.close() fails
+        (False, True),  # connection.close() fails
+        (True, True),  # both fail
+    ],
+)
+def test_close_error_handling(cursor_fails, conn_fails):
+    """Test that errors during cursor/connection close are handled gracefully."""
+    # Setup mock driver
+    mock_create_connection = Mock()
+    driver = BaseDriver(mock_create_connection, DBMS_TYPE.UNKNOWN)
+
+    # Setup mocks
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_create_connection.return_value = mock_conn
+
+    # Configure failures
+
+    if conn_fails:
+        mock_conn.close.side_effect = Exception("Connection close failed")
+    if cursor_fails:
+        mock_cursor.close.side_effect = Exception("Cursor close failed")
+
+    # Mock schema inference to succeed
+    expected_schema = StructType([StructField("test_col", StringType())])
+    driver.infer_schema_from_description = Mock(return_value=expected_schema)
+
+    # Test - should succeed despite close errors and log the failure
+    with patch(
+        "snowflake.snowpark._internal.data_source.drivers.base_driver.logger"
+    ) as mock_logger:
+        result = driver.infer_schema_from_description_with_error_control(
+            "test_table", False
+        )
+
+        assert result == expected_schema
+
+        # Use regex to match the log message flexibly
+        mock_logger.debug.assert_called()
+        args, kwargs = mock_logger.debug.call_args
+        assert re.search(r"Failed to close", args[0])


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2174093

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [x] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Best effort to close cursor and connection in dbapi; failures are non-critical and can be ignored.
