### PR TITLE
SNOW-2372686: Write large_pandas_backend_df.to_snowflake() via parquet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 - Hybrid execution mode is now enabled by default. Certain operations on smaller data will now automatically execute in native pandas in-memory. Use `from modin.config import AutoSwitchBackend; AutoSwitchBackend.disable()` to turn this off and force all execution to occur in Snowflake.
 - Added a session parameter `pandas_hybrid_execution_enabled` to enable/disable hybrid execution as an alternative to using `AutoSwitchBackend`.
 - Removed an unnecessary `SHOW OBJECTS` query issued from `read_snowflake` under certain conditions.
+- Improved performance of `DataFrame.to_snowflake` and `pd.to_snowflake(dataframe)` for large data by uploading data via a parquet file.
 
 ## 1.39.0 (2025-09-17)
 

--- a/src/snowflake/snowpark/modin/config/envvars.py
+++ b/src/snowflake/snowpark/modin/config/envvars.py
@@ -116,8 +116,25 @@ class SnowflakePandasTransferThreshold(EnvironmentVariable, type=int):
     default = 100_000
 
 
-# have to monkey patch this into modin right now to use config contexts
+class PandasToSnowflakeParquetThresholdBytes(EnvironmentVariable, type=int):
+    """
+    When a pandas-backend dataframe's shallow memory usage exceeds this
+    threshold, implement to_snowflake() by writing the dataframe to a parquet
+    file and loading the parquet file into Snowflake.
+    """
+
+    varname = "SNOWFLAKE_PANDAS_MAX_TO_SNOWFLAKE_MEMORY_BYTES"
+    # This default comes from experimentation on integer data. At about this
+    # point, insertion
+    default = 100_000
+
+
+# have to monkey patch these variables into modin right now to use config
+# contexts
 modin_config.SnowflakePandasTransferThreshold = SnowflakePandasTransferThreshold
+modin_config.PandasToSnowflakeParquetThresholdBytes = (
+    PandasToSnowflakeParquetThresholdBytes
+)
 
 
 class EnvWithSibilings(

--- a/src/snowflake/snowpark/modin/config/envvars.py
+++ b/src/snowflake/snowpark/modin/config/envvars.py
@@ -125,8 +125,8 @@ class PandasToSnowflakeParquetThresholdBytes(EnvironmentVariable, type=int):
 
     varname = "SNOWFLAKE_PANDAS_MAX_TO_SNOWFLAKE_MEMORY_BYTES"
     # This default comes from experimentation on integer data. At about this
-    # point, insertion
-    default = 100_000
+    # point, insertion via parquet appears to be faster on a 3XL warehouse.
+    default = 3_000_000
 
 
 # have to monkey patch these variables into modin right now to use config

--- a/src/snowflake/snowpark/modin/plugin/_internal/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/utils.py
@@ -980,6 +980,38 @@ def extract_all_duplicates(elements: Sequence[Hashable]) -> Sequence[Hashable]:
     return unique_duplicated_elements
 
 
+def validate_column_labels_for_to_snowflake(
+    index_column_labels: Sequence[Hashable], data_column_labels: Sequence[Hashable]
+) -> None:
+    """
+    Validate column labels for to_snowflake.
+
+    Check that the column labels are not duplicated, and that the data column
+    labels are not None.
+
+    Args:
+        index_column_labels: index column labels
+        data_column_labels: data column labels
+
+    Returns:
+        None
+    """
+    duplicates = extract_all_duplicates((*index_column_labels, *data_column_labels))
+    if len(duplicates) > 0:
+        raise ValueError(
+            f"Duplicated labels {duplicates} found in index columns {index_column_labels} and data columns {data_column_labels}. "
+            f"Snowflake does not allow duplicated identifiers, please rename to make sure there is no duplication "
+            f"among both index and data columns."
+        )
+
+    if any(is_all_label_components_none(label) for label in data_column_labels):
+        raise ValueError(
+            f"Label None is found in the data columns {data_column_labels}, which is invalid in Snowflake. "
+            "Please give it a name by set the dataframe columns like df.columns=['A', 'B'],"
+            " or set the series name if it is a series like series.name='A'."
+        )
+
+
 def is_duplicate_free(names: Sequence[Hashable]) -> bool:
     """
     check whether names contains duplicates
@@ -2300,3 +2332,52 @@ def new_snow_df(*args: Any, **kwargs: Any) -> pd.DataFrame:
     """
     with config_context(AutoSwitchBackend=False):
         return pd.DataFrame(*args, **kwargs)
+
+
+def extract_and_validate_index_labels_for_to_snowflake(
+    index_label_param: Any, num_index_columns: int
+) -> list[Hashable]:
+    """
+    Extract and validate index labels for read snowflake.
+
+    Args:
+        index_label_param: index_label parameter
+        num_index_columns: number of index columns
+    Returns:
+        list of index column labels
+    """
+    index_column_labels = (
+        index_label_param
+        if isinstance(index_label_param, list)
+        else [index_label_param]
+    )
+    if len(index_column_labels) != num_index_columns:
+        raise ValueError(
+            f"Length of 'index_label' should match number of levels, which is {num_index_columns}"
+        )
+    return index_column_labels
+
+
+def handle_if_exists_for_to_snowflake(
+    if_exists: str, name: Union[str, Iterable[str]]
+) -> None:
+    """
+    Handle if_exists for to_snowflake.
+
+    Validate if_exists for to_snowflake and raise an error if the table
+    already exists and if_exists == "fail".
+
+    Args:
+        if_exists: if_exists parameter
+        name: name parameter
+    Returns:
+        None
+    """
+    if if_exists not in ("fail", "replace", "append"):
+        raise ValueError(f"'{if_exists}' is not valid for if_exists")
+    if if_exists == "fail" and pd.session._table_exists(
+        parse_table_name(name) if isinstance(name, str) else name
+    ):
+        raise ValueError(
+            f"Table '{name}' already exists. Set 'if_exists' parameter as 'replace' to override existing table."
+        )

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -95,7 +95,6 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
 from snowflake.snowpark._internal.type_utils import ColumnOrName
 from snowflake.snowpark._internal.utils import (
     generate_random_alphanumeric,
-    parse_table_name,
     random_name_for_temp_object,
 )
 from snowflake.snowpark.column import CaseExpr, Column as SnowparkColumn
@@ -350,6 +349,8 @@ from snowflake.snowpark.modin.plugin._internal.unpivot_utils import (
     unpivot_empty_df,
 )
 from snowflake.snowpark.modin.plugin._internal.utils import (
+    extract_and_validate_index_labels_for_to_snowflake,
+    handle_if_exists_for_to_snowflake,
     new_snow_series,
     INDEX_LABEL,
     ROW_COUNT_COLUMN_LABEL,
@@ -365,7 +366,6 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     create_frame_with_data_columns,
     create_ordered_dataframe_from_pandas,
     create_initial_ordered_dataframe,
-    extract_all_duplicates,
     extract_pandas_label_from_snowflake_quoted_identifier,
     fill_missing_levels_for_pandas_label,
     fill_none_in_index_labels,
@@ -382,6 +382,7 @@ from snowflake.snowpark.modin.plugin._internal.utils import (
     parse_object_construct_snowflake_quoted_identifier_and_extract_pandas_label,
     parse_snowflake_object_construct_identifier_to_map,
     unquote_name_if_quoted,
+    validate_column_labels_for_to_snowflake,
 )
 from snowflake.snowpark.modin.plugin._internal.where_utils import (
     validate_expected_boolean_data_columns,
@@ -1878,12 +1879,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # Include index columns
             if index_label:
                 index_column_labels = (
-                    index_label if isinstance(index_label, list) else [index_label]
-                )
-                if len(index_column_labels) != self._modin_frame.num_index_columns:
-                    raise ValueError(
-                        f"Length of 'index_label' should match number of levels, which is {self._modin_frame.num_index_columns}"
+                    extract_and_validate_index_labels_for_to_snowflake(
+                        index_label_param=index_label,
+                        num_index_columns=self._modin_frame.num_index_columns,
                     )
+                )
             else:
                 index_column_labels = frame.index_column_pandas_labels
 
@@ -1902,23 +1902,10 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
             # label for the data column, set the label to be None
             data_column_labels = [None]
 
-        # check if there is any data column label is none
-        if any(is_all_label_components_none(label) for label in data_column_labels):
-            raise ValueError(
-                f"Label None is found in the data columns {data_column_labels}, which is invalid in Snowflake. "
-                "Please give it a name by set the dataframe columns like df.columns=['A', 'B'],"
-                " or set the series name if it is a series like series.name='A'."
-            )
-
-        # perform a column name duplication check
-        index_and_data_columns = data_column_labels + index_column_labels
-        duplicates = extract_all_duplicates(index_and_data_columns)
-        if duplicates:
-            raise ValueError(
-                f"Duplicated labels {duplicates} found in index columns {index_column_labels} and data columns {data_column_labels}. "
-                f"Snowflake does not allow duplicated identifiers, please rename to make sure there is no duplication "
-                f"among both index and data columns."
-            )
+        validate_column_labels_for_to_snowflake(
+            index_column_labels=index_column_labels,
+            data_column_labels=data_column_labels,
+        )
 
         # rename snowflake quoted identifiers for the retained index columns and data columns to
         # be the same as quoted pandas labels.
@@ -2020,23 +2007,14 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         table_type: Literal["", "temp", "temporary", "transient"] = "",
     ) -> None:
         self._warn_lost_snowpark_pandas_type()
+        handle_if_exists_for_to_snowflake(if_exists=if_exists, name=name)
 
-        if if_exists not in ("fail", "replace", "append"):
-            # Same error message as native pandas.
-            raise ValueError(f"'{if_exists}' is not valid for if_exists")
         if if_exists == "fail":
             mode = "errorifexists"
         elif if_exists == "replace":
             mode = "overwrite"
         else:
             mode = "append"
-
-        if mode == "errorifexists" and pd.session._table_exists(
-            parse_table_name(name) if isinstance(name, str) else name
-        ):
-            raise ValueError(
-                f"Table '{name}' already exists. Set 'if_exists' parameter as 'replace' to override existing table."
-            )
 
         self._to_snowpark_dataframe_from_snowpark_pandas_dataframe(
             index, index_label

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -98,7 +98,7 @@ def to_snowflake(  # noqa: F811
         self.memory_usage(deep=False).sum()
         <= PandasToSnowflakeParquetThresholdBytes.get()
     ):
-        return self.set_backend("snowflake").to_snowflake(
+        return self.set_backend("Snowflake").to_snowflake(
             name=name,
             if_exists=if_exists,
             index=index,

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -80,7 +80,7 @@ def _convert_to_snowflake_table_name_to_write_pandas_table_name(name: str) -> st
 # We use extensions, as we want to make clear that a Snowpark pandas DataFrame is NOT a
 # pandas DataFrame.
 @_register_dataframe_accessor("to_snowflake", backend="Pandas")
-def to_snowflake(  # noqa: F811
+def pandas_to_snowflake(
     self,
     name: Union[str, Iterable[str]],
     if_exists: Optional[Literal["fail", "replace", "append"]] = "fail",
@@ -169,7 +169,7 @@ def to_snowflake(  # noqa: F811
 
 # Implementation note: Arguments names and types are kept consistent with pandas.DataFrame.to_sql
 @register_dataframe_accessor("to_snowflake")
-def to_snowflake(  # noqa: F811
+def to_snowflake(
     self,
     name: Union[str, Iterable[str]],
     if_exists: Optional[Literal["fail", "replace", "append"]] = "fail",

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -505,8 +505,6 @@ def _read_snowflake_ray_backend(
     return df.set_backend("Ray")
 
 
-@_register_pd_accessor("to_snowflake", backend="Pandas")
-@doc(_TO_SNOWFLAKE_DOC)
 def to_snowflake(
     obj: Union[DataFrame, Series],
     name: Union[str, Iterable[str]],
@@ -525,32 +523,9 @@ def to_snowflake(
     )
 
 
-@_register_pd_accessor("to_snowflake", backend="Snowflake")
-@doc(_TO_SNOWFLAKE_DOC)
-def to_snowflake(  # noqa: F811
-    obj: Union[DataFrame, Series],
-    name: Union[str, Iterable[str]],
-    if_exists: Optional[Literal["fail", "replace", "append"]] = "fail",
-    index: bool = True,
-    index_label: Optional[IndexLabel] = None,
-    table_type: Literal["", "temp", "temporary", "transient"] = "",
-) -> None:
-    _snowpark_pandas_obj_check(obj)
-    return obj.to_snowflake(name, if_exists, index, index_label, table_type)
-
-
-@_register_pd_accessor("to_snowflake", backend="Ray")
-@doc(_TO_SNOWFLAKE_DOC)
-def to_snowflake(  # noqa: F811
-    obj: Union[DataFrame, Series],
-    name: Union[str, Iterable[str]],
-    if_exists: Optional[Literal["fail", "replace", "append"]] = "fail",
-    index: bool = True,
-    index_label: Optional[IndexLabel] = None,
-    table_type: Literal["", "temp", "temporary", "transient"] = "",
-) -> None:
-    _snowpark_pandas_obj_check(obj)
-    return obj.to_snowflake(name, if_exists, index, index_label, table_type)
+_register_pd_accessor(name="to_snowflake", backend="Snowflake")(to_snowflake)
+_register_pd_accessor(name="to_snowflake", backend="Ray")(to_snowflake)
+_register_pd_accessor(name="to_snowflake", backend="Pandas")(to_snowflake)
 
 
 @_register_pd_accessor("to_snowpark")

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -413,6 +413,34 @@ _READ_SNOWFLAKE_DOC = """
         `SELECT * FROM TABLE` or `DESCRIBE TABLE` to see the column names.
 """
 
+_TO_SNOWFLAKE_DOC = """
+    Save the Snowpark pandas DataFrame or Series as a Snowflake table.
+
+    Args:
+        obj: Either a Snowpark pandas DataFrame or Series
+        name:
+            Name of the SQL table or fully-qualified object identifier
+        if_exists:
+            How to behave if table already exists. default 'fail'
+                - fail: Raise ValueError.
+                - replace: Drop the table before inserting new values.
+                - append: Insert new values to the existing table. The order of insertion is not guaranteed.
+        index: default True
+            If true, save DataFrame index columns as table columns.
+        index_label:
+            Column label for index column(s). If None is given (default) and index is True,
+            then the index names are used. A sequence should be given if the DataFrame uses MultiIndex.
+        table_type:
+            The table type of table to be created. The supported values are: ``temp``, ``temporary``,
+            and ``transient``. An empty string means to create a permanent table. Learn more about table
+            types `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
+
+    See also:
+        - :func:`DataFrame.to_snowflake <modin.pandas.DataFrame.to_snowflake>`
+        - :func:`Series.to_snowflake <modin.pandas.Series.to_snowflake>`
+        - :func:`read_snowflake <modin.pandas.read_snowflake>`
+"""
+
 
 @register_snowflake_accessor("read_snowflake")
 @doc(
@@ -477,7 +505,8 @@ def _read_snowflake_ray_backend(
     return df.set_backend("Ray")
 
 
-@_register_pd_accessor("to_snowflake")
+@_register_pd_accessor("to_snowflake", backend="Pandas")
+@doc(_TO_SNOWFLAKE_DOC)
 def to_snowflake(
     obj: Union[DataFrame, Series],
     name: Union[str, Iterable[str]],
@@ -486,33 +515,49 @@ def to_snowflake(
     index_label: Optional[IndexLabel] = None,
     table_type: Literal["", "temp", "temporary", "transient"] = "",
 ) -> None:
-    """
-    Save the Snowpark pandas DataFrame or Series as a Snowflake table.
+    _snowpark_pandas_obj_check(obj)
+    # We have a DataFrame.to_snowflake() implementation for the pandas backend
+    return (
+        obj.to_snowflake(
+            name=name,
+            if_exists=if_exists,
+            index=index,
+            index_label=index_label,
+            table_type=table_type,
+        )
+        if isinstance(obj, DataFrame)
+        else _check_obj_and_set_backend_to_snowflake(obj)._query_compiler.to_snowflake(
+            name, if_exists, index, index_label, table_type
+        )
+    )
 
-    Args:
-        obj: Either a Snowpark pandas DataFrame or Series
-        name:
-            Name of the SQL table or fully-qualified object identifier
-        if_exists:
-            How to behave if table already exists. default 'fail'
-                - fail: Raise ValueError.
-                - replace: Drop the table before inserting new values.
-                - append: Insert new values to the existing table. The order of insertion is not guaranteed.
-        index: default True
-            If true, save DataFrame index columns as table columns.
-        index_label:
-            Column label for index column(s). If None is given (default) and index is True,
-            then the index names are used. A sequence should be given if the DataFrame uses MultiIndex.
-        table_type:
-            The table type of table to be created. The supported values are: ``temp``, ``temporary``,
-            and ``transient``. An empty string means to create a permanent table. Learn more about table
-            types `here <https://docs.snowflake.com/en/user-guide/tables-temp-transient.html>`_.
 
-    See also:
-        - :func:`DataFrame.to_snowflake <modin.pandas.DataFrame.to_snowflake>`
-        - :func:`Series.to_snowflake <modin.pandas.Series.to_snowflake>`
-        - :func:`read_snowflake <modin.pandas.read_snowflake>`
-    """
+@_register_pd_accessor("to_snowflake", backend="Snowflake")
+@doc(_TO_SNOWFLAKE_DOC)
+def to_snowflake(  # noqa: F811
+    obj: Union[DataFrame, Series],
+    name: Union[str, Iterable[str]],
+    if_exists: Optional[Literal["fail", "replace", "append"]] = "fail",
+    index: bool = True,
+    index_label: Optional[IndexLabel] = None,
+    table_type: Literal["", "temp", "temporary", "transient"] = "",
+) -> None:
+    _snowpark_pandas_obj_check(obj)
+    return obj._query_compiler.to_snowflake(
+        name, if_exists, index, index_label, table_type
+    )
+
+
+@_register_pd_accessor("to_snowflake", backend="Ray")
+@doc(_TO_SNOWFLAKE_DOC)
+def to_snowflake(  # noqa: F811
+    obj: Union[DataFrame, Series],
+    name: Union[str, Iterable[str]],
+    if_exists: Optional[Literal["fail", "replace", "append"]] = "fail",
+    index: bool = True,
+    index_label: Optional[IndexLabel] = None,
+    table_type: Literal["", "temp", "temporary", "transient"] = "",
+) -> None:
     return _check_obj_and_set_backend_to_snowflake(obj)._query_compiler.to_snowflake(
         name, if_exists, index, index_label, table_type
     )

--- a/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/pd_extensions.py
@@ -516,19 +516,12 @@ def to_snowflake(
     table_type: Literal["", "temp", "temporary", "transient"] = "",
 ) -> None:
     _snowpark_pandas_obj_check(obj)
-    # We have a DataFrame.to_snowflake() implementation for the pandas backend
-    return (
-        obj.to_snowflake(
-            name=name,
-            if_exists=if_exists,
-            index=index,
-            index_label=index_label,
-            table_type=table_type,
-        )
-        if isinstance(obj, DataFrame)
-        else _check_obj_and_set_backend_to_snowflake(obj)._query_compiler.to_snowflake(
-            name, if_exists, index, index_label, table_type
-        )
+    return obj.to_snowflake(
+        name=name,
+        if_exists=if_exists,
+        index=index,
+        index_label=index_label,
+        table_type=table_type,
     )
 
 
@@ -543,9 +536,7 @@ def to_snowflake(  # noqa: F811
     table_type: Literal["", "temp", "temporary", "transient"] = "",
 ) -> None:
     _snowpark_pandas_obj_check(obj)
-    return obj._query_compiler.to_snowflake(
-        name, if_exists, index, index_label, table_type
-    )
+    return obj.to_snowflake(name, if_exists, index, index_label, table_type)
 
 
 @_register_pd_accessor("to_snowflake", backend="Ray")
@@ -558,9 +549,8 @@ def to_snowflake(  # noqa: F811
     index_label: Optional[IndexLabel] = None,
     table_type: Literal["", "temp", "temporary", "transient"] = "",
 ) -> None:
-    return _check_obj_and_set_backend_to_snowflake(obj)._query_compiler.to_snowflake(
-        name, if_exists, index, index_label, table_type
-    )
+    _snowpark_pandas_obj_check(obj)
+    return obj.to_snowflake(name, if_exists, index, index_label, table_type)
 
 
 @_register_pd_accessor("to_snowpark")

--- a/src/snowflake/snowpark/modin/plugin/extensions/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/utils.py
@@ -639,13 +639,20 @@ def register_non_snowflake_accessors(
         )
 
         # Register methods that move to Snowflake backend
-        # TODO(SNOW-2288765): Improve performance of to_snowflake() by writing
-        # to a Snowflake table directly instead of going through Snowpark
-        # pandas.
         for method in ("to_snowflake", "to_snowpark", "to_iceberg"):
-            register_accessor_func(name=method, backend=backend)(
-                _make_non_snowflake_accessor(method=method)
-            )
+            # We have a proper implementation of to_snowflake() for dataframes
+            # on the pandas backend, but the rest of SNOW-2288765 still remains.
+            # TODO(SNOW-2288765): Improve performance of to_snowflake() by writing
+            # to a Snowflake table directly instead of going through Snowpark
+            # pandas.
+            if not (
+                method == "to_snowflake"
+                and backend == "Pandas"
+                and object_type == "DataFrame"
+            ):
+                register_accessor_func(name=method, backend=backend)(
+                    _make_non_snowflake_accessor(method=method)
+                )
 
         # Register methods that are not implemented on non-Snowflake backends
         for method in (

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -3,29 +3,106 @@
 #
 
 import logging
+from random import Random
 import re
+import string
 
 import modin.pandas as pd
 import pandas as native_pd
 import pytest
+from modin.config import context as config_context
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import VALID_PANDAS_LABELS, VALID_SNOWFLAKE_COLUMN_NAMES
 from tests.integ.utils.sql_counter import SqlCounter, sql_count_checker
+from modin.config import PandasToSnowflakeParquetThresholdBytes
+
+from tests.utils import Utils
+
+
+def _generate_lower_case_table_name_unquoted() -> str:
+    return "snowpark_temp_table_" + "".join(
+        Random().choice(string.ascii_lowercase + string.digits) for _ in range(10)
+    )
+
+
+@pytest.fixture
+def lower_case_table_name_unquoted(session):
+    name = _generate_lower_case_table_name_unquoted()
+    yield name
+    Utils.drop_table(session, name)
+
+
+@pytest.fixture
+def lower_case_table_name_quoted(session):
+    name = '"' + _generate_lower_case_table_name_unquoted() + '"'
+    yield name
+    Utils.drop_table(session, name)
+
+
+@pytest.fixture
+def upper_case_table_name_quoted(session):
+    name = '"' + _generate_lower_case_table_name_unquoted().upper() + '"'
+    yield name
+    Utils.drop_table(session, name)
+
+
+@pytest.fixture
+def upper_case_table_name_with_space_quoted(session):
+    name = '" ' + _generate_lower_case_table_name_unquoted().upper() + ' "'
+    yield name
+    Utils.drop_table(session, name)
+
+
+@pytest.fixture(params=("pandas", "snowflake"), autouse=True)
+def starting_backend(request) -> str:
+    with config_context(Backend=request.param):
+        yield
+
+
+@pytest.fixture(
+    params=[0, int(1e9)], autouse=True, ids=lambda param: f"parquet_threshold_{param}"
+)
+def parquet_threshold(request):
+    with config_context(PandasToSnowflakeParquetThresholdBytes=request.param):
+        yield
+
+
+def to_snowflake_counter(*, df: pd.DataFrame, if_exists: str) -> SqlCounter:
+    if (
+        df.get_backend() == "Pandas"
+        and df.memory_usage(deep=False).sum()
+        > PandasToSnowflakeParquetThresholdBytes.get()
+    ):
+        # In this case we are using a parquet file to load pandas data to
+        # Snowflake.
+        # if if_exists='fail', we issue a query to check whether the table
+        # exists. In any case, we do issue more queries to make the parquet
+        # file, stage it, and load it into a table, but the SqlCounter doesn't
+        # track those queries.
+        query_count = 1 if if_exists == "fail" else 0
+    elif if_exists in ("append", "fail"):
+        query_count = 2
+    else:
+        assert if_exists == "replace"
+        # In this case, we can skip the query that checks whether the table
+        # exists.
+        query_count = 1
+    return SqlCounter(query_count=query_count)
 
 
 @pytest.mark.parametrize("index", [True, False])
 @pytest.mark.parametrize("index_labels", [None, ["my_index"]])
-# one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=2)
 def test_to_snowflake_index(test_table_name, index, index_labels):
     df = pd.DataFrame(
-        {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
+        {"a": [1, 2, 3], "b": [4, 5, 6]}, index=native_pd.Index([2, 3, 4], name="index")
     )
 
-    df.to_snowflake(
-        test_table_name, if_exists="replace", index=index, index_label=index_labels
-    )
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(
+            test_table_name, if_exists=if_exists, index=index, index_label=index_labels
+        )
     expected_columns = []
     if index:
         # if index is retained in the result, add it as the first expected column
@@ -38,7 +115,6 @@ def test_to_snowflake_index(test_table_name, index, index_labels):
     verify_columns(test_table_name, expected_columns)
 
 
-@sql_count_checker(query_count=1)
 def test_to_snowflake_multiindex(test_table_name):
     index = native_pd.MultiIndex.from_arrays(
         [[1, 1, 2, 2], ["red", "blue", "red", "blue"]], names=("number", "color")
@@ -47,7 +123,9 @@ def test_to_snowflake_multiindex(test_table_name):
         [[1] * 2, [2] * 2, [3] * 2, [4] * 2], index=index, columns=["a", "b"]
     )
     snow_df = pd.DataFrame(native_df)
-    snow_df.to_snowflake(test_table_name, if_exists="replace", index=True)
+    if_exists = "replace"
+    with to_snowflake_counter(df=snow_df, if_exists=if_exists):
+        snow_df.to_snowflake(test_table_name, if_exists=if_exists, index=True)
     verify_columns(test_table_name, ["number", "color", "a", "b"])
 
     with pytest.raises(
@@ -94,14 +172,17 @@ def test_to_snowflake_if_exists(session, test_table_name):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
     # Verify new table is created
-    with SqlCounter(query_count=2):
-        df.to_snowflake(test_table_name, if_exists="fail", index=False)
-        verify_columns(test_table_name, ["a", "b"])
+    if_exists = "fail"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
+    verify_columns(test_table_name, ["a", "b"])
 
-    # Verify attempt to write to existing table fails
+    # Verify attempt to write to existing table fails.
+    # Just one query to find that the table already exists.
+    if_exists = "fail"
     with SqlCounter(query_count=1):
         with pytest.raises(ValueError):
-            df.to_snowflake(test_table_name, if_exists="fail", index=False)
+            df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
 
     # Verify by default attempt to write to existing table fails
     with SqlCounter(query_count=1):
@@ -109,23 +190,26 @@ def test_to_snowflake_if_exists(session, test_table_name):
             df.to_snowflake(test_table_name, index=False)
 
     # Verify existing table is replaced with new data
+    if_exists = "replace"
     df = pd.DataFrame({"a": [1, 2, 3], "c": [4, 5, 6]})
-    with SqlCounter(query_count=2):
-        df.to_snowflake(test_table_name, if_exists="replace", index=False)
-        verify_columns(test_table_name, ["a", "c"])
-        verify_num_rows(session, test_table_name, 3)
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
+    verify_columns(test_table_name, ["a", "c"])
+    verify_num_rows(session, test_table_name, 3)
 
     # Verify data is appended to existing table
-    with SqlCounter(query_count=3):
-        df.to_snowflake(test_table_name, if_exists="append", index=False)
-        verify_columns(test_table_name, ["a", "c"])
-        verify_num_rows(session, test_table_name, 6)
+    if_exists = "append"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
+    verify_columns(test_table_name, ["a", "c"])
+    verify_num_rows(session, test_table_name, 6)
 
     # Verify pd.to_snowflake operates the same
-    with SqlCounter(query_count=3):
-        pd.to_snowflake(df, test_table_name, if_exists="append", index=False)
-        verify_columns(test_table_name, ["a", "c"])
-        verify_num_rows(session, test_table_name, 9)
+    if_exists = "append"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        pd.to_snowflake(df, test_table_name, if_exists=if_exists, index=False)
+    verify_columns(test_table_name, ["a", "c"])
+    verify_num_rows(session, test_table_name, 9)
 
     # Verify invalid 'if_exists' input.
     with SqlCounter(query_count=0):
@@ -134,87 +218,96 @@ def test_to_snowflake_if_exists(session, test_table_name):
 
 
 @pytest.mark.parametrize("index_label", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=1)
 def test_to_snowflake_index_labels(index_label, test_table_name):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    df.to_snowflake(
-        test_table_name, if_exists="replace", index=True, index_label=index_label
-    )
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(
+            test_table_name, if_exists=if_exists, index=True, index_label=index_label
+        )
     verify_columns(test_table_name, [str(index_label), "a", "b"])
 
 
 @pytest.mark.parametrize("col_name", VALID_PANDAS_LABELS)
-@sql_count_checker(query_count=1)
-def test_to_snowflake_column_names_from_panadas(col_name, test_table_name):
+def test_to_snowflake_column_names_from_pandas(col_name, test_table_name):
     df = pd.DataFrame({col_name: [1, 2, 3], "b": [4, 5, 6]})
-    df.to_snowflake(test_table_name, if_exists="replace", index=False)
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists="replace", index=False)
     verify_columns(test_table_name, [str(col_name), "b"])
 
 
 @pytest.mark.parametrize("col_name", VALID_SNOWFLAKE_COLUMN_NAMES)
 @pytest.mark.parametrize("if_exists", ["append", "replace"])
 def test_column_names_with_read_snowflake_and_to_snowflake(
-    col_name, if_exists, session
+    col_name, if_exists, session, test_table_name
 ):
-    with SqlCounter(query_count=6 if if_exists == "append" else 5):
-        # Create a table
-        session.sql(f"create or replace table t1 ({col_name} int)").collect()
-        session.sql("insert into t1 values (1), (2), (3)").collect()
-        data = session.sql(f"select {col_name} from t1").collect()
-        assert len(data) == 3
-        # Capture column names of origing table.
-        expected_columns = session.table("t1").columns
+    # Create a table
+    session.sql(f"create or replace table {test_table_name} ({col_name} int)").collect()
+    session.sql(f"insert into {test_table_name} values (1), (2), (3)").collect()
+    data = session.sql(f"select {col_name} from {test_table_name}").collect()
+    assert len(data) == 3
 
-        df = pd.read_snowflake("t1")
-        df.to_snowflake("t1", if_exists=if_exists, index=False)
-        # Verify column names are not updated here.
-        assert expected_columns == session.table("t1").columns
-        data = session.sql(f"select {col_name} from t1").collect()
-        assert len(data) == (6 if if_exists == "append" else 3)
+    # Capture column names of origing table.
+    expected_columns = session.table(test_table_name).columns
+
+    df = pd.read_snowflake(test_table_name)
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
+    # Verify column names are not updated here.
+    assert expected_columns == session.table(test_table_name).columns
+    data = session.sql(f"select {col_name} from {test_table_name}").collect()
+    assert len(data) == (6 if if_exists == "append" else 3)
 
 
-@sql_count_checker(query_count=1)
 def test_to_snowflake_column_with_quotes(session, test_table_name):
     df = pd.DataFrame({'a"b': [1, 2, 3], 'a""b': [4, 5, 6]})
-    df.to_snowflake(test_table_name, if_exists="replace", index=False)
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
     verify_columns(test_table_name, ['a"b', 'a""b'])
 
 
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
 def test_to_snowflake_index_label_none(test_table_name):
     # no index
-    with SqlCounter(query_count=1):
-        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-        df.to_snowflake(test_table_name, if_exists="replace")
-        verify_columns(test_table_name, ["index", "a", "b"])
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists)
+    verify_columns(test_table_name, ["index", "a", "b"])
 
     # named index
-    with SqlCounter(query_count=2):
-        df = pd.DataFrame(
-            {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
-        )
-        df.to_snowflake(test_table_name, if_exists="replace", index_label=[None])
-        verify_columns(test_table_name, ["index", "a", "b"])
+    if_exists = "replace"
+    df = pd.DataFrame(
+        {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
+    )
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index_label=[None])
+    verify_columns(test_table_name, ["index", "a", "b"])
 
     # nameless index
-    with SqlCounter(query_count=2):
-        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4]))
-        df.to_snowflake(test_table_name, if_exists="replace", index_label=[None])
-        verify_columns(test_table_name, ["index", "a", "b"])
+    if_exists = "replace"
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4]))
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists, index_label=[None])
+    verify_columns(test_table_name, ["index", "a", "b"])
 
 
 # one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=4)
 def test_to_snowflake_index_label_none_data_column_conflict(test_table_name):
     df = pd.DataFrame({"index": [1, 2, 3], "a": [4, 5, 6]})
-    df.to_snowflake(test_table_name, if_exists="replace")
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists)
     # If the column name "index" is taken by one of the data columns,
     # then "level_0" is used instead for naming the index column.
     # This is based on the behavior of reset_index.
     verify_columns(test_table_name, ["level_0", "index", "a"])
 
     df = pd.DataFrame(
-        {"index": [1, 2, 3], "a": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
+        {"index": [1, 2, 3], "a": [4, 5, 6]},
+        index=native_pd.Index([2, 3, 4], name="index"),
     )
     # If the index already has a name, "index", then "level_0" is not used,
     # and a ValueError is raised instead.
@@ -224,15 +317,16 @@ def test_to_snowflake_index_label_none_data_column_conflict(test_table_name):
 
     # nameless index
     df = pd.DataFrame({"index": [1, 2, 3], "a": [4, 5, 6]}, index=pd.Index([2, 3, 4]))
-    df.to_snowflake(test_table_name, if_exists="replace", index_label=[None])
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(test_table_name, if_exists=if_exists, index_label=[None])
     verify_columns(test_table_name, ["level_0", "index", "a"])
 
 
-# one extra query to convert index to native pandas when creating the snowpark pandas dataframe
-@sql_count_checker(query_count=1)
+@sql_count_checker(query_count=0)
 def test_to_snowflake_data_label_none_raises(test_table_name):
     df = pd.DataFrame(
-        {"a": [1, 2, 3], "b": [4, 5, 6]}, index=pd.Index([2, 3, 4], name="index")
+        {"a": [1, 2, 3], "b": [4, 5, 6]}, index=native_pd.Index([2, 3, 4], name="index")
     )
     df.columns = ["c", None]
 
@@ -243,11 +337,11 @@ def test_to_snowflake_data_label_none_raises(test_table_name):
         df.to_snowflake(test_table_name, if_exists="replace")
 
 
-@sql_count_checker(query_count=2)
-def test_to_snowflake_with_dropped_row_position():
+def test_to_snowflake_with_dropped_row_position(test_table_name):
     snow_df = pd.DataFrame({"a": [1, 2, 3], "b": [2, 4, 5]})
     snow_df = snow_df.groupby("a").count().reset_index()
-    snow_df.to_snowflake("out", index=False, table_type="temporary")
+    with to_snowflake_counter(df=snow_df, if_exists="fail"):
+        snow_df.to_snowflake(test_table_name, index=False, table_type="temporary")
 
 
 def verify_columns(table_name: str, expected: list[str]) -> None:
@@ -260,7 +354,6 @@ def verify_num_rows(session, table_name: str, expected: int) -> None:
     assert actual == expected
 
 
-@sql_count_checker(query_count=1)
 def test_timedelta_to_snowflake_with_read_snowflake(test_table_name, caplog):
     with caplog.at_level(logging.WARNING):
         df = pd.DataFrame(
@@ -270,7 +363,28 @@ def test_timedelta_to_snowflake_with_read_snowflake(test_table_name, caplog):
                 "t": native_pd.timedelta_range("1 days", periods=3),
             }
         )
-        df.to_snowflake(test_table_name, index=False, if_exists="replace")
+        if_exists = "replace"
+        with to_snowflake_counter(df=df, if_exists=if_exists):
+            df.to_snowflake(test_table_name, index=False, if_exists=if_exists)
         df = pd.read_snowflake(test_table_name)
-        assert df.dtypes[-1] == "int64"
+        assert df.dtypes[-1] == "float64"
         assert "`TimedeltaType` may be lost in `to_snowflake`'s result" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "table_name_fixture",
+    (
+        "lower_case_table_name_unquoted",
+        "lower_case_table_name_quoted",
+        "upper_case_table_name_quoted",
+        "upper_case_table_name_with_space_quoted",
+    ),
+)
+def test_table_name(request, table_name_fixture):
+    name = request.getfixturevalue(table_name_fixture)
+    native_df = native_pd.DataFrame({"a": [1]})
+    df = pd.DataFrame(native_df)
+    if_exists = "replace"
+    with to_snowflake_counter(df=df, if_exists=if_exists):
+        df.to_snowflake(name, if_exists=if_exists, index=False)
+    pd.read_snowflake(name)

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -65,17 +65,20 @@ def valid_unquoted_identifier_table_name(session):
     Utils.drop_table(session, name)
 
 
-@pytest.fixture(params=("pandas", "snowflake"), autouse=True)
-def starting_backend(request) -> str:
-    with config_context(Backend=request.param):
-        yield
-
-
 @pytest.fixture(
-    params=[0, int(1e9)], autouse=True, ids=lambda param: f"parquet_threshold_{param}"
+    params=[
+        ("pandas", 0),
+        ("pandas", int(1e9)),
+        ("snowflake", 0),
+    ],
+    autouse=True,
+    ids=lambda param: f"backend_{param[0]}-parquet_threshold_{param[1]}",
 )
-def parquet_threshold(request):
-    with config_context(PandasToSnowflakeParquetThresholdBytes=request.param):
+def starting_backend_and_parquet_threshold(request):
+    with config_context(
+        Backend=request.param[0],
+        PandasToSnowflakeParquetThresholdBytes=request.param[1],
+    ):
         yield
 
 


### PR DESCRIPTION
To implement to_snowflake() for a Snowpark pandas dataframe on the pandas backend with large enough data, upload data via a parquet file instead of via a Snowpark dataframe. The Snowpark dataframe typically inserts values through parametrized SQL queries.

Benchmarking showed that a good threshold to switch to parquet was roughly 3 MB, so I've set that as the configurable default switching threshold. Performance of this approach seems to improve with dataset size. Exporting an 800 MB dataframe took about 55 seconds via parquet versus about 429 seconds via the old method, so we get over 7x speedup.

This work took me much longer than expected, so I am sending out this PR with just the changes for DataFrame.to_snowflake(). We can address Series.to_snowflake() separately.

We can take a similar approach to speed up pandas_backend_df.move_to('snowflake').

<details>
<summary>benchmark script with a 3XL warehouse</summary>

```python
import pandas as native_pd
import modin.pandas as pd
import snowflake.snowpark.modin.plugin
import numpy as np
import datetime
from snowflake.snowpark.session import Session
from tests.utils import Utils
from multiprocessing import Pool
import psutil



from time import perf_counter

def get_benchmark_result(input_data: native_pd.DataFrame, method: str):
    if method == "parquet":
        pd.session.pandas_to_snowflake_row_limit = 0
    else:
        pd.session.pandas_to_snowflake_row_limit = int(1e99)

    df = pd.DataFrame(input_data).set_backend('pandas').pin_backend()
    table = Utils.random_table_name()
    start = perf_counter()
    df.to_snowflake(table)
    end = perf_counter()
    Utils.drop_table(pd.session, table)
    return {
        "time": datetime.timedelta(seconds=end-start),
        "memory_usage": input_data.memory_usage().sum(),
        "num_rows": input_data.shape[0],
        "num_columns": input_data.shape[1],
        "method": method
    }



# num_processes = psutil.cpu_count(logical=False)
# for 
session = Session.builder.create()
rows = []
for input_data in (
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e0), 1))),     
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e3), 1))),    
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e3), 3))),     
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e4), 1))),
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e4), 3))),    
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e5), 1))),    
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e5), 3))),     
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e6), 1))),
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e6), 3))),    
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e6), 10))),
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e7), 1))),
    native_pd.DataFrame(np.random.randint(low=0,high=1000,size=(int(1e7), 10))),    
):
    for method in ("parquet", "snowpark"):
        rows.append(get_benchmark_result(input_data, method=method))

native_pd.DataFrame(rows).to_parquet('to_snowflake_timing_2', index=False)
```

</details>

<img width="571" height="432" alt="to_snowflake_timing_2" src="https://github.com/user-attachments/assets/0f652f6e-4510-4a94-9a75-028f5e09f2b0" />
