### PR TITLE
remove types and dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Catalog API now uses SQL commands instead of SnowAPI calls. This new implementation is more reliable now.
 
+#### Dependency Updates
+
+- Catalog API no longer uses types declared in `snowflake.core` and therefore this dependency was removed.
+
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ DEVELOPMENT_REQUIREMENTS = [
     "pytest-assume",  # sql counter check
     "decorator",  # sql counter check
     "tox",  # used for setting up testing environments
-    "snowflake.core>=1.0.0, <2",  # Catalog
     "psutil",  # testing for telemetry
     "lxml",  # used in XML reader unit tests
 ]

--- a/src/snowflake/snowpark/_immutable_attr_dict.py
+++ b/src/snowflake/snowpark/_immutable_attr_dict.py
@@ -1,0 +1,180 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import keyword
+import json
+
+from collections.abc import Mapping
+
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    Tuple,
+    Optional,
+    Union,
+)
+
+
+class ImmutableAttrDict(Mapping):
+    """
+    An immutable mapping whose (identifier-valid, non-keyword, non-private) keys
+    are also available as read-only attributes. Nested mappings are recursively
+    wrapped as ImmutableAttrDict instances.
+
+    By default also recursively freezes:
+        - dict / Mapping  -> ImmutableAttrDict
+        - list / tuple    -> tuple
+        - set             -> frozenset
+        - other types     -> unchanged
+
+    Access:
+        d.foo   (if 'foo' is a valid identifier key)
+        d['foo'] (always works)
+
+    Invalid / reserved keys (not identifiers, keywords, or starting with '_')
+    are still accessible via item lookup but not as attributes.
+    """
+
+    __slots__ = ("_data", "_frozen")
+
+    # ------------- Construction / conversion helpers -----------------
+    @classmethod
+    def _convert(cls, value: Any) -> Any:
+        """Recursively convert nested structures."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, Mapping):
+            # Ensure plain dict form for predictability
+            return cls(value)
+        if isinstance(value, list) or isinstance(value, tuple):
+            return tuple(cls._convert(v) for v in value)
+        if isinstance(value, set):
+            return frozenset(cls._convert(v) for v in value)
+        # For other iterables you could add handling if desired.
+        return value
+
+    @staticmethod
+    def _is_exposable_attr_name(name: str) -> bool:
+        """Return True if name can safely be set as an attribute."""
+        return bool(
+            name
+            and name[0] != "_"
+            and name.isidentifier()
+            and not keyword.iskeyword(name)
+        )
+
+    def __init__(
+        self,
+        mapping: Optional[Union[Mapping[str, Any], Iterable[Tuple[str, Any]]]] = None,
+        **kwargs: Any,
+    ) -> None:
+        combined: Dict[str, Any] = {}
+        if mapping is not None:
+            if isinstance(mapping, Mapping):
+                combined.update(mapping)
+            else:
+                for k, v in mapping:
+                    combined[k] = v
+        combined.update(kwargs)
+
+        # Deep-convert values first
+        converted: Dict[str, Any] = {k: self._convert(v) for k, v in combined.items()}
+
+        object.__setattr__(self, "_data", converted)
+
+        # Expose attribute names only for "safe" keys
+        for k, v in converted.items():
+            if self._is_exposable_attr_name(k):
+                object.__setattr__(self, k, v)
+
+        object.__setattr__(self, "_frozen", True)
+
+    # ------------- Factory methods -----------------
+    @classmethod
+    def from_json(cls, j: str) -> "ImmutableAttrDict":
+        parsed = json.loads(j)
+        if not isinstance(parsed, Mapping):
+            raise TypeError("JSON root must be an object to build ImmutableAttrDict")
+        return cls(parsed)
+
+    # ------------- Mapping interface -----------------
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data.get(key, default)
+
+    # ------------- Attribute fallback -----------------
+    def __getattr__(self, name: str) -> Any:
+        data = object.__getattribute__(self, "_data")
+        if name in data and self._is_exposable_attr_name(name):
+            return data[name]
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
+
+    # ------------- Immutability enforcement -----------------
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+        if object.__getattribute__(self, "_frozen"):
+            raise AttributeError(
+                f"{type(self).__name__} is immutable; cannot set attribute {name!r}"
+            )
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if name.startswith("_"):
+            object.__delattr__(self, name)
+            return
+        if object.__getattribute__(self, "_frozen"):
+            raise AttributeError(
+                f"{type(self).__name__} is immutable; cannot delete attribute {name!r}"
+            )
+        object.__delattr__(self, name)
+
+    # ------------- Utilities -----------------
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Return a shallow copy of the underlying storage.
+        Nested ImmutableAttrDict instances are preserved (not converted).
+        For a fully "plain" structure you can use to_plain().
+        """
+        return dict(self._data)
+
+    def to_plain(self) -> Dict[str, Any]:
+        """
+        Recursively convert back to plain Python types:
+            ImmutableAttrDict -> dict
+            tuple/frozenset   -> list (or list for frozenset)
+        """
+
+        def unwrap(v: Any) -> Any:
+            if isinstance(v, ImmutableAttrDict):
+                return {k: unwrap(v._data[k]) for k in v._data}
+            if isinstance(v, tuple):
+                return [unwrap(x) for x in v]
+            if isinstance(v, frozenset):
+                return [unwrap(x) for x in v]
+            return v
+
+        return {k: unwrap(v) for k, v in self._data.items()}
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self._data})"
+
+    def __reduce__(self):
+        return (type(self), (self._data,))

--- a/src/snowflake/snowpark/catalog.py
+++ b/src/snowflake/snowpark/catalog.py
@@ -4,24 +4,16 @@
 
 from ctypes import ArgumentError
 import re
-from typing import List, Optional, Union, TYPE_CHECKING
+from typing import (
+    List,
+    Optional,
+    Union,
+    TYPE_CHECKING,
+)
 
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
+from snowflake.snowpark._immutable_attr_dict import ImmutableAttrDict
 from snowflake.snowpark.exceptions import SnowparkSQLException, NotFoundError
-
-try:
-    from snowflake.core.database import Database  # type: ignore
-    from snowflake.core.database._generated.models import Database as ModelDatabase  # type: ignore
-    from snowflake.core.procedure import Procedure
-    from snowflake.core.schema import Schema  # type: ignore
-    from snowflake.core.schema._generated.models import Schema as ModelSchema  # type: ignore
-    from snowflake.core.table import Table, TableColumn
-    from snowflake.core.user_defined_function import UserDefinedFunction
-    from snowflake.core.view import View
-except ImportError as e:
-    raise ImportError(
-        "Missing optional dependency: 'snowflake.core'."
-    ) from e  # pragma: no cover
 
 from snowflake.snowpark._internal.type_utils import (
     convert_sp_to_sf_type,
@@ -32,6 +24,34 @@ from snowflake.snowpark.types import DataType
 
 if TYPE_CHECKING:
     from snowflake.snowpark.session import Session
+
+
+class Database(ImmutableAttrDict):
+    ...
+
+
+class Schema(ImmutableAttrDict):
+    ...
+
+
+class View(ImmutableAttrDict):
+    ...
+
+
+class Procedure(ImmutableAttrDict):
+    ...
+
+
+class UserDefinedFunction(ImmutableAttrDict):
+    ...
+
+
+class Table(ImmutableAttrDict):
+    ...
+
+
+class TableColumn(ImmutableAttrDict):
+    ...
 
 
 class Catalog:
@@ -191,7 +211,7 @@ class Catalog:
 
         return list(
             map(
-                lambda row: Database._from_model(ModelDatabase.from_json(str(row[0]))),
+                lambda row: Database.from_json(str(row[0])),
                 df.collect(),
             )
         )
@@ -230,7 +250,7 @@ class Catalog:
 
         return list(
             map(
-                lambda row: Schema._from_model(ModelSchema.from_json(str(row[0]))),
+                lambda row: Schema.from_json(str(row[0])),
                 df.collect(),
             )
         )


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-2267482](https://snowflakecomputing.atlassian.net/browse/SNOW-2267482)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR follows up on #3942 and completely removes the dependency on `snowflake.core` by introducing a class that will look like the old pydantic classes. `ImmutableAttrDict` is a class that's like a dictionary, but allows attr access to its values and becomes frozen after creation, the types from `snowflake.core` were replaced by child classes of `ImmutableAttrDict`.


[SNOW-2267482]: https://snowflakecomputing.atlassian.net/browse/SNOW-2267482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ