### PR TITLE
SNOW-2213898 - Update assertion code to convert hybrid Pandas df

### DIFF
--- a/tests/integ/modin/utils.py
+++ b/tests/integ/modin/utils.py
@@ -261,7 +261,11 @@ def assert_snowpark_pandas_equal_to_pandas(
     if expected_dtypes is not None:
         kwargs.update(check_dtype=False)
 
-    snow_to_native = snow.to_pandas(statement_params=statement_params)
+    # Only Snowflake supports the statement_params parameter
+    if snow.get_backend() == "Snowflake":
+        snow_to_native = snow.to_pandas(statement_params=statement_params)
+    else:
+        snow_to_native = snow.to_pandas()
 
     if isinstance(expected_pandas, native_pd.DataFrame):
         assert isinstance(snow, DataFrame)


### PR DESCRIPTION
SNOW-2213898 - Update assertion code to convert hybrid Pandas df to Pandas

This partially resolves issues with running the current snowpandas tests with hybrid mode. The assertion code assumes we have a Snowflake backed dataframe, and to_pandas has different parameters than the native version.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
