### PR TITLE
SNOW-2436917: fix udxf/sproc registration regression

### DIFF
--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1134,7 +1134,7 @@ def resolve_imports_and_packages(
     skip_upload_on_content_match: bool = False,
     is_permanent: bool = False,
     force_inline_code: bool = False,
-    **kwargs,
+    _suppress_local_package_warnings: bool = False,
 ) -> Tuple[
     Optional[str],
     Optional[str],
@@ -1168,9 +1168,7 @@ def resolve_imports_and_packages(
                     packages,
                     include_pandas=is_pandas_udf,
                     statement_params=statement_params,
-                    _suppress_local_package_warnings=kwargs.get(
-                        "_suppress_local_package_warnings", False
-                    ),
+                    _suppress_local_package_warnings=_suppress_local_package_warnings,
                 )
                 if packages is not None
                 else session._resolve_packages(
@@ -1179,9 +1177,7 @@ def resolve_imports_and_packages(
                     validate_package=False,
                     include_pandas=is_pandas_udf,
                     statement_params=statement_params,
-                    _suppress_local_package_warnings=kwargs.get(
-                        "_suppress_local_package_warnings", False
-                    ),
+                    _suppress_local_package_warnings=_suppress_local_package_warnings,
                 )
             )
 

--- a/src/snowflake/snowpark/stored_procedure.py
+++ b/src/snowflake/snowpark/stored_procedure.py
@@ -955,7 +955,10 @@ class StoredProcedureRegistration:
             is_permanent=is_permanent,
             force_inline_code=force_inline_code,
             artifact_repository=artifact_repository,
-            **kwargs,
+            _suppress_local_package_warnings=kwargs.get(
+                "_suppress_local_package_warnings", False
+            ),
+            # DO NOT pass **kwargs here, as it can lead to TypeError: multiple values for the same argument
         )
 
         runtime_version_from_requirement = None

--- a/src/snowflake/snowpark/udaf.py
+++ b/src/snowflake/snowpark/udaf.py
@@ -799,7 +799,10 @@ class UDAFRegistration:
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
             artifact_repository=artifact_repository,
-            **kwargs,
+            _suppress_local_package_warnings=kwargs.get(
+                "_suppress_local_package_warnings", False
+            ),
+            # DO NOT pass **kwargs here, as it can lead to TypeError: multiple values for the same argument
         )
 
         runtime_version_from_requirement = None

--- a/src/snowflake/snowpark/udf.py
+++ b/src/snowflake/snowpark/udf.py
@@ -994,7 +994,10 @@ class UDFRegistration:
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
             artifact_repository=artifact_repository,
-            **kwargs,
+            _suppress_local_package_warnings=kwargs.get(
+                "_suppress_local_package_warnings", False
+            ),
+            # DO NOT pass **kwargs here, as it can lead to TypeError: multiple values for the same argument
         )
 
         runtime_version_from_requirement = None

--- a/src/snowflake/snowpark/udtf.py
+++ b/src/snowflake/snowpark/udtf.py
@@ -1056,7 +1056,10 @@ class UDTFRegistration:
             skip_upload_on_content_match=skip_upload_on_content_match,
             is_permanent=is_permanent,
             artifact_repository=artifact_repository,
-            **kwargs,
+            _suppress_local_package_warnings=kwargs.get(
+                "_suppress_local_package_warnings", False
+            )
+            # DO NOT pass **kwargs here, as it can lead to TypeError: multiple values for the same argument
         )
 
         runtime_version_from_requirement = None

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -561,6 +561,18 @@ def test_session_register_sp(session, local_testing_mode):
     )
     assert add_sp(1, 2) == 3
 
+    # testing SNOW-2436917
+    add_sp_passing_session = session.sproc.register(
+        lambda session_, x, y: session_.create_dataframe([(x, y)])
+        .to_df("a", "b")
+        .select(col("a") + col("b"))
+        .collect()[0][0],
+        session=session,
+        return_type=IntegerType(),
+        input_types=[IntegerType(), IntegerType()],
+    )
+    assert add_sp_passing_session(1, 2) == 3
+
     query_tag = f"QUERY_TAG_{Utils.random_alphanumeric_str(10)}"
     add_sp = session.sproc.register(
         lambda session_, x, y: session_.create_dataframe([(x, y)])

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -396,6 +396,23 @@ def test_session_register_udf(session, local_testing_mode):
             Row(7),
         ],
     )
+
+    # testing SNOW-SNOW-2436917
+    add_udf_passing_session = session.udf.register(
+        lambda x, y: x + y,
+        session=session,
+        return_type=IntegerType(),
+        input_types=[IntegerType(), IntegerType()],
+    )
+    assert isinstance(add_udf_passing_session.func, Callable)
+    Utils.check_answer(
+        df.select(add_udf_passing_session("a", "b")).collect(),
+        [
+            Row(3),
+            Row(7),
+        ],
+    )
+
     # Query tags not supported in local testing.
     if not local_testing_mode:
         query_tag = f"QUERY_TAG_{Utils.random_alphanumeric_str(10)}"

--- a/tests/integ/test_udtf.py
+++ b/tests/integ/test_udtf.py
@@ -1335,6 +1335,17 @@ def test_udtf_comment(session):
     ddl_sql = f"select get_ddl('FUNCTION', '{echo_udtf.name}(number)')"
     assert comment in session.sql(ddl_sql).collect()[0][0]
 
+    # testing SNOW-SNOW-2436917
+    echo_udtf_passing_session = session.udtf.register(
+        EchoUDTF,
+        output_schema=["num"],
+        comment=comment,
+        session=session,
+    )
+
+    ddl_sql = f"select get_ddl('FUNCTION', '{echo_udtf_passing_session.name}(number)')"
+    assert comment in session.sql(ddl_sql).collect()[0][0]
+
 
 @pytest.mark.parametrize("from_file", [True, False])
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

Fixes a regression introduced in #3812, **kwargs will lead to multiple values for argument TypeError as users may mis-use the public facing api



2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
