### PR TITLE
NO-SNOW: Update line number check to handle python 3.10

### DIFF
--- a/tests/integ/test_trace_sql_errors_to_df.py
+++ b/tests/integ/test_trace_sql_errors_to_df.py
@@ -23,7 +23,7 @@ pytestmark = [
         run=False,
     ),
     pytest.mark.skipif(
-        sys.version_info < (3, 11),
+        sys.version_info < (3, 10),
         reason="Line numbers are flaky in Python 3.9",
         run=False,
     ),
@@ -65,7 +65,12 @@ def test_python_source_location_in_session_sql(session):
         ex.value.debug_context
     )
     line_number = Utils.get_current_line_number_sys()
-    assert f"lines {line_number - 8}-{line_number - 6}" in str(ex.value.debug_context)
+    if sys.version_info < (3, 11):
+        assert f"line {line_number - 8}" in str(ex.value.debug_context)
+    else:
+        assert f"lines {line_number - 8}-{line_number - 6}" in str(
+            ex.value.debug_context
+        )
 
 
 def test_join_ambiguous_column_error(session):

--- a/tests/integ/test_trace_sql_errors_to_df.py
+++ b/tests/integ/test_trace_sql_errors_to_df.py
@@ -23,7 +23,7 @@ pytestmark = [
         run=False,
     ),
     pytest.mark.skipif(
-        sys.version_info < (3, 10),
+        sys.version_info < (3, 11),
         reason="Line numbers are flaky in Python 3.9",
         run=False,
     ),

--- a/tests/integ/test_trace_sql_errors_to_df.py
+++ b/tests/integ/test_trace_sql_errors_to_df.py
@@ -23,7 +23,7 @@ pytestmark = [
         run=False,
     ),
     pytest.mark.skipif(
-        sys.version_info < (3, 10),
+        sys.version_info < (3, 11),
         reason="Line numbers are flaky in Python 3.9",
         run=False,
     ),
@@ -65,12 +65,7 @@ def test_python_source_location_in_session_sql(session):
         ex.value.debug_context
     )
     line_number = Utils.get_current_line_number_sys()
-    if sys.version_info < (3, 11):
-        assert f"line {line_number - 8}" in str(ex.value.debug_context)
-    else:
-        assert f"lines {line_number - 8}-{line_number - 6}" in str(
-            ex.value.debug_context
-        )
+    assert f"lines {line_number - 8}-{line_number - 6}" in str(ex.value.debug_context)
 
 
 def test_join_ambiguous_column_error(session):
@@ -385,29 +380,22 @@ def test_existing_view_with_schema_qualified_names_using_session_sql(session):
     temp_view_name = Utils.random_name_for_temp_object(TempObjectType.VIEW)
     db = session.get_current_database()
     sc = session.get_current_schema()
-    try:
+    session.sql(
+        f"CREATE VIEW {db}.{sc}.{temp_view_name} AS SELECT 1 AS a, 2 AS b"
+    ).collect()
+
+    with pytest.raises(SnowparkSQLException) as ex:
         session.sql(
-            f"CREATE VIEW {db}.{sc}.{temp_view_name} AS SELECT 1 AS a, 2 AS b"
+            f"CREATE VIEW {db}.{sc}.{temp_view_name} AS SELECT 3 AS a, 4 AS b"
         ).collect()
 
-        with pytest.raises(SnowparkSQLException) as ex:
-            session.sql(
-                f"CREATE VIEW {db}.{sc}.{temp_view_name} AS SELECT 3 AS a, 4 AS b"
-            ).collect()
-
-        db = db.strip('"')
-        sc = sc.strip('"')
-        expected_message = f"Object '{db}.{sc}.{temp_view_name}' was first referenced"
-        assert expected_message in str(ex.value.debug_context)
-        line_number = Utils.get_current_line_number_sys()
-        if sys.version_info < (3, 11):
-            assert f"line {line_number - 13}" in str(ex.value.debug_context)
-        else:
-            assert f"lines {line_number - 13}-{line_number - 11}" in str(
-                ex.value.debug_context
-            )
-    finally:
-        Utils.drop_view(session, temp_view_name)
+    db = db.strip('"')
+    sc = sc.strip('"')
+    expected_message = f"Object '{db}.{sc}.{temp_view_name}' was first referenced"
+    assert expected_message in str(ex.value.debug_context)
+    line_number = Utils.get_current_line_number_sys()
+    assert f"lines {line_number - 13}-{line_number - 11}" in str(ex.value.debug_context)
+    Utils.drop_view(session, temp_view_name)
 
 
 def test_existing_view_with_schema_qualified_names_using_dataframe_methods(session):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Example failure: https://github.com/snowflakedb/snowpark-python/actions/runs/16744274500/job/47399231532.

  Current test expects start and end line number but 3.10 and older python only captures start line number. Update the test to reflect this change.
