### PR TITLE
NO-SNOW: skip map_cat test due to improper structured type session parameter settings

### DIFF
--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -7426,7 +7426,7 @@ def map_cat(
 
     Example::
         >>> df = session.sql("select {'k1': 'v1'} :: MAP(STRING,STRING) as A, {'k2': 'v2'} :: MAP(STRING,STRING) as B")
-        >>> df.select(map_cat("A", "B")).show()
+        >>> df.select(map_cat("A", "B")).show()  # doctest: +SKIP
         ---------------------------
         |"MAP_CAT(""A"", ""B"")"  |
         ---------------------------
@@ -7437,7 +7437,7 @@ def map_cat(
         ---------------------------
         <BLANKLINE>
         >>> df = session.sql("select {'k1': 'v1'} :: MAP(STRING,STRING) as A, {'k2': 'v2'} :: MAP(STRING,STRING) as B, {'k3': 'v3'} :: MAP(STRING,STRING) as C")
-        >>> df.select(map_cat("A", "B", "C")).show()
+        >>> df.select(map_cat("A", "B", "C")).show()  # doctest: +SKIP
         -------------------------------------------
         |"MAP_CAT(MAP_CAT(""A"", ""B""), ""C"")"  |
         -------------------------------------------


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT
ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE

they should both set to true or both to false to get the function work
however, in our test deployment, it's improperly set that ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT is false and the other ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE is true

I need to check why they are set differently, skipping the test first to reduce noise
