### PR TITLE
SNOW-2221567: Fix pd.read_excel bug when reading files inside stage inner directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 
 #### Bug Fixes
 
+- Fix a `pd.read_excel` bug when reading files inside stage inner directory.
+
 ## 1.34.0 (2025-07-15)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -173,7 +173,7 @@ def _file_from_stage(filepath_or_buffer):
     with tempfile.TemporaryDirectory() as local_temp_dir:
         session.file.get(filepath_or_buffer, local_temp_dir)
         _, stripped_filepath = extract_stage_name_and_prefix(filepath_or_buffer)
-        yield os.path.join(local_temp_dir, stripped_filepath)
+        yield os.path.join(local_temp_dir, os.path.basename(stripped_filepath))
 
 
 class PandasOnSnowflakeIO(BaseIO):

--- a/tests/integ/modin/io/test_read_excel.py
+++ b/tests/integ/modin/io/test_read_excel.py
@@ -55,3 +55,24 @@ def test_read_excel_from_stage(session, resources_path):
             native_pd.read_excel(filename),
             check_dtype=False,
         )
+
+
+def test_read_excel_from_stage_inner_directory(session, resources_path):
+    test_files = TestFiles(resources_path)
+
+    filename = test_files.test_file_excel
+
+    stage_name = Utils.random_stage_name()
+    Utils.create_stage(session, stage_name, is_temporary=True)
+
+    # Upload file to inner directory in stage
+    inner_dir = "data/excel_files"
+    stage_path_with_dir = f"@{stage_name}/{inner_dir}"
+    Utils.upload_to_stage(session, stage_path_with_dir, filename, compress=False)
+
+    with SqlCounter(query_count=2):
+        assert_frame_equal(
+            pd.read_excel(f"@{stage_name}/{inner_dir}/{os.path.basename(filename)}"),
+            native_pd.read_excel(filename),
+            check_dtype=False,
+        )


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2221567

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Fix pd.read_excel bug when reading files inside stage inner directory.
