### PR TITLE
SNOW-2217451: Skip NumPy 2.x incompatible tests on Python 3.10+

### DIFF
--- a/tests/integ/modin/frame/test_apply.py
+++ b/tests/integ/modin/frame/test_apply.py
@@ -893,8 +893,8 @@ import scipy.stats  # noqa: E402
             ["scipy>1.1", "numpy<2.0"],
             7,
             marks=pytest.mark.skipif(
-                sys.version_info.major == 3 and sys.version_info.minor == 12,
-                reason="SNOW-2046982: test raises ModuleNotFoundError when run in python 3.12",
+                sys.version_info.major == 3 and sys.version_info.minor >= 10,
+                reason="SNOW-2046982: test raises ModuleNotFoundError when run in python 3.10+",
             ),
         ),
         # TODO: SNOW-1478188 Re-enable quarantined tests for 8.23
@@ -935,7 +935,14 @@ def test_apply_axis1_with_3rd_party_libraries_and_decorator(
     "packages,expected_query_count",
     [
         (["scipy", "numpy"], 7),
-        (["scipy>1.1", "numpy<2.0"], 7),
+        param(
+            ["scipy>1.1", "numpy<2.0"],
+            7,
+            marks=pytest.mark.skipif(
+                sys.version_info.major == 3 and sys.version_info.minor >= 10,
+                reason="SNOW-2046982: test raises ModuleNotFoundError when run in python 3.10+",
+            ),
+        ),
         ([scipy, np], 9),
     ],
 )

--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -4,6 +4,7 @@
 
 import datetime
 import re
+import sys
 
 import modin.pandas as pd
 import numpy as np
@@ -664,7 +665,14 @@ import scipy.stats  # noqa: E402
     "packages,expected_query_count",
     [
         (["scipy", "numpy"], 26),
-        (["scipy>1.1", "numpy<2.0"], 26),
+        param(
+            ["scipy>1.1", "numpy<2.0"],
+            26,
+            marks=pytest.mark.skipif(
+                sys.version_info.major == 3 and sys.version_info.minor >= 10,
+                reason="SNOW-2046982: test raises ModuleNotFoundError when run in python 3.10+",
+            ),
+        ),
         # TODO: SNOW-1478188 Re-enable quarantined tests for 8.23
         # [scipy, np], 9),
     ],


### PR DESCRIPTION
Extends existing Python 3.12 skip condition to Python 3.10 and 3.11 for test cases using ["scipy>1.1", "numpy<2.0"] package constraints.

This prevents "No module named 'numpy._core.numeric'" errors that occur when NumPy 2.x is installed in environments running these tests.

Related to: SNOW-2046982

Test cases affected:
- test_apply_axis1_with_3rd_party_libraries_and_decorator[packages1-7]
- test_apply_axis1_with_dynamic_pivot_and_with_3rd_party_libraries_and_decorator[packages1-7]
- test_apply_axis0_with_3rd_party_libraries_and_decorator[packages1-26]

Fixes SNOW-2217451