### PR TITLE
SNOW-2444540: Cap scipy<=1.16.0 in tests temporarily.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,10 @@ DEVELOPMENT_REQUIREMENTS = [
     "lxml",  # used in XML reader unit tests
 ]
 MODIN_DEVELOPMENT_REQUIREMENTS = [
-    "scipy",  # Snowpark pandas 3rd party library testing
+    # Snowpark pandas 3rd party library testing. Cap the scipy version because
+    # Snowflake cannot find newer versions of scipy for python 3.11+. See
+    # SNOW-2452791.
+    "scipy<=1.16.0",
     "statsmodels",  # Snowpark pandas 3rd party library testing
     "scikit-learn",  # Snowpark pandas 3rd party library testing
     # plotly version restricted due to foreseen change in query counts in version 6.0.0+


### PR DESCRIPTION
Snowflake can't find scipy>1.16.0 for UDFs with python >=3.11.

This change fixes the doctests according to this check:

```bash
PYTHON_VERSION=3.11 python -m tox -r -e "py${PYTHON_VERSION}-doctest-snowparkpandasdoctest-modin-ci"  -- -k "apply or map or transform"
```