### PR TITLE
SNOW-2362488: Improve the error message of XSD validation when mode=failfast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 #### Improvements
 
 - Improved `DataFrameReader.dbapi` (PuPr) reading performance by setting the default `fetch_size` parameter value to 100000.
+- Improved error message for XSD validation failure when reading XML files using `session.read.option('rowValidationXSDPath', <xsd_path>).xml(<stage_file_path>)`.
 
 ### Snowpark pandas API Updates
 

--- a/src/snowflake/snowpark/_internal/xml_reader.py
+++ b/src/snowflake/snowpark/_internal/xml_reader.py
@@ -503,7 +503,8 @@ def process_xml_range(
                     yield {column_name_of_corrupt_record: record_str}
                 elif mode == "FAILFAST":
                     raise RuntimeError(
-                        f"Malformed XML record at bytes {record_start}-{record_end}: {e}"
+                        f"Malformed XML record at bytes {record_start}-{record_end}: {e}\n"
+                        f"XML record string: {record_str}"
                     )
 
             if record_end > approx_end:

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -416,3 +416,15 @@ def test_read_xml_row_validation_xsd_path(session):
     assert result[0]["'price'"] == '"44.95"'
     assert result[0]["'publish_date'"] == '"2000-10-01"'
     assert result[0]["'_id'"] == '"bk101"'
+
+
+def test_read_xml_row_validation_xsd_path_failfast(session):
+    row_tag = "book"
+    df = (
+        session.read.option("rowTag", row_tag)
+        .option("rowValidationXSDPath", f"@{tmp_stage_name}/{test_file_books_xsd}")
+        .option("mode", "failfast")
+        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+    )
+    with pytest.raises(SnowparkSQLException, match="XML record string:"):
+        df.collect()

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -420,11 +420,7 @@ def test_read_xml_row_validation_xsd_path(session):
 
 def test_read_xml_row_validation_xsd_path_failfast(session):
     row_tag = "book"
-    df = (
-        session.read.option("rowTag", row_tag)
-        .option("rowValidationXSDPath", f"@{tmp_stage_name}/{test_file_books_xsd}")
-        .option("mode", "failfast")
-        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
-    )
     with pytest.raises(SnowparkSQLException, match="XML record string:"):
-        df.collect()
+        session.read.option("rowTag", row_tag).option(
+            "rowValidationXSDPath", f"@{tmp_stage_name}/{test_file_books_xsd}"
+        ).option("mode", "failfast").xml(f"@{tmp_stage_name}/{test_file_books_xml}")


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2362488

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Added malformed xml record string to the error message
