### PR TITLE
SNOW-1900052 - Add basic telemetry data to modin telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ local ingestion. By default, local ingestion uses multithreading. Multiprocessin
 - Added support for complex column expression as input for `functions.explode`.
 - Added debuggability improvements to show which Python lines an SQL compilation error corresponds to. Enable it using `snowflake.snowpark.context.configure_development_features()`. This feature also depends on AST collection to be enabled in the session which can be done using `session.ast_enabled = True`.
 - Set enforce_ordering=True when calling `to_snowpark_pandas()` from a snowpark dataframe containing DML/DDL queries instead of throwing a NotImplementedError.
+- Set the 'type' and other standard fields for modin telemetry.
 
 #### Bug Fixes
 
@@ -49,6 +50,8 @@ local ingestion. By default, local ingestion uses multithreading. Multiprocessin
 #### Improvements
 - Add a data type guard to the cost functions for hybrid execution mode (PrPr) which checks for data type compatibility.
 - Added automatic switching to the pandas backend in hybrid execution mode (PrPr) for many methods that are not directly implemented in Snowpark pandas.
+- Set the 'type' and other standard fields for modin telemetry.
+
 
 #### Dependency Updates
 - Added tqdm and ipywidgets as dependencies so that progress bars appear when switching between modin backends.

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -92,6 +92,9 @@ def _send_modin_api_telemetry(
     }
 
     message: dict = {
+        **session._conn._telemetry_client._create_basic_telemetry_data(
+            SnowparkPandasTelemetryField.TYPE_SNOWPARK_PANDAS_FUNCTION_USAGE.value
+        ),
         TelemetryField.KEY_DATA.value: data,
         PCTelemetryField.KEY_SOURCE.value: "modin",
     }

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -220,6 +220,11 @@ def test_send_modin_api_telemetry(send_mock):
                 "category": "modin",
             },
             "source": "modin",
+            "type": "snowpark_pandas_function_usage",
+            "version": ANY,
+            "python_version": ANY,
+            "operating_system": ANY,
+            "interactive": ANY,
         }
     )
 


### PR DESCRIPTION
SNOW-1900052 - Add basic telemetry data to modin telemetry

We are currently receiving telemetry; but this will allow it to be typed correctly with less processing.

pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [x] I am adding a new telemetry message (modification)
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
