### PR TITLE
NO-SNOW: Further reduce number of tests run in precommit

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -108,15 +108,16 @@ jobs:
           - cloud-provider: azure
             python-version: "3.12"
             os: ubuntu-latest-64-cores
-          # run py 3.12 tests on aws across all operating systems
+          # run py 3.12 tests on aws on ubuntu and macos
           - python-version: "3.12"
-            cloud-provider: aws
+            cloud-provider: gcp
             os: ubuntu-latest-64-cores
           - python-version: "3.12"
             cloud-provider: aws
             os: macos-latest
+          # run py 3.12 tests on gcp on windows to help take load off aws runners
           - python-version: "3.12"
-            cloud-provider: aws
+            cloud-provider: gcp
             os: windows-latest-64-cores
     steps:
       - name: Checkout Code
@@ -458,29 +459,25 @@ jobs:
       matrix:
         # matrix is empty for pre-commit, tests are only added
         # through the include directive
+        # We split Python version and OS differences across the different clouds to make sure
+        # the actions runners do not get overwhelmed.
+        # When support for a new Python version is added in the future, avoid adding a new task
+        # --just replace the version on an old one, and let the daily job handle full python
+        # version/cloud/OS permutation coverage.
         include:
-          # only run py3.9 tests on ubuntu+aws to isolate 3.9 failures
+          # The steps below are configured to run only doctests for macos-3.12-aws
           - python-version: "3.9"
-            os: ubuntu-latest-64-cores
-            cloud-provider: aws
-          # only run gcp tests with latest python and ubuntu
-          - cloud-provider: gcp
-            python-version: "3.12"
-            os: ubuntu-latest-64-cores
-          # only run azure tests with latest python and ubuntu
-          - cloud-provider: azure
-            python-version: "3.12"
-            os: ubuntu-latest-64-cores
-          # run py 3.12 tests on aws across all operating systems
-          - python-version: "3.12"
-            cloud-provider: aws
-            os: ubuntu-latest-64-cores
-          - python-version: "3.12"
-            cloud-provider: aws
             os: macos-latest
+            cloud-provider: aws
+          - cloud-provider: gcp
+            python-version: "3.11"
+            os: windows-latest-64-cores
+          - cloud-provider: azure
+            python-version: "3.10"
+            os: ubuntu-latest-64-cores
           - python-version: "3.12"
             cloud-provider: aws
-            os: windows-latest-64-cores
+            os: ubuntu-latest-64-cores
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

#3511 changed our precommit checks to use an explicitly-enumerated set of cloud/OS/python version permutations, but inadvertently increased the number of tests run for modin. This has seemingly caused significant slowdowns in CI over the last couple days. This is apparent in the number of tests run on main [before](https://github.com/snowflakedb/snowpark-python/actions/runs/16064288311/job/45335934246) and [after](https://github.com/snowflakedb/snowpark-python/actions/runs/16067104754) the PR; its effects were not immediately apparent because the PR was merged on a Friday when there was a low volume of other PRs being run.

This PR reverts the permutations of cloud/OS/python combinations used for modin tests to their previous state (current main runs 6 modin tests, while this PR runs 4), and also moves an additional Snowpark Python test off AWS.

The differences in test matrices in old main (prior to #3511), current main, and this PR are shown below.
![Screenshot 2025-07-08 at 13 45 25](https://github.com/user-attachments/assets/854e9da8-3417-46df-935d-d4fa853a4b66)
