### PR TITLE
SNOW-2432532: Update a test regex.

### DIFF
--- a/tests/integ/modin/hybrid/test_switch_operations.py
+++ b/tests/integ/modin/hybrid/test_switch_operations.py
@@ -1201,7 +1201,7 @@ def test_malformed_decorator_conditions():
     # Test malformed condition with callable first element but non-string second element
     with pytest.raises(
         ValueError,
-        match="Invalid condition at index 0.*when first element is callable.*second element must be string",
+        match="Invalid condition at index 0.*when first element is callable.*second element must be a string",
     ):
 
         @register_query_compiler_method_not_implemented(


### PR DESCRIPTION
Commit d9a78495309ae13d01015d3ec4713ba8dee29967 changed the error message for certain malformed NotImplementedError decorators, but did not update the corresponding regex in an integration test. This commit fixes the regex so that `tests/integ/modin/hybrid/test_switch_operations.py::test_malformed_decorator_conditions` passes.