### PR TITLE
SNOW-2389912: Ensure hybrid execution is actually enabled by default

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -577,8 +577,11 @@ jobs:
         run: uv pip install tox --system
       - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
         name: Check AutoSwitchBackend default value
-        # SNOW-2389912: ensure hybrid is correctly enabled by default
-        run: python -m tox -e "py${PYTHON_VERSION}-snowparkpandashybridcheck-modin-ci"
+        # SNOW-2389912: Ensure hybrid is correctly enabled by default. We can't use pytest because
+        # our test suite sets the AutoSwitchBackend variable explicitly.
+        run: |
+          python -m tox -e "py${PYTHON_VERSION}-snowparkpandashybridcheck_sessionfirst-modin-ci" \
+          && python -m tox -e "py${PYTHON_VERSION}-snowparkpandashybridcheck_pluginfirst-modin-ci"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           cloud_provider: ${{ matrix.cloud-provider }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -575,6 +575,13 @@ jobs:
         run: uv pip install -U setuptools pip wheel --system
       - name: Install tox
         run: uv pip install tox --system
+      - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
+        name: Check AutoSwitchBackend default value
+        # SNOW-2389912: ensure hybrid is correctly enabled by default
+        run: python -m tox -e "py${PYTHON_VERSION}-snowparkpandashybridcheck-modin-ci"
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          cloud_provider: ${{ matrix.cloud-provider }}
         # only run doctest for macos on aws
       - if: ${{ matrix.os == 'macos-latest' && matrix.cloud-provider == 'aws' }}
         name: Run Snowpark pandas API doctests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Release History
 
-## 1.40.1 (YYY-MM-DD)
-
-### Snowpark pandas API Updates
-
-### Bug Fixes
-
-- Fixed a bug where `AutoSwitchBackend` would be inappropriately disabled if a Snowpark session was created before running `import snowflake.snowpark.modin.plugin`.
-
 ## 1.40.0 (YYYY-MM-DD)
 
 ### Snowpark Python API Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.40.1 (YYY-MM-DD)
+
+### Snowpark pandas API Updates
+
+### Bug Fixes
+
+- Fixed a bug where `AutoSwitchBackend` would be inappropriately disabled if a Snowpark session was created before running `import snowflake.snowpark.modin.plugin`.
+
 ## 1.40.0 (YYYY-MM-DD)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -759,13 +759,16 @@ class Session:
             try:
                 from modin.config import AutoSwitchBackend
 
-                pandas_hybrid_execution_enabled: bool = (
-                    self._conn._get_client_side_session_parameter(
-                        _SNOWPARK_PANDAS_HYBRID_EXECUTION_ENABLED,
-                        AutoSwitchBackend().get(),
-                    )
+                pandas_hybrid_execution_enabled: Union[
+                    bool, None
+                ] = self._conn._get_client_side_session_parameter(
+                    _SNOWPARK_PANDAS_HYBRID_EXECUTION_ENABLED, None
                 )
-                AutoSwitchBackend.put(pandas_hybrid_execution_enabled)
+                # Only set AutoSwitchBackend if the session parameter was already set.
+                # snowflake.snowpark.modin.plugin sets AutoSwitchBackend to True if it was
+                # not already set, so we should not change the variable if it's in its default state.
+                if pandas_hybrid_execution_enabled is not None:
+                    AutoSwitchBackend.put(pandas_hybrid_execution_enabled)
             except Exception:
                 # Continue session initialization even if Modin configuration fails
                 pass

--- a/tox.ini
+++ b/tox.ini
@@ -135,7 +135,9 @@ commands =
     # This one is only called by jenkins job and the only difference from `snowparkpandasnotdoctest` is that it uses
     # MODIN_PYTEST_NO_COV_CMD instead of MODIN_PYTEST_CMD
     snowparkpandasjenkins: {env:MODIN_PYTEST_NO_COV_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin
-    snowparkpandashybridcheck: python -c "from snowflake.snowpark.session import Session; Session.builder.getOrCreate(); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
+    # These jobs run outside pytest since we manipulate AutoSwitchBackend during pytest setup and we want to test a fresh session.
+    snowparkpandashybridcheck_sessionfirst: python -c "from snowflake.snowpark.session import Session; Session.builder.getOrCreate(); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
+    snowparkpandashybridcheck_pluginfirst: python -c "import snowflake.snowpark.modin.plugin; from snowflake.snowpark.session import Session; Session.builder.getOrCreate(); from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
     # Snowpark IR commands:
     ast: {env:SNOWFLAKE_PYTEST_DAILY_CMD} -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,7 @@ commands =
     # This one is only called by jenkins job and the only difference from `snowparkpandasnotdoctest` is that it uses
     # MODIN_PYTEST_NO_COV_CMD instead of MODIN_PYTEST_CMD
     snowparkpandasjenkins: {env:MODIN_PYTEST_NO_COV_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin
+    snowparkpandashybridcheck: python -c "from snowflake.snowpark.session import Session; Session.builder.getOrCreate(); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
     # Snowpark IR commands:
     ast: {env:SNOWFLAKE_PYTEST_DAILY_CMD} -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -136,8 +136,8 @@ commands =
     # MODIN_PYTEST_NO_COV_CMD instead of MODIN_PYTEST_CMD
     snowparkpandasjenkins: {env:MODIN_PYTEST_NO_COV_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin
     # These jobs run outside pytest since we manipulate AutoSwitchBackend during pytest setup and we want to test a fresh session.
-    snowparkpandashybridcheck_sessionfirst: python -c "from tests.parameters import CONNECTION_PARAMETERS; from snowflake.snowpark.session import Session; Session.builder.configs(CONNECTION_PARAMETERS); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
-    snowparkpandashybridcheck_pluginfirst: python -c "from tests.parameters import CONNECTION_PARAMETERS; import snowflake.snowpark.modin.plugin; from snowflake.snowpark.session import Session; Session.builder.configs(CONNECTION_PARAMETERS); from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
+    snowparkpandashybridcheck_sessionfirst: python -c "from tests.parameters import CONNECTION_PARAMETERS; from snowflake.snowpark.session import Session; Session.builder.configs(CONNECTION_PARAMETERS).create(); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
+    snowparkpandashybridcheck_pluginfirst: python -c "from tests.parameters import CONNECTION_PARAMETERS; import snowflake.snowpark.modin.plugin; from snowflake.snowpark.session import Session; Session.builder.configs(CONNECTION_PARAMETERS).create(); from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
     # Snowpark IR commands:
     ast: {env:SNOWFLAKE_PYTEST_DAILY_CMD} -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -136,8 +136,8 @@ commands =
     # MODIN_PYTEST_NO_COV_CMD instead of MODIN_PYTEST_CMD
     snowparkpandasjenkins: {env:MODIN_PYTEST_NO_COV_CMD} --durations=20 -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} {env:SNOW_1314507_WORKAROUND_RERUN_FLAGS} tests/unit/modin tests/integ/modin
     # These jobs run outside pytest since we manipulate AutoSwitchBackend during pytest setup and we want to test a fresh session.
-    snowparkpandashybridcheck_sessionfirst: python -c "from snowflake.snowpark.session import Session; Session.builder.getOrCreate(); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
-    snowparkpandashybridcheck_pluginfirst: python -c "import snowflake.snowpark.modin.plugin; from snowflake.snowpark.session import Session; Session.builder.getOrCreate(); from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
+    snowparkpandashybridcheck_sessionfirst: python -c "from tests.parameters import CONNECTION_PARAMETERS; from snowflake.snowpark.session import Session; Session.builder.configs(CONNECTION_PARAMETERS); import snowflake.snowpark.modin.plugin; from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
+    snowparkpandashybridcheck_pluginfirst: python -c "from tests.parameters import CONNECTION_PARAMETERS; import snowflake.snowpark.modin.plugin; from snowflake.snowpark.session import Session; Session.builder.configs(CONNECTION_PARAMETERS); from modin.config import AutoSwitchBackend; assert AutoSwitchBackend.get() is True"
     # Snowpark IR commands:
     ast: {env:SNOWFLAKE_PYTEST_DAILY_CMD} -m "{env:SNOWFLAKE_TEST_TYPE}" {posargs:} tests
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2389912

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Hybrid execution was accidentally disabled by default in #3789 in certain cases, which wrote to the `AutoSwitchBackend` variable during [session initialization](https://github.com/snowflakedb/snowpark-python/blob/d02aa5ce540afa6e10e536107880659f7321f589/src/snowflake/snowpark/session.py#L759-L768) before the [https://github.com/snowflakedb/snowpark-python/blob/d02aa5ce540afa6e10e536107880659f7321f589/src/snowflake/snowpark/modin/plugin/__init__.py#L1[…]86](https://github.com/snowflakedb/snowpark-python/blob/d02aa5ce540afa6e10e536107880659f7321f589/src/snowflake/snowpark/modin/plugin/__init__.py#L185-L186) (which checked if `AutoSwitchBackend` was explicitly set) could occur. If the session was initialized before plugin import, this would force the flag to be set to False inappropriately.