### PR TITLE
Fix limit when there is no grouping expression in aggregation

### DIFF
--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -334,7 +334,9 @@ class RelationalGroupedDataFrame:
             exclude_grouping_columns=exclude_grouping_columns,
             _emit_ast=False,
         )
-        df._ops_after_agg = set()
+        # if no grouping exprs, there is already a LIMIT 1 in the query
+        # see aggregate_statement in analyzer_utils.py
+        df._ops_after_agg = set() if self._grouping_exprs else {"limit"}
 
         if _emit_ast:
             df._ast_id = stmt.uid
@@ -525,7 +527,9 @@ class RelationalGroupedDataFrame:
             ),
             _emit_ast=False,
         )
-        df._ops_after_agg = set()
+        # if no grouping exprs, there is already a LIMIT 1 in the query
+        # see aggregate_statement in analyzer_utils.py
+        df._ops_after_agg = set() if self._grouping_exprs else {"limit"}
 
         if _emit_ast:
             stmt = working_dataframe._session._ast_batch.bind()
@@ -758,7 +762,9 @@ class RelationalGroupedDataFrame:
             exclude_grouping_columns=exclude_grouping_columns,
             _emit_ast=False,
         )
-        df._ops_after_agg = set()
+        # if no grouping exprs, there is already a LIMIT 1 in the query
+        # see aggregate_statement in analyzer_utils.py
+        df._ops_after_agg = set() if self._grouping_exprs else {"limit"}
 
         # TODO: count seems similar to mean, min, .... Can we unify implementation here?
         if _emit_ast:
@@ -805,7 +811,9 @@ class RelationalGroupedDataFrame:
             agg_exprs.append(expr)
 
         df = self._to_df(agg_exprs, exclude_grouping_columns=exclude_grouping_columns)
-        df._ops_after_agg = set()
+        # if no grouping exprs, there is already a LIMIT 1 in the query
+        # see aggregate_statement in analyzer_utils.py
+        df._ops_after_agg = set() if self._grouping_exprs else {"limit"}
 
         if _emit_ast:
             stmt = self._dataframe._session._ast_batch.bind()

--- a/tests/integ/test_df_aggregate.py
+++ b/tests/integ/test_df_aggregate.py
@@ -721,6 +721,19 @@ def test_agg_sort_snowpark_connect_compatible(session):
         context._is_snowpark_connect_compatible_mode = original_value
 
 
+def test_agg_no_grouping_exprs_limit_snowpark_connect_compatible(session):
+    original_value = context._is_snowpark_connect_compatible_mode
+    try:
+        context._is_snowpark_connect_compatible_mode = True
+        df = session.create_dataframe([[1, 2], [3, 4], [1, 4]], schema=["A", "B"])
+        result = df.agg(sum_(col("a"))).limit(2)
+        Utils.check_answer(result, [Row(5)])
+        result = df.group_by().agg(sum_(col("b"))).limit(2)
+        Utils.check_answer(result, [Row(10)])
+    finally:
+        context._is_snowpark_connect_compatible_mode = original_value
+
+
 @pytest.mark.skipif(
     "config.getoption('local_testing_mode', default=False)",
     reason="HAVING and ORDER BY append are not supported in local testing mode",


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.
    There is already a LIMIT 1 in aggregation expression if there is no grouping columns https://github.com/snowflakedb/snowpark-python/blob/b5178d3c314ee298bba5e43e3c19fc3732621ccc/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py#L642
