### PR TITLE
SNOW-2304052 - Add the ability to filter out certain tests when running under hybrid mode

### DIFF
--- a/tests/integ/modin/series/test_unary_op.py
+++ b/tests/integ/modin/series/test_unary_op.py
@@ -122,6 +122,7 @@ def test_ser_unary_invalid_in_sf_negative(func, data):
         ([3, [2, 3]], "Failed to cast variant value"),
     ],
 )
+@pytest.mark.no_hybrid  # this test is disabled when running under hybrid execution
 def test_ser_unary_invalid_in_both_native_and_sf_negative(
     func, invalid_value, expected_sf_error
 ):

--- a/tests/integ/modin/test_dtype_mapping.py
+++ b/tests/integ/modin/test_dtype_mapping.py
@@ -326,6 +326,7 @@ from tests.utils import Utils
         ),
     ],
 )
+@pytest.mark.no_hybrid
 def test_read_snowflake_data_types(
     session,
     test_table_name,

--- a/tox.ini
+++ b/tox.ini
@@ -267,6 +267,7 @@ markers =
     compiler: tests run from the compiler directory
     scala: tests run from the scala directory
     mock: tests run from the mock directory
+    no_hybrid: tests that cannot run under hybrid mode
 addopts = --doctest-modules --timeout=1200
 norecursedirs = tests/perf/data_source
 


### PR DESCRIPTION
SNOW-2304052 - Add the ability to filter out certain tests when running under hybrid mode
Not all tests pass under hybrid mode, largely because they were built for the snowflake backend specifically. Still we want to run a significant number of these with hybrid mode enabled to help triage and categorize potiential semantic issues.

This PR adds the ability to park specific tests (itegration only) with a pytest marker, @pytest.mark.no_hybrid for skipping. We also have a reference csv of a test run with hybrid which is used for skipping certain tests.

This allows us to guard against regressions, provide for incremental development of hybrid, and triage existing differences to determine where effort should be spent.

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
