### PR TITLE
Set pandas requirement to be 2.3.1 in MODIN_REQUIREMENTS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ PANDAS_REQUIREMENTS = [
 MODIN_REQUIREMENTS = [
     *PANDAS_REQUIREMENTS,
     f"modin{MODIN_DEPENDENCY_VERSION}",
+    "pandas<=2.3.1",
     "tqdm",  # For progress bars during backend switching
     "ipywidgets",  # For enhanced progress bars in Jupyter notebooks
 ]


### PR DESCRIPTION
This PR sets `pandas<=2.3.1` in `MODIN_REQUIREMENTS` to avoid the following issue with `pandas==2.3.2` not being in the Snowflake anaconda channel.

> RuntimeError: Cannot add package pandas==2.3.2 because it is not available in Snowflake and Session.custom_package_usage_config['enabled'] is not set to True. To upload these packages, you can set it to True or find the directory of these packages and add it via Session.add_import. See details at https://docs.snowflake.com/en/developer-guide/snowpark/python/creating-udfs.html#using-third-party-packages-from-anaconda-in-a-udf.