### PR TITLE
NO-SNOW: Add udf marker to modin tests

### DIFF
--- a/.github/workflows/daily_modin_precommit_py311_py312_py13.yml
+++ b/.github/workflows/daily_modin_precommit_py311_py312_py13.yml
@@ -76,7 +76,7 @@ jobs:
             download_name: macos
           - image_name: windows-latest-64-cores
             download_name: windows
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         cloud-provider: [aws, azure, gcp]
     steps:
       - name: Checkout Code

--- a/tests/integ/modin/frame/test_apply.py
+++ b/tests/integ/modin/frame/test_apply.py
@@ -34,6 +34,8 @@ from tests.integ.modin.utils import (
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import RUNNING_ON_GH, running_on_public_ci
 
+pytestmark = [pytest.mark.udf]
+
 # TODO SNOW-891796: replace native_pd with pd after allowing using snowpandas module/function in UDF
 
 # test data which has a python type as return type that is not a pandas Series/pandas DataFrame/tuple/list

--- a/tests/integ/modin/frame/test_apply_axis_0.py
+++ b/tests/integ/modin/frame/test_apply_axis_0.py
@@ -26,6 +26,8 @@ from tests.integ.modin.utils import (
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import RUNNING_ON_GH
 
+pytestmark = [pytest.mark.udf]
+
 # test data which has a python type as return type that is not a pandas Series/pandas DataFrame/tuple/list
 BASIC_DATA_FUNC_PYTHON_RETURN_TYPE_MAP = [
     [[[1.0, 2.2], [3, np.nan]], np.min, "float"],

--- a/tests/integ/modin/frame/test_cache_result.py
+++ b/tests/integ/modin/frame/test_cache_result.py
@@ -177,6 +177,7 @@ class TestCacheResultReducesQueryCount:
             )
 
     @pytest.mark.skipif(RUNNING_ON_GH, reason="Slow test")
+    @pytest.mark.udf
     def test_cache_result_post_apply(self, inplace, simple_test_data):
         # In this test, the caching doesn't aid in the query counts since
         # the implementation of apply(axis=1) itself contains intermediate

--- a/tests/integ/modin/groupby/test_all_any.py
+++ b/tests/integ/modin/groupby/test_all_any.py
@@ -100,6 +100,7 @@ def test_all_any_invalid_types(data, msg):
 
 
 @sql_count_checker(query_count=4, join_count=1, udtf_count=1)
+@pytest.mark.udf
 def test_all_any_chained():
     data = {
         "by": ["a", "a", "b", "c", "c"],

--- a/tests/integ/modin/groupby/test_groupby_apply.py
+++ b/tests/integ/modin/groupby/test_groupby_apply.py
@@ -28,6 +28,8 @@ from tests.integ.modin.utils import (
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 from tests.utils import RUNNING_ON_GH
 
+pytestmark = [pytest.mark.udf]
+
 # Use the workaround shown below for applying functions that are attributes
 # of this module.
 # https://github.com/cloudpipe/cloudpickle?tab=readme-ov-file#overriding-pickles-serialization-mechanism-for-importable-constructs

--- a/tests/integ/modin/groupby/test_groupby_transform.py
+++ b/tests/integ/modin/groupby/test_groupby_transform.py
@@ -17,6 +17,8 @@ from tests.integ.modin.utils import (
 )
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
 
+pytestmark = [pytest.mark.udf]
+
 
 def eval_snowpark_pandas_result(*args, **kwargs):
     # Some calls to the native pandas function propagate attrs while some do not, depending on the values of its arguments.

--- a/tests/integ/modin/hybrid/test_df_creation_backend.py
+++ b/tests/integ/modin/hybrid/test_df_creation_backend.py
@@ -4,6 +4,7 @@
 
 import tempfile
 import pandas as native_pd
+import pytest
 
 # We're comparing an object with the native pandas backend, so we use the pandas testing utility
 # here rather than our own internal one.
@@ -72,6 +73,7 @@ def test_from_list(us_holidays_data):
         assert_series_equal(row.to_pandas(), native_row)
 
 
+@pytest.mark.udf
 def test_move_threshold_setting():
     with config_context(NativePandasMaxRows=10):
         with SqlCounter(

--- a/tests/integ/modin/test_modin_stored_procedures.py
+++ b/tests/integ/modin/test_modin_stored_procedures.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import pytest
 import modin.pandas as pd
 import pandas as native_pd
 
@@ -12,12 +13,12 @@ from snowflake.snowpark.functions import sproc
 from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import multithreaded_run
 
+pytestmark = [pytest.mark.udf]
 
 # Must pin modin version to match version available in Snowflake Anaconda
-SPROC_MODIN_VERSION = "0.30.1"
+SPROC_MODIN_VERSION = "0.33.2"
 
 PACKAGE_LIST = [
-    # modin 0.30.1 supports any pandas 2.2.x, so just pick whichever one is installed in the client.
     # Note that because we specify `snowflake-snowpark-python` as a package here, it will pick whatever
     # version of the package is available in anaconda, not the latest `main` branch.
     # The behavior of stored procedures with `main` is verified in server-side tests and the stored

--- a/tests/integ/modin/test_session.py
+++ b/tests/integ/modin/test_session.py
@@ -255,6 +255,7 @@ def test_snowpark_pandas_session_class_does_not_exist_snow_1022098():
         lambda df: df.groupby(0).apply(lambda x: x + 1),
     ],
 )
+@pytest.mark.udf
 class TestApplyLikeMethodsWithMultipleSessionsSnow1216902:
     """
     Test some cases from SNOW-1216902

--- a/tests/integ/modin/test_sql_counter.py
+++ b/tests/integ/modin/test_sql_counter.py
@@ -125,6 +125,7 @@ def test_sql_counter_with_context_manager_outside_loop(session):
 
 
 @sql_count_checker(query_count=5, join_count=2, udtf_count=1)
+@pytest.mark.udf
 def test_sql_counter_with_df_udtf_count():
     df = pd.DataFrame([[1, 2], [3, 4]]).apply(lambda x: str(type(x)), axis=1, raw=True)
     assert len(df) == 2


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Adds `pytest.mark.udf` to relevant modin tests, and automatically skips them if the detected runtime contains Python 3.13 or pandas 2.3, neither of which are currently supported on the server. This also adds Python 3.13 to the modin daily test matrix.