### PR TITLE
SNOW-2276751: improve dbapi thread based ingestion error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 #### Dependency Updates
 
+#### Improvements
+
+- Enhanced error handling in `DataFrameReader.dbapi` thread-based ingestion to prevent unnecessary operations, which improves resource efficiency.
+
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/src/snowflake/snowpark/_internal/data_source/utils.py
+++ b/src/snowflake/snowpark/_internal/data_source/utils.py
@@ -183,15 +183,7 @@ def _task_fetch_data_from_source(
 
     for i, result in enumerate(worker.read(partition)):
         if stop_event and stop_event.is_set():
-            parquet_queue.put(
-                (
-                    PARTITION_TASK_ERROR_SIGNAL,
-                    SnowparkDataframeReaderException(
-                        "Data fetching stopped by thread failure"
-                    ),
-                )
-            )
-            break
+            return
         convert_to_parquet_bytesio(result, i)
 
     parquet_queue.put((f"{PARTITION_TASK_COMPLETE_SIGNAL_PREFIX}{partition_idx}", None))

--- a/tests/integ/test_data_source_api.py
+++ b/tests/integ/test_data_source_api.py
@@ -1369,37 +1369,10 @@ def test_threading_error_handling_with_stop_event(session):
         ):
             assert stop_event
             processed_partitions.put(partition_idx)
-
             # Simulate error on the second partition (partition_idx=1)
             if partition_idx == 1:
                 assert not stop_event.is_set()
-                # Add a small delay to ensure other threads have started
-                import time
-
-                time.sleep(0.05)
-                # Raise an error that should trigger the stop event mechanism
                 raise RuntimeError("Simulated thread error in partition 1")
-
-            # For other partitions, add delay to simulate longer-running work
-            # This ensures they will still be running when partition 1 fails
-            if partition_idx in [0, 2]:
-                import time
-
-                time.sleep(
-                    0.1
-                )  # Longer delay to ensure they're still running when error occurs
-
-            # For other partitions, check stop event and exit gracefully if set
-            if stop_event and stop_event.is_set():
-                parquet_queue.put(
-                    (
-                        PARTITION_TASK_ERROR_SIGNAL,
-                        SnowparkDataframeReaderException(
-                            "Data fetching stopped by thread failure"
-                        ),
-                    )
-                )
-                return
 
             # Otherwise proceed normally
             return original_task_fetch(
@@ -1441,16 +1414,11 @@ def test_threading_error_handling_with_stop_event(session):
                     column="id",
                     upper_bound=10,
                     lower_bound=0,
-                    num_partitions=3,  # Create 3 partitions to test multi-threading
-                    max_workers=3,
+                    num_partitions=9,  # Create 9 partitions to test multi-threading
+                    max_workers=2,
                     custom_schema=SQLITE3_DB_CUSTOM_SCHEMA_STRING,
                     fetch_with_process=False,  # Use threading mode
                 )
-            # Give threads a moment to be cancelled/complete
-            import time
-
-            time.sleep(0.2)
-
             # Convert queues to lists for assertion checks using helper function
             processed_list = drain_queue(processed_partitions)
             cancelled_list = drain_queue(cancelled_futures)
@@ -1458,11 +1426,12 @@ def test_threading_error_handling_with_stop_event(session):
 
             # Verify threading behavior: 3 futures created, partition 1 failed, some (but not all) futures cancelled
             assert (
-                len(created_list) == 3
+                9
+                > len(created_list)
+                > 1  # at least 0 and 1 must be created in order to process
                 and len(processed_list) >= 1
                 and 1 in processed_list
-                and len(cancelled_list) > 0
-                and len(cancelled_list) < 3
+                and 9 > len(cancelled_list) > 0
             ), f"Threading verification failed: created={len(created_list)}, processed={processed_list}, cancelled={len(cancelled_list)}"
 
             # Additional verification: check that cancelled futures were indeed not done when cancelled


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2276751

- improve dbapi thread based ingestion error handling, do not over send stop events in case there is error in one thread and immediately returns
- improve the test case to avoid flakiness


3. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

4. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
