### PR TITLE
SNOW-2380267: Fix column_multiindex_pandas_df.to_snowflake().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
   - Fixed an issue that caused the program to hang during multithreaded Parquet based ingestion when a data fetching error occurred.
   - Fixed a bug in schema parsing when custom schema strings used upper-cased data type names (NUMERIC, NUMBER, DECIMAL, VARCHAR, STRING, TEXT).
 - Fixed a bug in `Session.create_dataframe` where schema string parsing failed when using upper-cased data type names (e.g., NUMERIC, NUMBER, DECIMAL, VARCHAR, STRING, TEXT).
+- Fixed a bug where writing Snowpark pandas dataframes on the pandas backend with a column multiindex to Snowflake with `to_snowflake` would raise `KeyError`.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/dataframe_extensions.py
@@ -150,7 +150,11 @@ def pandas_to_snowflake(
         )
 
     pd.session.write_pandas(
-        pandas_frame.rename(str, axis=1),
+        # use set_axis() this way so that we can also flatten the tuple column
+        # labels of a column multi-index, e.g. if `pandas_frame` has columns
+        # pd.MultiIndex.from_tuples([('a', 0), ('b', 'c')]), then this will
+        # rename the columns to ["('a', 0)", "('b', 'c')"]
+        pandas_frame.set_axis([str(column) for column in pandas_frame.columns], axis=1),
         # We want to pass table_name as is, but quote column names. This is
         # undocumented behavior of to_snowflake() on the "Snowflake" backend, so
         # we mimic it here.

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -129,7 +129,7 @@ def test_to_snowflake_index(test_table_name, index, index_labels):
     verify_columns(test_table_name, expected_columns)
 
 
-def test_to_snowflake_multiindex(test_table_name):
+def test_to_snowflake_row_multiindex(test_table_name):
     index = native_pd.MultiIndex.from_arrays(
         [[1, 1, 2, 2], ["red", "blue", "red", "blue"]], names=("number", "color")
     )
@@ -148,6 +148,17 @@ def test_to_snowflake_multiindex(test_table_name):
         snow_df.to_snowflake(
             test_table_name, if_exists="replace", index=True, index_label=["a"]
         )
+
+
+def test_column_multiindex(test_table_name):
+    native_df = native_pd.DataFrame(
+        [[1, 2]], columns=pd.MultiIndex.from_tuples([("a", 0), ("b", "c")])
+    )
+    snow_df = pd.DataFrame(native_df)
+    if_exists = "replace"
+    with to_snowflake_counter(dataset=snow_df, if_exists=if_exists):
+        snow_df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
+    verify_columns(test_table_name, [str(column) for column in native_df.columns])
 
 
 @pytest.mark.parametrize(

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -156,7 +156,7 @@ def test_column_multiindex(test_table_name):
     )
     snow_df = pd.DataFrame(native_df)
     if_exists = "replace"
-    with to_snowflake_counter(dataset=snow_df, if_exists=if_exists):
+    with to_snowflake_counter(df=snow_df, if_exists=if_exists):
         snow_df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
     verify_columns(test_table_name, [str(column) for column in native_df.columns])
 


### PR DESCRIPTION
Stop raising `KeyError` for pandas_backend_df_with_column_multiindex.to_snowflake().
