### PR TITLE
SNOW-2333472: More hybrid benchmark fixes

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/extensions/base_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/base_overrides.py
@@ -70,6 +70,7 @@ from snowflake.snowpark.modin.plugin._typing import ListLike
 from snowflake.snowpark.modin.plugin.compiler.snowflake_query_compiler import (
     HYBRID_SWITCH_FOR_UNIMPLEMENTED_METHODS,
 )
+from snowflake.snowpark.modin.plugin._internal.utils import new_snow_series
 from snowflake.snowpark.modin.plugin.extensions.utils import (
     ensure_index,
     extract_validate_and_try_convert_named_aggs_from_kwargs,
@@ -1166,10 +1167,11 @@ def _to_series_list(self, index: pd.Index) -> list[pd.Series]:
     # TODO: SNOW-1119855: Modin upgrade - modin.pandas.base.BasePandasDataset
     if isinstance(index, pd.MultiIndex):
         return [
-            pd.Series(index.get_level_values(level)) for level in range(index.nlevels)
+            new_snow_series(index.get_level_values(level))
+            for level in range(index.nlevels)
         ]
     elif isinstance(index, pd.Index):
-        return [pd.Series(index)]
+        return [new_snow_series(index)]
     else:
         raise Exception("invalid index: " + str(index))
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_overrides.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_overrides.py
@@ -77,6 +77,7 @@ from snowflake.snowpark.modin.plugin._internal.aggregation_utils import (
     is_snowflake_agg_func,
 )
 from snowflake.snowpark.modin.plugin._internal.utils import (
+    new_snow_series,
     add_extra_columns_and_select_required_columns,
     assert_fields_are_none,
     convert_index_to_list_of_qcs,
@@ -1827,7 +1828,7 @@ def rename(
         )
 
     if isinstance(index, dict):
-        index = Series(index)
+        index = new_snow_series(index)
 
     new_qc = self._query_compiler.rename(
         index_renamer=index, columns_renamer=columns, level=level, errors=errors


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2333472

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

This PR addresses failures in `rename` and setting `index` (items 1 and 2 in the ticket). Items 3 and 4 are test setup issues, addressed in the benchmarking repo here: https://github.com/snowflakedb/snowpark-pandas-performance/pull/105.

I reran the hybrid CSV generation as well, but the size of the csv file _increased_, possibly due to other pandas tests being added before this PR was made. I'll omit updates to it for now, but we may want to do a more comprehensive audit to find internal points where we should use `new_snow_series`/`new_snow_df` (which disable auto-switching) instead of `pd.Series`/`pd.DataFrame`, since glancing at the error output seemed to indicate a large body of those errors.

We cannot do a bulk find-and-replace for these constructors, since in some cases wrapping a result in a Series/DF is the last operation before returning from a frontend method, and auto-switching may or may not be desirable. However, this is arguably a bug since explicit switching should only be decided by the QC caster; if so, we should consider updating modin to always disable casting before calling a frontend method.