### PR TITLE
SNOW-2364008: Remove unnecessary warning for XML reader and xpath function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 
 #### Improvements
 
+- Removed unnecessary warnings about local package version mismatch when using `session.read.option('rowTag', <tag_name>).xml(<stage_file_path>)` or `xpath` functions.
 - Improved `DataFrameReader.dbapi` (PuPr) reading performance by setting the default `fetch_size` parameter value to 100000.
 
 ### Snowpark pandas API Updates

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1134,6 +1134,7 @@ def resolve_imports_and_packages(
     skip_upload_on_content_match: bool = False,
     is_permanent: bool = False,
     force_inline_code: bool = False,
+    **kwargs,
 ) -> Tuple[
     Optional[str],
     Optional[str],
@@ -1167,6 +1168,9 @@ def resolve_imports_and_packages(
                     packages,
                     include_pandas=is_pandas_udf,
                     statement_params=statement_params,
+                    _suppress_local_package_warnings=kwargs.get(
+                        "_suppress_local_package_warnings", False
+                    ),
                 )
                 if packages is not None
                 else session._resolve_packages(
@@ -1175,6 +1179,9 @@ def resolve_imports_and_packages(
                     validate_package=False,
                     include_pandas=is_pandas_udf,
                     statement_params=statement_params,
+                    _suppress_local_package_warnings=kwargs.get(
+                        "_suppress_local_package_warnings", False
+                    ),
                 )
             )
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1407,11 +1407,6 @@ class DataFrameReader:
         metadata_project, metadata_schema = self._get_metadata_project_and_schema()
 
         if format == "XML" and XML_ROW_TAG_STRING in self._cur_options:
-            warning(
-                "rowTag",
-                "rowTag for reading XML file is in private preview since 1.31.0. Do not use it in production.",
-            )
-
             if is_in_stored_procedure():  # pragma: no cover
                 # create a temp stage for udtf import files
                 # we have to use "temp" object instead of "scoped temp" object in stored procedure
@@ -1447,6 +1442,7 @@ class DataFrameReader:
                 input_types=input_types,
                 packages=["snowflake-snowpark-python", "lxml<6"],
                 replace=True,
+                _suppress_local_package_warnings=True,
             )
         else:
             xml_reader_udtf = None

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -955,6 +955,7 @@ class StoredProcedureRegistration:
             is_permanent=is_permanent,
             force_inline_code=force_inline_code,
             artifact_repository=artifact_repository,
+            **kwargs,
         )
 
         runtime_version_from_requirement = None

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -799,6 +799,7 @@ class UDAFRegistration:
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
             artifact_repository=artifact_repository,
+            **kwargs,
         )
 
         runtime_version_from_requirement = None

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -994,6 +994,7 @@ class UDFRegistration:
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
             artifact_repository=artifact_repository,
+            **kwargs,
         )
 
         runtime_version_from_requirement = None

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -1056,6 +1056,7 @@ class UDTFRegistration:
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
             artifact_repository=artifact_repository,
+            **kwargs,
         )
 
         runtime_version_from_requirement = None

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import logging
 import json
 import pytest
 
@@ -396,6 +397,19 @@ def test_read_xml_ignore_surrounding_whitespace(
         .xml(f"@{tmp_stage_name}/{test_file_null_value_xml}")
     )
     Utils.check_answer(df, [expected_row])
+
+
+def test_read_xml_warning_local_package(session, caplog):
+    row_tag = "book"
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        session.read.option("rowTag", row_tag).xml(
+            f"@{tmp_stage_name}/{test_file_books_xml}"
+        )
+    assert (
+        "Your UDF might not work when the package version is different between the server and your local environment"
+        not in caplog.text
+    )
 
 
 def test_read_xml_row_validation_xsd_path(session):

--- a/tests/integ/test_xpath.py
+++ b/tests/integ/test_xpath.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import logging
 import json
 import pytest
 
@@ -329,3 +330,16 @@ def test_xpath_return_types(session):
     assert isinstance(schema["BOOL_COL"].datatype, BooleanType)
     assert isinstance(schema["FLOAT_COL"].datatype, DoubleType)
     assert isinstance(schema["INT_COL"].datatype, LongType)
+
+
+def test_xpath_warning_local_package(session, caplog):
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        df = session.create_dataframe(
+            [["<root><a>1</a><a>2</a><a>3</a></root>"]], schema=["xml"]
+        )
+        df.select(xpath("xml", "//a/text()").alias("values")).collect()
+    assert (
+        "Your UDF might not work when the package version is different between the server and your local environment"
+        not in caplog.text
+    )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2364008

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   
This pull request removes unnecessary warnings about local package version mismatches when using the `rowTag` option for XML reading and the `xpath` function, both of which are in private preview. It introduces an internal mechanism to suppress these warnings in relevant scenarios, updates the codebase to support this, and adds tests to ensure the warnings are properly suppressed.

**Warning suppression improvements:**

* Removed warnings about local package version mismatches when using `session.read.option('rowTag', <tag_name>).xml(<stage_file_path>)` and `xpath` functions, as these features are in private preview and the warnings are not needed for end users. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR89) [[2]](diffhunk://#diff-670c84c5cba126be65546dbdede874b07fac0ac9dfda5872d1ed31660bb9356cL1410-L1414)
* Added an internal `_suppress_local_package_warnings` flag to package resolution logic and updated all relevant registration and reading functions to accept and pass this flag through, ensuring warnings are suppressed where appropriate. 
* 
**Testing enhancements:**

* Added integration and unit tests to verify that local package version mismatch warnings are not emitted when using the XML `rowTag` option and `xpath` functions, and that the suppression mechanism works as intended. 