### PR TITLE
SNOW-2262562: Return empty DF instead of None for pd.explain_switch(simple=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 #### Bug Fixes
 
 - Fixed an issue in hybrid execution mode (PrPr) where `pd.to_datetime` and `pd.to_timedelta` would unexpectedly raise `IndexError`.
+- Fixed a bug where `pd.explain_switch` would raise `IndexError` or return `None` if called before any potential switch operations were performed.
 
 ## 1.36.0 (2025-08-05)
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -420,6 +420,7 @@ def _telemetry_helper(
     elif (
         result is None
         and func.__name__ not in ["to_snowflake", "to_iceberg"]
+        and len(args) > 0
         and is_snowpark_pandas_dataframe_or_series_type(args[0])
     ):
         args[0]._query_compiler.snowpark_pandas_api_calls = (

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -974,10 +974,14 @@ def explain_switch_simple() -> Union[native_pd.DataFrame, None]:
 
     stats = get_hybrid_switch_log()
     if len(stats) <= 0:
-        return None  # pragma: no cover
-    stats["decision"] = stats.groupby(["group", "mode"]).ffill()["decision"]
-    stats["api"] = stats.groupby(["source", "group", "mode"]).ffill()["api"]
-    stats["mode"] = stats.groupby(["source", "group"]).ffill()["mode"]
+        stats["source"] = []
+        stats["mode"] = []
+        stats["decision"] = []
+        stats["api"] = []
+    else:
+        stats["decision"] = stats.groupby(["group", "mode"]).ffill()["decision"]
+        stats["api"] = stats.groupby(["source", "group", "mode"]).ffill()["api"]
+        stats["mode"] = stats.groupby(["source", "group"]).ffill()["mode"]
     stats = (
         stats[
             [

--- a/tests/integ/modin/hybrid/test_switch_operations.py
+++ b/tests/integ/modin/hybrid/test_switch_operations.py
@@ -22,6 +22,9 @@ from snowflake.snowpark.modin.plugin._internal.row_count_estimation import (
 from snowflake.snowpark.modin.plugin._internal.utils import (
     MODIN_IS_AT_LEAST_0_34_0,
 )
+from snowflake.snowpark.modin.plugin._internal.telemetry import (
+    clear_hybrid_switch_log,
+)
 from modin.core.storage_formats.base.query_compiler import QCCoercionCost
 from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
     SnowflakeQueryCompiler,
@@ -286,12 +289,24 @@ def test_groupby_agg_post_op_switch(operation, small_snow_df):
     assert small_snow_df.get_backend() == "Snowflake"
 
 
+@sql_count_checker(query_count=0)
+def test_explain_switch_empty():
+    clear_hybrid_switch_log()
+    empty_switch = pd.explain_switch()
+    assert len(empty_switch) == 0
+    empty_switch_cols = empty_switch.columns.tolist()
+    empty_switch_index_names = empty_switch.index.names
+    pd.DataFrame().move_to("Snowflake")
+    new_switch = pd.explain_switch()
+    assert len(new_switch) > 0
+    new_switch_cols = new_switch.columns.tolist()
+    new_switch_index_names = new_switch.index.names
+    assert new_switch_cols == empty_switch_cols
+    assert new_switch_index_names == empty_switch_index_names
+
+
 @sql_count_checker(query_count=1)
 def test_explain_switch(init_transaction_tables, us_holidays_data):
-    from snowflake.snowpark.modin.plugin._internal.telemetry import (
-        clear_hybrid_switch_log,
-    )
-
     clear_hybrid_switch_log()
     df_transactions = pd.read_snowflake("REVENUE_TRANSACTIONS")
     df_us_holidays = pd.DataFrame(us_holidays_data, columns=["Holiday", "Date"])


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2262562

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

`pd.explain_switch(simple=True)` would return `None` if no operations were performed, which looks weird in an interactive environment because nothing is printed.

The bug cited in the ticket occurs because the previous implementation of `explain_switch` tripped an uncommon code path in telemetry that checked if a function returned None and if its first argument was a Snowpark pandas DF/Series. This PR adds a defensive length check to telemetry to avoid the IndexError, and also changes `explain_switch(simple=True)` to always return an empty DF instead of None. When `simple=False`, it already returned an empty frame, though column labels are left unset.