### PR TITLE
SNOW-2241331: Unable to use numpy.unique through sklearn.metrics._scorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Hybrid execution row estimate improvements and a reduction of eager calls.
 - Add a new configuration variable to control transfer costs out of Snowflake when using hybrid execution.
 - Added support for creating permanent and immutable UDFs/UDTFs with `DataFrame/Series/GroupBy.apply`, `map`, and `transform` by passing the `snowflake_udf_params` keyword argument. See documentation for details.
+- Added support for mapping np.unique to DataFrame and Series inputs using pd.unique.
 
 #### Bug Fixes
 

--- a/docs/source/modin/numpy.rst
+++ b/docs/source/modin/numpy.rst
@@ -25,6 +25,15 @@ NumPy ufuncs called with Snowpark pandas arguments will ignore kwargs.
 |                             | dispatcher at all, and the normal NumPy behavior   |
 |                             | will occur.)                                       |
 +-----------------------------+----------------------------------------------------+
+| ``np.unique``               | Mapped to pd.unique, will stack a DataFrame to     |
+|                             | convert to Series. Always returns an ndarray like  |
+|                             | pd.unique. Does not implement any arguments other  |
+|                             | than the input array. This function will result in |
+|                             | materialization of the unique set because usages of|
+|                             | this function depend on numpy-specific behavior.   |
+|                             | Only the initial call to unique will be            |
+|                             | distributed.                                       |
++-----------------------------+----------------------------------------------------+
 | ``np.full_like``            | Mapped to pd.DataFrame(value, index=range(height), |
 |                             |                        columns=range(width))       |
 +-----------------------------+----------------------------------------------------+

--- a/src/snowflake/snowpark/modin/plugin/utils/numpy_to_pandas.py
+++ b/src/snowflake/snowpark/modin/plugin/utils/numpy_to_pandas.py
@@ -121,6 +121,70 @@ def where_mapper(
     return NotImplemented
 
 
+def unique_mapper(
+    ar: Union[pd.DataFrame, pd.Series],
+    return_index: bool = False,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    axis: Optional[int] = None,
+    equal_nan: bool = True,
+    sorted: bool = True,
+) -> np.ndarray:
+    """
+    Maps and executes the numpy unique signature to the pandas where signature
+    if it can be handled, otherwise returns NotImplemented. No parameters
+    are supported beyond the input ar array. A DataFrame will first be stacked
+    so that the pd.unique function can be used.
+
+    Numpy np.unique signature:
+    Return unique elements in an ndarray, Series, or DataFrame (ar) as a
+    sorted ndarray
+
+    Pandas pd.unique signature:
+    Return unique elements of a Series as an unsorted ndarray
+
+    Parameters
+    ----------
+    ar : A modin pandas DataFrame or Series
+    return_index : NotImplemented ( returns an ndarray )
+    return_inverse : NotImplemented
+    return_counts : NotImplemented
+    axis : NotImplemented
+    equal_nan : NotImplemented
+    sorted : NotImplemented
+
+    Returns
+    -------
+    Returns an ndarray, sorted
+
+    """
+    if return_index:
+        return NotImplemented
+    if return_inverse:
+        return NotImplemented
+    if return_counts:
+        return NotImplemented
+    if axis is not None:
+        return NotImplemented
+    if not equal_nan:
+        return NotImplemented
+    if not sorted:
+        return NotImplemented
+    input_values = ar
+
+    # pd.unique does not take DataFrames, so we stack it into a Series.
+    if isinstance(input_values, pd.DataFrame):
+        input_values = input_values.stack().reset_index(drop=True)
+
+    # pandas.unique and modin.pandas.unique differ from np.unique in
+    # the sense that by default, numpy sorts the result. Unlike the
+    # where mapper we always return a numpy array the same as we do
+    # in pd.unique.
+    result_unsorted = pd.unique(input_values)
+    result_unsorted.sort()
+    return result_unsorted
+
+
 def may_share_memory_mapper(a: Any, b: Any, max_work: Optional[int] = None) -> bool:
     """
     Maps and executes the numpy may_share_memory signature and always
@@ -171,6 +235,7 @@ def map_to_bools(inputs: Any) -> Any:
 # functions are called by numpy
 numpy_to_pandas_func_map = {
     "where": where_mapper,
+    "unique": unique_mapper,
     "may_share_memory": may_share_memory_mapper,
     "full_like": full_like_mapper,
 }

--- a/tests/integ/modin/test_numpy.py
+++ b/tests/integ/modin/test_numpy.py
@@ -57,6 +57,39 @@ def test_np_may_share_memory():
         assert not np.may_share_memory(snow_df_A, native_df_A)
 
 
+@sql_count_checker(query_count=2)
+def test_np_unique():
+    # tests np.unique usage as seen in
+    # scikit-learn/sklearn/metrics/_ranking.py::average_precision_score
+    # and other places in the scikit-learn library
+    y_true_np = np.array([0, 0, 1, 1])
+    y_true_snow = pd.Series([0, 0, 1, 1])
+    res_np = np.unique(y_true_np)
+    res_snow = np.unique(y_true_snow)
+    assert (res_np == res_snow).all()
+
+    y_true_np_2d = np.array([[1, 2, 5, 6], [1, 2, 3, 4]])
+    y_true_snow_2d = pd.DataFrame({"a": [1, 2, 5, 6], "b": [1, 2, 3, 4]})
+    res_np = np.unique(y_true_np_2d)
+    res_snow = np.unique(y_true_snow_2d)
+    assert (res_np == res_snow).all()
+
+    # Verify that numpy throws type errors when we return NotImplemented
+    # when using optional parameters
+    with pytest.raises(TypeError):
+        np.unique(y_true_snow_2d, return_index=True)
+    with pytest.raises(TypeError):
+        np.unique(y_true_snow_2d, return_inverse=True)
+    with pytest.raises(TypeError):
+        np.unique(y_true_snow_2d, return_counts=True)
+    with pytest.raises(TypeError):
+        np.unique(y_true_snow_2d, axis=1)
+    with pytest.raises(TypeError):
+        np.unique(y_true_snow_2d, equal_nan=False)
+    with pytest.raises(TypeError):
+        np.unique(y_true_snow_2d, sorted=False)
+
+
 def test_full_like():
     data = {
         "A": [0, 1, 2, 0, 1, 2, 0, 1, 2],


### PR DESCRIPTION
Map np.unique(df) to pd.unique with appropriate handling for DataFrames/Series. As with np.unique and pd.unique we return an ndarray, which is a materialized result set. We cannot avoid this because usages of this function often chain operations which expect an ndarray. This is specifically implemented to improve scikit-learn compatibility.


   Fixes SNOW-2241331:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
