### PR TITLE
SNOW-2266293: Cap pyarrow<21 in snowpark pandas jenkins tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ setenv = SNOWPARK_LOCAL_TESTING_INTERNAL_TELEMETRY=1
 allowlist_externals = bash
 description = run the tests with pytest under {basepython}
 deps =
+    {env:SNOWFLAKE_PYTEST_MODIN_JENKINS_PYARROW_CAP}
     pip >= 19.3.1
     pytest-xdist
     pytest-timeout
@@ -86,6 +87,8 @@ setenv =
     MODIN_PYTEST_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources
     MODIN_PYTEST_DAILY_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_DAILY_PARALLELISM:} {env:SNOWFLAKE_PYTEST_COV_CMD} --ignore=tests/resources
     MODIN_PYTEST_NO_COV_CMD = pytest {env:SNOWFLAKE_PYTEST_VERBOSITY:} {env:SNOWFLAKE_PYTEST_PARALLELISM:} --ignore=tests/resources
+    # Cap pyarrow<21 for Snowpark pandas tests on Jenkins due to SNOW-2266293
+    snowparkpandasjenkins: SNOWFLAKE_PYTEST_MODIN_JENKINS_PYARROW_CAP = pyarrow<21
 
 passenv =
     AWS_ACCESS_KEY_ID


### PR DESCRIPTION
With this fix, Snowpark pandas daily Jenkins tests no longer fail due to failure to install pyarrow: https://snowpark-python-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/SnowparkPythonSnowPandasDailyRegressRunner/198110/console

Fixes SNOW-2266293
