### PR TITLE
Clarify AsyncJob.status() docstring with QueryStatus values

### DIFF
--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -269,7 +269,7 @@ class AsyncJob:
 
         Possible values are the names from `snowflake.connector.cursor.QueryStatus`, e.g.
         `RUNNING`, `SUCCESS`, `FAILED_WITH_ERROR`, `ABORTING`, `ABORTED`, `QUEUED`,
-        `DISCONNECTED`, `RESUMING_WAREHOUSE`, `QUEUED_REPAIRING_WAREHOUSE`, `RESTARTED`,
+        `FAILED_WITH_INCIDENT`, `DISCONNECTED`, `RESUMING_WAREHOUSE`, `QUEUED_REPAIRING_WAREHOUSE`, `RESTARTED`,
         `BLOCKED`, `NO_DATA`.
         """
         status = self._session._conn._conn.get_query_status(self.query_id)


### PR DESCRIPTION
1. Which Jira issue is this PR addressing?

   Fixes [SNOW-2395063](https://github.com/snowflakedb/snowpark-python/issues/3851)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Description:

   Update `AsyncJob.status()`’s docstring so it enumerates the Python Connector’s
   `QueryStatus.name` values that Snowpark returns, making the possible return values
   discoverable directly from the Snowpark docs.


[SNOW-2395063]: https://snowflakecomputing.atlassian.net/browse/SNOW-2395063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ