### PR TITLE
SNOW-2128687: Fix all FractionalTypes being casted to FloatType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ local ingestion. By default, local ingestion uses multithreading. Multiprocessin
 - Fixed a bug caused by redundant validation when creating an iceberg table.
 - Fixed a bug in `DataFrameReader.dbapi` (PrPr) where closing the cursor or connection could unexpectedly raise an error and terminate the program.
 - Fixed ambiguous column errors when using table functions in `DataFrame.select()` that have output columns matching the input DataFrame's columns. This improvement works when dataframe columns are provided as `Column` objects.
+- Fixed a bug where having a NULL in a column with DecimalTypes would cast the column to FloatTypes instead and lead to precision loss.
 
 ### Snowpark Local Testing Updates
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -23,6 +23,7 @@ from snowflake.snowpark.types import (
     DataType,
     DateType,
     DecimalType,
+    FloatType,
     GeographyType,
     GeometryType,
     MapType,
@@ -128,7 +129,10 @@ def to_sql(
     if isinstance(datatype, _IntegralType):
         if value is None:
             return "NULL :: INT"
-    if isinstance(datatype, _FractionalType):
+    if isinstance(datatype, DecimalType):
+        if value is None:
+            return f"NULL :: DECIMAL({datatype.precision},{datatype.scale})"
+    if isinstance(datatype, FloatType):
         if value is None:
             return "NULL :: FLOAT"
     if isinstance(datatype, StringType):

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -23,6 +23,8 @@ from snowflake.snowpark.types import (
     DataType,
     DateType,
     DecimalType,
+    DoubleType,
+    FileType,
     FloatType,
     GeographyType,
     GeometryType,
@@ -35,11 +37,9 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
     VectorType,
-    FileType,
     _FractionalType,
     _IntegralType,
     _NumericType,
-    DoubleType,
 )
 
 MILLIS_PER_DAY = 24 * 3600 * 1000

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -39,6 +39,7 @@ from snowflake.snowpark.types import (
     _FractionalType,
     _IntegralType,
     _NumericType,
+    DoubleType,
 )
 
 MILLIS_PER_DAY = 24 * 3600 * 1000
@@ -132,7 +133,7 @@ def to_sql(
     if isinstance(datatype, DecimalType):
         if value is None:
             return f"NULL :: DECIMAL({datatype.precision},{datatype.scale})"
-    if isinstance(datatype, FloatType):
+    if isinstance(datatype, (FloatType, DoubleType)):
         if value is None:
             return "NULL :: FLOAT"
     if isinstance(datatype, StringType):

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -3227,17 +3227,3 @@ def test_limit(session):
 |     |     |
 -------------\n""".lstrip()
     )
-
-
-def test_filter(session):
-    data = [
-        (Decimal("123.45"), 1),
-        (Decimal("678.90"), 2),
-        (Decimal("0.0"), 3),
-        (None, 4),
-    ]
-    decimal_df = session.create_dataframe(data)
-
-    filtered_df = decimal_df.filter(col("amount") == Decimal("123.45"))
-
-    filtered_df._show_string(_emit_ast=session.ast_enabled)

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -3227,3 +3227,17 @@ def test_limit(session):
 |     |     |
 -------------\n""".lstrip()
     )
+
+
+def test_filter(session):
+    data = [
+        (Decimal("123.45"), 1),
+        (Decimal("678.90"), 2),
+        (Decimal("0.0"), 3),
+        (None, 4),
+    ]
+    decimal_df = session.create_dataframe(data)
+
+    filtered_df = decimal_df.filter(col("amount") == Decimal("123.45"))
+
+    filtered_df._show_string(_emit_ast=session.ast_enabled)

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1116,6 +1116,19 @@ def test_filter(session):
     expected = []
     assert res == expected
 
+    data = [
+        (Decimal("123.45"), 1),
+        (Decimal("678.90"), 2),
+        (Decimal("0.0"), 3),
+        (None, 4),
+    ]
+    decimal_df = session.create_dataframe(data, ["amount", "id"])
+
+    res = decimal_df.filter(col("amount") == Decimal("123.45")).collect()
+
+    expected = [Row(AMOUNT=Decimal("123.450000000000000000"), ID=1)]
+    assert res == expected
+
 
 @pytest.mark.xfail(
     "config.getoption('local_testing_mode', default=False)",

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1093,7 +1093,7 @@ def test_df_subscriptable(session):
     assert res == expected
 
 
-def test_filter(session):
+def test_filter(session, local_testing_mode):
     """Tests for df.filter()."""
     df = session.range(1, 10, 2)
     res = df.filter(col("id") > 4).collect()
@@ -1116,18 +1116,21 @@ def test_filter(session):
     expected = []
     assert res == expected
 
-    data = [
-        (Decimal("123.45"), 1),
-        (Decimal("678.90"), 2),
-        (Decimal("0.0"), 3),
-        (None, 4),
-    ]
-    decimal_df = session.create_dataframe(data, ["amount", "id"])
+    if (
+        not local_testing_mode
+    ):  # TODO: SNOW-2197035: local testing bug with NULL floats and Decimals
+        data = [
+            (Decimal("123.45"), 1),
+            (Decimal("678.90"), 2),
+            (Decimal("0.0"), 3),
+            (None, 4),
+        ]
+        decimal_df = session.create_dataframe(data, ["amount", "id"])
 
-    res = decimal_df.filter(col("amount") == Decimal("123.45")).collect()
+        res = decimal_df.filter(col("amount") == Decimal("123.45")).collect()
 
-    expected = [Row(AMOUNT=Decimal("123.450000000000000000"), ID=1)]
-    assert res == expected
+        expected = [Row(AMOUNT=Decimal("123.450000000000000000"), ID=1)]
+        assert res == expected
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2128687

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
