### PR TITLE
Add stored proc test skip

### DIFF
--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -3234,6 +3234,10 @@ def test_limit(session):
     "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: Alter Session not supported in local testing",
 )
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="FEAT: Not supported in stored procedures",
+)
 def test_year_month_interval_type_dataframe(session):
     schema = StructType(
         [

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1694,6 +1694,10 @@ def test_create_dataframe_with_basic_data_types(session):
     "config.getoption('local_testing_mode', default=False)",
     reason="FEAT: Alter Session not supported in local testing",
 )
+@pytest.mark.skipif(
+    IS_IN_STORED_PROC,
+    reason="FEAT: Alter Session not supported in local testing",
+)
 def test_create_dataframe_with_year_month_interval_type(session):
     schema = StructType([StructField("interval_col", YearMonthIntervalType())])
     data = [["1-2"], ["-2-3"]]

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -1696,7 +1696,7 @@ def test_create_dataframe_with_basic_data_types(session):
 )
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
-    reason="FEAT: Alter Session not supported in local testing",
+    reason="FEAT: Not supported in stored procedures",
 )
 def test_create_dataframe_with_year_month_interval_type(session):
     schema = StructType([StructField("interval_col", YearMonthIntervalType())])


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Addresses this test failure:
   https://s3.us-west-2.amazonaws.com/sfc-eng-jenkins-dpe-ci.snowflakecomputing.com/log_viewer/index.html?file=regression_logs/plid_ckxisshg/REG_LIGHTWEIGHT_PROD_PARAMETERS_SNOWFORT_BAZEL_X86/snowfort:t_python_sp_integ/test_python_sp_integ_dataframe.py::TestPythonSPInteg/jbid_eksuobmqjbsk/snowci_output.log

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

  
