### PR TITLE
SNOW-2360274: Fix schema query sql generation for structured types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Bug Fixes
 
 - Fixed a bug that `DataFrame.limit()` fail if there is parameter binding in the executed SQL.
+- Fixed a bug in schema query generation that could cause invalid sql to be genrated when using nested structured types.
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Bug Fixes
 
 - Fixed a bug that `DataFrame.limit()` fail if there is parameter binding in the executed SQL.
-- Fixed a bug in schema query generation that could cause invalid sql to be genrated when using nested structured types.
+- Added an experimental fix for a bug in schema query generation that could cause invalid sql to be genrated when using nested structured types.
 
 #### New Features
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -533,12 +533,12 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
             # Key values can never be null
             key = schema_expression(data_type.key_type, False)
             if context._enable_fix_2360274:
+                value = "NULL"
+            else:
                 # Value nullability is variable. Defaults to True
                 value = schema_expression(
                     data_type.value_type, data_type.value_contains_null
                 )
-            else:
-                value = "NULL"
             return f"object_construct_keep_null({key}, {value}) :: {convert_sp_to_sf_type(data_type)}"
         return "to_object(parse_json('0'))"
     if isinstance(data_type, StructType):

--- a/src/snowflake/snowpark/context.py
+++ b/src/snowflake/snowpark/context.py
@@ -39,6 +39,7 @@ _debug_eager_schema_validation = False
 # This is an internal-only global flag, used to determine whether to enable query line tracking for tracing sql compilation errors.
 _enable_trace_sql_errors_to_dataframe = False
 
+# SNOW-2362050: Enable this fix by default.
 # Global flag for fix 2360274. When enabled schema queries will use NULL as a place holder for any values inside structured objects
 _enable_fix_2360274 = False
 

--- a/src/snowflake/snowpark/context.py
+++ b/src/snowflake/snowpark/context.py
@@ -39,6 +39,9 @@ _debug_eager_schema_validation = False
 # This is an internal-only global flag, used to determine whether to enable query line tracking for tracing sql compilation errors.
 _enable_trace_sql_errors_to_dataframe = False
 
+# Global flag for fix 2360274. When enabled schema queries will use NULL as a place holder for any values inside structured objects
+_enable_fix_2360274 = False
+
 
 def configure_development_features(
     *,

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1776,6 +1776,9 @@ def test_snow_2360274_repro(
 ):
     if not structured_type_support:
         pytest.skip("Test requires structured type support.")
+
+    agg_table_name = f"snowpark_2360274_repro_agg_{uuid.uuid4().hex[:5]}".upper()
+
     nested_field_name = (
         "value" if context._should_use_structured_type_semantics() else '"value"'
     )
@@ -1783,22 +1786,24 @@ def test_snow_2360274_repro(
         [
             StructField("ID", LongType(), nullable=False),
             StructField(
-                "VALS_OBJ",
+                "VALS_ARR",
                 ArrayType(
                     StructType(
-                        [StructField(nested_field_name, StringType(), nullable=True)]
+                        [StructField(nested_field_name, StringType(10), nullable=True)]
                     )
                 ),
                 nullable=True,
             ),
             StructField(
                 "VALS_MAP",
-                ArrayType(MapType(StringType(), StringType())),
+                MapType(StringType(10), StringType(10)),
                 nullable=True,
             ),
             StructField(
-                "VALS_ARR",
-                ArrayType(ArrayType(StringType())),
+                "VALS_OBJ",
+                StructType(
+                    [StructField(nested_field_name, StringType(10), nullable=True)]
+                ),
                 nullable=True,
             ),
             StructField("TAG", StringType(2), nullable=False),
@@ -1806,34 +1811,42 @@ def test_snow_2360274_repro(
     )
 
     def inner():
-        agged = structured_type_session.sql(
+        structured_type_session.sql(
             f"""
-        WITH SRC(ID, VALUE) AS (
+            CREATE
+            OR REPLACE TABLE {agg_table_name} (
+                ID INT NOT NULL,
+                VALS_ARR ARRAY(OBJECT({nested_field_name} STRING(10))) NOT NULL,
+                VALS_MAP MAP(STRING(10), STRING(10)) NOT NULL,
+                VALS_OBJ OBJECT({nested_field_name} STRING(10)) NOT NULL
+            ) AS WITH SRC(ID, VALUE) AS (
+                SELECT
+                    $1,
+                    $2
+                FROM
+                VALUES
+                    (1, 'A'),
+                    (1, 'B'),
+                    (2, 'A')
+            )
             SELECT
-                $1,
-                $2
+                ID,
+                CAST(
+                    ARRAY_AGG(OBJECT_CONSTRUCT('value', VALUE)) AS ARRAY(OBJECT({nested_field_name} STRING))
+                ) AS VALS_ARR,
+                CAST(
+                    OBJECT_CONSTRUCT('value', VALUE) AS MAP(STRING, STRING)
+                ) AS VALS_MAP,
+                CAST(
+                    OBJECT_CONSTRUCT('value', VALUE) AS OBJECT({nested_field_name} STRING)
+                ) AS VALS_OBJ,
             FROM
-            VALUES
-                (1, 'A'),
-                (1, 'B'),
-                (2, 'A')
-        )
-        SELECT
-            ID,
-            CAST(
-                ARRAY_AGG(OBJECT_CONSTRUCT('value', VALUE)) AS ARRAY(OBJECT({nested_field_name} STRING))
-            ) AS VALS_OBJ,
-            CAST(
-                ARRAY_AGG(OBJECT_CONSTRUCT('value', VALUE)) AS ARRAY(MAP(STRING, STRING))
-            ) AS VALS_MAP,
-            CAST(
-                ARRAY_AGG(ARRAY_CONSTRUCT('value', VALUE)) AS ARRAY(ARRAY(STRING))
-            ) AS VALS_ARR,
-        FROM
-            SRC
-        GROUP BY
-            ID"""
-        )
+                SRC
+            GROUP BY
+                ID, VALS_MAP, VALS_OBJ"""
+        ).collect()
+
+        agged = structured_type_session.table(agg_table_name)
 
         reference = structured_type_session.sql(
             """
@@ -1842,15 +1855,19 @@ def test_snow_2360274_repro(
         )
 
         joined = agged.join(reference, on=agged.id == reference.id, how="inner").select(
-            agged.id.alias("ID"), "VALS_OBJ", "VALS_MAP", "VALS_ARR", "TAG"
+            agged.id.alias("ID"), "VALS_ARR", "VALS_MAP", "VALS_OBJ", "TAG"
         )
         Utils.is_schema_same(joined.schema, expected_schema, case_sensitive=False)
 
-    with mock.patch.object(context, "_enable_fix_2360274", fix_enabled):
-        if fix_enabled:
-            inner()
-        else:
-            with pytest.raises(
-                SnowparkSQLException, match="Unsupported data type 'STRUCTURED_OBJECT'"
-            ):
+    try:
+        with mock.patch.object(context, "_enable_fix_2360274", fix_enabled):
+            if fix_enabled:
                 inner()
+            else:
+                with pytest.raises(
+                    SnowparkSQLException,
+                    match="Unsupported data type 'STRUCTURED_OBJECT'",
+                ):
+                    inner()
+    finally:
+        Utils.drop_table(structured_type_session, agg_table_name)

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -1771,7 +1771,9 @@ def test_lob_collect_max_size(session, server_side_max_string, type_string, data
     reason="Structured types are not supported in Local Testing",
 )
 @pytest.mark.parametrize("fix_enabled", [True, False])
-def test_snow_2360274_repro(session, fix_enabled):
+def test_snow_2360274_repro(
+    structured_type_session, structured_type_support, fix_enabled
+):
     if not structured_type_support:
         pytest.skip("Test requires structured type support.")
     expected_schema = StructType(
@@ -1789,7 +1791,7 @@ def test_snow_2360274_repro(session, fix_enabled):
     )
 
     def inner():
-        agged = session.sql(
+        agged = structured_type_session.sql(
             """
         WITH SRC(ID, VALUE) AS (
             SELECT
@@ -1812,7 +1814,7 @@ def test_snow_2360274_repro(session, fix_enabled):
             ID"""
         )
 
-        reference = session.sql(
+        reference = structured_type_session.sql(
             """
         SELECT $1 AS ID, $2 AS TAG FROM VALUES (1, 'AB'), (2, 'B')
         """

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -2291,6 +2291,7 @@ def test_sproc_artifact_repository(session):
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="artifact repository requires Python 3.9+"
 )
+@pytest.mark.skip("SNOW-2362946: Skip until root cause is found.")
 def test_sproc_artifact_repository_from_file(session, tmpdir):
     source = dedent(
         """


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2360274

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

  The sql generation for describe queries has an edge case that can cause invalid sql to be generated when using nested structured types. The schema_expression function does it's best to respect nullability when generating schema queries. Snowflake does not support nullability inside of structured types so this should not be needed for structured types. This fix short circuits the sql generation by replacing the recursive call with NULLs. I have not found any cases in which this would break, but to be extra sure it's not a BCR I am gating it behind a context variable. In order to use this bugfix you will have to set `context. _enable_fix_2360274` to be True.