### PR TITLE
SNOW-2441438: Add modin dependency to import error tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -236,6 +236,7 @@ commands = python -m pip list --format=columns
            python -c "print(r'{envpython}')"
 
 [testenv:snowpark_pandas_modin_pandas_import_error]
+deps = .[modin-development]
 description = test error messages when importing unsupported modin or pandas versions
 basepython = python3.9
 setenv = TEST_INCORRECT_MODIN_PANDAS_VERSIONS=True


### PR DESCRIPTION
With this change, `tox -e snowpark_pandas_modin_pandas_import_error` passes instead of failing.