### PR TITLE
SNOW-2254287: Remove deepcopy of large data during optimization stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Bug Fixes
 
+- Fixed a bug in CTE optimization stage where `deepcopy` of internal plans would cause a memory spike when a dataframe is created locally using `session.create_dataframe()` using a large input data.
 - Fixed a bug in `DataFrameReader.parquet` where the `ignore_case` option in the `infer_schema_options` was not respected.
 - Fixed a bug that `to_pandas()` has different format of column name when query result format is set to 'JSON' and 'ARROW'.
 #### New Features

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -208,7 +208,9 @@ def _deepcopy_selectable_fields(
     """
     Make a deep copy of the fields from the from_selectable to the to_selectable
     """
-    to_selectable.pre_actions = deepcopy(from_selectable.pre_actions)
+    # shallow copy pre_actions as it can have large data for BatchInsertQuery which should
+    # never be modified during the optimization stage.
+    to_selectable.pre_actions = copy(from_selectable.pre_actions)
     to_selectable.post_actions = deepcopy(from_selectable.post_actions)
     to_selectable.flatten_disabled = from_selectable.flatten_disabled
     to_selectable._column_states = deepcopy(from_selectable._column_states)

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -211,7 +211,7 @@ def _deepcopy_selectable_fields(
     # shallow copy pre_actions as it can have large data for BatchInsertQuery which should
     # never be modified during the optimization stage.
     to_selectable.pre_actions = copy(from_selectable.pre_actions)
-    to_selectable.post_actions = deepcopy(from_selectable.post_actions)
+    to_selectable.post_actions = copy(from_selectable.post_actions)
     to_selectable.flatten_disabled = from_selectable.flatten_disabled
     to_selectable._column_states = deepcopy(from_selectable._column_states)
     to_selectable.expr_to_alias = deepcopy(from_selectable.expr_to_alias)

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -733,7 +733,7 @@ class SnowflakePlan(LogicalPlan):
             plan = SnowflakePlan(
                 [copy.copy(q) for q in (self.queries or [])],
                 self.schema_query,
-                copy.deepcopy(self.post_actions) if self.post_actions else None,
+                copy.copy(self.post_actions) if self.post_actions else None,
                 copy.copy(self.expr_to_alias) if self.expr_to_alias else None,
                 self.source_plan,
                 self.is_ddl_on_temp_object,

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -336,8 +336,8 @@ def get_snowflake_plan_queries(
     ):
         # make a copy of the original query to avoid any update to the
         # original query object
-        plan_queries = copy.deepcopy(plan.queries)
-        post_action_queries = copy.deepcopy(plan.post_actions)
+        plan_queries = copy.copy(plan.queries)
+        post_action_queries = copy.copy(plan.post_actions)
         table_names = []
         definition_queries = []
         final_query_params = []


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2254287, #3641

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   I ran the following pipeline to reproduce the original reported issue above

```
data = [(x, x*2) for x in range(int(1e5))]
df = session.create_dataframe(data, schema=["id", "value"])
df = df.union(df)
df = df.cache_result()
```

I was successfully able to reproduce the memory spike due to deepcopy see the flamegraphs below

### Disabled
Heap: 170MB
RSS: 240MB

<img width="1721" height="831" alt="Screenshot 2025-08-07 at 1 39 57 PM" src="https://github.com/user-attachments/assets/a810b3a4-5222-4bb6-88d2-b92d8869520a" />

### Enabled Original
Heap: 436MB
RSS: 549MB

<img width="1721" height="1177" alt="Screenshot 2025-08-07 at 1 41 59 PM" src="https://github.com/user-attachments/assets/b5b60f4d-c264-41d1-8b73-5f6a9dfe0b58" />

---

### Enabled with Current Changes
Heap: 170MB
RSS: 246 MB
<img width="1721" height="844" alt="Screenshot 2025-08-07 at 1 45 27 PM" src="https://github.com/user-attachments/assets/b0000ae4-6be4-418d-bdf4-d41c19ba00f4" />

