### PR TITLE
SNOW-2282132: Fix external stage prefix inferrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Bug Fixes
 
 - Fixed the repr of TimestampType to match the actual subtype it represents.
-- Fixed a bug in schema inference caused that caused incorrect stage prefixes to be used.
+- Fixed a bug in schema inference that caused incorrect stage prefixes to be used.
 
 #### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bug Fixes
 
 - Fixed the repr of TimestampType to match the actual subtype it represents.
+- Fixed a bug in schema inference caused that caused incorrect stage prefixes to be used.
 
 #### Deprecations
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -689,7 +689,9 @@ def create_or_update_statement_params_with_query_tag(
     return ret
 
 
-def get_stage_parts(stage_location: str) -> tuple[str, str]:
+def get_stage_parts(
+    stage_location: str, *, return_full_stage_name: bool = False
+) -> tuple[str, str]:
     normalized = unwrap_stage_location_single_quote(stage_location)
     if not normalized.endswith("/"):
         normalized = f"{normalized}/"
@@ -707,6 +709,9 @@ def get_stage_parts(stage_location: str) -> tuple[str, str]:
             # the path is after it
             full_stage_name = normalized[:i]
             path = normalized[i + 1 :]
+            if return_full_stage_name:
+                return full_stage_name.removeprefix("@"), path
+
             # Find the last match of the first group, which should be the stage name.
             # If not found, the stage name should be invalid
             res = re.findall(SNOWFLAKE_STAGE_NAME_PATTERN, full_stage_name)

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1047,7 +1047,7 @@ class DataFrameReader:
                     should_fallback = True
                 except Exception as e:
                     warning(
-                        "infer_schema_patter_matching",
+                        "infer_schema_pattern_matching",
                         f"Failed to infer schema for provided pattern {pattern} with error:\n{e}",
                     )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -4,6 +4,7 @@
 import json
 import multiprocessing as mp
 import os
+import re
 import sys
 import time
 import queue
@@ -1014,20 +1015,41 @@ class DataFrameReader:
             )["data"]
 
             if len(matches):
-                should_fallback = True
-                files = []
-                # Construct a list of file prefixes not including the stage
-                for match in matches:
-                    # Try to remove any protocol
-                    (pre, _, post) = match[0].partition("://")
-                    match = post if post else pre
-                    files.append(match.partition("/")[2])
+                try:
+                    stage, _ = get_stage_parts(path)
+                    stage_description = self._session._conn.run_query(
+                        f"describe stage {stage}"
+                    )["data"]
+                    stage_locations_json = [
+                        x for x in stage_description if x[0] == "STAGE_LOCATION"
+                    ][0][3]
+                    stage_locations = (
+                        json.loads(stage_locations_json)
+                        if stage_locations_json
+                        else [stage]
+                    )
+                    regexes = [
+                        re.compile(f"^{re.escape(location)}", re.IGNORECASE)
+                        for location in stage_locations
+                    ]
 
-                infer_schema_options["FILES"] = files
+                    files = []
+                    # Construct a list of file prefixes not including the stage
+                    for match in matches:
+                        prefix = match[0]
+                        for regex in regexes:
+                            prefix = regex.sub("", prefix)
+                        files.append(prefix)
+                    infer_schema_options["FILES"] = files
 
-                # Reconstruct path using just stage and any qualifiers
-                stage, _ = get_stage_parts(path)
-                infer_path = path.partition(stage)[0] + stage
+                    # Reconstruct path using just stage and any qualifiers
+                    infer_path = path.partition(stage)[0] + stage
+                    should_fallback = True
+                except Exception as e:
+                    warning(
+                        "infer_schema_patter_matching",
+                        f"Failed to infer schema for provided pattern {pattern} with error:\n{e}",
+                    )
 
         infer_schema_query = infer_schema_statement(
             infer_path, file_format_name, infer_schema_options or None

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1796,13 +1796,18 @@ def test_pattern(session, mode):
     reason="Local testing does not support file.put",
 )
 @pytest.mark.parametrize("mode", ["select", "copy"])
-@pytest.mark.parametrize("stage_template", [
-    None,
-    "TESTDB_SNOWPARK_PYTHON.PUBLIC.extern_test_stage/{}",
-    "TESTDB_SNOWPARK_PYTHON.PUBLIC.extern_test_stage_via_integration/{}"
-])
+@pytest.mark.parametrize(
+    "stage_template",
+    [
+        None,
+        "TESTDB_SNOWPARK_PYTHON.PUBLIC.extern_test_stage/{}",
+        "TESTDB_SNOWPARK_PYTHON.PUBLIC.extern_test_stage_via_integration/{}",
+    ],
+)
 def test_pattern_with_infer(session, mode, stage_template):
-    stage_name = (stage_template or "{}").format(Utils.random_name_for_temp_object(TempObjectType.STAGE))
+    stage_name = (stage_template or "{}").format(
+        Utils.random_name_for_temp_object(TempObjectType.STAGE)
+    )
 
     if current_account(session) != "SFCTEST0_AWS_US_WEST_2":
         pytest.skip("Test requires resources in sfctest0 test account")

--- a/tests/integ/scala/test_dataframe_reader_suite.py
+++ b/tests/integ/scala/test_dataframe_reader_suite.py
@@ -1878,7 +1878,7 @@ def test_pattern_with_infer(session, mode, stage_template):
         assert df.schema == expected_schema
         Utils.check_answer(df, expected_rows * 3)
 
-        if not stage_template:
+        if stage_template is None:
             # Test using fully qualified stage name
             reader = base_reader()
             df = reader.csv(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2282132

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

This PR fixes a bug in inference statement generation that would cause incorrect file prefixes to be included in the query.

The conditions for this issue are probably easiest to see via example. For the three cases below assume that two csv files have been uploaded to the stage, `good1.csv.gz` and `bad1.csv.gz`. The user has specified to use the pattern `.*good.*` to select files to load. Both of them have been uploaded to the `path` prefix.

Each scenario causes snowpark to execute a query similar to `list @<stage_name>/path/ pattern = '.*good.*'`. 

### Scenario 1: Regular Stage `INTERN_STAGE`

The matching files from the list query include a single file `snowpark_temp_stage_n1by6keh0z/path/good1.csv.gz`. Note that even though the stage is uppercased the prefix returned is not. The previous solution would have cut everything before the first `/` off to get the prefix and that would have been correct.

### Scenario 2: External Stage `EXTERN_STAGE`

This scenario uses a stage that is backed by an external s3 bucket. This time the result of the list query looks like this. `s3://example-bucket-name/path/good1.csv.gz'. Parsing this prefix requires removing the protocol and then similar to the previous case removing everything before the first `/` creates a valid stage prefix.

### Scenario 3: External Integration Backed Stage `EXTERN_INT_STAGE`

In this scenario the stage is backed by an external access integration that has specified the stage location to be `s3://example-bucket-name/my-data-prefix`. The result of the list query looks like this: `s3://example-bucket-name/my-data-prefix/path/good1.csv.gz'. This time the existing logic falls apart as after removing the protocol and first part of the prefix we're left with `my-data-prefix/path/good1.csv.gz` which is not a valid location in the stage. Unfortunately the list query does not return enough information to know how much of the remaining part of the prefix needs to be removed.

This PR fixes this by running a describe on the stage before processing the matching file paths. Each of the reported bucket locations that is reported by the describe is used to generate a case insensitive regex that allows a more exact prefix to be removed. When the describe does not have a location configured this means that the stage is internal and just the stage name needs to be removed.

I think there could be situations in which a role is not allowed to describe the stage so I've included some fallback logic that will instead use the old logic of reading all files.