### PR TITLE
SNOW-2189056: Support some snowflake extensions on other backends.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
   `pd.to_pandas()`, `pd.to_snowpark()`, `pd.to_snowflake()`,
   `DataFrame.to_iceberg()`, `DataFrame.to_pandas()`, `DataFrame.to_snowpark()`,
   `DataFrame.to_snowflake()`, `Series.to_iceberg()`, `Series.to_pandas()`,
-  `Series.to_snowpark()`, and `Series.to_snowflake()` on the Pandas and Ray
+  `Series.to_snowpark()`, and `Series.to_snowflake()` on the "Pandas" and "Ray"
   backends. Previously, only some of these functions and methods were supported
   on the Pandas backend.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@
 ### Snowpark pandas API Updates
 
 #### New Features
-- Added support for `pd.read_snowflake()`, `pd.to_iceberg()`, `pd.to_pandas()`,
-  `pd.to_snowpark()`, `pd.to_snowflake()`, `DataFrame.to_iceberg()`,
-  `DataFrame.to_pandas()`, `DataFrame.to_snowpark()`, `DataFrame.to_snowflake()`,
-  `Series.to_iceberg()`, `Series.to_pandas()`, `Series.to_snowpark()`, and
-  `Series.to_snowflake()` on the Pandas and Ray backends.
+- Completed support for `pd.read_snowflake()`, `pd.to_iceberg()`,
+  `pd.to_pandas()`, `pd.to_snowpark()`, `pd.to_snowflake()`,
+  `DataFrame.to_iceberg()`, `DataFrame.to_pandas()`, `DataFrame.to_snowpark()`,
+  `DataFrame.to_snowflake()`, `Series.to_iceberg()`, `Series.to_pandas()`,
+  `Series.to_snowpark()`, and `Series.to_snowflake()` on the Pandas and Ray
+  backends. Previously, only some of these functions and methods were supported
+  on the Pandas backend.
 
 #### Improvements
 - Set the default transfer limit in hybrid execution for data leaving Snowflake to 100k, which can be overridden with the SnowflakePandasTransferThreshold environment variable. This configuration is appropriate for scenarios with two available engines, "Pandas" and "Snowflake" on relational workloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,23 @@
 ### Snowpark pandas API Updates
 
 #### New Features
+- Added support for `pd.read_snowflake()`, `pd.to_iceberg()`, `pd.to_pandas()`,
+  `pd.to_snowpark()`, `pd.to_snowflake()`, `DataFrame.to_iceberg()`,
+  `DataFrame.to_pandas()`, `DataFrame.to_snowpark()`, `DataFrame.to_snowflake()`,
+  `Series.to_iceberg()`, `Series.to_pandas()`, `Series.to_snowpark()`, and
+  `Series.to_snowflake()` on the Pandas and Ray backends.
 
 #### Improvements
 - Set the default transfer limit in hybrid execution for data leaving Snowflake to 100k, which can be overridden with the SnowflakePandasTransferThreshold environment variable. This configuration is appropriate for scenarios with two available engines, "Pandas" and "Snowflake" on relational workloads.
 
 #### Dependency Updates
+
 #### Bug Fixes
+- Raised `NotImplementedError` instead of `AttributeError` on attempting to call
+  Snowflake extension functions/methods `to_dynamic_table()`, `cache_result()`,
+  `to_view()`, `create_or_replace_dynamic_table()`, and
+  `create_or_replace_view()` on dataframes or series using the pandas or ray 
+  backends.
 
 ## 1.37.0 (YYYY-MM-DD)
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -21,7 +21,10 @@ from pandas._typing import IndexLabel
 from snowflake.snowpark._internal.type_utils import ColumnOrName
 from snowflake.snowpark.async_job import AsyncJob
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
-from snowflake.snowpark.modin.plugin.extensions.utils import add_cache_result_docstring
+from snowflake.snowpark.modin.plugin.extensions.utils import (
+    add_cache_result_docstring,
+    register_non_snowflake_accessors,
+)
 from snowflake.snowpark.modin.plugin.utils.warning_message import (
     materialization_warning,
 )
@@ -30,17 +33,8 @@ from snowflake.snowpark.row import Row
 register_dataframe_accessor = functools.partial(
     _register_dataframe_accessor, backend="Snowflake"
 )
-_register_dataframe_accessor(name="to_pandas", backend="Pandas")(
-    pd.DataFrame._to_pandas
-)
-_register_dataframe_accessor(name="to_snowflake", backend="Pandas")(
-    lambda self, *args, **kwargs: self.move_to("Snowflake").to_snowflake(
-        *args, **kwargs
-    )
-)
-_register_dataframe_accessor(name="to_snowpark", backend="Pandas")(
-    lambda self, *args, **kwargs: self.move_to("Snowflake").to_snowpark(*args, **kwargs)
-)
+
+register_non_snowflake_accessors(_register_dataframe_accessor, "DataFrame")
 
 
 # Snowflake specific dataframe methods

--- a/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/series_extensions.py
@@ -21,7 +21,10 @@ from pandas._typing import Axis, IndexLabel
 from snowflake.snowpark._internal.type_utils import ColumnOrName
 from snowflake.snowpark.async_job import AsyncJob
 from snowflake.snowpark.dataframe import DataFrame as SnowparkDataFrame
-from snowflake.snowpark.modin.plugin.extensions.utils import add_cache_result_docstring
+from snowflake.snowpark.modin.plugin.extensions.utils import (
+    add_cache_result_docstring,
+    register_non_snowflake_accessors,
+)
 from snowflake.snowpark.modin.plugin.utils.warning_message import (
     materialization_warning,
 )
@@ -31,15 +34,8 @@ from snowflake.snowpark.row import Row
 register_series_accessor = functools.partial(
     _register_series_accessor, backend="Snowflake"
 )
-_register_series_accessor(name="to_pandas", backend="Pandas")(pd.Series._to_pandas)
-_register_series_accessor("to_snowflake", backend="Pandas")(
-    lambda self, *args, **kwargs: self.move_to("Snowflake").to_snowflake(
-        *args, **kwargs
-    )
-)
-_register_series_accessor("to_snowpark", backend="Pandas")(
-    lambda self, *args, **kwargs: self.move_to("Snowflake").to_snowpark(*args, **kwargs)
-)
+
+register_non_snowflake_accessors(_register_series_accessor, "Series")
 
 
 @register_series_accessor("_set_axis_name")

--- a/src/snowflake/snowpark/modin/plugin/extensions/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/utils.py
@@ -638,8 +638,9 @@ def register_non_snowflake_accessors(
         )
 
         # Register methods that move to Snowflake backend
-        # TODO: Improve performance of to_snowflake() by writing to a Snowflake
-        # table directly instead of going through Snowpark pandas.
+        # TODO(SNOW-2288765): Improve performance of to_snowflake() by writing
+        # to a Snowflake table directly instead of going through Snowpark
+        # pandas.
         for method in ("to_snowflake", "to_snowpark", "to_iceberg"):
             register_accessor_func(name=method, backend=backend)(
                 _make_non_snowflake_accessor(method=method)

--- a/tests/integ/modin/hybrid/test_data_movement.py
+++ b/tests/integ/modin/hybrid/test_data_movement.py
@@ -65,9 +65,7 @@ def test_move_to_ray(session, pandas_df):
         df_equals(result_df, snow_df)
 
 
-@pytest.mark.skip(
-    reason="Connection credentials for session creation are not accessible in test environments",
-)
+@pytest.mark.skip(reason="SNOW-2276090")
 @sql_count_checker(query_count=4)
 def test_move_from_ray(session, pandas_df):
     with config_context(Backend="Ray", AutoSwitchBackend=False):

--- a/tests/integ/modin/hybrid/test_extensions.py
+++ b/tests/integ/modin/hybrid/test_extensions.py
@@ -13,6 +13,7 @@ from pytest import param
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from tests.utils import iceberg_supported
 
 
 @pytest.fixture(
@@ -147,7 +148,7 @@ def test_read_snowflake_on_different_backend(
     assert result_df.to_pandas().astype(native_df.dtypes).equals(native_df)
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 @pytest.mark.parametrize(
     "object_backend",
     [param("Ray", marks=pytest.mark.skip(reason="SNOW-2276090")), "Pandas"],
@@ -158,7 +159,10 @@ def test_dataframe_to_iceberg(
     to_iceberg,
     test_table_name,
     global_backend,
+    local_testing_mode,
 ):
+    if not iceberg_supported(session, local_testing_mode=local_testing_mode):
+        pytest.skip("Test requires iceberg support.")
     native_dataframe = native_pd.DataFrame([1])
     modin_dataframe = pd.DataFrame(native_dataframe).set_backend(object_backend)
 
@@ -186,7 +190,7 @@ def test_dataframe_to_iceberg(
     )
 
 
-@sql_count_checker(query_count=4)
+@sql_count_checker(query_count=5)
 @pytest.mark.parametrize(
     "object_backend",
     [param("Ray", marks=pytest.mark.skip(reason="SNOW-2276090")), "Pandas"],
@@ -197,7 +201,10 @@ def test_series_to_iceberg(
     to_iceberg,
     test_table_name,
     global_backend,
+    local_testing_mode,
 ):
+    if not iceberg_supported(session, local_testing_mode=local_testing_mode):
+        pytest.skip("Test requires iceberg support.")
     native_series = native_pd.Series([1, 2, 3], name="x")
     modin_series = pd.Series(native_series).set_backend(object_backend)
 

--- a/tests/integ/modin/hybrid/test_extensions.py
+++ b/tests/integ/modin/hybrid/test_extensions.py
@@ -230,39 +230,48 @@ def test_series_to_iceberg(
     "function,method_name",
     (
         param(
-            lambda obj, *args, **kwargs: obj.create_or_replace_view(*args, **kwargs),
+            lambda obj: obj.create_or_replace_view(name="test_view"),
             "create_or_replace_view",
             id="create_or_replace_view_method",
         ),
         param(
-            lambda obj, *args, **kwargs: obj.create_or_replace_dynamic_table(
-                *args, **kwargs
+            lambda obj: obj.create_or_replace_dynamic_table(
+                name="test_dynamic_table",
             ),
             "create_or_replace_dynamic_table",
             id="create_or_replace_dynamic_table_method",
         ),
         param(
-            lambda obj, *args, **kwargs: obj.to_view(*args, **kwargs),
+            lambda obj: obj.to_view(name="test_view"),
             "to_view",
             id="to_view_method",
         ),
         param(
-            pd.to_view,
+            lambda obj: pd.to_view(obj, name="test_view"),
             "to_view",
             id="to_view_function",
         ),
         param(
-            lambda obj, *args, **kwargs: obj.to_dynamic_table(*args, **kwargs),
+            lambda obj: obj.to_dynamic_table(
+                name="test_dynamic_table",
+                warehouse="test_warehouse",
+                lag="test_lag",
+            ),
             "to_dynamic_table",
             id="to_dynamic_table_method",
         ),
         param(
-            pd.to_dynamic_table,
+            lambda obj: pd.to_dynamic_table(
+                obj,
+                name="test_dynamic_table",
+                warehouse="test_warehouse",
+                lag="test_lag",
+            ),
             "to_dynamic_table",
             id="to_dynamic_table_function",
         ),
         param(
-            lambda obj, *args, **kwargs: obj.cache_result(*args, **kwargs),
+            lambda obj: obj.cache_result(),
             "cache_result",
             id="cache_result_method",
         ),

--- a/tests/integ/modin/hybrid/test_extensions.py
+++ b/tests/integ/modin/hybrid/test_extensions.py
@@ -2,77 +2,263 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import re
+
 import modin.pandas as pd
 import pandas as native_pd
-import snowflake.snowpark.modin.plugin  # noqa: F401
-from snowflake.snowpark._internal.utils import TempObjectType
-
-from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
-from tests.utils import Utils
+import pytest
 from modin.config import context as modin_config_context
+from numpy.testing import assert_array_equal
+from pytest import param
+
+import snowflake.snowpark.modin.plugin  # noqa: F401
+from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            lambda obj, *args, **kwargs: obj.to_iceberg(*args, **kwargs),
+            id="method",
+        ),
+        pytest.param(pd.to_iceberg, id="function"),
+    ]
+)
+def to_iceberg(request):
+    return request.param
 
 
 @sql_count_checker(query_count=0)
-def test_to_pandas():
-    # SNOW-2106995: to_pandas should be registered on the pandas backend
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    assert df.get_backend() == "Pandas"
-    assert df.to_pandas().equals(df._to_pandas())
-    assert df["a"].to_pandas().equals(df["a"]._to_pandas())
+@pytest.mark.parametrize("backend", ["Ray", "Pandas"])
+@pytest.mark.parametrize(
+    "to_pandas",
+    [
+        pytest.param(lambda obj: obj.to_pandas(), id="method"),
+        pytest.param(pd.to_pandas, id="function"),
+    ],
+)
+def test_to_pandas(backend, to_pandas):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).set_backend(backend)
+    assert to_pandas(df).equals(df._to_pandas())
+    assert to_pandas(df["a"]).equals(df["a"]._to_pandas())
 
 
-def test_to_snowflake_and_to_snowpark():
-    # SNOW-2115929: to_snowflake/to_snowpark should be registered on the pandas backend
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    with SqlCounter(query_count=5):
-        assert df.get_backend() == "Pandas"
-        assert (
-            df.to_snowpark()
-            .to_pandas()  # query #1
-            .equals(df.move_to("snowflake").to_snowpark().to_pandas())  # query #2
-        )
-        assert df.get_backend() == "Pandas"
-        df.to_snowflake(
-            "hybrid_temp_test", if_exists="replace", index=False
-        )  # query #3
-        assert (
-            pd.read_snowflake("hybrid_temp_test")  # query #4
-            .to_pandas()  # query #5
-            # to_snowflake() and back round trip changes dtypes.
-            .astype(df.to_pandas().dtypes)  # no queries (data is native)
-            .equals(df.to_pandas())
-        )
+@pytest.mark.parametrize(
+    "backend", [param("Ray", marks=pytest.mark.skip(reason="SNOW-2276090")), "Pandas"]
+)
+@pytest.mark.parametrize(
+    "to_snowpark",
+    [
+        param(
+            lambda object, *args, **kwargs: object.to_snowpark(*args, **kwargs),
+            id="method",
+        ),
+        param(
+            lambda object, *args, **kwargs: pd.to_snowpark(object, *args, **kwargs),
+            id="function",
+        ),
+    ],
+)
+@sql_count_checker(query_count=4)
+def test_to_snowpark(backend, to_snowpark):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).set_backend(backend)
+    assert (
+        to_snowpark(df)
+        .to_pandas()  # query #1
+        .equals(df.move_to("snowflake").to_snowpark().to_pandas())  # query #2
+    )
+    assert df.get_backend() == backend
 
-    with SqlCounter(query_count=5):
-        column = df["a"]
-        assert column.get_backend() == "Pandas"
-        assert (
-            column.to_snowpark()
-            .to_pandas()  # query #1
-            .equals(column.move_to("snowflake").to_snowpark().to_pandas())  # query #2
-        )
-        assert column.get_backend() == "Pandas"
-        column.to_snowflake(
-            "hybrid_temp_test", if_exists="replace", index=False
-        )  # query #3
-        assert (
-            pd.read_snowflake("hybrid_temp_test")  # query #4
-            .to_pandas()  # query #5
-            # # to_snowflake() and back round trip changes dtypes.
-            .astype(column.to_pandas().dtype)  # no queries (data is native)
-            .equals(column.to_pandas().to_frame())
-        )
+    column = df["a"]
+    assert column.get_backend() == backend
+    assert (
+        to_snowpark(column)
+        .to_pandas()  # query #3
+        .equals(column.move_to("snowflake").to_snowpark().to_pandas())  # query #4
+    )
+    assert column.get_backend() == backend
 
 
-@modin_config_context(Backend="Pandas")
-def test_read_snowflake_on_pandas_backend():
-    native_df = native_pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-    snowpark_df = pd.session.create_dataframe(native_df)
-    snowpark_df.write.save_as_table(table_name, table_type="temp")
+@pytest.mark.parametrize(
+    "backend", [param("Ray", marks=pytest.mark.skip(reason="SNOW-2276090")), "Pandas"]
+)
+@pytest.mark.parametrize(
+    "to_snowflake",
+    [
+        param(
+            lambda object, *args, **kwargs: object.to_snowflake(*args, **kwargs),
+            id="method",
+        ),
+        param(
+            lambda object, *args, **kwargs: pd.to_snowflake(object, *args, **kwargs),
+            id="function",
+        ),
+    ],
+)
+@sql_count_checker(query_count=6)
+def test_to_snowflake(backend, to_snowflake, test_table_name):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).set_backend(backend)
+    to_snowflake(df, test_table_name, if_exists="replace", index=False)  # query #1
+    assert (
+        pd.read_snowflake(test_table_name)  # query #2
+        .to_pandas()  # query #3
+        # to_snowflake() and back round trip changes dtypes.
+        .astype(df.to_pandas().dtypes)  # no queries (data is native)
+        .equals(df.to_pandas())
+    )
 
-    with SqlCounter(query_count=2):
-        result_df = pd.read_snowflake(table_name)
+    column = df["a"]
+    assert column.get_backend() == backend
+    to_snowflake(column, test_table_name, if_exists="replace", index=False)  # query #4
+    assert (
+        pd.read_snowflake(test_table_name)  # query #5
+        .to_pandas()  # query #6
+        # # to_snowflake() and back round trip changes dtypes.
+        .astype(column.to_pandas().dtype)  # no queries (data is native)
+        .equals(column.to_pandas().to_frame())
+    )
 
-    assert result_df.get_backend() == "Pandas"
-    assert result_df.to_pandas().astype(native_df.dtypes).equals(native_df)
+
+@pytest.mark.parametrize("backend", ["Pandas", "Ray"])
+def test_read_snowflake_on_different_backend(backend, test_table_name):
+    with modin_config_context(Backend=backend):
+        native_df = native_pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        snowpark_df = pd.session.create_dataframe(native_df)
+        snowpark_df.write.save_as_table(test_table_name, table_type="temp")
+
+        with SqlCounter(query_count=2):
+            result_df = pd.read_snowflake(test_table_name)
+
+        assert result_df.get_backend() == backend
+        assert result_df.to_pandas().astype(native_df.dtypes).equals(native_df)
+
+
+@sql_count_checker(query_count=4)
+@pytest.mark.parametrize(
+    "backend", [param("Ray", marks=pytest.mark.skip(reason="SNOW-2276090")), "Pandas"]
+)
+def test_dataframe_to_iceberg(
+    backend,
+    session,
+    to_iceberg,
+    test_table_name,
+):
+    native_dataframe = native_pd.DataFrame([1])
+    modin_dataframe = pd.DataFrame(native_dataframe).set_backend(backend)
+
+    session.sql(
+        "CREATE EXTERNAL VOLUME if not exists python_connector_iceberg_exvol"
+    ).collect()
+    iceberg_config = {
+        "external_volume": "python_connector_iceberg_exvol",
+        "catalog": "SNOWFLAKE",
+        "base_location": "python_connector_merge_gate",
+        "storage_serialization_policy": "OPTIMIZED",
+    }
+    to_iceberg(
+        modin_dataframe,
+        table_name=test_table_name,
+        mode="overwrite",
+        iceberg_config=iceberg_config,
+        index=False,
+    )
+    snow_dataframe = pd.read_snowflake(test_table_name)
+    assert_array_equal(
+        # Snowpark handles index objects differently from native pandas, so just check values
+        snow_dataframe.values,
+        native_dataframe.values,
+    )
+
+
+@sql_count_checker(query_count=4)
+@pytest.mark.parametrize(
+    "backend", [param("Ray", marks=pytest.mark.skip(reason="SNOW-2276090")), "Pandas"]
+)
+def test_series_to_iceberg(
+    backend,
+    session,
+    to_iceberg,
+    test_table_name,
+):
+    native_series = native_pd.Series([1, 2, 3], name="x")
+    modin_series = pd.Series(native_series).set_backend(backend)
+
+    session.sql(
+        "CREATE EXTERNAL VOLUME if not exists python_connector_iceberg_exvol"
+    ).collect()
+    iceberg_config = {
+        "external_volume": "python_connector_iceberg_exvol",
+        "catalog": "SNOWFLAKE",
+        "base_location": "python_connector_merge_gate",
+        "storage_serialization_policy": "OPTIMIZED",
+    }
+    to_iceberg(
+        modin_series,
+        table_name=test_table_name,
+        mode="overwrite",
+        iceberg_config=iceberg_config,
+        index=False,
+    )
+    snow_series = pd.read_snowflake(test_table_name).iloc[:, 0]
+    assert_array_equal(
+        # Snowpark handles index objects differently from native pandas, so just check values
+        snow_series.values,
+        native_series.values,
+    )
+
+
+@sql_count_checker(query_count=0)
+@pytest.mark.parametrize("backend", ["Ray", "Pandas"])
+@pytest.mark.parametrize(
+    "function,method_name",
+    (
+        param(
+            lambda obj, *args, **kwargs: obj.create_or_replace_view(*args, **kwargs),
+            "create_or_replace_view",
+            id="create_or_replace_view_method",
+        ),
+        param(
+            lambda obj, *args, **kwargs: obj.create_or_replace_dynamic_table(
+                *args, **kwargs
+            ),
+            "create_or_replace_dynamic_table",
+            id="create_or_replace_dynamic_table_method",
+        ),
+        param(
+            lambda obj, *args, **kwargs: obj.to_view(*args, **kwargs),
+            "to_view",
+            id="to_view_method",
+        ),
+        param(
+            pd.to_view,
+            "to_view",
+            id="to_view_function",
+        ),
+        param(
+            lambda obj, *args, **kwargs: obj.to_dynamic_table(*args, **kwargs),
+            "to_dynamic_table",
+            id="to_dynamic_table_method",
+        ),
+        param(
+            pd.to_dynamic_table,
+            "to_dynamic_table",
+            id="to_dynamic_table_function",
+        ),
+        param(
+            lambda obj, *args, **kwargs: obj.cache_result(*args, **kwargs),
+            "cache_result",
+            id="cache_result_method",
+        ),
+    ),
+)
+@pytest.mark.parametrize("modin_class", [pd.DataFrame, pd.Series])
+def test_unimplemented_extensions(function, method_name, backend, modin_class):
+    with modin_config_context(Backend=backend):
+        object = modin_class([1])
+        with pytest.raises(
+            NotImplementedError,
+            match=re.escape(
+                f"Modin supports the method {modin_class.__name__}.{method_name} on the Snowflake backend, but not on the backend {backend}."
+            ),
+        ):
+            function(object)


### PR DESCRIPTION
Make sure that we support the function and method variants of `to_snowflake()`, `to_snowpark()`, `to_iceberg()`, `read_snowflake()`, and `to_pandas()` on the pandas and Ray backends. Prior to this commit, we only supported some of these functions and methods on the Pandas backend.

Fixes SNOW-2189056