### PR TITLE
SNOW-2201113: skip checking string length for regression tests due to LOB issue

### DIFF
--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -2200,7 +2200,7 @@ def test_enforce_existing_file_format_object_doesnt_exist(session):
 
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
-    reason="STRING types have different precision in stored procs",
+    reason="TODO: SNOW-2201113, STRING types have different precision in stored procs due to LOB",
 )
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
@@ -2352,6 +2352,14 @@ def test_try_cast(session):
         ]
     )
 
+    lob_schema = StructType(
+        [
+            StructField("A", StringType(134217728), True),
+            StructField("B", DecimalType(2, 1), True),
+            StructField("C", BooleanType(), True),
+        ]
+    )
+
     def write_csv(data):
         with tempfile.NamedTemporaryFile(
             mode="w+",
@@ -2393,7 +2401,8 @@ def test_try_cast(session):
 
         # df1 uses constrained types
         df1 = default_reader.csv(f"@{stage_name}/")
-        assert df1.schema == schema
+        # TODO: SNOW-2201113, revert the condition once the LOB issue is fixed
+        assert df1.schema == schema or df1.schema == lob_schema
         # Try to load both files
         default_reader.option("PATTERN", None)
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
