### PR TITLE
SNOW-2230971: Support repr, joins, loc, reset_index, and binary ops in faster pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@
 - Fixed a bug in hybrid execution mode (PrPr) where calling numpy operations like `np.where` on modin objects with the Pandas backend would raise an `AttributeError`. This fix requires `modin` version 0.34.0 or newer.
 - Fixed issue in `df.melt` where the resulting values have an additional suffix applied.
 
+#### Improvements
+
+- Improved performance by deferring row position computation.
+
 ## 1.33.0 (2025-06-19)
 
 ### Snowpark Python API Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 - Added support for creating permanent and immutable UDFs/UDTFs with `DataFrame/Series/GroupBy.apply`, `map`, and `transform` by passing the `snowflake_udf_params` keyword argument. See documentation for details.
 
+#### Improvements
+
+- Improved performance by deferring row position computation. 
+  - The following operations are currently supported and can benefit from the optimization: `read_snowflake`, `repr`, `loc`, `reset_index`, `merge`, and binary operations.
+  - If a lazy object (e.g., DataFrame or Series) depends on a mix of supported and unsupported operations, the optimization will not be used.
+
 #### Bug Fixes
 
 - Fixed an issue where Snowpark pandas plugin would unconditionally disable `AutoSwitchBackend` even when users had explicitly configured it via environment variables or programmatically.
@@ -63,10 +69,6 @@
 
 - Reduced the number of UDFs/UDTFs created by repeated calls to `apply` or `map` with the same arguments on Snowpark pandas objects.
 - Added an example for reading a file from a stage in the docstring for `pd.read_excel`.
-- Improved performance by deferring row position computation. 
-  - The following operations are currently supported and can benefit from the optimization: `read_snowflake`, `repr`, `loc`, `reset_index`, `merge`, and binary operations.
-  - If a lazy object (e.g., DataFrame or Series) depends on a mix of supported and unsupported operations, the optimization will not be used.
-
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
 
 - Reduced the number of UDFs/UDTFs created by repeated calls to `apply` or `map` with the same arguments on Snowpark pandas objects.
 - Added an example for reading a file from a stage in the docstring for `pd.read_excel`.
+- Improved performance by deferring row position computation. 
+  - The following operations are currently supported and can benefit from the optimization: `read_snowflake`, `repr`, `loc`, `reset_index`, `merge`, and binary operations.
+  - If a lazy object (e.g., DataFrame or Series) depends on a mix of supported and unsupported operations, the optimization will not be used.
+
 
 #### Bug Fixes
 
@@ -121,10 +125,6 @@
 - Fixed a bug in hybrid execution mode (PrPr) where certain Series operations would raise `TypeError: numpy.ndarray object is not callable`.
 - Fixed a bug in hybrid execution mode (PrPr) where calling numpy operations like `np.where` on modin objects with the Pandas backend would raise an `AttributeError`. This fix requires `modin` version 0.34.0 or newer.
 - Fixed issue in `df.melt` where the resulting values have an additional suffix applied.
-
-#### Improvements
-
-- Improved performance by deferring row position computation.
 
 ## 1.33.0 (2025-06-19)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/concat_utils.py
@@ -336,7 +336,9 @@ def _select_columns(
     )
 
 
-def add_global_ordering_columns(frame: InternalFrame, position: int) -> InternalFrame:
+def add_global_ordering_columns(
+    frame: InternalFrame, position: int, dummy_row_pos_mode: bool = False
+) -> InternalFrame:
     """
     To create global ordering for concat (axis=0) operation we first ensure a
     row position column for local ordering within the frame. Then add another
@@ -351,7 +353,7 @@ def add_global_ordering_columns(frame: InternalFrame, position: int) -> Internal
         A new frame with updated ordering columns.
 
     """
-    frame = frame.ensure_row_position_column()
+    frame = frame.ensure_row_position_column(dummy_row_pos_mode)
     ordered_dataframe = frame.ordered_dataframe.sort(
         [OrderingColumn(frame.row_position_snowflake_quoted_identifier)]
     )

--- a/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/cut_utils.py
@@ -152,6 +152,7 @@ def compute_bin_indices(
     cuts_frame: InternalFrame,
     n_cuts: int,
     right: bool = True,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Given a frame of cuts, i.e. borders of bins (strictly increasing) compute for the data in values_frame the index of the bin they fall into.
@@ -183,7 +184,7 @@ def compute_bin_indices(
     # within OrderedDataFrame yet, we use the Snowpark layer directly. This should have no negative
     # consequences when it comes to building lazy graphs, as both cut and qcut are materializing operations.
 
-    cuts_frame = cuts_frame.ensure_row_position_column()
+    cuts_frame = cuts_frame.ensure_row_position_column(dummy_row_pos_mode)
     # perform asof join to find the closet to the cut frame data.
     asof_result = join(
         values_frame,

--- a/src/snowflake/snowpark/modin/plugin/_internal/generator_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/generator_utils.py
@@ -79,6 +79,7 @@ def generate_regular_range(
 
 def _create_qc_from_snowpark_dataframe(
     sp_df: DataFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> "snowflake_query_compiler.SnowflakeQueryCompiler":
     """
     Create a Snowflake query compiler from a Snowpark DataFrame, assuming the DataFrame only contains one column.
@@ -89,7 +90,9 @@ def _create_qc_from_snowpark_dataframe(
     Returns:
         A Snowflake query compiler
     """
-    odf = OrderedDataFrame(DataFrameReference(sp_df)).ensure_row_position_column()
+    odf = OrderedDataFrame(DataFrameReference(sp_df)).ensure_row_position_column(
+        dummy_row_pos_mode
+    )
 
     from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
         SnowflakeQueryCompiler,

--- a/src/snowflake/snowpark/modin/plugin/_internal/get_dummies_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/get_dummies_utils.py
@@ -184,6 +184,7 @@ def get_dummies_helper(
     columns: list[Hashable],
     prefixes: list[Hashable],
     prefix_sep: str,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Helper function for get dummies to perform encoding on given columns
@@ -222,9 +223,9 @@ def get_dummies_helper(
             )
 
     # append a lit true column as value column for pivot
-    new_internal_frame = internal_frame.ensure_row_position_column().append_column(
-        LIT_TRUE_COLUMN_PANDAS_LABEL, pandas_lit(True)
-    )
+    new_internal_frame = internal_frame.ensure_row_position_column(
+        dummy_row_pos_mode
+    ).append_column(LIT_TRUE_COLUMN_PANDAS_LABEL, pandas_lit(True))
     # the dummy column is appended as the last data column of the new_internal_frame
     row_position_column_snowflake_quoted_identifier = (
         new_internal_frame.row_position_snowflake_quoted_identifier

--- a/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/indexing_utils.py
@@ -109,6 +109,7 @@ class ValidIndex(Enum):
 def get_valid_index_values(
     frame: InternalFrame,
     first_or_last: ValidIndex,
+    dummy_row_pos_mode: bool = False,
 ) -> "Optional[Row]":  # type: ignore # noqa
     """
     Given an InternalFrame consisting of an array of booleans, filter for True values
@@ -124,7 +125,7 @@ def get_valid_index_values(
     -------
     Optional[Row]: The desired index (a Snowpark Row) if it exists, else None.
     """
-    frame = frame.ensure_row_position_column()
+    frame = frame.ensure_row_position_column(dummy_row_pos_mode)
     index_quoted_identifier = frame.index_column_snowflake_quoted_identifiers
     data_quoted_identifier = frame.data_column_snowflake_quoted_identifiers
     row_position_quoted_identifier = frame.row_position_snowflake_quoted_identifier
@@ -218,6 +219,7 @@ def validate_out_of_bound(key_max: Any, key_min: Any, axis_len: int) -> None:
 def get_frame_by_row_pos_frame(
     internal_frame: InternalFrame,
     key: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows from this internal_frame by row positions in the key frame
@@ -239,7 +241,9 @@ def get_frame_by_row_pos_frame(
 
     # boolean indexer
     if isinstance(key_datatype, BooleanType):
-        return _get_frame_by_row_pos_boolean_frame(internal_frame, key)
+        return _get_frame_by_row_pos_boolean_frame(
+            internal_frame, key, dummy_row_pos_mode
+        )
 
     # int indexer
     if isinstance(key_datatype, _FractionalType):
@@ -259,11 +263,13 @@ def get_frame_by_row_pos_frame(
             data_column_types=key.cached_data_column_snowpark_pandas_types[1:],
             index_column_types=key.cached_index_column_snowpark_pandas_types,
         )
-    return _get_frame_by_row_pos_int_frame(internal_frame, key)
+    return _get_frame_by_row_pos_int_frame(internal_frame, key, dummy_row_pos_mode)
 
 
 def _get_frame_by_row_pos_boolean_frame(
-    internal_frame: InternalFrame, key: InternalFrame
+    internal_frame: InternalFrame,
+    key: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows using the boolean frame positional key. The two frames will be inner joined on their row position column
@@ -276,8 +282,8 @@ def _get_frame_by_row_pos_boolean_frame(
     Returns:
         new frame with selected rows
     """
-    internal_frame = internal_frame.ensure_row_position_column()
-    key = key.ensure_row_position_column()
+    internal_frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
+    key = key.ensure_row_position_column(dummy_row_pos_mode)
 
     # inner join internal_frame with key frame on row_position
     joined_frame, result_column_mapper = join(
@@ -286,6 +292,7 @@ def _get_frame_by_row_pos_boolean_frame(
         how="inner",
         left_on=[internal_frame.row_position_snowflake_quoted_identifier],
         right_on=[key.row_position_snowflake_quoted_identifier],
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     # only true value in key's data column will be selected
@@ -311,7 +318,9 @@ def _get_frame_by_row_pos_boolean_frame(
 
 
 def _get_frame_by_row_pos_int_frame(
-    internal_frame: InternalFrame, key: InternalFrame
+    internal_frame: InternalFrame,
+    key: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows using the int frame positional key. The two frames will be inner joined on the internal_frame's row
@@ -324,9 +333,11 @@ def _get_frame_by_row_pos_int_frame(
     Returns:
         new frame with selected rows
     """
-    joined_key_frame = _get_adjusted_key_frame_by_row_pos_int_frame(internal_frame, key)
+    joined_key_frame = _get_adjusted_key_frame_by_row_pos_int_frame(
+        internal_frame, key, dummy_row_pos_mode
+    )
 
-    internal_frame = internal_frame.ensure_row_position_column()
+    internal_frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
 
     # join the new value column of the key with the row position column of the original dataframe
     # to get the new rows. The result will be ordered by the key frame order followed by internal
@@ -338,6 +349,7 @@ def _get_frame_by_row_pos_int_frame(
         right_on=[internal_frame.row_position_snowflake_quoted_identifier],
         how="inner",
         inherit_join_index=InheritJoinIndex.FROM_RIGHT,
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     # Note:
@@ -360,7 +372,9 @@ def _get_frame_by_row_pos_int_frame(
 
 
 def _get_adjusted_key_frame_by_row_pos_int_frame(
-    internal_frame: InternalFrame, key: InternalFrame
+    internal_frame: InternalFrame,
+    key: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Return the key frame with any negative row positions adjusted by the internal frame.  For example, if the original
@@ -373,8 +387,8 @@ def _get_adjusted_key_frame_by_row_pos_int_frame(
     Returns:
         new frame with adjusted row positions
     """
-    internal_frame = internal_frame.ensure_row_position_column()
-    key = key.ensure_row_position_column()
+    internal_frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
+    key = key.ensure_row_position_column(dummy_row_pos_mode)
 
     # The value in the key can be negative, and can be transformed into a positive value by adding the row count of the
     # internal frame. For example: if the key is pd.Series([-1, 0, 2, -2]), and the internal frame has total 4 rows,
@@ -396,7 +410,9 @@ def _get_adjusted_key_frame_by_row_pos_int_frame(
     count_ordered_dataframe = count_ordered_dataframe.limit(1, sort=False)
 
     # step 2: add a row position column (actually, value 0) as index column\
-    count_ordered_dataframe = count_ordered_dataframe.ensure_row_position_column()
+    count_ordered_dataframe = count_ordered_dataframe.ensure_row_position_column(
+        dummy_row_pos_mode
+    )
 
     count_frame = InternalFrame.create(
         ordered_dataframe=count_ordered_dataframe,
@@ -432,6 +448,7 @@ def _get_adjusted_key_frame_by_row_pos_int_frame(
         count_frame,
         "cross",
         inherit_join_index=InheritJoinIndex.FROM_LEFT,
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     # project a new column to create the new value column
@@ -460,7 +477,9 @@ def _get_adjusted_key_frame_by_row_pos_int_frame(
 
 
 def get_frame_by_row_pos_slice_frame(
-    internal_frame: InternalFrame, key: slice
+    internal_frame: InternalFrame,
+    key: slice,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows using the slice frame positional key. A filter will be applied on the frame based on the slice.
@@ -478,7 +497,7 @@ def get_frame_by_row_pos_slice_frame(
         raise ValueError("slice step cannot be zero.")
 
     # Row position column required for left and right bound comparison.
-    frame = internal_frame.ensure_row_position_column()
+    frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
     row_pos_col = col(frame.row_position_snowflake_quoted_identifier)
 
     def get_count_col() -> Column:
@@ -1081,6 +1100,7 @@ def get_index_frame_by_row_label_slice(
 def get_frame_by_row_label(
     internal_frame: InternalFrame,
     key: Union[InternalFrame, slice, tuple],
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows by labels in the key.
@@ -1112,7 +1132,9 @@ def get_frame_by_row_label(
     if isinstance(key_datatype, BooleanType):
         return _get_frame_by_row_label_boolean_frame(internal_frame, key)
 
-    return _get_frame_by_row_label_non_boolean_frame(internal_frame, key)
+    return _get_frame_by_row_label_non_boolean_frame(
+        internal_frame, key, dummy_row_pos_mode
+    )
 
 
 def _get_frame_by_row_multiindex_label_tuple(
@@ -1188,6 +1210,7 @@ def _get_frame_by_row_label_slice(
     internal_frame: InternalFrame,
     key: slice,
     key_level: Optional[int] = None,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows with slice key, e.g., slice(start, stop, step).
@@ -1251,7 +1274,7 @@ def _get_frame_by_row_label_slice(
         return slice_val
 
     start, stop, step = to_tuple(key.start), to_tuple(key.stop), key.step
-    frame = internal_frame.ensure_row_position_column()
+    frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
     row_pos_col = col(frame.row_position_snowflake_quoted_identifier)
 
     if key_level is not None:
@@ -1498,6 +1521,7 @@ def _get_frame_by_row_label_boolean_frame(
 def _get_frame_by_row_label_non_boolean_frame(
     internal_frame: InternalFrame,
     key: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Select rows where its index is equal to the index in the key value.
@@ -1550,6 +1574,7 @@ def _get_frame_by_row_label_non_boolean_frame(
         left_on=left_on,
         right_on=right_on,
         inherit_join_index=InheritJoinIndex.FROM_RIGHT,
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     # Note: reuse pandas labels from internal frame
@@ -1615,6 +1640,7 @@ def _set_2d_labels_helper_for_frame_item(
     matching_item_rows_by_label: bool,
     col_info: LocSetColInfo,
     index_is_bool_indexer: bool,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     This set 2d label helper method handles df[index, columns] = item where index is a non-boolean indexer and item is a
@@ -1672,14 +1698,17 @@ def _set_2d_labels_helper_for_frame_item(
             # values of each column, to match pandas broadcasting behavior in the case that we are
             # doing a loc set of multiple rows, but only provide 1 row (in which case pandas would
             # just set all of the rows to the provided rows).
-            internal_frame = internal_frame.ensure_row_position_column()
-            item = item.ensure_row_position_column()
+            internal_frame = internal_frame.ensure_row_position_column(
+                dummy_row_pos_mode
+            )
+            item = item.ensure_row_position_column(dummy_row_pos_mode)
             frame, mapping = join(
                 internal_frame,
                 item,
                 how="left",
                 left_on=[internal_frame.row_position_snowflake_quoted_identifier],
                 right_on=[item.row_position_snowflake_quoted_identifier],
+                dummy_row_pos_mode=dummy_row_pos_mode,
             )
             return _propagate_last_row_if_columns_are_short(
                 frame,
@@ -1760,9 +1789,9 @@ def _set_2d_labels_helper_for_frame_item(
     ), "TODO: SNOW-966427 handle it well in multiindex case"
 
     if not matching_item_rows_by_label:
-        index = index.ensure_row_position_column()
+        index = index.ensure_row_position_column(dummy_row_pos_mode)
         left_on = [index.row_position_snowflake_quoted_identifier]
-        item = item.ensure_row_position_column()
+        item = item.ensure_row_position_column(dummy_row_pos_mode)
         right_on = [item.row_position_snowflake_quoted_identifier]
     else:
         left_on = index.data_column_snowflake_quoted_identifiers
@@ -1774,10 +1803,12 @@ def _set_2d_labels_helper_for_frame_item(
         left_on=left_on,
         right_on=right_on,
         how="left",
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     index_with_item = index_with_item.strip_duplicates(
-        quoted_identifiers=[index.data_column_snowflake_quoted_identifiers[0]]
+        quoted_identifiers=[index.data_column_snowflake_quoted_identifiers[0]],
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     if not matching_item_rows_by_label:
@@ -1809,6 +1840,7 @@ def _set_2d_labels_helper_for_frame_item(
         left_on=internal_frame.index_column_snowflake_quoted_identifiers,
         right_on=index_with_item.data_column_snowflake_quoted_identifiers[:1],
         how="left",
+        dummy_row_pos_mode=dummy_row_pos_mode,
     ).result_frame
 
 
@@ -1816,6 +1848,7 @@ def _set_2d_labels_helper_for_non_frame_item(
     internal_frame: InternalFrame,
     index: Union[slice, Scalar, InternalFrame],
     index_is_bool_indexer: bool,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     The helper method for the case where item is not an internal frame
@@ -1851,6 +1884,7 @@ def _set_2d_labels_helper_for_non_frame_item(
             right_on=index_frame.index_column_snowflake_quoted_identifiers,
             how="outer",
             join_key_coalesce_config=[JoinKeyCoalesceConfig.LEFT],
+            dummy_row_pos_mode=dummy_row_pos_mode,
         ).result_frame
     elif index_is_bool_indexer:
         return align_on_index(
@@ -1860,7 +1894,8 @@ def _set_2d_labels_helper_for_non_frame_item(
         ).result_frame
     elif isinstance(index, InternalFrame):
         index = index.strip_duplicates(
-            quoted_identifiers=[index.data_column_snowflake_quoted_identifiers[0]]
+            quoted_identifiers=[index.data_column_snowflake_quoted_identifiers[0]],
+            dummy_row_pos_mode=dummy_row_pos_mode,
         )
 
         return join(
@@ -1869,6 +1904,7 @@ def _set_2d_labels_helper_for_non_frame_item(
             left_on=internal_frame.index_column_snowflake_quoted_identifiers,
             right_on=index.data_column_snowflake_quoted_identifiers,
             how="left",
+            dummy_row_pos_mode=dummy_row_pos_mode,
         ).result_frame
 
     # No need to join index, only need one join between the internal_frame and item
@@ -1884,6 +1920,7 @@ def _set_2d_labels_helper_for_single_column_wise_item(
     item_data_column_pandas_labels: list[Hashable],
     index_is_bool_indexer: bool,
     enforce_match_item_by_row_labels: bool,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     # If it's a single column with an item list, then we set the item values column-wise, for example,
@@ -1913,15 +1950,17 @@ def _set_2d_labels_helper_for_single_column_wise_item(
         columns=item_data_column_pandas_labels,
     )._query_compiler._modin_frame
 
-    item = item.ensure_row_position_column()
-    index = index.ensure_row_position_column()
+    item = item.ensure_row_position_column(dummy_row_pos_mode)
+    index = index.ensure_row_position_column(dummy_row_pos_mode)
 
     if index_is_bool_indexer:
-        index = _get_frame_by_row_pos_boolean_frame(internal_frame, key=index)
+        index = _get_frame_by_row_pos_boolean_frame(
+            internal_frame, key=index, dummy_row_pos_mode=dummy_row_pos_mode
+        )
         index = index.project_columns(
             [DEFAULT_DATA_COLUMN_LABEL],
             [col(id) for id in index.index_column_snowflake_quoted_identifiers],
-        ).ensure_row_position_column()
+        ).ensure_row_position_column(dummy_row_pos_mode)
 
     # First, we join the index and item based on the relative row positions.
     index_with_item_res = align(
@@ -1930,6 +1969,7 @@ def _set_2d_labels_helper_for_single_column_wise_item(
         left_on=[index.row_position_snowflake_quoted_identifier],
         right_on=[item.row_position_snowflake_quoted_identifier],
         how="coalesce",
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
     index_with_item = index_with_item_res.result_frame
     index_with_item_mapper = index_with_item_res.result_column_mapper
@@ -1968,14 +2008,15 @@ def _set_2d_labels_helper_for_single_column_wise_item(
         # with the labels of index, which become the first data column of index_with_item after the join.
         # deduplicate row index in index_with_item and use the last_value for the duplicate index
         index_with_item = index_with_item.strip_duplicates(
-            quoted_identifiers=[index.data_column_snowflake_quoted_identifiers[0]]
+            quoted_identifiers=[index.data_column_snowflake_quoted_identifiers[0]],
+            dummy_row_pos_mode=dummy_row_pos_mode,
         )
         left_on = internal_frame.index_column_snowflake_quoted_identifiers
         right_on = index_with_item.data_column_snowflake_quoted_identifiers[:1]
     else:
-        internal_frame = internal_frame.ensure_row_position_column()
+        internal_frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
         left_on = [internal_frame.row_position_snowflake_quoted_identifier]
-        index_with_item = index_with_item.ensure_row_position_column()
+        index_with_item = index_with_item.ensure_row_position_column(dummy_row_pos_mode)
         right_on = [index_with_item.row_position_snowflake_quoted_identifier]
 
     return align(
@@ -1984,6 +2025,7 @@ def _set_2d_labels_helper_for_single_column_wise_item(
         left_on=left_on,
         right_on=right_on,
         how="coalesce",
+        dummy_row_pos_mode=dummy_row_pos_mode,
     ).result_frame
 
 
@@ -2094,6 +2136,7 @@ def set_frame_2d_labels(
     index_is_bool_indexer: bool,
     deduplicate_columns: bool,
     frame_is_df_and_item_is_series: bool,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Helper function to handle the general loc set functionality. The general idea here is to join the key from ``index``
@@ -2236,11 +2279,12 @@ def set_frame_2d_labels(
             matching_item_rows_by_label,
             col_info,
             index_is_bool_indexer,
+            dummy_row_pos_mode,
         )
 
     if item_is_scalar:
         result_frame = _set_2d_labels_helper_for_non_frame_item(
-            internal_frame, index, index_is_bool_indexer
+            internal_frame, index, index_is_bool_indexer, dummy_row_pos_mode
         )
     elif not item_is_frame:
         assert is_list_like(item) and not any(
@@ -2278,7 +2322,7 @@ def set_frame_2d_labels(
         if len(item_values) == 1:
             # handle single value list similar to scalar
             result_frame = _set_2d_labels_helper_for_non_frame_item(
-                internal_frame, index, index_is_bool_indexer
+                internal_frame, index, index_is_bool_indexer, dummy_row_pos_mode
             )
             item_is_scalar = True
             item = item_values[0]
@@ -2316,7 +2360,7 @@ def set_frame_2d_labels(
                     raise ValueError(LOC_SET_ITEM_KV_MISMATCH_ERROR_MESSAGE)
                 item_column_values = item_values
                 result_frame = _set_2d_labels_helper_for_non_frame_item(
-                    internal_frame, index, index_is_bool_indexer
+                    internal_frame, index, index_is_bool_indexer, dummy_row_pos_mode
                 )
     # After 2-joins, we need to
     #   1) update original columns existed in ``columns``, e.g., "B", "C", "D";
@@ -2560,6 +2604,7 @@ def set_frame_2d_positional(
     set_as_coords: bool,
     item: Union[InternalFrame, Scalar],
     is_item_series: bool,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Helper function to handle the general (worst case) 2-join case where index (aka row_key) and item are both frames.
@@ -2619,7 +2664,9 @@ def set_frame_2d_positional(
     if isinstance(index_data_type, BooleanType):
         index = get_row_position_index_from_bool_indexer(index)
     else:
-        index = _get_adjusted_key_frame_by_row_pos_int_frame(internal_frame, index)
+        index = _get_adjusted_key_frame_by_row_pos_int_frame(
+            internal_frame, index, dummy_row_pos_mode
+        )
 
     assert isinstance(index_data_type, (_IntegralType, BooleanType))
     if isinstance(item, InternalFrame):
@@ -2630,7 +2677,9 @@ def set_frame_2d_positional(
 
         # Combine the index (key) and item (values) into one key-value frame.  Note that the column length of index
         # may be changed here and we need this to properly index into the kv_frame later.
-        kv_frame = get_kv_frame_from_index_and_item_frames(index, item)
+        kv_frame = get_kv_frame_from_index_and_item_frames(
+            index, item, dummy_row_pos_mode
+        )
         item_data_columns_len = len(item.data_column_snowflake_quoted_identifiers)
     else:
         item_type = SnowparkPandasType.get_snowpark_pandas_type_for_pandas_type(
@@ -2653,8 +2702,8 @@ def set_frame_2d_positional(
     #
     # In the join result, the original dataframe data is aligned with the items that are to replace for the rows.
 
-    frame = internal_frame.ensure_row_position_column()
-    kv_frame = kv_frame.ensure_row_position_column()
+    frame = internal_frame.ensure_row_position_column(dummy_row_pos_mode)
+    kv_frame = kv_frame.ensure_row_position_column(dummy_row_pos_mode)
     item_type = kv_frame.cached_data_column_snowpark_pandas_types[-1]
 
     # To match the columns of the original dataframe (see [df] above) and the item values (see [item] above) we
@@ -2672,6 +2721,7 @@ def set_frame_2d_positional(
         how="left",
         left_on=[frame.row_position_snowflake_quoted_identifier],
         right_on=[kv_frame.data_column_snowflake_quoted_identifiers[0]],
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     # Get the row position column from the index of the combined join (frame, index, item)
@@ -2700,7 +2750,7 @@ def set_frame_2d_positional(
         )
     )
 
-    df_kv_frame = df_kv_frame.ensure_row_position_column()
+    df_kv_frame = df_kv_frame.ensure_row_position_column(dummy_row_pos_mode)
 
     new_data_column_types = []
     for col_pos, snowflake_quoted_identifier_pair in enumerate(
@@ -2781,7 +2831,9 @@ def set_frame_2d_positional(
 
 
 def get_kv_frame_from_index_and_item_frames(
-    index: InternalFrame, item: InternalFrame
+    index: InternalFrame,
+    item: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Return the key-value frame from the key (index) and item (values) frames by aligning on the row positions.
@@ -2812,8 +2864,8 @@ def get_kv_frame_from_index_and_item_frames(
     # to be selected to replace with item values.  If the item has fewer rows, we follow the join with
     # a conditional lag to project down the last item row to the empty item rows.
 
-    index = index.ensure_row_position_column()
-    item = item.ensure_row_position_column()
+    index = index.ensure_row_position_column(dummy_row_pos_mode)
+    item = item.ensure_row_position_column(dummy_row_pos_mode)
 
     kv_frame, result_column_mapper = join(
         left=index,
@@ -2821,6 +2873,7 @@ def get_kv_frame_from_index_and_item_frames(
         left_on=[index.row_position_snowflake_quoted_identifier],
         right_on=[item.row_position_snowflake_quoted_identifier],
         how="left",
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     index_row_position_snowflake_quoted_identifier = (
@@ -2938,6 +2991,7 @@ def get_item_series_as_single_row_frame(
     item: InternalFrame,
     num_columns: int,
     move_index_to_cols: Optional[bool] = False,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Get an internal frame that transpose single data column into frame with single row.  For example, if the
@@ -2965,7 +3019,7 @@ def get_item_series_as_single_row_frame(
     -------
         Frame containing single row with columns for each row.
     """
-    item = item.ensure_row_position_column()
+    item = item.ensure_row_position_column(dummy_row_pos_mode)
     item_series_pandas_labels = (
         list(range(num_columns))
         if not move_index_to_cols
@@ -3061,7 +3115,9 @@ def get_item_series_as_single_row_frame(
     return item
 
 
-def get_row_position_index_from_bool_indexer(index: InternalFrame) -> InternalFrame:
+def get_row_position_index_from_bool_indexer(
+    index: InternalFrame, dummy_row_pos_mode: bool = False
+) -> InternalFrame:
     """
     Get the index positions for a bool_indexer frame.  Note that we the number of rows in the resulting dataframe
     can be less since rows with False value are omitted in the result.
@@ -3111,7 +3167,7 @@ def get_row_position_index_from_bool_indexer(index: InternalFrame) -> InternalFr
     #     2     |     2       |        1
     #     4     |     4       |        2
 
-    index = index.ensure_row_position_column()
+    index = index.ensure_row_position_column(dummy_row_pos_mode)
 
     (
         index_column_snowflake_quoted_identifier,
@@ -3168,6 +3224,7 @@ def get_row_pos_frame_from_row_key(
         "snowflake_query_compiler.SnowflakeQueryCompiler", Scalar, list, slice, tuple
     ],
     frame: InternalFrame,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Return a frame that contains the row positions if provided as a scalar/list/slice/etc
@@ -3189,7 +3246,7 @@ def get_row_pos_frame_from_row_key(
 
     if isinstance(key, slice):
         # If it is a slice, then use the row_position from the original frame and filter down based on the slice.
-        frame = frame.ensure_row_position_column()
+        frame = frame.ensure_row_position_column(dummy_row_pos_mode)
 
         key_frame = frame.project_columns(
             [MODIN_UNNAMED_SERIES_LABEL],

--- a/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/join_utils.py
@@ -165,6 +165,7 @@ def join(
     sort: Optional[bool] = False,
     join_key_coalesce_config: Optional[list[JoinKeyCoalesceConfig]] = None,
     inherit_join_index: InheritJoinIndex = InheritJoinIndex.FROM_LEFT,
+    dummy_row_pos_mode: bool = False,
 ) -> JoinOrAlignInternalFrameResult:
     """
     Join ``left`` and ``right`` frames.
@@ -267,6 +268,7 @@ def join(
         right_match_col=right_match_col,
         match_comparator=match_comparator,
         how=how,
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
     return _create_internal_frame_with_join_or_align_result(
         joined_ordered_dataframe,
@@ -1119,6 +1121,7 @@ def join_on_index_columns(
     right: InternalFrame,
     how: JoinTypeLit,
     sort: bool,
+    dummy_row_pos_mode: bool = False,
 ) -> JoinOrAlignInternalFrameResult:
     """
     Perform join operation on index columns with the specified method (`how`), and preserves order based on sort.
@@ -1150,6 +1153,7 @@ def join_on_index_columns(
         join_key_coalesce_config=[JoinKeyCoalesceConfig.LEFT]
         * len(index_join_info.left_join_quoted_identifiers),
         inherit_join_index=InheritJoinIndex.FROM_BOTH,
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
 
     joined_frame = _reorder_index_columns(
@@ -1237,6 +1241,7 @@ def align(
     right_on: list[str],
     how: AlignTypeLit = "outer",
     sort: AlignSortLit = "default_sort",
+    dummy_row_pos_mode: bool = False,
 ) -> JoinOrAlignInternalFrameResult:
     """
     Align the left and the right frame on given columns 'left_on' and 'right_on' with
@@ -1290,6 +1295,7 @@ def align(
         right_on_cols=right_on,
         how=how,
         enable_default_sort=(sort == "default_sort"),
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
     # aligned_ordered_frame after aligning on row_position columns
     # Example 1 (left is empty not empty):
@@ -1333,6 +1339,7 @@ def align_on_index(
     right: InternalFrame,
     how: AlignTypeLit = "outer",
     sort: AlignSortLit = "default_sort",
+    dummy_row_pos_mode: bool = False,
 ) -> JoinOrAlignInternalFrameResult:
     """
     Align the left and the right frame on the index columns with given join method (`how`).
@@ -1379,6 +1386,7 @@ def align_on_index(
         right_on=index_join_info.right_join_quoted_identifiers,
         how=how,
         sort=sort,
+        dummy_row_pos_mode=dummy_row_pos_mode,
     )
     if how == "outer":
         # index reorder should only be needed for outer join since this is the only method inherent

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -332,7 +332,7 @@ class OrderedDataFrame:
         """
         return [col.snowflake_quoted_identifier for col in self.ordering_columns]
 
-    def _row_position_snowpark_column(self) -> Column:
+    def _row_position_snowpark_column(self, dummy_row_pos_mode: bool) -> Column:
         """
         Returns a row position Snowpark column for the dataframe.
         If row position column already exist in the current dataframe, it will be directly returned.
@@ -345,7 +345,15 @@ class OrderedDataFrame:
         if self.row_position_snowflake_quoted_identifier is not None:
             return Column(self.row_position_snowflake_quoted_identifier)
 
-        return row_number().over(Window.order_by(self._ordering_snowpark_columns())) - 1
+        if dummy_row_pos_mode:
+            from snowflake.snowpark.modin.plugin._internal.utils import pandas_lit
+
+            return pandas_lit(1)
+        else:
+            return (
+                row_number().over(Window.order_by(self._ordering_snowpark_columns()))
+                - 1
+            )
 
     @property
     def projected_column_snowflake_quoted_identifiers(self) -> list[str]:
@@ -355,7 +363,9 @@ class OrderedDataFrame:
         """
         return list(self._projected_column_snowflake_quoted_identifiers_tuple)
 
-    def ensure_row_position_column(self) -> "OrderedDataFrame":
+    def ensure_row_position_column(
+        self, dummy_row_pos_mode: bool = False
+    ) -> "OrderedDataFrame":
         """
         Returns an OrderedDataFrame with a row position column, and the row position column is guaranteed to
         be part of the projected column.
@@ -389,7 +399,7 @@ class OrderedDataFrame:
         )
         ordered_dataframe = self.select(
             *self.projected_column_snowflake_quoted_identifiers,
-            self._row_position_snowpark_column().as_(
+            self._row_position_snowpark_column(dummy_row_pos_mode).as_(
                 row_position_snowflake_quoted_identifier
             ),
         )
@@ -1133,6 +1143,7 @@ class OrderedDataFrame:
             "MatchComparator"  # noqa: F821
         ] = None,
         how: JoinTypeLit = "inner",
+        dummy_row_pos_mode: bool = False,
     ) -> "OrderedDataFrame":
         """
         Performs equi join of the specified type (``how``) with the current
@@ -1182,6 +1193,59 @@ class OrderedDataFrame:
                     For other join methods, the ordering columns preserves the left order, followed by right order.
 
         """
+        left = self
+        if False and dummy_row_pos_mode and how not in ["asof", "cross"]:
+            if (
+                left_on_cols is not None
+                and len(left_on_cols) == 1
+                and "row_position" in left_on_cols[0]
+            ):
+                new_col = (
+                    row_number().over(
+                        Window.order_by(left._ordering_snowpark_columns())
+                    )
+                    - 1
+                )
+                new_identifier = left.generate_snowflake_quoted_identifiers(
+                    pandas_labels=["row_position_left"],
+                    wrap_double_underscore=True,
+                )[0]
+                new_col = new_col.as_(new_identifier)
+                new_ordered_dataframe = left.select("*", new_col)
+                new_ordered_dataframe.row_position_snowflake_quoted_identifier = (
+                    new_identifier
+                )
+                new_ordered_dataframe = new_ordered_dataframe.sort(
+                    OrderingColumn(new_identifier)
+                )
+                left = new_ordered_dataframe
+                left_on_cols = [new_identifier]
+            if (
+                right_on_cols is not None
+                and len(right_on_cols) == 1
+                and "row_position" in right_on_cols[0]
+            ):
+                new_col = (
+                    row_number().over(
+                        Window.order_by(right._ordering_snowpark_columns())
+                    )
+                    - 1
+                )
+                new_identifier = right.generate_snowflake_quoted_identifiers(
+                    pandas_labels=["row_position_right"],
+                    wrap_double_underscore=True,
+                )[0]
+                new_col = new_col.as_(new_identifier)
+                new_ordered_dataframe = right.select("*", new_col)
+                new_ordered_dataframe.row_position_snowflake_quoted_identifier = (
+                    new_identifier
+                )
+                new_ordered_dataframe = new_ordered_dataframe.sort(
+                    OrderingColumn(new_identifier)
+                )
+                right = new_ordered_dataframe
+                right_on_cols = [new_identifier]
+
         left_on_cols = left_on_cols or []
         right_on_cols = right_on_cols or []
         assert len(left_on_cols) == len(
@@ -1189,7 +1253,7 @@ class OrderedDataFrame:
         ), "left_on_cols and right_on_cols must be of same length"
         _raise_if_identifier_not_exists(
             left_on_cols,
-            self.projected_column_snowflake_quoted_identifiers,
+            left.projected_column_snowflake_quoted_identifiers,
             "join left_on_cols",
         )
 
@@ -1204,7 +1268,7 @@ class OrderedDataFrame:
             assert right_match_col, "right_match_col was not provided to ASOF Join"
             _raise_if_identifier_not_exists(
                 [left_match_col],
-                self.projected_column_snowflake_quoted_identifiers,
+                left.projected_column_snowflake_quoted_identifiers,
                 "join left_match_col",
             )
             _raise_if_identifier_not_exists(
@@ -1221,7 +1285,7 @@ class OrderedDataFrame:
             "right",
             "inner",
             "outer",
-        ] and self._is_self_join_on_row_position_column(
+        ] and left._is_self_join_on_row_position_column(
             left_on_cols, right, right_on_cols
         ):
             is_join_needed = False
@@ -1241,9 +1305,9 @@ class OrderedDataFrame:
             right.projected_column_snowflake_quoted_identifiers
         )
 
-        # the new projected columns are set to self._projected_columns + right._projected_column after de-conflict
+        # the new projected columns are set to left._projected_columns + right._projected_column after de-conflict
         projected_column_snowflake_quoted_identifiers = (
-            self.projected_column_snowflake_quoted_identifiers
+            left.projected_column_snowflake_quoted_identifiers
             + right.projected_column_snowflake_quoted_identifiers
         )
 
@@ -1254,9 +1318,9 @@ class OrderedDataFrame:
             new_df = OrderedDataFrame(
                 right._dataframe_ref,
                 projected_column_snowflake_quoted_identifiers=projected_column_snowflake_quoted_identifiers,
-                ordering_columns=self.ordering_columns,
-                row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
-                row_count_snowflake_quoted_identifier=self.row_count_snowflake_quoted_identifier,
+                ordering_columns=left.ordering_columns,
+                row_position_snowflake_quoted_identifier=left.row_position_snowflake_quoted_identifier,
+                row_count_snowflake_quoted_identifier=left.row_count_snowflake_quoted_identifier,
             )
             new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
                 self,
@@ -1274,7 +1338,7 @@ class OrderedDataFrame:
             return new_df
 
         # reproject the snowpark dataframe with only necessary columns
-        left_snowpark_dataframe_ref = self._to_projected_snowpark_dataframe_reference(
+        left_snowpark_dataframe_ref = left._to_projected_snowpark_dataframe_reference(
             include_ordering_columns=True
         )
         right_snowpark_dataframe_ref = right._to_projected_snowpark_dataframe_reference(
@@ -1334,9 +1398,9 @@ class OrderedDataFrame:
         # for right join, we preserve the right order first, then left order.
         # for all join type, left order is preserved first, then right order.
         if how == "right":
-            ordering_columns = right.ordering_columns + self.ordering_columns
+            ordering_columns = right.ordering_columns + left.ordering_columns
         else:
-            ordering_columns = self.ordering_columns + right.ordering_columns
+            ordering_columns = left.ordering_columns + right.ordering_columns
 
         new_df = OrderedDataFrame(
             DataFrameReference(
@@ -1429,6 +1493,7 @@ class OrderedDataFrame:
         right_on_cols: list[str],
         how: AlignTypeLit = "outer",
         enable_default_sort: bool = True,
+        dummy_row_pos_mode: bool = False,
     ) -> "OrderedDataFrame":
         """
         Performs align operation of the specified join type (``how``) with the current
@@ -1540,8 +1605,8 @@ class OrderedDataFrame:
             right.projected_column_snowflake_quoted_identifiers
         )
         # generate row position column for self and right, which is needed for align on column equivalence check
-        left = self.ensure_row_position_column()
-        right = right.ensure_row_position_column()
+        left = self.ensure_row_position_column(dummy_row_pos_mode)
+        right = right.ensure_row_position_column(dummy_row_pos_mode)
 
         # whether the alignment is performed on the row position column of each dataframe.
         # In other words, this indicates whether the alignment is applied on a unique column
@@ -1560,6 +1625,7 @@ class OrderedDataFrame:
             left_on_cols=left_on_cols,
             right_on_cols=right_on_cols,
             how=how if direct_join_map else "outer",
+            dummy_row_pos_mode=dummy_row_pos_mode,
         )
 
         sort = False
@@ -1886,6 +1952,7 @@ class OrderedDataFrame:
             ),
             projected_column_snowflake_quoted_identifiers=projected_dataframe_ref.snowflake_quoted_identifiers,
             ordering_columns=self.ordering_columns,
+            row_position_snowflake_quoted_identifier=self.row_position_snowflake_quoted_identifier,
         )
         new_df.row_count_upper_bound = RowCountEstimator.upper_bound(
             self,

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1239,11 +1239,7 @@ class OrderedDataFrame:
             is_join_needed = False
 
         if is_join_needed and dummy_row_pos_mode and how not in ["asof", "cross"]:
-            if (
-                left_on_cols is not None
-                and len(left_on_cols) == 1
-                and "row_position" in left_on_cols[0]
-            ):
+            if left_on_cols == [left.row_position_snowflake_quoted_identifier]:
                 new_col = (
                     row_number().over(
                         Window.order_by(left._ordering_snowpark_columns())
@@ -1264,11 +1260,7 @@ class OrderedDataFrame:
                 )
                 left = new_ordered_dataframe
                 left_on_cols = [new_identifier]
-            if (
-                right_on_cols is not None
-                and len(right_on_cols) == 1
-                and "row_position" in right_on_cols[0]
-            ):
+            if right_on_cols == [right.row_position_snowflake_quoted_identifier]:
                 new_col = (
                     row_number().over(
                         Window.order_by(right._ordering_snowpark_columns())

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -332,7 +332,7 @@ class OrderedDataFrame:
         """
         return [col.snowflake_quoted_identifier for col in self.ordering_columns]
 
-    def _row_position_snowpark_column(self, dummy_row_pos_mode: bool) -> Column:
+    def _row_position_snowpark_column(self, dummy_row_pos_mode: bool = False) -> Column:
         """
         Returns a row position Snowpark column for the dataframe.
         If row position column already exist in the current dataframe, it will be directly returned.
@@ -348,7 +348,7 @@ class OrderedDataFrame:
         if dummy_row_pos_mode:
             from snowflake.snowpark.modin.plugin._internal.utils import pandas_lit
 
-            return pandas_lit(1)
+            return pandas_lit(0)
         else:
             return (
                 row_number().over(Window.order_by(self._ordering_snowpark_columns()))

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -1939,7 +1939,7 @@ class OrderedDataFrame:
         See detailed docstring in Snowpark DataFrame's limit.
         """
         projected_dataframe_ref = self._to_projected_snowpark_dataframe_reference(
-            include_ordering_columns=True, sort=sort
+            include_ordering_columns=True, include_row_position_column=True, sort=sort
         )
         snowpark_dataframe = projected_dataframe_ref.snowpark_dataframe.limit(
             n=n, offset=offset

--- a/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/transpose_utils.py
@@ -64,6 +64,7 @@ def prepare_and_unpivot_for_transpose(
     original_frame: InternalFrame,
     query_compiler: "SnowflakeQueryCompiler",  # type: ignore[name-defined] # noqa: F821
     is_single_row: bool = False,
+    dummy_row_pos_mode: bool = False,
 ) -> Union[UnpivotResultInfo, "SnowflakeQueryCompiler"]:  # type: ignore[name-defined] # noqa: F821
 
     # Check if the columns are all json serializable, if not, then go through fallback path.  The transpose approach
@@ -75,7 +76,7 @@ def prepare_and_unpivot_for_transpose(
         return DataFrameDefault.register(native_pd.DataFrame.transpose)(query_compiler)
 
     # Ensure there is a row position since preserving order is important for unpivot and transpose.
-    original_frame = original_frame.ensure_row_position_column()
+    original_frame = original_frame.ensure_row_position_column(dummy_row_pos_mode)
 
     # Transpose is implemented with unpivot followed by pivot. However when the input dataframe is empty, there are two issues
     # 1) unpivot on empty table returns empty, which results in missing values in UNPIVOT_NAME_COLUMN

--- a/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/unpivot_utils.py
@@ -492,6 +492,7 @@ def clean_up_unpivot(
     pandas_id_columns: Optional[list[Hashable]] = None,
     snowflake_id_quoted_columns: Optional[list[str]] = None,
     ignore_index: Optional[bool] = False,
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Cleans up an unpivot operation and reconstructs the index.
@@ -614,7 +615,7 @@ def clean_up_unpivot(
         variables_column_quoted,
         value_column_quoted,
     ]
-    ordered_dataframe = ordered_dataframe.ensure_row_position_column()
+    ordered_dataframe = ordered_dataframe.ensure_row_position_column(dummy_row_pos_mode)
 
     # setup the index names for the internal frame
     index_column_quoted_names = [
@@ -657,6 +658,7 @@ def _simple_unpivot(
     pandas_value_columns: list[Hashable],
     pandas_var_name: Optional[Hashable],
     pandas_value_name: Optional[Hashable],
+    dummy_row_pos_mode: bool = False,
 ) -> InternalFrame:
     """
     Performs a melt/unpivot on a a dataframe, when the index can be
@@ -820,7 +822,7 @@ def _simple_unpivot(
     ordered_dataframe = ordered_dataframe.select(
         *unpivoted_columns, ordering_column_case_expr, value_column
     ).sort(OrderingColumn(ordering_column_name))
-    ordered_dataframe = ordered_dataframe.ensure_row_position_column()
+    ordered_dataframe = ordered_dataframe.ensure_row_position_column(dummy_row_pos_mode)
 
     ###########################################################################################
     # OrderedDataFrame at this point, prior to creation of the new InternalFrame

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -439,12 +439,12 @@ def create_initial_ordered_dataframe(
         else:
             if dummy_row_pos_mode:
                 row_position_column_str = (
-                    f"1 as {row_position_snowflake_quoted_identifier}"
+                    f"0 as {row_position_snowflake_quoted_identifier}"
                 )
             else:
                 row_position_column_str = f"ROW_NUMBER() OVER (ORDER BY 1) - 1 as {row_position_snowflake_quoted_identifier}"
             row_position_column_str_for_count = (
-                f"1 as {row_position_snowflake_quoted_identifier}"
+                f"0 as {row_position_snowflake_quoted_identifier}"
             )
 
         columns_to_select = ", ".join(

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -498,9 +498,10 @@ def create_initial_ordered_dataframe(
                 f"Failed to create Snowpark pandas DataFrame out of query {table_name_or_query} with error {ex}",
                 error_code=SnowparkPandasErrorCode.GENERAL_SQL_EXCEPTION.value,
             ) from ex
-        ordered_dataframe = (
+        initial_ordered_dataframe = (
             snowpark_pandas_df._query_compiler._modin_frame.ordered_dataframe
         )
+        ordered_dataframe = initial_ordered_dataframe
         row_position_snowflake_quoted_identifier = (
             ordered_dataframe.row_position_snowflake_quoted_identifier
         )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -2083,9 +2083,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             return self._shift_values_axis_1(periods, fill_value)
 
     def _shift_values_axis_0(
-        self,
-        periods: int,
-        fill_value: Hashable,
+        self, periods: int, fill_value: Hashable,
     ) -> "SnowflakeQueryCompiler":
         """
         Shift rows and fill new columns with fill_value.

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -13858,6 +13858,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             if len(new_frame.index_column_snowflake_quoted_identifiers) == 1 and (
                 ROW_POSITION_COLUMN_LABEL
                 in new_frame.index_column_snowflake_quoted_identifiers[0]
+                or INDEX_LABEL in new_frame.index_column_snowflake_quoted_identifiers[0]
             ):
                 new_col = (
                     row_number().over(

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -3661,7 +3661,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if len(index_column_pandas_labels_remained) == 0:
             index_column_snowflake_quoted_identifier = (
                 ordered_dataframe.generate_snowflake_quoted_identifiers(
-                    pandas_labels=[ROW_POSITION_COLUMN_LABEL],
+                    pandas_labels=[INDEX_LABEL],
                     wrap_double_underscore=True,
                 )[0]
             )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -10,6 +10,7 @@ import inspect
 import itertools
 import json
 import logging
+import os
 import re
 from collections import Counter, defaultdict
 import typing
@@ -1375,8 +1376,18 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/plugin/pd_extensions.py
         """
+        dummy_row_pos_optimization_enabled = (
+            os.environ.get(
+                "SNOWPARK_PANDAS_DUMMY_ROW_POS_OPTIMIZATION_ENABLED", "true"
+            ).lower()
+            == "true"
+        )
         relaxed_query_compiler = None
-        if not enforce_ordering and not dummy_row_pos_mode:
+        if (
+            dummy_row_pos_optimization_enabled
+            and not enforce_ordering
+            and not dummy_row_pos_mode
+        ):
             relaxed_query_compiler = cls.from_snowflake(
                 name_or_query=name_or_query,
                 index_col=index_col,

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -585,6 +585,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             frame, InternalFrame
         ), "frame is None or not a InternalFrame"
         self._modin_frame = frame
+        self._dummy_row_pos_mode = False
+        self._relaxed_query_compiler: Optional[SnowflakeQueryCompiler] = None
         # self.snowpark_pandas_api_calls a list of lazy Snowpark pandas telemetry api calls
         # Copying and modifying self.snowpark_pandas_api_calls and self._method_call_counts
         # is taken care of in telemetry decorators
@@ -1367,11 +1369,23 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         index_col: Optional[Union[str, list[str]]] = None,
         columns: Optional[list[str]] = None,
         enforce_ordering: bool = False,
+        dummy_row_pos_mode: bool = False,
     ) -> "SnowflakeQueryCompiler":
         """
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/plugin/pd_extensions.py
         """
+        relaxed_query_compiler = None
+        if not enforce_ordering and not dummy_row_pos_mode:
+            relaxed_query_compiler = cls.from_snowflake(
+                name_or_query=name_or_query,
+                index_col=index_col,
+                columns=columns,
+                enforce_ordering=enforce_ordering,
+                dummy_row_pos_mode=True,
+            )
+            relaxed_query_compiler._dummy_row_pos_mode = True
+
         if columns is not None and not isinstance(columns, list):
             raise ValueError("columns must be provided as list, i.e ['A'].")
 
@@ -1382,6 +1396,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ) = create_initial_ordered_dataframe(
             table_name_or_query=name_or_query,
             enforce_ordering=enforce_ordering,
+            dummy_row_pos_mode=dummy_row_pos_mode,
         )
         pandas_labels_to_snowflake_quoted_identifiers_map = {
             # pandas labels of resulting Snowpark pandas dataframe will be snowflake identifier
@@ -1490,7 +1505,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 row_position_snowflake_quoted_identifier
             ]
 
-        return cls(
+        qc = cls(
             InternalFrame.create(
                 ordered_dataframe=ordered_dataframe,
                 data_column_pandas_labels=data_column_pandas_labels,
@@ -1504,6 +1519,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 index_column_types=None,
             )
         )
+        if relaxed_query_compiler is not None:
+            qc._relaxed_query_compiler = relaxed_query_compiler
+        return qc
 
     @classmethod
     def from_file_with_pandas(
@@ -2058,7 +2076,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             return self._shift_values_axis_1(periods, fill_value)
 
     def _shift_values_axis_0(
-        self, periods: int, fill_value: Hashable
+        self,
+        periods: int,
+        fill_value: Hashable,
     ) -> "SnowflakeQueryCompiler":
         """
         Shift rows and fill new columns with fill_value.
@@ -2071,7 +2091,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             SnowflakeQueryCompiler
         """
         # Shift using LAG window operation over row position window together with fill_value.
-        frame = self._modin_frame.ensure_row_position_column()
+        frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         row_position_quoted_identifier = frame.row_position_snowflake_quoted_identifier
 
         timedelta_invalid_fill_value_error_message = f"value should be a 'Timedelta' or 'NaT'. Got '{type(fill_value).__name__}' instead."
@@ -2356,8 +2378,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         assert (
             len(key._modin_frame.data_column_pandas_labels) == 1
         ), "need to be a series"
-        self_frame = self._modin_frame.ensure_row_position_column()
-        other_frame = key._modin_frame.ensure_row_position_column()
+        self_frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
+        other_frame = key._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
 
         # TODO: SNOW-935748 improve the workaround below for MultiIndex names
         # The original index names. This value is used instead of the new internal frames'
@@ -2484,14 +2510,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         # Step 1: Convert other to a Series and join on the row position with self.
         other_qc = Series(other)._query_compiler
-        self_frame = self._modin_frame.ensure_row_position_column()
-        other_frame = other_qc._modin_frame.ensure_row_position_column()
+        self_frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
+        other_frame = other_qc._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         new_frame = join_utils.align(
             left=self_frame,
             right=other_frame,
             left_on=[self_frame.row_position_snowflake_quoted_identifier],
             right_on=[other_frame.row_position_snowflake_quoted_identifier],
             how="coalesce",
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         ).result_frame
 
         # Step 2: The operation will be performed as a broadcast operation over all columns, therefore iterate
@@ -2630,6 +2661,24 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         # Native pandas does not support binary operations between a Series and a list-like object.
 
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None and (
+            not isinstance(other, SnowflakeQueryCompiler)
+            or other._relaxed_query_compiler is not None
+        ):
+            relaxed_query_compiler = self._relaxed_query_compiler.binary_op(
+                op=op,
+                other=other
+                if not isinstance(other, SnowflakeQueryCompiler)
+                else other._relaxed_query_compiler,
+                axis=axis,
+                level=level,
+                fill_value=fill_value,
+                squeeze_self=squeeze_self,
+                **kwargs,
+            )
+            relaxed_query_compiler._dummy_row_pos_mode = True
+
         from modin.pandas.utils import is_scalar
 
         # fail explicitly for unsupported scenarios
@@ -2651,15 +2700,27 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if is_scalar(other):
             # (Case 1): other is scalar
             # -------------------------
-            return self._binary_op_scalar_rhs(op, other, fill_value)
+            qc = self._binary_op_scalar_rhs(op, other, fill_value)
+            qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+            if relaxed_query_compiler is not None:
+                qc._relaxed_query_compiler = relaxed_query_compiler
+            return qc
 
         if not isinstance(other, (Series, DataFrame)) and is_list_like(other):
             # (Case 2): other is list-like
             # ----------------------------
             if axis == 0:
-                return self._binary_op_list_like_rhs_axis_0(op, other, fill_value)
+                qc = self._binary_op_list_like_rhs_axis_0(op, other, fill_value)
+                qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+                if relaxed_query_compiler is not None:
+                    qc._relaxed_query_compiler = relaxed_query_compiler
+                return qc
             else:  # axis=1
-                return self._binary_op_list_like_rhs_axis_1(op, other, fill_value)
+                qc = self._binary_op_list_like_rhs_axis_1(op, other, fill_value)
+                qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+                if relaxed_query_compiler is not None:
+                    qc._relaxed_query_compiler = relaxed_query_compiler
+                return qc
 
         if squeeze_self and isinstance(other, Series):
             # (Case 3): Series/Series
@@ -2734,9 +2795,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
 
             # return only newly created column. Because column has been appended, this is the last column indexed by -1
-            return SnowflakeQueryCompiler(
+            qc = SnowflakeQueryCompiler(
                 get_frame_by_col_pos(internal_frame=new_frame, columns=[-1])
             )
+            qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+            if relaxed_query_compiler is not None:
+                qc._relaxed_query_compiler = relaxed_query_compiler
+            return qc
         elif squeeze_self or isinstance(other, Series):
             # (Case 4): Series/DataFrame or DataFrame/Series
             # --------------------------
@@ -2747,14 +2812,22 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # However, pandas allows to call Series <binop> DataFrame with axis=0 set. In this case, the parameter
             # axis=0 is ignored and the result works the same as if axis=1 is invoked.
             if not squeeze_self and axis == 0:
-                return self._binary_op_between_dataframe_and_series_along_axis_0(
+                qc = self._binary_op_between_dataframe_and_series_along_axis_0(
                     op, other._query_compiler, fill_value
                 )
+                qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+                if relaxed_query_compiler is not None:
+                    qc._relaxed_query_compiler = relaxed_query_compiler
+                return qc
 
             # Invoke axis=1 case, this is the correct pandas behavior if squeeze_self is True and axis=0 also.
-            return self._binary_op_between_dataframe_and_series_along_axis_1(
+            qc = self._binary_op_between_dataframe_and_series_along_axis_1(
                 op, other._query_compiler, squeeze_self, fill_value
             )
+            qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+            if relaxed_query_compiler is not None:
+                qc._relaxed_query_compiler = relaxed_query_compiler
+            return qc
         else:
             # (Case 5): DataFrame/DataFrame
             # -----------------------------
@@ -2764,9 +2837,13 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
             # The axis parameter is ignored for DataFrame <binop> DataFrame operations. The default axis behavior
             # is always aligning by columns (axis=1). Binary operations between DataFrames support fill_value.
-            return self._binary_op_between_dataframes(
+            qc = self._binary_op_between_dataframes(
                 op, other._query_compiler, fill_value
             )
+            qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+            if relaxed_query_compiler is not None:
+                qc._relaxed_query_compiler = relaxed_query_compiler
+            return qc
 
     def _bool_reduce_helper(
         self,
@@ -2995,7 +3072,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             "decreasing",
         ], "Invalid value passed to function"
         modin_frame = self._modin_frame
-        modin_frame = modin_frame.ensure_row_position_column()
+        modin_frame = modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         row_position_column = modin_frame.row_position_snowflake_quoted_identifier
         monotonic_decreasing_snowflake_quoted_id = None
         monotonic_increasing_snowflake_quoted_id = None
@@ -3108,7 +3187,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         _filter_column_snowflake_quoted_id = None
         is_index = kwargs.get("_is_index", False)
         if is_index:
-            modin_frame = modin_frame.ensure_row_position_column()
+            modin_frame = modin_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
             row_position_column = modin_frame.row_position_snowflake_quoted_identifier
             modin_frame = modin_frame.append_column("indices", col(row_position_column))
             # We will also add columns to check for monotonicity so that we can throw a similar error as native pandas
@@ -3220,7 +3301,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             ]
             if method not in ["nearest", None]:
                 new_qc = SnowflakeQueryCompiler(
-                    new_modin_frame.ensure_row_position_column()
+                    new_modin_frame.ensure_row_position_column(
+                        dummy_row_pos_mode=self._dummy_row_pos_mode
+                    )
                 )
                 ordering_column = (
                     new_qc._modin_frame.row_position_snowflake_quoted_identifier
@@ -3535,6 +3618,18 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Returns:
             A new SnowflakeQueryCompiler instance with updated index.
         """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None and not drop:
+            relaxed_query_compiler = self._relaxed_query_compiler.reset_index(
+                level=level,
+                drop=drop,
+                col_level=col_level,
+                col_fill=col_fill,
+                allow_duplicates=allow_duplicates,
+                names=names,
+            )
+            relaxed_query_compiler._dummy_row_pos_mode = True
+
         if allow_duplicates is no_default:
             allow_duplicates = False
         # These levels will be moved from index columns to data columns
@@ -3566,12 +3661,14 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         if len(index_column_pandas_labels_remained) == 0:
             index_column_snowflake_quoted_identifier = (
                 ordered_dataframe.generate_snowflake_quoted_identifiers(
-                    pandas_labels=[INDEX_LABEL],
+                    pandas_labels=[ROW_POSITION_COLUMN_LABEL],
                     wrap_double_underscore=True,
                 )[0]
             )
             # duplicate the row position column as the new index column
-            ordered_dataframe = ordered_dataframe.ensure_row_position_column()
+            ordered_dataframe = ordered_dataframe.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
             ordered_dataframe = append_columns(
                 ordered_dataframe,
                 index_column_snowflake_quoted_identifier,
@@ -3684,7 +3781,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             index_column_types=index_column_types_remained,
         )
 
-        return SnowflakeQueryCompiler(internal_frame)
+        qc = SnowflakeQueryCompiler(internal_frame)
+        if relaxed_query_compiler is not None:
+            qc._relaxed_query_compiler = relaxed_query_compiler
+        return qc
 
     # TODO: Eliminate from Modin QC layer and call `first_last_valid_index` directly from frontend
     def first_valid_index(self) -> Union[Scalar, tuple[Scalar]]:
@@ -3725,7 +3825,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         qc = self.notna().any(axis=1, bool_only=False, skipna=True)
         # Filter for True values and get index based on first_or_last
         valid_index_values = get_valid_index_values(
-            frame=qc._modin_frame, first_or_last=first_or_last
+            frame=qc._modin_frame,
+            first_or_last=first_or_last,
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         )
 
         if valid_index_values:
@@ -3910,7 +4012,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # We want to provide stable sort even if user provided sort kind is not 'stable'. We are doing this to make
         # ordering deterministic.
         # Snowflake backend sort is unstable. Add row position to ordering columns to make sort stable.
-        internal_frame = self._modin_frame.ensure_row_position_column()
+        internal_frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         ordered_dataframe = internal_frame.ordered_dataframe.sort(
             *ordering_columns,
             OrderingColumn(internal_frame.row_position_snowflake_quoted_identifier),
@@ -4158,7 +4262,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # if it is (for the min_by/max_by function).
         first_last_present = is_first_last_in_agg_funcs(column_to_agg_func)
         if first_last_present:
-            internal_frame = internal_frame.ensure_row_position_column()
+            internal_frame = internal_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
             agg_kwargs[
                 "_first_last_row_pos_col"
             ] = internal_frame.row_position_snowflake_quoted_identifier
@@ -4224,7 +4330,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # when sort is False, the order is decided by the position of the groupby
             # keys in the original dataframe. In order to recover the order, we retain
             # min(row_position) in the aggregation result.
-            internal_frame = internal_frame.ensure_row_position_column()
+            internal_frame = internal_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
             row_position_quoted_identifier = (
                 internal_frame.row_position_snowflake_quoted_identifier
             )
@@ -4485,7 +4593,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             force_single_group=force_single_group,
         )
 
-        new_internal_df = _modin_frame.ensure_row_position_column()
+        new_internal_df = _modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
 
         # drop the rows if any value in groupby key is NaN
         ordered_dataframe = new_internal_df.ordered_dataframe
@@ -4524,7 +4634,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         """
 
-        ordered_dataframe = ordered_dataframe.ensure_row_position_column()
+        ordered_dataframe = ordered_dataframe.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         row_position_snowflake_quoted_identifier = (
             ordered_dataframe.row_position_snowflake_quoted_identifier
         )
@@ -5069,7 +5181,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     count("*")
                     .over(Window.partition_by(partition_list))
                     .alias(count_alias),
-                ).ensure_row_position_column()
+                ).ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
                 # Count value is used for calculating max and average rank from
                 # min rank in function make_groupby_rank_col_for_method
                 count_val = col(
@@ -5765,7 +5879,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         """
         self._raise_not_implemented_error_for_timedelta()
 
-        frame = self._modin_frame.ensure_row_position_column()
+        frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         qc = (
             # .indices aggregates row position numbers, so we add a row
             # position data column and then aggregate that.
@@ -6687,7 +6803,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 agg_funcs = [
                     (
                         get_frame_by_row_label(
-                            internal_frame=self._modin_frame, key=(row_label,)
+                            internal_frame=self._modin_frame,
+                            key=(row_label,),
+                            dummy_row_pos_mode=self._dummy_row_pos_mode,
                         ),
                         fn if is_list_like(fn) else [fn],
                     )
@@ -7131,8 +7249,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         else:
             # rename given Series (as SnowflakeQueryCompiler) to the desired label
             value = value.set_columns([pandas_label])
-            self_frame = self._modin_frame.ensure_row_position_column()
-            value_frame = value._modin_frame.ensure_row_position_column()
+            self_frame = self._modin_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
+            value_frame = value._modin_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
 
             new_internal_frame = join_utils.align(
                 left=self_frame,
@@ -7140,6 +7262,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 left_on=[self_frame.row_position_snowflake_quoted_identifier],
                 right_on=[value_frame.row_position_snowflake_quoted_identifier],
                 how="coalesce",
+                dummy_row_pos_mode=self._dummy_row_pos_mode,
             ).result_frame
 
         # New column is added at the end. Move this to desired location as specified by
@@ -8136,6 +8259,28 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
 
         left = self
+        relaxed_query_compiler = None
+        if (
+            left._relaxed_query_compiler is not None
+            and right._relaxed_query_compiler is not None
+            and how not in ["asof", "cross"]
+        ):
+            relaxed_query_compiler = left._relaxed_query_compiler.merge(
+                right=right._relaxed_query_compiler,
+                how=how,
+                on=on,
+                left_on=left_on,
+                right_on=right_on,
+                left_index=left_index,
+                right_index=right_index,
+                sort=sort,
+                suffixes=suffixes,
+                copy=copy,
+                indicator=indicator,
+                validate=validate,
+            )
+            relaxed_query_compiler._dummy_row_pos_mode = True
+
         join_index_on_index = left_index and right_index
         # As per this bug fix in pandas 2.2.x outer join always produce sorted results.
         # https://github.com/pandas-dev/pandas/pull/54611/files
@@ -8208,9 +8353,17 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # columns-to-columns or columns-to-index. So we have different code path to
             # handle this.
             merged_frame, _ = join_utils.join_on_index_columns(
-                left_frame, right_frame, how=how, sort=sort
+                left_frame,
+                right_frame,
+                how=how,
+                sort=sort,
+                dummy_row_pos_mode=self._dummy_row_pos_mode,
             )
-            return SnowflakeQueryCompiler(merged_frame)
+            merged_qc = SnowflakeQueryCompiler(merged_frame)
+            merged_qc._dummy_row_pos_mode = self._dummy_row_pos_mode
+            if relaxed_query_compiler is not None:
+                merged_qc._relaxed_query_compiler = relaxed_query_compiler
+            return merged_qc
 
         coalesce_config = join_utils.get_coalesce_config(
             left_keys=left_keys,
@@ -8248,6 +8401,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             right_on=right_on_identifiers,
             sort=sort,
             join_key_coalesce_config=coalesce_config,
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         ).result_frame
 
         # Add indicator column
@@ -8284,6 +8438,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
 
         merged_qc = SnowflakeQueryCompiler(merged_frame)
+        merged_qc._dummy_row_pos_mode = self._dummy_row_pos_mode
 
         # If an index column from left frame is joined with data column from right
         # frame and both have same name, pandas moves this index column to data column.
@@ -8305,6 +8460,8 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # both are false.
             merged_qc = merged_qc.reset_index(drop=True)
 
+        if relaxed_query_compiler is not None:
+            merged_qc._relaxed_query_compiler = relaxed_query_compiler
         return merged_qc
 
     def merge_asof(
@@ -8507,7 +8664,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         # add a row position column for partition by
         # the every batch size in vectorized udtf will be 1
-        new_internal_df = self._modin_frame.ensure_row_position_column()
+        new_internal_df = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         row_position_snowflake_quoted_identifier = (
             new_internal_df.row_position_snowflake_quoted_identifier
         )
@@ -9224,7 +9383,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                         curr_frame = col_results[0]._modin_frame
                         for next_qc in col_results[1:]:
                             curr_frame = join_utils.align(
-                                curr_frame, next_qc._modin_frame, [], [], how="left"
+                                curr_frame,
+                                next_qc._modin_frame,
+                                [],
+                                [],
+                                how="left",
+                                dummy_row_pos_mode=self._dummy_row_pos_mode,
                             ).result_frame
                         qc_result = SnowflakeQueryCompiler(curr_frame)
                     else:
@@ -9972,12 +10136,15 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         if isinstance(index, slice):
             with_row_selector = get_frame_by_row_pos_slice_frame(
-                internal_frame=self._modin_frame, key=index
+                internal_frame=self._modin_frame,
+                key=index,
+                dummy_row_pos_mode=self._dummy_row_pos_mode,
             )
         else:
             with_row_selector = get_frame_by_row_pos_frame(
                 internal_frame=self._modin_frame,
                 key=index._modin_frame,
+                dummy_row_pos_mode=self._dummy_row_pos_mode,
             )
 
         with_col_selector = get_frame_by_col_pos(
@@ -10291,6 +10458,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         -------
         SnowflakeQueryCompiler
         """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None and (
+            not isinstance(index, SnowflakeQueryCompiler)
+            or index._relaxed_query_compiler is not None
+        ):
+            relaxed_query_compiler = self._relaxed_query_compiler.take_2d_labels(
+                index=index
+                if not isinstance(index, SnowflakeQueryCompiler)
+                else index._relaxed_query_compiler,
+                columns=columns,
+            )
+            relaxed_query_compiler._dummy_row_pos_mode = True
+
         if self._modin_frame.is_multiindex(axis=0) and (
             is_scalar(index) or isinstance(index, tuple)
         ):
@@ -10308,28 +10488,36 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             index = pd.Series(index).set_backend("Snowflake")
             if index.dtype == "bool":
                 # boolean list like indexer is always select rows by row position
-                return SnowflakeQueryCompiler(
+                qc = SnowflakeQueryCompiler(
                     get_frame_by_col_label(
                         get_frame_by_row_pos_frame(
                             internal_frame=self._modin_frame,
                             key=index._query_compiler._modin_frame,
+                            dummy_row_pos_mode=self._dummy_row_pos_mode,
                         ),
                         columns,
                     )
                 )
+                if relaxed_query_compiler is not None:
+                    qc._relaxed_query_compiler = relaxed_query_compiler
+                return qc
             index = index._query_compiler
 
-        return SnowflakeQueryCompiler(
+        qc = SnowflakeQueryCompiler(
             get_frame_by_col_label(
                 get_frame_by_row_label(
                     internal_frame=self._modin_frame,
                     key=index._modin_frame
                     if isinstance(index, SnowflakeQueryCompiler)
                     else index,
+                    dummy_row_pos_mode=self._dummy_row_pos_mode,
                 ),
                 columns,
             )
         )
+        if relaxed_query_compiler is not None:
+            qc._relaxed_query_compiler = relaxed_query_compiler
+        return qc
 
     def has_multiindex(self, axis: int = 0) -> bool:
         """
@@ -10819,6 +11007,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             index_is_bool_indexer=index_is_bool_indexer,
             deduplicate_columns=deduplicate_columns,
             frame_is_df_and_item_is_series=frame_is_df_and_item_is_series,
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         )
 
         return SnowflakeQueryCompiler(result_frame)
@@ -10847,7 +11036,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         -------
         SnowflakeQueryCompiler
         """
-        row_positions_frame = get_row_pos_frame_from_row_key(index, self._modin_frame)
+        row_positions_frame = get_row_pos_frame_from_row_key(
+            index, self._modin_frame, dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
 
         column_positions = get_valid_col_pos_list_from_columns(
             columns, self.get_axis_len(1)
@@ -10860,6 +11051,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             set_as_coords=set_as_coords,
             item=item if is_scalar(item) else item._modin_frame,
             is_item_series=is_item_series,
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         )
 
         return SnowflakeQueryCompiler(result_frame)
@@ -10891,7 +11083,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             key_frame = Series(key)._query_compiler._modin_frame
 
         new_frame = get_frame_by_row_pos_frame(
-            self._modin_frame, key_frame
+            self._modin_frame, key_frame, dummy_row_pos_mode=self._dummy_row_pos_mode
         )  # pragma: no cover
 
         return SnowflakeQueryCompiler(new_frame)
@@ -10947,8 +11139,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             elif is_list_like(cond):
                 cond_frame = self.from_pandas(
                     pandas.DataFrame(cond)
-                )._modin_frame.ensure_row_position_column()
-                joined_frame = joined_frame.ensure_row_position_column()
+                )._modin_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
+                joined_frame = joined_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
                 joined_frame, _ = join_utils.join(
                     joined_frame,
                     cond_frame,
@@ -10981,8 +11177,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             elif is_list_like(replacement):
                 repl_frame = self.from_pandas(
                     pandas.DataFrame(replacement)
-                )._modin_frame.ensure_row_position_column()
-                joined_frame = joined_frame.ensure_row_position_column()
+                )._modin_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
+                joined_frame = joined_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
                 joined_frame, _ = join_utils.join(
                     joined_frame,
                     repl_frame,
@@ -11232,8 +11432,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                     ]
                 }
         else:
-            frame = frame.ensure_row_position_column()
-            cond_frame = cond_frame.ensure_row_position_column()
+            frame = frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
+            cond_frame = cond_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
             joined_frame, result_column_mapper = join_utils.join(
                 frame,
                 cond_frame,
@@ -11354,8 +11558,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                         right_on=[],
                     )
             else:
-                joined_frame = joined_frame.ensure_row_position_column()
-                other_frame = other_frame.ensure_row_position_column()
+                joined_frame = joined_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
+                other_frame = other_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
                 joined_frame, result_column_mapper = join_utils.join(
                     joined_frame,
                     other_frame,
@@ -11696,7 +11904,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             method = FillNAMethod.get_enum_for_string_method(method)
             method_is_ffill = method is FillNAMethod.FFILL_METHOD
             if axis == 0:
-                self._modin_frame = self._modin_frame.ensure_row_position_column()
+                self._modin_frame = self._modin_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=self._dummy_row_pos_mode
+                )
                 if method_is_ffill:
                     func = last_value
                     if limit is None:
@@ -12984,7 +13194,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             count_df = ordered_dataframe.select(
                 col_ident,
                 count("*").over(Window.partition_by(col_ident)).alias(count_alias),
-            ).ensure_row_position_column()
+            ).ensure_row_position_column(dummy_row_pos_mode=self._dummy_row_pos_mode)
             count_val = col(count_df.projected_column_snowflake_quoted_identifiers[1])
             rank_col = self._make_rank_col_for_method(
                 col_ident, method, na_option, ascending, pct, row_val, count_val
@@ -13486,7 +13696,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             count_identifier = internal_frame.data_column_snowflake_quoted_identifiers[
                 0
             ]
-        internal_frame = internal_frame.ensure_row_position_column()
+        internal_frame = internal_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
 
         # When sort=True, sort by the frequency (count column);
         # otherwise, respect the original order (use the original ordering columns)
@@ -13553,7 +13765,16 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         # 2. retrieve all columns
         # 3. filter on rows with recursive count
 
-        frame = self._modin_frame.ensure_row_position_column()
+        if self._relaxed_query_compiler is None:
+            frame = self._modin_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
+        else:
+            frame = (
+                self._relaxed_query_compiler._modin_frame.ensure_row_position_column(
+                    dummy_row_pos_mode=True
+                )
+            )
         use_cached_row_count = frame.ordered_dataframe.row_count is not None
 
         # If the row count is already cached, there's no need to include it in the query.
@@ -13585,25 +13806,92 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             )
 
             row_count_expr = col(frame.row_count_snowflake_quoted_identifier)
+
         row_position_snowflake_quoted_identifier = (
             frame.row_position_snowflake_quoted_identifier
         )
 
-        # filter frame based on num_rows.
-        # always return all columns as this may also result in a query.
-        # in the future could analyze plan to see whether retrieving column count would trigger a query, if not
-        # simply filter out based on static schema
-        num_rows_for_head_and_tail = num_rows_to_display // 2 + 1
-        new_frame = frame.filter(
-            (
-                col(row_position_snowflake_quoted_identifier)
-                <= num_rows_for_head_and_tail
+        if self._relaxed_query_compiler is None:
+            # filter frame based on num_rows.
+            # always return all columns as this may also result in a query.
+            # in the future could analyze plan to see whether retrieving column count would trigger a query, if not
+            # simply filter out based on static schema
+            num_rows_for_head_and_tail = num_rows_to_display // 2 + 1
+            new_frame = frame.filter(
+                (
+                    col(row_position_snowflake_quoted_identifier)
+                    <= num_rows_for_head_and_tail
+                )
+                | (
+                    col(row_position_snowflake_quoted_identifier)
+                    >= row_count_expr - num_rows_for_head_and_tail
+                )
             )
-            | (
-                col(row_position_snowflake_quoted_identifier)
-                >= row_count_expr - num_rows_for_head_and_tail
+        else:
+            # filter frame using a limit clause.
+            # always return all columns as this may also result in a query.
+            # in the future could analyze plan to see whether retrieving column count would trigger a query, if not
+            # simply filter out based on static schema
+            new_frame = InternalFrame.create(
+                ordered_dataframe=frame.ordered_dataframe.limit(
+                    n=num_rows_to_display + 1, sort=False
+                ),
+                data_column_pandas_index_names=frame.data_column_pandas_index_names,
+                data_column_pandas_labels=frame.data_column_pandas_labels,
+                data_column_snowflake_quoted_identifiers=frame.data_column_snowflake_quoted_identifiers,
+                index_column_pandas_labels=frame.index_column_pandas_labels,
+                index_column_snowflake_quoted_identifiers=frame.index_column_snowflake_quoted_identifiers,
+                data_column_types=frame.cached_data_column_snowpark_pandas_types,
+                index_column_types=frame.cached_index_column_snowpark_pandas_types,
             )
-        )
+            if len(new_frame.index_column_snowflake_quoted_identifiers) == 1 and (
+                ROW_POSITION_COLUMN_LABEL
+                in new_frame.index_column_snowflake_quoted_identifiers[0]
+            ):
+                new_col = (
+                    row_number().over(
+                        Window.order_by(
+                            new_frame.ordered_dataframe._ordering_snowpark_columns()
+                        )
+                    )
+                    - 1
+                )
+                new_col = new_col + iff(
+                    new_col < num_rows_to_display // 2,
+                    0,
+                    row_count_expr - num_rows_to_display - 1,
+                )
+                new_identifier = new_frame.ordered_dataframe.generate_snowflake_quoted_identifiers(
+                    pandas_labels=[
+                        ROW_POSITION_COLUMN_LABEL
+                        if new_frame.ordered_dataframe.row_position_snowflake_quoted_identifier
+                        is None
+                        else extract_pandas_label_from_snowflake_quoted_identifier(
+                            new_frame.ordered_dataframe.row_position_snowflake_quoted_identifier
+                        )
+                    ],
+                    wrap_double_underscore=True,
+                )[
+                    0
+                ]
+                new_col = new_col.as_(new_identifier)
+                new_ordered_dataframe = new_frame.ordered_dataframe.select("*", new_col)
+                new_ordered_dataframe.row_position_snowflake_quoted_identifier = (
+                    new_identifier
+                )
+                new_ordered_dataframe = new_ordered_dataframe.sort(
+                    OrderingColumn(new_identifier)
+                )
+                new_frame = InternalFrame.create(
+                    ordered_dataframe=new_ordered_dataframe,
+                    data_column_pandas_index_names=new_frame.data_column_pandas_index_names,
+                    data_column_pandas_labels=new_frame.data_column_pandas_labels,
+                    data_column_snowflake_quoted_identifiers=new_frame.data_column_snowflake_quoted_identifiers,
+                    index_column_pandas_labels=new_frame.index_column_pandas_labels,
+                    index_column_snowflake_quoted_identifiers=[new_identifier],
+                    data_column_types=new_frame.cached_data_column_snowpark_pandas_types,
+                    index_column_types=new_frame.cached_index_column_snowpark_pandas_types,
+                )
 
         # retrieve frame as pandas object
         new_qc = SnowflakeQueryCompiler(new_frame)
@@ -13896,7 +14184,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ordered_dataframe = ordered_dataframe.select(
             index_identifier,
             col(col_identifier).cast(FloatType()).as_(col_after_cast_identifier),
-        ).ensure_row_position_column()
+        ).ensure_row_position_column(dummy_row_pos_mode=self._dummy_row_pos_mode)
         internal_frame = InternalFrame.create(
             ordered_dataframe=ordered_dataframe,
             data_column_pandas_labels=[col_label],
@@ -14253,7 +14541,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                         padded_qc._modin_frame.data_column_snowflake_quoted_identifiers,
                     ),
                 ),
-            ).ensure_row_position_column()
+            ).ensure_row_position_column(dummy_row_pos_mode=self._dummy_row_pos_mode)
             top_freq_qc = SnowflakeQueryCompiler(
                 InternalFrame.create(
                     ordered_dataframe=ordered_dataframe,
@@ -14893,7 +15181,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         elif window_func == WindowFunction.EXPANDING:
             check_and_raise_error_expanding_window_supported_by_snowflake(window_kwargs)
 
-        frame = query_compiler._modin_frame.ensure_row_position_column()
+        frame = query_compiler._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         row_position_quoted_identifier = frame.row_position_snowflake_quoted_identifier
 
         if isinstance(window, int) or window_func == WindowFunction.EXPANDING:
@@ -15003,6 +15293,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 right=other_qc._modin_frame,
                 left_on=frame.index_column_snowflake_quoted_identifiers,
                 right_on=other_qc._modin_frame.index_column_snowflake_quoted_identifiers,
+                dummy_row_pos_mode=self._dummy_row_pos_mode,
             )
 
             # columns that exist in both dfs
@@ -15690,7 +15981,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         Snowpark pandas :class:`~modin.pandas.Series`
             Boolean series for each duplicated rows.
         """
-        frame = self._modin_frame.ensure_row_position_column()
+        frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
 
         # When frame has no data columns, the result should be an empty series of dtype bool,
         # which is internally represented as an empty dataframe with only the MODIN_UNNAMED_SERIES_LABEL column
@@ -15751,7 +16044,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
                 .select(row_position_post_dedup_quoted_identifier)
             )
 
-        row_position_post_dedup = row_position_post_dedup.ensure_row_position_column()
+        row_position_post_dedup = row_position_post_dedup.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         row_position_post_dedup_frame = InternalFrame.create(
             ordered_dataframe=row_position_post_dedup,
             data_column_pandas_labels=["row_position_post_dedup"],
@@ -16180,6 +16475,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             left_on=self_frame.index_column_snowflake_quoted_identifiers,
             right_on=other_frame.index_column_snowflake_quoted_identifiers,
             how="outer",
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         )
 
         left_right_pairs = prepare_binop_pairs_between_dataframe_and_dataframe(
@@ -18409,7 +18705,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
         labels_frame = SnowflakeQueryCompiler.from_pandas(
             pandas.DataFrame(labels)
-        )._modin_frame.ensure_row_position_column()
+        )._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
 
         # Join with labels and return result from there, i.e. replace value of i with labels[i].
         join_ret = join_utils.join(
@@ -19385,8 +19683,12 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             True if self index is equal to other index, False otherwise.
         """
         # Join on row position columns to compare order of data.
-        self_frame = self._modin_frame.ensure_row_position_column()
-        other_frame = other._modin_frame.ensure_row_position_column()
+        self_frame = self._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
+        other_frame = other._modin_frame.ensure_row_position_column(
+            dummy_row_pos_mode=self._dummy_row_pos_mode
+        )
         join_result = join_utils.join(
             self_frame,
             other_frame,
@@ -19984,6 +20286,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             right=other._modin_frame,
             left_on=self._modin_frame.index_column_snowflake_quoted_identifiers,
             right_on=other._modin_frame.index_column_snowflake_quoted_identifiers,
+            dummy_row_pos_mode=self._dummy_row_pos_mode,
         )
 
         # compare each column in `self` to the corresponding column in `other`.
@@ -20440,7 +20743,9 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ), "Internal error. Only SeriesGroupBy has a unique() method."
 
         compiler = SnowflakeQueryCompiler(
-            self._modin_frame.ensure_row_position_column()
+            self._modin_frame.ensure_row_position_column(
+                dummy_row_pos_mode=self._dummy_row_pos_mode
+            )
         )
         compiler, by_list = resample_and_extract_groupby_column_pandas_labels(
             compiler, by, groupby_kwargs.get("level", None)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -2083,7 +2083,7 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             return self._shift_values_axis_1(periods, fill_value)
 
     def _shift_values_axis_0(
-        self, periods: int, fill_value: Hashable,
+        self, periods: int, fill_value: Hashable
     ) -> "SnowflakeQueryCompiler":
         """
         Shift rows and fill new columns with fill_value.

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -250,16 +250,11 @@ class PandasOnSnowflakeIO(BaseIO):
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/plugin/pd_extensions.py
         """
-        dummy_row_pos_mode = (
-            os.environ.get("SNOWPARK_PANDAS_DUMMY_ROW_POS_MODE", "true").lower()
-            == "true"
-        )
         return cls.query_compiler_cls.from_snowflake(
             name_or_query,
             index_col,
             columns,
             enforce_ordering=enforce_ordering,
-            dummy_row_pos_mode=dummy_row_pos_mode,
         )
 
     @classmethod

--- a/src/snowflake/snowpark/modin/plugin/io/snow_io.py
+++ b/src/snowflake/snowpark/modin/plugin/io/snow_io.py
@@ -250,8 +250,16 @@ class PandasOnSnowflakeIO(BaseIO):
         See detailed docstring and examples in ``read_snowflake`` in frontend layer:
         src/snowflake/snowpark/modin/plugin/pd_extensions.py
         """
+        dummy_row_pos_mode = (
+            os.environ.get("SNOWPARK_PANDAS_DUMMY_ROW_POS_MODE", "true").lower()
+            == "true"
+        )
         return cls.query_compiler_cls.from_snowflake(
-            name_or_query, index_col, columns, enforce_ordering=enforce_ordering
+            name_or_query,
+            index_col,
+            columns,
+            enforce_ordering=enforce_ordering,
+            dummy_row_pos_mode=dummy_row_pos_mode,
         )
 
     @classmethod

--- a/tests/integ/modin/frame/test_aggregate.py
+++ b/tests/integ/modin/frame/test_aggregate.py
@@ -812,7 +812,7 @@ def test_sum_min_count(min_count, axis):
     )
 
 
-@sql_count_checker(query_count=3, union_count=4)
+@sql_count_checker(query_count=4, union_count=4)
 def test_agg_valid_variant_col(session, test_table_name):
     pandas_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/frame/test_create_or_replace_dynamic_table.py
@@ -48,7 +48,7 @@ def test_create_or_replace_dynamic_table_enforce_ordering_raises(session) -> Non
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=7)
 def test_create_or_replace_dynamic_table_no_enforce_ordering(session) -> None:
     try:
         # create table
@@ -84,7 +84,7 @@ def test_create_or_replace_dynamic_table_no_enforce_ordering(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_create_or_replace_dynamic_table_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -131,7 +131,7 @@ def test_create_or_replace_dynamic_table_multiple_sessions_no_enforce_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_index(session, index, index_labels):
     try:
         # create table
@@ -177,7 +177,7 @@ def test_create_or_replace_dynamic_table_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/frame/test_create_or_replace_view.py
+++ b/tests/integ/modin/frame/test_create_or_replace_view.py
@@ -85,7 +85,7 @@ def test_create_or_replace_view_multiple_sessions_enforce_ordering_raises(
         pd.session = session
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_create_or_replace_view_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -127,7 +127,7 @@ def test_create_or_replace_view_multiple_sessions_no_enforce_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_index(session, index, index_labels):
     try:
         # create table
@@ -167,7 +167,7 @@ def test_create_or_replace_view_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/frame/test_to_dynamic_table.py
+++ b/tests/integ/modin/frame/test_to_dynamic_table.py
@@ -62,7 +62,7 @@ def test_to_dynamic_table_enforce_ordering_raises(session, to_dynamic_table) -> 
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=7)
 def test_to_dynamic_table_no_enforce_ordering(session, to_dynamic_table) -> None:
     try:
         # create table
@@ -98,7 +98,7 @@ def test_to_dynamic_table_no_enforce_ordering(session, to_dynamic_table) -> None
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_to_dynamic_table_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -153,7 +153,7 @@ def test_to_dynamic_table_multiple_sessions_no_enforce_ordering(
         (False, ["my_index"], []),
     ],
 )
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_index(
     session, index, index_labels, expected_index_columns, to_dynamic_table
 ):
@@ -204,7 +204,7 @@ def test_to_dynamic_table_index(
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_multiindex(session, to_dynamic_table):
     try:
         # create table

--- a/tests/integ/modin/frame/test_to_iceberg.py
+++ b/tests/integ/modin/frame/test_to_iceberg.py
@@ -41,7 +41,7 @@ def to_iceberg(request):
     return request.param
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=7)
 def test_to_iceberg(session, native_pandas_df_basic, to_iceberg):
     if not iceberg_supported(session, local_testing_mode=False):
         pytest.skip("Test requires iceberg support.")

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -17,7 +17,7 @@ from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_to_snowflake_index(test_table_name, index, index_labels):
     df = pd.DataFrame(
         {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
@@ -38,7 +38,7 @@ def test_to_snowflake_index(test_table_name, index, index_labels):
     verify_columns(test_table_name, expected_columns)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_multiindex(test_table_name):
     index = native_pd.MultiIndex.from_arrays(
         [[1, 1, 2, 2], ["red", "blue", "red", "blue"]], names=("number", "color")
@@ -94,7 +94,7 @@ def test_to_snowflake_if_exists(session, test_table_name):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
     # Verify new table is created
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df.to_snowflake(test_table_name, if_exists="fail", index=False)
         verify_columns(test_table_name, ["a", "b"])
 
@@ -110,19 +110,19 @@ def test_to_snowflake_if_exists(session, test_table_name):
 
     # Verify existing table is replaced with new data
     df = pd.DataFrame({"a": [1, 2, 3], "c": [4, 5, 6]})
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df.to_snowflake(test_table_name, if_exists="replace", index=False)
         verify_columns(test_table_name, ["a", "c"])
         verify_num_rows(session, test_table_name, 3)
 
     # Verify data is appended to existing table
-    with SqlCounter(query_count=4):
+    with SqlCounter(query_count=5):
         df.to_snowflake(test_table_name, if_exists="append", index=False)
         verify_columns(test_table_name, ["a", "c"])
         verify_num_rows(session, test_table_name, 6)
 
     # Verify pd.to_snowflake operates the same
-    with SqlCounter(query_count=4):
+    with SqlCounter(query_count=5):
         pd.to_snowflake(df, test_table_name, if_exists="append", index=False)
         verify_columns(test_table_name, ["a", "c"])
         verify_num_rows(session, test_table_name, 9)
@@ -134,7 +134,7 @@ def test_to_snowflake_if_exists(session, test_table_name):
 
 
 @pytest.mark.parametrize("index_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_index_labels(index_label, test_table_name):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     df.to_snowflake(
@@ -144,7 +144,7 @@ def test_to_snowflake_index_labels(index_label, test_table_name):
 
 
 @pytest.mark.parametrize("col_name", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_column_names_from_panadas(col_name, test_table_name):
     df = pd.DataFrame({col_name: [1, 2, 3], "b": [4, 5, 6]})
     df.to_snowflake(test_table_name, if_exists="replace", index=False)
@@ -156,7 +156,7 @@ def test_to_snowflake_column_names_from_panadas(col_name, test_table_name):
 def test_column_names_with_read_snowflake_and_to_snowflake(
     col_name, if_exists, session
 ):
-    with SqlCounter(query_count=7 if if_exists == "append" else 6):
+    with SqlCounter(query_count=8 if if_exists == "append" else 7):
         # Create a table
         session.sql(f"create or replace table t1 ({col_name} int)").collect()
         session.sql("insert into t1 values (1), (2), (3)").collect()
@@ -173,7 +173,7 @@ def test_column_names_with_read_snowflake_and_to_snowflake(
         assert len(data) == (6 if if_exists == "append" else 3)
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_column_with_quotes(session, test_table_name):
     df = pd.DataFrame({'a"b': [1, 2, 3], 'a""b': [4, 5, 6]})
     df.to_snowflake(test_table_name, if_exists="replace", index=False)
@@ -183,13 +183,13 @@ def test_to_snowflake_column_with_quotes(session, test_table_name):
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
 def test_to_snowflake_index_label_none(test_table_name):
     # no index
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         df.to_snowflake(test_table_name, if_exists="replace")
         verify_columns(test_table_name, ["index", "a", "b"])
 
     # named index
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df = pd.DataFrame(
             {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
         )
@@ -197,14 +197,14 @@ def test_to_snowflake_index_label_none(test_table_name):
         verify_columns(test_table_name, ["index", "a", "b"])
 
     # nameless index
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4]))
         df.to_snowflake(test_table_name, if_exists="replace", index_label=[None])
         verify_columns(test_table_name, ["index", "a", "b"])
 
 
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_snowflake_index_label_none_data_column_conflict(test_table_name):
     df = pd.DataFrame({"index": [1, 2, 3], "a": [4, 5, 6]})
     df.to_snowflake(test_table_name, if_exists="replace")
@@ -260,7 +260,7 @@ def verify_num_rows(session, table_name: str, expected: int) -> None:
     assert actual == expected
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_timedelta_to_snowflake_with_read_snowflake(test_table_name, caplog):
     with caplog.at_level(logging.WARNING):
         df = pd.DataFrame(

--- a/tests/integ/modin/frame/test_to_snowpark.py
+++ b/tests/integ/modin/frame/test_to_snowpark.py
@@ -50,7 +50,7 @@ def native_pandas_df_basic():
 
 
 @pytest.mark.parametrize("index", [True, False])
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowpark_with_read_snowflake(tmp_table_basic, index) -> None:
     snow_dataframe = pd.read_snowflake(tmp_table_basic)
     # Follow read_snowflake with a sort operation to ensure that ordering is stable and tests are not flaky.
@@ -149,7 +149,7 @@ def test_to_snowpark_with_multiindex(tmp_table_basic, index, index_labels) -> No
     assert snowpark_df.schema[start + 1].column_identifier.quoted_name == '"b"'
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_to_snowpark_with_operations(session, tmp_table_basic) -> None:
     snowpandas_df = pd.read_snowflake(tmp_table_basic)
     # Follow read_snowflake with a sort operation to ensure that ordering is stable and tests are not flaky.
@@ -189,7 +189,7 @@ def test_to_snowpark_with_duplicated_columns_raise(native_pandas_df_basic) -> No
         snow_dataframe.to_snowpark()
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_to_snowpark_with_none_index_label(tmp_table_basic) -> None:
     snowpandas_df = pd.read_snowflake(tmp_table_basic)
     # Follow read_snowflake with a sort operation to ensure that ordering is stable and tests are not flaky.

--- a/tests/integ/modin/frame/test_to_view.py
+++ b/tests/integ/modin/frame/test_to_view.py
@@ -97,7 +97,7 @@ def test_to_view_multiple_sessions_enforce_ordering_raises(
         pd.session = session
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_to_view_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -146,7 +146,7 @@ def test_to_view_multiple_sessions_no_enforce_ordering(
         (False, ["my_index"], []),
     ],
 )
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_index(session, index, index_labels, expected_index_columns, to_view):
     try:
         # create table
@@ -191,7 +191,7 @@ def test_to_view_index(session, index, index_labels, expected_index_columns, to_
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_multiindex(session, to_view):
     try:
         # create table
@@ -228,7 +228,7 @@ def test_to_view_multiindex(session, to_view):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_to_view_multiindex_length_mismatch_raises(session, to_view):
     try:
         # create table

--- a/tests/integ/modin/groupby/test_groupby_basic_agg.py
+++ b/tests/integ/modin/groupby/test_groupby_basic_agg.py
@@ -89,7 +89,7 @@ def test_basic_single_group_row_groupby(
         ),
     ],
 )
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_single_group_row_groupby_with_variant(
     session,
     test_table_name,
@@ -132,7 +132,7 @@ def test_single_group_row_groupby_with_variant(
         )
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_groupby_agg_with_decimal_dtype(session, agg_method) -> None:
     # create table
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -1158,7 +1158,7 @@ def test_groupby_min_count_methods_with_nullable_type(
     )
 
 
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_groupby_agg_on_valid_variant_column(session, test_table_name):
     pandas_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/groupby/test_groupby_basic_agg.py
+++ b/tests/integ/modin/groupby/test_groupby_basic_agg.py
@@ -159,7 +159,7 @@ def test_groupby_agg_with_decimal_dtype(session, agg_method) -> None:
         eval_snowpark_pandas_result(snowpark_pandas_groupby, pandas_groupby, agg_method)
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_groupby_agg_with_decimal_dtype_named_agg(session) -> None:
     # create table
     table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/hybrid/test_extensions.py
+++ b/tests/integ/modin/hybrid/test_extensions.py
@@ -24,7 +24,7 @@ def test_to_pandas():
 def test_to_snowflake_and_to_snowpark():
     # SNOW-2115929: to_snowflake/to_snowpark should be registered on the pandas backend
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    with SqlCounter(query_count=5):
+    with SqlCounter(query_count=6):
         assert df.get_backend() == "Pandas"
         assert (
             df.to_snowpark()
@@ -43,7 +43,7 @@ def test_to_snowflake_and_to_snowpark():
             .equals(df.to_pandas())
         )
 
-    with SqlCounter(query_count=5):
+    with SqlCounter(query_count=6):
         column = df["a"]
         assert column.get_backend() == "Pandas"
         assert (
@@ -71,7 +71,7 @@ def test_read_snowflake_on_pandas_backend():
     snowpark_df = pd.session.create_dataframe(native_df)
     snowpark_df.write.save_as_table(table_name, table_type="temp")
 
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         result_df = pd.read_snowflake(table_name)
 
     assert result_df.get_backend() == "Pandas"

--- a/tests/integ/modin/hybrid/test_switch_operations.py
+++ b/tests/integ/modin/hybrid/test_switch_operations.py
@@ -61,7 +61,7 @@ def test_move_to_me_cost_with_incompatible_dtype(caplog):
         df_incompatible.move_to("Snowflake")
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_merge(init_transaction_tables, us_holidays_data):
     df_transactions = pd.read_snowflake("REVENUE_TRANSACTIONS")
     df_us_holidays = pd.DataFrame(us_holidays_data, columns=["Holiday", "Date"])
@@ -75,7 +75,7 @@ def test_merge(init_transaction_tables, us_holidays_data):
     assert combined.get_backend() == "Snowflake"
 
 
-@sql_count_checker(query_count=7)
+@sql_count_checker(query_count=9)
 def test_filtered_data(init_transaction_tables):
     # When data is filtered, the engine should change when it is sufficiently small.
     df_transactions = pd.read_snowflake("REVENUE_TRANSACTIONS")
@@ -103,7 +103,7 @@ def test_filtered_data(init_transaction_tables):
     )
 
 
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_apply(init_transaction_tables, us_holidays_data):
     df_transactions = pd.read_snowflake("REVENUE_TRANSACTIONS")
     df_us_holidays = pd.DataFrame(us_holidays_data, columns=["Holiday", "Date"])
@@ -196,7 +196,7 @@ def test_groupby_agg_post_op_switch(operation, small_snow_df):
     assert small_snow_df.get_backend() == "Snowflake"
 
 
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=2)
 def test_explain_switch(us_holidays_data):
     from snowflake.snowpark.modin.plugin._internal.telemetry import (
         clear_hybrid_switch_log,

--- a/tests/integ/modin/io/test_read_snowflake_iceberg.py
+++ b/tests/integ/modin/io/test_read_snowflake_iceberg.py
@@ -45,7 +45,7 @@ def test_read_snowflake_iceberg(session, enforce_ordering, local_testing_mode):
         """
         ).collect()
 
-    expected_query_counts = [3, 1] if not enforce_ordering else [5, 3]
+    expected_query_counts = [4, 2] if not enforce_ordering else [5, 3]
 
     with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe directly from iceberg table
@@ -60,7 +60,7 @@ def test_read_snowflake_iceberg(session, enforce_ordering, local_testing_mode):
         # compare two dataframes
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(df, pdf)
 
-    expected_query_counts = [3, 1] if not enforce_ordering else [6, 4]
+    expected_query_counts = [4, 2] if not enforce_ordering else [6, 4]
 
     with SqlCounter(query_count=expected_query_counts[0]):
         # create dataframe from a query referencing an iceberg table

--- a/tests/integ/modin/io/test_read_snowflake_query_call.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_call.py
@@ -63,7 +63,7 @@ def filter_by_role(session, table_name, role):
             session.sql("DROP PROCEDURE filter_by_role(VARCHAR, VARCHAR)").collect()
 
 
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=7, sproc_count=2)
 def test_read_snowflake_call_sproc_enforce_ordering_neg(session):
     session.sql(
         """

--- a/tests/integ/modin/io/test_read_snowflake_query_call.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_call.py
@@ -103,7 +103,7 @@ def filter_by_role(session, table_name, role):
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_system_function(session, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         df = pd.read_snowflake(
             "SELECT SYSTEM$TYPEOF(TRUE)",

--- a/tests/integ/modin/io/test_read_snowflake_query_cte.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_cte.py
@@ -17,8 +17,8 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_basic_cte(session, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
-    expected_union_count = 2 if enforce_ordering else 4
+    expected_query_count = 6 if enforce_ordering else 4
+    expected_union_count = 2 if enforce_ordering else 6
     with SqlCounter(query_count=expected_query_count, union_count=expected_union_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -37,8 +37,8 @@ def test_read_snowflake_query_basic_cte(session, enforce_ordering):
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_recursive_cte(enforce_ordering):
-    expected_query_count = 5 if enforce_ordering else 2
-    expected_union_count = 1 if enforce_ordering else 2
+    expected_query_count = 5 if enforce_ordering else 3
+    expected_union_count = 1 if enforce_ordering else 3
     with SqlCounter(query_count=expected_query_count, union_count=expected_union_count):
         SQL_QUERY = """WITH RECURSIVE current_f (current_val, previous_val) AS
                         (
@@ -64,9 +64,9 @@ def test_read_snowflake_query_recursive_cte(enforce_ordering):
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_complex_recursive_cte(session, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
-    expected_join_count = 1 if enforce_ordering else 2
-    expected_union_count = 1 if enforce_ordering else 2
+    expected_query_count = 6 if enforce_ordering else 4
+    expected_join_count = 1 if enforce_ordering else 3
+    expected_union_count = 1 if enforce_ordering else 3
     with SqlCounter(
         query_count=expected_query_count,
         join_count=expected_join_count,

--- a/tests/integ/modin/io/test_read_snowflake_query_order_by.py
+++ b/tests/integ/modin/io/test_read_snowflake_query_order_by.py
@@ -24,7 +24,7 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_select_star_with_order_by(session, caplog, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # This test ensures that the presence of an ORDER BY causes us not to take the fastpath
         # of select * from table, where we just do `pd.read_snowflake("table")` instead.
@@ -55,7 +55,7 @@ def test_select_star_with_order_by(session, caplog, enforce_ordering):
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_no_order_by_but_column_name_shadows(session, caplog, enforce_ordering):
-    expected_query_count = 5 if enforce_ordering else 2
+    expected_query_count = 5 if enforce_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -81,7 +81,7 @@ def test_no_order_by_but_column_name_shadows(session, caplog, enforce_ordering):
 def test_order_by_and_column_name_shadows(
     session, caplog, order_by_col, enforce_ordering
 ):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         # Want random permutation, but need to make sure that there are no duplicates in the sorting column
@@ -112,7 +112,7 @@ def test_order_by_and_column_name_shadows(
 def test_order_by_as_column_name_should_not_warn_negative(
     session, caplog, enforce_ordering
 ):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -138,7 +138,7 @@ def test_order_by_as_column_name_should_not_warn_negative(
 def test_inner_order_by_should_be_ignored_and_no_outer_order_by_negative(
     session, caplog, enforce_ordering
 ):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         session.create_dataframe(
@@ -166,7 +166,7 @@ def test_inner_order_by_should_be_ignored_and_no_outer_order_by_negative(
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_order_by_with_no_limit_but_colname_shadows(session, caplog, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         native_df = native_pd.DataFrame(
@@ -191,7 +191,7 @@ def test_order_by_with_no_limit_but_colname_shadows(session, caplog, enforce_ord
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_order_by_with_limit_and_name_shadows(session, caplog, enforce_ordering):
-    expected_query_count = 5 if enforce_ordering else 2
+    expected_query_count = 5 if enforce_ordering else 3
     with SqlCounter(query_count=expected_query_count):
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         native_df = native_pd.DataFrame(
@@ -214,8 +214,8 @@ def test_order_by_with_limit_and_name_shadows(session, caplog, enforce_ordering)
 def test_read_snowflake_query_complex_query_with_join_and_order_by(
     session, caplog, enforce_ordering
 ):
-    expected_query_count = 7 if enforce_ordering else 4
-    expected_join_count = 1 if enforce_ordering else 2
+    expected_query_count = 7 if enforce_ordering else 5
+    expected_join_count = 1 if enforce_ordering else 3
     with SqlCounter(query_count=expected_query_count, join_count=expected_join_count):
         # create table
         table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -252,7 +252,7 @@ def test_read_snowflake_query_complex_query_with_join_and_order_by(
 @pytest.mark.parametrize("ordinal", [1, 2, 28])
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_order_by_with_position_key(session, ordinal, caplog, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         column_order = [
             "col12",

--- a/tests/integ/modin/io/test_read_snowflake_select_query.py
+++ b/tests/integ/modin/io/test_read_snowflake_select_query.py
@@ -70,7 +70,7 @@ def test_read_snowflake_basic_query_with_weird_formatting(session, enforce_order
 def test_read_snowflake_basic_query_with_comment_preceding_sql_inline_string(
     session, enforce_ordering
 ):
-    expected_query_count = 7 if enforce_ordering else 4
+    expected_query_count = 7 if enforce_ordering else 6
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/io/test_read_snowflake_select_query.py
+++ b/tests/integ/modin/io/test_read_snowflake_select_query.py
@@ -33,7 +33,7 @@ from tests.utils import Utils
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_basic_query_with_weird_formatting(session, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -70,7 +70,7 @@ def test_read_snowflake_basic_query_with_weird_formatting(session, enforce_order
 def test_read_snowflake_basic_query_with_comment_preceding_sql_inline_string(
     session, enforce_ordering
 ):
-    expected_query_count = 7 if enforce_ordering else 3
+    expected_query_count = 7 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -160,7 +160,7 @@ def test_read_snowflake_basic_query_with_comment_preceding_sql_multiline_string(
 @pytest.mark.parametrize("only_nulls", [True, False])
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_none_nan_condition(session, only_nulls, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -191,7 +191,7 @@ def test_read_snowflake_query_none_nan_condition(session, only_nulls, enforce_or
 def test_read_snowflake_query_aliased_columns(
     session, col_name_and_alias_tuple, enforce_ordering
 ):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         col_name, alias = col_name_and_alias_tuple
@@ -217,7 +217,7 @@ def test_read_snowflake_query_aliased_columns(
 def test_read_snowflake_query_aliased_columns_and_columns_kwarg_specified(
     session, col_name_and_alias_tuple, enforce_ordering
 ):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         col_name, alias = col_name_and_alias_tuple
@@ -241,8 +241,7 @@ def test_read_snowflake_query_aliased_columns_and_columns_kwarg_specified(
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_with_columns(session, enforce_ordering):
-    expected_query_count = 4 if enforce_ordering else 3
-    with SqlCounter(query_count=expected_query_count):
+    with SqlCounter(query_count=4):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         Utils.create_table(
@@ -263,8 +262,7 @@ def test_read_snowflake_query_with_columns(session, enforce_ordering):
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_with_index_col_and_columns(session, enforce_ordering):
-    expected_query_count = 4 if enforce_ordering else 3
-    with SqlCounter(query_count=expected_query_count):
+    with SqlCounter(query_count=4):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         Utils.create_table(
@@ -292,8 +290,7 @@ def test_read_snowflake_query_with_index_col_and_columns(session, enforce_orderi
 def test_read_snowflake_query_with_index_col_and_columns_overlap(
     session, enforce_ordering
 ):
-    expected_query_count = 4 if enforce_ordering else 3
-    with SqlCounter(query_count=expected_query_count):
+    with SqlCounter(query_count=4):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         Utils.create_table(
@@ -318,7 +315,7 @@ def test_read_snowflake_query_with_index_col_and_columns_overlap(
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_additional_derived_column(session, enforce_ordering):
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 6 if enforce_ordering else 4
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -379,8 +376,7 @@ def test_read_snowflake_query_non_existing(
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_duplicate_columns(session, enforce_ordering):
-    expected_query_count = 7 if enforce_ordering else 5
-    with SqlCounter(query_count=expected_query_count):
+    with SqlCounter(query_count=7):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
         Utils.create_table(session, table_name, '"X" int, Y int', is_temporary=True)
@@ -446,8 +442,8 @@ def test_read_snowflake_query_table_bad_sql_negative(bad_sql, enforce_ordering) 
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_complex_query_with_join(session, enforce_ordering):
-    expected_query_count = 7 if enforce_ordering else 4
-    expected_join_count = 1 if enforce_ordering else 2
+    expected_query_count = 7 if enforce_ordering else 5
+    expected_join_count = 1 if enforce_ordering else 3
     with SqlCounter(query_count=expected_query_count, join_count=expected_join_count):
         # create table
         table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -486,7 +482,7 @@ def test_read_snowflake_query_complex_query_with_join(session, enforce_ordering)
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
 def test_read_snowflake_query_connect_by(session, enforce_ordering):
-    expected_query_count = 8 if enforce_ordering else 5
+    expected_query_count = 8 if enforce_ordering else 6
     with SqlCounter(query_count=expected_query_count):
         # create table
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)

--- a/tests/integ/modin/series/test_create_or_replace_dynamic_table.py
+++ b/tests/integ/modin/series/test_create_or_replace_dynamic_table.py
@@ -48,7 +48,7 @@ def test_create_or_replace_dynamic_table_enforce_ordering_raises(session) -> Non
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=7)
 def test_create_or_replace_dynamic_table_no_enforce_ordering(session) -> None:
     try:
         # create table
@@ -84,7 +84,7 @@ def test_create_or_replace_dynamic_table_no_enforce_ordering(session) -> None:
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_create_or_replace_dynamic_table_multiple_sessions_enforce_ordering(
     session,
     db_parameters,
@@ -131,7 +131,7 @@ def test_create_or_replace_dynamic_table_multiple_sessions_enforce_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_index(session, index, index_labels):
     try:
         # create table
@@ -177,7 +177,7 @@ def test_create_or_replace_dynamic_table_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_dynamic_table_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/series/test_create_or_replace_view.py
+++ b/tests/integ/modin/series/test_create_or_replace_view.py
@@ -76,7 +76,7 @@ def test_create_or_replace_view_multiple_sessions_enforce_ordering_raises(
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_create_or_replace_view_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -118,7 +118,7 @@ def test_create_or_replace_view_multiple_sessions_no_enforce_ordering(
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_index(session, index, index_labels):
     try:
         # create table
@@ -158,7 +158,7 @@ def test_create_or_replace_view_index(session, index, index_labels):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_create_or_replace_view_multiindex(session):
     try:
         # create table

--- a/tests/integ/modin/series/test_str_accessor.py
+++ b/tests/integ/modin/series/test_str_accessor.py
@@ -725,7 +725,7 @@ def test_str_len_list_coin_base(session, enable_sql_simplifier):
     expected_udf_count = 2
     if session.sql_simplifier_enabled:
         expected_udf_count = 1
-    with SqlCounter(query_count=9, udf_count=expected_udf_count):
+    with SqlCounter(query_count=5):
         from tests.utils import Utils
 
         table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
@@ -740,6 +740,8 @@ def test_str_len_list_coin_base(session, enable_sql_simplifier):
         df = pd.read_snowflake(table_name)
         # Follow read_snowflake with a sort operation to ensure that ordering is stable and tests are not flaky.
         df = df.sort_values(df.columns.to_list(), ignore_index=True)
+
+    with SqlCounter(query_count=5, udf_count=expected_udf_count):
 
         def compute_num_shared_card_users(x):
             """

--- a/tests/integ/modin/series/test_to_dynamic_table.py
+++ b/tests/integ/modin/series/test_to_dynamic_table.py
@@ -62,7 +62,7 @@ def test_to_dynamic_table_enforce_ordering_raises(session, to_dynamic_table) -> 
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=7)
 def test_to_dynamic_table_no_enforce_ordering(session, to_dynamic_table) -> None:
     try:
         # create table
@@ -98,7 +98,7 @@ def test_to_dynamic_table_no_enforce_ordering(session, to_dynamic_table) -> None
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_to_dynamic_table_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -153,7 +153,7 @@ def test_to_dynamic_table_multiple_sessions_no_enforce_ordering(
         (False, ["my_index"], []),
     ],
 )
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_index(
     session, index, index_labels, expected_index_columns, to_dynamic_table
 ):
@@ -196,7 +196,7 @@ def test_to_dynamic_table_index(
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_dynamic_table_multiindex(session, to_dynamic_table):
     try:
         # create table

--- a/tests/integ/modin/series/test_to_iceberg.py
+++ b/tests/integ/modin/series/test_to_iceberg.py
@@ -34,7 +34,7 @@ def to_iceberg(request):
     return request.param
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=7)
 def test_to_iceberg(session, native_pandas_ser_basic, to_iceberg):
     if not iceberg_supported(session, local_testing_mode=False):
         pytest.skip("Test requires iceberg support.")

--- a/tests/integ/modin/series/test_to_snowflake.py
+++ b/tests/integ/modin/series/test_to_snowflake.py
@@ -30,7 +30,7 @@ def _verify_num_rows(session, table_name: str, expected: int) -> None:
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-@sql_count_checker(query_count=2, join_count=1)
+@sql_count_checker(query_count=3, join_count=1)
 def test_to_snowflake_index(test_table_name, snow_series, index, index_labels):
     snow_series.to_snowflake(
         test_table_name, if_exists="replace", index=index, index_label=index_labels
@@ -59,14 +59,14 @@ def test_to_snowflake_index_name_conflict_negative(test_table_name, snow_series)
         snow_series.to_snowflake(test_table_name, if_exists="replace", index_label="a")
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_index_label_none(test_table_name):
     snow_series = pd.Series([1, 2, 3], name="a", index=native_pd.Index([4, 5, 6]))
     snow_series.to_snowflake(test_table_name, if_exists="replace", index=True)
     _verify_columns(test_table_name, ["index", "a"])
 
 
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_to_snowflake_multiindex(test_table_name, snow_series):
     index = native_pd.MultiIndex.from_arrays(
         [[1, 1, 2, 2], ["red", "blue", "red", "blue"]], names=("number", "color")
@@ -88,18 +88,18 @@ def test_to_snowflake_index_label_invalid_length_negative(test_table_name, snow_
 
 def test_to_snowflake_if_exists(session, test_table_name, snow_series):
     # Verify new table is created
-    with SqlCounter(query_count=3):
+    with SqlCounter(query_count=4):
         snow_series.to_snowflake(test_table_name, if_exists="fail", index=False)
         _verify_columns(test_table_name, ["a"])
 
     # Verify existing table is replaced with new data
-    with SqlCounter(query_count=2):
+    with SqlCounter(query_count=3):
         snow_series = pd.Series([4, 5, 6], name="b")
         snow_series.to_snowflake(test_table_name, if_exists="replace", index=False)
         _verify_columns(test_table_name, ["b"])
 
     # Verify data is appended to existing table
-    with SqlCounter(query_count=5):
+    with SqlCounter(query_count=6):
         _verify_num_rows(session, test_table_name, 3)
         snow_series.to_snowflake(test_table_name, if_exists="append", index=False)
         _verify_columns(test_table_name, ["b"])
@@ -125,7 +125,7 @@ def test_to_snowflake_if_exists_negative(session, test_table_name, snow_series):
 
 
 @pytest.mark.parametrize("index_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2, join_count=1)
+@sql_count_checker(query_count=3, join_count=1)
 def test_to_snowflake_index_column_labels(index_label, test_table_name, snow_series):
     snow_series.to_snowflake(
         test_table_name, if_exists="replace", index=True, index_label=index_label
@@ -134,7 +134,7 @@ def test_to_snowflake_index_column_labels(index_label, test_table_name, snow_ser
 
 
 @pytest.mark.parametrize("col_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=2, join_count=1)
+@sql_count_checker(query_count=3, join_count=1)
 def test_to_snowflake_data_column_labels(col_label, test_table_name, snow_series):
     snow_series = snow_series.rename(col_label)
     snow_series.to_snowflake(test_table_name, if_exists="replace", index=False)

--- a/tests/integ/modin/series/test_to_view.py
+++ b/tests/integ/modin/series/test_to_view.py
@@ -88,7 +88,7 @@ def test_to_view_multiple_sessions_enforce_ordering_raises(
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=5)
+@sql_count_checker(query_count=6)
 def test_to_view_multiple_sessions_no_enforce_ordering(
     session,
     db_parameters,
@@ -137,7 +137,7 @@ def test_to_view_multiple_sessions_no_enforce_ordering(
         (False, ["my_index"], []),
     ],
 )
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_index(session, index, index_labels, expected_index_columns, to_view):
     try:
         # create table
@@ -174,7 +174,7 @@ def test_to_view_index(session, index, index_labels, expected_index_columns, to_
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=6)
+@sql_count_checker(query_count=8)
 def test_to_view_multiindex(session, to_view):
     try:
         # create table
@@ -214,7 +214,7 @@ def test_to_view_multiindex(session, to_view):
         Utils.drop_table(session, table_name)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_to_view_multiindex_length_mismatch_raises(session, to_view):
     try:
         # create table

--- a/tests/integ/modin/strings/test_get_dummies_dataframe.py
+++ b/tests/integ/modin/strings/test_get_dummies_dataframe.py
@@ -204,7 +204,7 @@ def test_get_dummies_multiple_columns():
 # https://snowflakecomputing.atlassian.net/browse/SNOW-1050112
 # Customer issue: Calling get_dummies on the result of
 # pd.read_snowflake directly results in a ValueError.
-@sql_count_checker(query_count=3, join_count=2)
+@sql_count_checker(query_count=4, join_count=2)
 def test_get_dummies_pandas_after_read_snowflake(session):
     pandas_df = native_pd.DataFrame(
         {

--- a/tests/integ/modin/test_concat.py
+++ b/tests/integ/modin/test_concat.py
@@ -1190,7 +1190,7 @@ def test_concat_object_with_same_index_with_dup_sort(join):
     assert_frame_equal(snow_res, expected_result)
 
 
-@sql_count_checker(query_count=3, join_count=0)
+@sql_count_checker(query_count=4, join_count=0)
 def test_concat_series_from_same_df(join):
     num_cols = 4
     select_data = [f'{i} as "{i}"' for i in range(num_cols)]
@@ -1215,7 +1215,7 @@ def test_concat_series_from_same_df(join):
     assert_frame_equal(df, final_df)
 
 
-@sql_count_checker(query_count=3, join_count=0)
+@sql_count_checker(query_count=4, join_count=0)
 def test_df_creation_from_series_from_same_df():
     num_cols = 6
     select_data = [f'{i} as "{i}"' for i in range(num_cols)]

--- a/tests/integ/modin/test_df_to_snowpark_pandas.py
+++ b/tests/integ/modin/test_df_to_snowpark_pandas.py
@@ -50,7 +50,7 @@ def tmp_table_basic(session):
 def test_to_snowpark_pandas_basic(
     session, tmp_table_basic, index_col, columns, enforce_ordering
 ) -> None:
-    expected_query_count = 4 if enforce_ordering else 2
+    expected_query_count = 6 if enforce_ordering else 3
     # One less query when we don't have a multi-index
     with SqlCounter(
         query_count=expected_query_count
@@ -93,7 +93,7 @@ def test_to_snowpark_pandas_basic(
 def test_to_snowpark_pandas_from_views(
     session, tmp_table_basic, enforce_ordering
 ) -> None:
-    with SqlCounter(query_count=4 if enforce_ordering else 2):
+    with SqlCounter(query_count=6 if enforce_ordering else 3):
         snowpark_df = session.sql(
             f"SELECT ID, SHOE_MODEL FROM {tmp_table_basic} WHERE ID > 1"
         )
@@ -113,7 +113,7 @@ def test_to_snowpark_pandas_from_views(
 def test_to_snowpark_pandas_with_operations(
     session, tmp_table_basic, enforce_ordering
 ) -> None:
-    with SqlCounter(query_count=4 if enforce_ordering else 2):
+    with SqlCounter(query_count=6 if enforce_ordering else 3):
         snowpark_df = session.table(tmp_table_basic)
         snowpark_df = (
             snowpark_df.select(
@@ -176,7 +176,6 @@ def test_to_snowpark_pandas_columns_not_list_raises(
             )
 
 
-@sql_count_checker(query_count=8)
 def test_to_snowpark_pandas_with_multiple_queries_forces_ordering(
     session,
     resources_path,
@@ -199,5 +198,6 @@ def test_to_snowpark_pandas_with_multiple_queries_forces_ordering(
     snowpark_df = (
         session.read.option("purge", False).schema(user_schema).csv(test_file_on_stage)
     )
-    df = snowpark_df.to_snowpark_pandas(enforce_ordering=False)
-    assert len(df.columns) == 3
+    with SqlCounter(query_count=8):
+        df = snowpark_df.to_snowpark_pandas(enforce_ordering=False)
+        assert len(df.columns) == 3

--- a/tests/integ/modin/test_df_to_snowpark_pandas.py
+++ b/tests/integ/modin/test_df_to_snowpark_pandas.py
@@ -50,7 +50,7 @@ def tmp_table_basic(session):
 def test_to_snowpark_pandas_basic(
     session, tmp_table_basic, index_col, columns, enforce_ordering
 ) -> None:
-    expected_query_count = 6 if enforce_ordering else 3
+    expected_query_count = 4 if enforce_ordering else 3
     # One less query when we don't have a multi-index
     with SqlCounter(
         query_count=expected_query_count
@@ -93,7 +93,7 @@ def test_to_snowpark_pandas_basic(
 def test_to_snowpark_pandas_from_views(
     session, tmp_table_basic, enforce_ordering
 ) -> None:
-    with SqlCounter(query_count=6 if enforce_ordering else 3):
+    with SqlCounter(query_count=4 if enforce_ordering else 3):
         snowpark_df = session.sql(
             f"SELECT ID, SHOE_MODEL FROM {tmp_table_basic} WHERE ID > 1"
         )
@@ -113,7 +113,7 @@ def test_to_snowpark_pandas_from_views(
 def test_to_snowpark_pandas_with_operations(
     session, tmp_table_basic, enforce_ordering
 ) -> None:
-    with SqlCounter(query_count=6 if enforce_ordering else 3):
+    with SqlCounter(query_count=4 if enforce_ordering else 3):
         snowpark_df = session.table(tmp_table_basic)
         snowpark_df = (
             snowpark_df.select(
@@ -176,6 +176,7 @@ def test_to_snowpark_pandas_columns_not_list_raises(
             )
 
 
+@sql_count_checker(query_count=8)
 def test_to_snowpark_pandas_with_multiple_queries_forces_ordering(
     session,
     resources_path,
@@ -198,6 +199,5 @@ def test_to_snowpark_pandas_with_multiple_queries_forces_ordering(
     snowpark_df = (
         session.read.option("purge", False).schema(user_schema).csv(test_file_on_stage)
     )
-    with SqlCounter(query_count=8):
-        df = snowpark_df.to_snowpark_pandas(enforce_ordering=False)
-        assert len(df.columns) == 3
+    df = snowpark_df.to_snowpark_pandas(enforce_ordering=False)
+    assert len(df.columns) == 3

--- a/tests/integ/modin/test_df_to_snowpark_pandas.py
+++ b/tests/integ/modin/test_df_to_snowpark_pandas.py
@@ -137,30 +137,30 @@ def test_to_snowpark_pandas_with_operations(
 
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])
-@sql_count_checker(query_count=0)
 def test_to_snowpark_pandas_duplicated_columns_raises(
     session, tmp_table_basic, enforce_ordering
 ) -> None:
-    sql_simplifier_enabled_original = session.sql_simplifier_enabled
-    # Error is raised only when SQL simplifier is enabled.
-    session.sql_simplifier_enabled = True
+    with SqlCounter(query_count=0 if enforce_ordering else 2):
+        sql_simplifier_enabled_original = session.sql_simplifier_enabled
+        # Error is raised only when SQL simplifier is enabled.
+        session.sql_simplifier_enabled = True
 
-    snowpark_df = session.table(tmp_table_basic)
-    snowpark_df = snowpark_df.select(
-        Column("ID"),
-        Column("FOOT_SIZE").as_('"shoe"'),
-        Column("SHOE_MODEL").as_('"shoe"'),
-    )
+        snowpark_df = session.table(tmp_table_basic)
+        snowpark_df = snowpark_df.select(
+            Column("ID"),
+            Column("FOOT_SIZE").as_('"shoe"'),
+            Column("SHOE_MODEL").as_('"shoe"'),
+        )
 
-    pattern = (
-        "duplicate column name 'shoe'"
-        if enforce_ordering
-        else "ambiguous column name 'shoe'"
-    )
+        pattern = (
+            "duplicate column name 'shoe'"
+            if enforce_ordering
+            else "ambiguous column name 'shoe'"
+        )
 
-    with pytest.raises(SnowparkSQLException, match=pattern):
-        snowpark_df.to_snowpark_pandas(enforce_ordering=enforce_ordering).head()
-    session.sql_simplifier_enabled = sql_simplifier_enabled_original
+        with pytest.raises(SnowparkSQLException, match=pattern):
+            snowpark_df.to_snowpark_pandas(enforce_ordering=enforce_ordering).head()
+        session.sql_simplifier_enabled = sql_simplifier_enabled_original
 
 
 @pytest.mark.parametrize("enforce_ordering", [True, False])

--- a/tests/integ/modin/test_dtype_mapping.py
+++ b/tests/integ/modin/test_dtype_mapping.py
@@ -486,7 +486,7 @@ def test_read_snowflake_data_types_array_undefined_negative(
     expected_to_pandas_dtype,
     expected_to_pandas,
 ):
-    expected_query_count = 8 if isinstance(samples, list) and len(samples) > 1 else 4
+    expected_query_count = 9 if isinstance(samples, list) and len(samples) > 1 else 5
     with SqlCounter(query_count=expected_query_count):
         Utils.create_table(session, test_table_name, col_name_type, is_temporary=True)
         if not isinstance(samples, list):

--- a/tests/integ/modin/test_from_pandas_to_pandas.py
+++ b/tests/integ/modin/test_from_pandas_to_pandas.py
@@ -477,7 +477,7 @@ def test_from_pandas_duplicate_labels():
         ("transient", 100),
     ],
 )
-@sql_count_checker(query_count=8)
+@sql_count_checker(query_count=9)
 def test_determinism_with_repeated_to_pandas(session, table_type, n_rows) -> None:
     ref_df = native_pd.DataFrame(
         {
@@ -550,7 +550,7 @@ def test_single_row_frame_to_series_to_pandas():
     assert_series_equal(snow_series, expected_series, check_dtype=False)
 
 
-@sql_count_checker(query_count=3)
+@sql_count_checker(query_count=4)
 def test_empty_variant_type_frame_to_pandas(session):
     # Tests type conversion of empty dataframes that have columns with the ARRAY and MAP types.
     # These dataframes must be constructed from pd.read_snowflake to have the correct type, since

--- a/tests/integ/modin/test_ordered_dataframe.py
+++ b/tests/integ/modin/test_ordered_dataframe.py
@@ -895,7 +895,7 @@ def test_limit(ordered_df):
         '"b"',
     ]
     assert new_ordered_df.ordering_columns == ordered_df.ordering_columns
-    assert new_ordered_df.row_position_snowflake_quoted_identifier is None
+    assert new_ordered_df.row_position_snowflake_quoted_identifier is not None
 
 
 @sql_count_checker(query_count=1)

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -64,7 +64,7 @@ def _extract_snowpark_pandas_telemetry_log_data(
 @patch(
     "snowflake.snowpark.modin.plugin._internal.telemetry._send_snowpark_pandas_telemetry_helper"
 )
-@sql_count_checker(query_count=2)
+@sql_count_checker(query_count=3)
 def test_snowpark_pandas_telemetry_standalone_function_decorator(
     send_telemetry_mock,
     session,

--- a/tests/integ/modin/test_to_numpy.py
+++ b/tests/integ/modin/test_to_numpy.py
@@ -76,7 +76,7 @@ def test_to_numpy_basic(data, pandas_obj, func):
                 assert r1 == r2
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 def test_tz_aware_data_to_numpy(session):
     table_name = random_name_for_temp_object(TempObjectType.TABLE)
     Utils.create_table(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2230971

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Support repr, joins, loc, reset_index, and binary ops in faster pandas.
   The env variable `SNOWPARK_PANDAS_DUMMY_ROW_POS_OPTIMIZATION_ENABLED` can be used to turn off the optimization. It's turned on by default. 
