### PR TITLE
[SNOW-2020306] Update application tracking for notebooks

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -220,6 +220,8 @@ class ServerConnection:
                     applications.append("streamlit")
                 if importlib.util.find_spec("snowflake.ml"):
                     applications.append("SnowparkML")
+                if importlib.util.find_spec("snowbook"):
+                    applications = ["Snowflake Web App (snowsight_notebook)"]
                 self._lower_case_parameters[PARAM_APPLICATION] = (
                     ":".join(applications) or get_application_name()
                 )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-2020306](https://snowflakecomputing.atlassian.net/browse/SNOW-2020306) and [SNOW-2227655](https://snowflakecomputing.atlassian.net/browse/SNOW-2227655)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Update application in server_connections to track queries are created from snowflake SPCS notebook runs. This will categorize usage attribution better for notebooks

Testing
- Added unit tests for _add_application_parameters


[SNOW-2020306]: https://snowflakecomputing.atlassian.net/browse/SNOW-2020306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-2227655]: https://snowflakecomputing.atlassian.net/browse/SNOW-2227655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ