### PR TITLE
SNOW-2318100: Downgrade the log message about DataFrame reference updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@
 #### New Features
 
 #### Improvements
-- Removed the logging.DEBUG message saying that the Snowpark `DataFrame`
-  reference of an internal `DataFrameReference` object has changed.
+- Downgraded to level `logging.DEBUG - 1` the log message saying that the
+  Snowpark `DataFrame` reference of an internal `DataFrameReference` object
+  has changed.
 
 #### Dependency Updates
 

--- a/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/ordered_dataframe.py
@@ -680,6 +680,11 @@ class OrderedDataFrame:
             dataframe_ref.cached_snowflake_quoted_identifiers_tuple = tuple(
                 new_column_identifiers
             )
+            _logger.log(
+                # log at level DEBUG - 1 because we make this update very often.
+                level=logging.DEBUG - 1,
+                msg=f"The Snowpark DataFrame in DataFrameReference with id={dataframe_ref._id} is updated",
+            )
 
         new_df = OrderedDataFrame(
             dataframe_ref,


### PR DESCRIPTION
e.g. prior to this commit, try running `pytest tests/integ/modin/frame/test_quantile.py` locally and you get 152 messages like  "The Snowpark DataFrame in DataFrameReference with id=[...] is updated"  for 24 test cases. I don’t think everyone who works on pandas even know what this message means. I know what it means, but I have never used it. It makes it difficult to debug many test failures because it often appears many times in a single test case.

This commit changes the level of the message to `DEBUG - 1` so it doesn't appear by default when we run `pytest`.