### PR TITLE
SNOW-2292908: Skip flaky modin hybrid tests on Windows

### DIFF
--- a/tests/integ/modin/hybrid/conftest.py
+++ b/tests/integ/modin/hybrid/conftest.py
@@ -7,6 +7,15 @@ import pytest
 import modin.pandas as pd
 from modin.config import context as config_context
 
+from tests.utils import IS_WINDOWS
+
+
+if IS_WINDOWS:
+    # Ray startup is extremely flaky on Windows when multiple pytest workers are used.
+    # https://snowflakecomputing.atlassian.net/browse/SNOW-2292908
+    # https://github.com/modin-project/modin/issues/7387
+    pytest.skip(allow_module_level=True)
+
 
 @pytest.fixture(autouse=True, scope="function")
 def enable_autoswitch():

--- a/tests/integ/modin/hybrid/conftest.py
+++ b/tests/integ/modin/hybrid/conftest.py
@@ -14,7 +14,11 @@ if IS_WINDOWS:
     # Ray startup is extremely flaky on Windows when multiple pytest workers are used.
     # https://snowflakecomputing.atlassian.net/browse/SNOW-2292908
     # https://github.com/modin-project/modin/issues/7387
-    pytest.skip(allow_module_level=True)
+    @pytest.fixture(scope="module")
+    def skip_if_windows():
+        pytest.skip(
+            reason="skipping tests requiring Ray on Windows", allow_module_level=True
+        )
 
 
 @pytest.fixture(autouse=True, scope="function")


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2292908

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Per @sfc-gh-mvashishtha 's investigation, Ray startup is extremely flaky in Windows environments when multiple pytest workers are running. As such, we should skip tests that rely on Ray.