### PR TITLE
[SNOW-2138082]: Add relative path support for SnowflakeFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Improved `query` parameter in `DataFrameReader.dbapi` (PrPr) so that parentheses are not needed around the query.
 - Improved error experience in `DataFrameReader.dbapi` (PrPr) when exception happen during inferring schema of target data source.
 
+
 ### Snowpark Local Testing Updates
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@
 
 ### Snowpark Local Testing Updates
 
-- Added local testing support for reading files with `SnowflakeFile` using local file paths, the Snow URL semantic (snow://...), local testing framework stages, and Snowflake stages (@stage/file_path).
 
 #### New Features
+
+- Added local testing support for reading files with `SnowflakeFile` using local file paths, the Snow URL semantic (snow://...), local testing framework stages, and Snowflake stages (@stage/file_path).
 
 #### Improvements
 

--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -81,6 +81,7 @@ class SnowflakeFile(RawIOBase):
     We provide a local implementation of SnowflakeFile to aid in local testing.
     This currently supports using read APIs on relative paths, mocked stages
     (sessions in local testing mode that aren't connected to a real stage), and Snowflake stages.
+    Scoped and Stage URLs (https://) are not yet supported.
 
     Note:
         1. All of the implementation in this file is for local testing purposes.
@@ -118,6 +119,9 @@ class SnowflakeFile(RawIOBase):
         # Attributes required for local testing functionality
         _DEFAULT_READ_BUFFER_SIZE = 32 * 1024
         self._pos = 0
+        if self._file_location.startswith("https://"):
+            raise ValueError("Scoped and Stage URLs are not yet supported.")
+
         self._is_stage_file = (
             True
             if self._file_location.startswith(tuple(SNOWFLAKE_PATH_PREFIXES))

--- a/src/snowflake/snowpark/files.py
+++ b/src/snowflake/snowpark/files.py
@@ -17,7 +17,6 @@ from io import (
     SEEK_CUR,
 )
 from snowflake.snowpark._internal.utils import (
-    RELATIVE_PATH_PREFIX,
     SNOWFLAKE_PATH_PREFIXES,
 )
 from typing import Sequence
@@ -119,25 +118,14 @@ class SnowflakeFile(RawIOBase):
         # Attributes required for local testing functionality
         _DEFAULT_READ_BUFFER_SIZE = 32 * 1024
         self._pos = 0
-        self._is_local_file = (
-            True
-            if self._file_location.startswith((RELATIVE_PATH_PREFIX, "C:"))
-            else False
-        )
         self._is_stage_file = (
             True
             if self._file_location.startswith(tuple(SNOWFLAKE_PATH_PREFIXES))
             else False
         )
-
-        # Validate the file location
-        if not self._is_local_file and not self._is_stage_file:
-            raise ValueError(
-                f"Invalid file location '{self._file_location}'. "
-                "File location must be a local file path or a stage file URL."
-            )
-
+        self._is_local_file = not self._is_stage_file
         self._file_size = 0
+
         if self._is_local_file and mode in _READ_MODES:
             # Buffered Reader used to support BufferedIOBase methods such as read1 and readinto1
             encoding = "utf-8" if mode == "r" else None

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -375,6 +375,19 @@ def test_read_relative_path_snowflakefile(
         os.remove(temp_file)
 
 
+def test_read_scoped_url_snowflakefile():
+    scoped_url = "https://example.com/path/to/file.txt"
+
+    def read_file(file_location: str, mode: str) -> Union[str, bytes]:
+        with SnowflakeFile.open(file_location, mode) as f:
+            return f.read()
+
+    with pytest.raises(
+        ValueError, match="Scoped and Stage URLs are not yet supported."
+    ):
+        read_file(scoped_url, "r")
+
+
 @pytest.mark.parametrize(
     _STANDARD_ARGS,
     _STANDARD_ARGVALUES,

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -352,6 +352,18 @@ def test_read_deleted_snowflakefile(mode, tmp_path):
         sf_open(temp_file)
 
 
+@pytest.mark.parametrize(["read_mode", "write_mode"], [("r", "w"), ("rb", "wb")])
+def test_read_relative_path_snowflakefile(read_mode, write_mode, tmp_path):
+    test_msg, temp_file = Utils.write_test_msg(write_mode, tmp_path)
+    temp_file = os.path.relpath(temp_file)
+
+    def read_file(file_location: str, mode: str) -> Union[str, bytes]:
+        with SnowflakeFile.open(file_location, mode) as f:
+            return f.read()
+
+    assert read_file(temp_file, read_mode) == test_msg
+
+
 @pytest.mark.parametrize(
     _STANDARD_ARGS,
     _STANDARD_ARGVALUES,

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -352,9 +352,18 @@ def test_read_deleted_snowflakefile(mode, tmp_path):
         sf_open(temp_file)
 
 
-@pytest.mark.parametrize(["read_mode", "write_mode"], [("r", "w"), ("rb", "wb")])
-def test_read_relative_path_snowflakefile(read_mode, write_mode, tmp_path):
-    test_msg, temp_file = Utils.write_test_msg(write_mode, tmp_path)
+@pytest.mark.parametrize(
+    ["read_mode", "write_mode", "use_tmp_path"],
+    [("r", "w", True), ("r", "w", False), ("rb", "wb", True), ("rb", "wb", False)],
+)
+def test_read_relative_path_snowflakefile(
+    read_mode, write_mode, use_tmp_path, tmp_path
+):
+    if use_tmp_path:
+        test_msg, temp_file = Utils.write_test_msg(write_mode, tmp_path)
+    else:
+        # Write to a temp file in the current directory
+        test_msg, temp_file = Utils.write_test_msg(write_mode, "")
     temp_file = os.path.relpath(temp_file)
 
     def read_file(file_location: str, mode: str) -> Union[str, bytes]:
@@ -362,6 +371,8 @@ def test_read_relative_path_snowflakefile(read_mode, write_mode, tmp_path):
             return f.read()
 
     assert read_file(temp_file, read_mode) == test_msg
+    if not use_tmp_path:
+        os.remove(temp_file)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2138082

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Removes enforcement that the path passed to SnowflakeFile has to be an absolute path.