### PR TITLE
SNOW-2261400: Fix incorrect join condition in repeated subquery elimination 

### DIFF
--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -252,16 +252,24 @@ def encode_query_id(node: "TreeNode") -> Optional[str]:
         # to avoid being detected as a common subquery.
         return None
 
+    def stringify(d):
+        if isinstance(d, dict):
+            key_value_pairs = list(d.items())
+            key_value_pairs.sort(key=lambda x: x[0])
+            return str(key_value_pairs)
+        else:
+            return str(d)
+
     string = query
     if query_params:
         string = f"{string}#{query_params}"
     if hasattr(node, "expr_to_alias") and node.expr_to_alias:
-        string = f"{string}#{node.expr_to_alias}"
+        string = f"{string}#{stringify(node.expr_to_alias)}"
     if (
         hasattr(node, "df_aliased_col_name_to_real_col_name")
         and node.df_aliased_col_name_to_real_col_name
     ):
-        string = f"{string}#{node.df_aliased_col_name_to_real_col_name}"
+        string = f"{string}#{stringify(node.df_aliased_col_name_to_real_col_name)}"
 
     try:
         return hashlib.sha256(string.encode()).hexdigest()[:10]

--- a/src/snowflake/snowpark/_internal/compiler/cte_utils.py
+++ b/src/snowflake/snowpark/_internal/compiler/cte_utils.py
@@ -224,8 +224,8 @@ def get_duplicated_node_complexity_distribution(
 
 def encode_query_id(node: "TreeNode") -> Optional[str]:
     """
-    Encode the query and its query parameter into an id using sha256.
-
+    Encode the query, its query parameter, expr_to_alias and df_aliased_col_name_to_real_col_name
+    into an id using sha256.
 
     Returns:
         If encode succeed, return the first 10 encoded value.
@@ -252,7 +252,17 @@ def encode_query_id(node: "TreeNode") -> Optional[str]:
         # to avoid being detected as a common subquery.
         return None
 
-    string = f"{query}#{query_params}" if query_params else query
+    string = query
+    if query_params:
+        string = f"{string}#{query_params}"
+    if hasattr(node, "expr_to_alias") and node.expr_to_alias:
+        string = f"{string}#{node.expr_to_alias}"
+    if (
+        hasattr(node, "df_aliased_col_name_to_real_col_name")
+        and node.df_aliased_col_name_to_real_col_name
+    ):
+        string = f"{string}#{node.df_aliased_col_name_to_real_col_name}"
+
     try:
         return hashlib.sha256(string.encode()).hexdigest()[:10]
     except Exception as ex:

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -636,13 +636,10 @@ def test_cte_preserves_join_suffix_aliases(session, use_different_df):
     # the second one is incorrect join condition as we have rsuffix for join alias
     assert 'ON ("AD_GROUP_ID_WITH_AD_GROUP" = "AD_GROUP_ID")' in union_sql
     assert 'ON ("AD_GROUP_ID" = "AD_GROUP_ID")' not in union_sql
-    # when using different df_ad_group, because rsuffix in join, they have different alias map (expr_to_alias),
-    # so they are considered different and we can't convert them to a CTE
-    assert (
-        count_number_of_ctes(Utils.normalize_sql(union_sql)) == 0
-        if use_different_df
-        else 1
-    )
+    # when using different df_ad_group with disambiguation, because rsuffix in join,
+    # they have different alias map (expr_to_alias), so they are considered different and we can't convert them to a CTE
+    # However there is still a CTE for create_dataframe call
+    assert count_number_of_ctes(Utils.normalize_sql(union_sql)) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cte.py
+++ b/tests/unit/test_cte.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import hashlib
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -103,3 +105,25 @@ def test_encode_node_id_with_query_select_sql(mock_session, mock_analyzer):
         encode_node_id_with_query(select_statement_node)
         == f"{expected_hash}_SelectStatement"
     )
+
+
+def test_encode_node_id_with_query_includes_aliases():
+    node = SimpleNamespace(
+        sql_query="select col1 from t",
+        query_params=(("p1", 1), ("p2", "x")),
+        expr_to_alias=(("expr1", "alias1"),),
+        df_aliased_col_name_to_real_col_name=(("ALIAS1", "COL1"),),
+    )
+
+    expected_string = node.sql_query
+    if node.query_params:
+        expected_string = f"{expected_string}#{node.query_params}"
+    if node.expr_to_alias:
+        expected_string = f"{expected_string}#{node.expr_to_alias}"
+    if node.df_aliased_col_name_to_real_col_name:
+        expected_string = (
+            f"{expected_string}#{node.df_aliased_col_name_to_real_col_name}"
+        )
+
+    expected_hash = hashlib.sha256(expected_string.encode()).hexdigest()[:10]
+    assert encode_node_id_with_query(node) == f"{expected_hash}_SimpleNamespace"

--- a/tests/unit/test_cte.py
+++ b/tests/unit/test_cte.py
@@ -111,19 +111,22 @@ def test_encode_node_id_with_query_includes_aliases():
     node = SimpleNamespace(
         sql_query="select col1 from t",
         query_params=(("p1", 1), ("p2", "x")),
-        expr_to_alias=(("expr1", "alias1"),),
-        df_aliased_col_name_to_real_col_name=(("ALIAS1", "COL1"),),
+        expr_to_alias={"uuid1": "ALIAS1"},
+        df_aliased_col_name_to_real_col_name={"ALIAS1": "col1"},
     )
+
+    def stringify_dict(d: dict) -> str:
+        key_value_pairs = list(d.items())
+        key_value_pairs.sort(key=lambda x: x[0])
+        return str(key_value_pairs)
 
     expected_string = node.sql_query
     if node.query_params:
         expected_string = f"{expected_string}#{node.query_params}"
     if node.expr_to_alias:
-        expected_string = f"{expected_string}#{node.expr_to_alias}"
+        expected_string = f"{expected_string}#{stringify_dict(node.expr_to_alias)}"
     if node.df_aliased_col_name_to_real_col_name:
-        expected_string = (
-            f"{expected_string}#{node.df_aliased_col_name_to_real_col_name}"
-        )
+        expected_string = f"{expected_string}#{stringify_dict(node.df_aliased_col_name_to_real_col_name)}"
 
     expected_hash = hashlib.sha256(expected_string.encode()).hexdigest()[:10]
     assert encode_node_id_with_query(node) == f"{expected_hash}_SimpleNamespace"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2261400

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Now we consider the dataframe with the same query but different alias map as different, as they will have different join conditions in parent queries. 
