### PR TITLE
SNOW-2397930: Add support for isna, isnull, notna, and notnull in faster pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
 - Improved performance of `DataFrame.to_snowflake` and `pd.to_snowflake(dataframe)` for large data by uploading data via a parquet file. You can control the dataset size at which Snowpark pandas switches to parquet with the variable `modin.config.PandasToSnowflakeParquetThresholdBytes`.
 - Improved performance of `Series.to_snowflake` and `pd.to_snowflake(series)` for large data by uploading data via a parquet file. You can control the dataset size at which Snowpark pandas switches to parquet with the variable `modin.config.PandasToSnowflakeParquetThresholdBytes`.
 - Set `cte_optimization_enabled` to True for all Snowpark pandas sessions.
+- Add support for `isna`, `isnull`, `notna`, `notnull` in faster pandas.
 
 ## 1.39.1 (2025-09-25)
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -10732,6 +10732,17 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
     def isna(self) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _isna_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._isna_internal()
+
+        qc = self._isna_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _isna_internal(self) -> "SnowflakeQueryCompiler":
+        """
         Check for each element of self whether it's NaN.
 
         Returns
@@ -10746,6 +10757,17 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         return SnowflakeQueryCompiler(new_internal_frame)
 
     def notna(self) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _notna_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._notna_internal()
+
+        qc = self._notna_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _notna_internal(self) -> "SnowflakeQueryCompiler":
         """
         Check for each element of `self` whether it's existing (non-missing) value.
 

--- a/tests/integ/modin/test_faster_pandas.py
+++ b/tests/integ/modin/test_faster_pandas.py
@@ -3,6 +3,7 @@
 #
 
 import copy
+from contextlib import contextmanager
 import modin.pandas as pd
 import pandas as native_pd
 import pytest
@@ -16,6 +17,17 @@ from snowflake.snowpark.session import (
 from tests.integ.modin.utils import assert_frame_equal, assert_index_equal
 from tests.integ.utils.sql_counter import sql_count_checker
 from tests.utils import Utils
+
+
+@contextmanager
+def session_parameter_override(session, parameter_name, value):
+    """Context manager to temporarily override a session parameter and restore it afterwards"""
+    original_value = getattr(session, parameter_name)
+    setattr(session, parameter_name, value)
+    try:
+        yield
+    finally:
+        setattr(session, parameter_name, original_value)
 
 
 @sql_count_checker(query_count=5, join_count=1)
@@ -141,43 +153,41 @@ def test_read_filter_groupby_agg(session):
 def test_read_filter_join_flag_disabled(session):
     # test a chain of operations that are fully supported in faster pandas
     # but with the dummy_row_pos_optimization_enabled flag turned off
-    original_setting = session.dummy_row_pos_optimization_enabled
-    session.dummy_row_pos_optimization_enabled = False
+    with session_parameter_override(
+        session, "dummy_row_pos_optimization_enabled", False
+    ):
+        # create tables
+        table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([[1, 11], [2, 12], [3, 13]], columns=["A", "B"])
+        ).write.save_as_table(table_name1, table_type="temp")
+        table_name2 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([[1, 21], [2, 22], [3, 23]], columns=["C", "D"])
+        ).write.save_as_table(table_name2, table_type="temp")
 
-    # create tables
-    table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-    session.create_dataframe(
-        native_pd.DataFrame([[1, 11], [2, 12], [3, 13]], columns=["A", "B"])
-    ).write.save_as_table(table_name1, table_type="temp")
-    table_name2 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
-    session.create_dataframe(
-        native_pd.DataFrame([[1, 21], [2, 22], [3, 23]], columns=["C", "D"])
-    ).write.save_as_table(table_name2, table_type="temp")
+        # create snow dataframes
+        df1 = pd.read_snowflake(table_name1)
+        df2 = pd.read_snowflake(table_name2)
+        snow_result = df1[df1["B"] > 11].merge(
+            df2[df2["D"] == 22], left_on="A", right_on="C"
+        )
 
-    # create snow dataframes
-    df1 = pd.read_snowflake(table_name1)
-    df2 = pd.read_snowflake(table_name2)
-    snow_result = df1[df1["B"] > 11].merge(
-        df2[df2["D"] == 22], left_on="A", right_on="C"
-    )
+        # verify that the input dataframes have an empty relaxed query compiler
+        assert df1._query_compiler._relaxed_query_compiler is None
+        assert df2._query_compiler._relaxed_query_compiler is None
+        # verify that the output dataframe also has an empty relaxed query compiler
+        assert snow_result._query_compiler._relaxed_query_compiler is None
 
-    # verify that the input dataframes have an empty relaxed query compiler
-    assert df1._query_compiler._relaxed_query_compiler is None
-    assert df2._query_compiler._relaxed_query_compiler is None
-    # verify that the output dataframe also has an empty relaxed query compiler
-    assert snow_result._query_compiler._relaxed_query_compiler is None
+        # create pandas dataframes
+        native_df1 = df1.to_pandas()
+        native_df2 = df2.to_pandas()
+        native_result = native_df1[native_df1["B"] > 11].merge(
+            native_df2[native_df2["D"] == 22], left_on="A", right_on="C"
+        )
 
-    # create pandas dataframes
-    native_df1 = df1.to_pandas()
-    native_df2 = df2.to_pandas()
-    native_result = native_df1[native_df1["B"] > 11].merge(
-        native_df2[native_df2["D"] == 22], left_on="A", right_on="C"
-    )
-
-    # compare results
-    assert_frame_equal(snow_result, native_result)
-
-    session.dummy_row_pos_optimization_enabled = original_setting
+        # compare results
+        assert_frame_equal(snow_result, native_result)
 
 
 @pytest.mark.parametrize("func", ["isna", "isnull", "notna", "notnull"])


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2397930

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add support for isna, isnull, notna, and notnull in faster pandas.
