### PR TITLE
SNOW-2257191: Bugfix join bug due to dataframe alias

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer.py
@@ -912,7 +912,8 @@ class Analyzer:
 
         for c in logical_plan.children:  # post-order traversal of the tree
             resolved = self.resolve(c)
-            df_aliased_col_name_to_real_col_name.update(resolved.df_aliased_col_name_to_real_col_name)  # type: ignore
+            for alias, dict_ in resolved.df_aliased_col_name_to_real_col_name.items():
+                df_aliased_col_name_to_real_col_name[alias].update(dict_)
             resolved_children[c] = resolved
 
         if isinstance(logical_plan, Selectable):
@@ -944,9 +945,8 @@ class Analyzer:
         res = self.do_resolve_with_resolved_children(
             logical_plan, resolved_children, df_aliased_col_name_to_real_col_name
         )
-        res.df_aliased_col_name_to_real_col_name.update(
-            df_aliased_col_name_to_real_col_name
-        )
+        for alias, dict_ in df_aliased_col_name_to_real_col_name.items():
+            res.df_aliased_col_name_to_real_col_name[alias].update(dict_)
         return res
 
     def do_resolve_with_resolved_children(

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -877,7 +877,7 @@ class SelectStatement(Selectable):
         self._projection_in_str = None
         self._query_params = None
         self.expr_to_alias.update(self.from_.expr_to_alias)
-        self.df_aliased_col_name_to_real_col_name.update(
+        self.df_aliased_col_name_to_real_col_name = deepcopy(
             self.from_.df_aliased_col_name_to_real_col_name
         )
         self.api_calls = (

--- a/src/snowflake/snowpark/_internal/compiler/utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/utils.py
@@ -252,9 +252,10 @@ def update_resolvable_node(
         # df_aliased_col_name_to_real_col_name is updated at the frontend api
         # layer when alias is called, not produced during code generation. Should
         # always retain the original value of the map.
-        node.df_aliased_col_name_to_real_col_name.update(
+        node.df_aliased_col_name_to_real_col_name = copy.deepcopy(
             node.from_.df_aliased_col_name_to_real_col_name
         )
+
         # projection_in_str for SelectStatement runs a analyzer.analyze() which
         # needs the correct expr_to_alias map setup. This map is setup during
         # snowflake plan generation and cached for later use. Calling snowflake_plan


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2257191

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   In this PR we fix update of `df_aliased_col_name_to_real_col_name` child to parent by making sure all dictionaries within the default dict are copied by value instead of reference.