### PR TITLE
NO-SNOW: Fix local test on windows.

### DIFF
--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -23,7 +23,7 @@ from snowflake.snowpark._internal.utils import generate_random_alphanumeric
 from snowflake.snowpark.mock.exceptions import SnowparkLocalTestingException
 from snowflake.snowpark.exceptions import SnowparkSessionException
 from snowflake.snowpark import Session
-from tests.utils import Utils
+from tests.utils import IS_WINDOWS, Utils
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -374,6 +374,10 @@ def test_read_relative_path_snowflakefile(
     read_mode, write_mode, use_tmp_path, tmp_path
 ):
     if use_tmp_path:
+        if IS_WINDOWS:
+            pytest.skip(
+                "Windows does not support relpath between drives. tmp_dir is on C: while the working dir on a mounted drive."
+            )
         test_msg, temp_file = Utils.write_test_msg(write_mode, tmp_path)
     else:
         # Write to a temp file in the current directory


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR disables some failing tests on windows. Pytest always creates its tmp_path on the C: drive. The tests are mounted into docker as a separate drive. Windows does not support creating a relpath between drives so this case will always fail.