### PR TITLE
SNOW-2464676: Add support for str.isdigit/islower/isupper/istitle/lower/upper/title in faster pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@
   - `groupby.size`
   - `concat`
   - `copy`
+  - `str.isdigit`
+  - `str.islower`
+  - `str.isupper`
+  - `str.istitle`
+  - `str.lower`
+  - `str.upper`
+  - `str.title`
+  
 - Make faster pandas disabled by default (opt-in instead of opt-out).
 
 ## 1.41.0 (2025-10-23)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -18894,6 +18894,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
     def str_isdigit(self) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _str_isdigit_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._str_isdigit_internal()
+            )
+
+        qc = self._str_isdigit_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_isdigit_internal(self) -> "SnowflakeQueryCompiler":
+        """
         Check whether all characters in each string are digits.
 
         Returns
@@ -18909,6 +18922,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ErrorMessage.method_not_implemented_error("isspace", "Series.str")
 
     def str_islower(self) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _str_islower_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._str_islower_internal()
+            )
+
+        qc = self._str_islower_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_islower_internal(self) -> "SnowflakeQueryCompiler":
         """
         Check whether all characters in each string are lowercase.
 
@@ -18928,6 +18954,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
     def str_isupper(self) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _str_isupper_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._str_isupper_internal()
+            )
+
+        qc = self._str_isupper_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_isupper_internal(self) -> "SnowflakeQueryCompiler":
+        """
         Check whether all characters in each string are uppercase.
 
         Returns
@@ -18945,6 +18984,19 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         return SnowflakeQueryCompiler(new_internal_frame)
 
     def str_istitle(self) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _str_istitle_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._str_istitle_internal()
+            )
+
+        qc = self._str_istitle_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_istitle_internal(self) -> "SnowflakeQueryCompiler":
         """
         Check whether each string is titlecase.
         We do a regex matching as follows
@@ -18974,6 +19026,17 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
     def str_lower(self) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _str_lower_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._str_lower_internal()
+
+        qc = self._str_lower_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_lower_internal(self) -> "SnowflakeQueryCompiler":
+        """
         Convert strings to lowercase.
 
         Returns
@@ -18987,6 +19050,17 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
 
     def str_upper(self) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _str_upper_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._str_upper_internal()
+
+        qc = self._str_upper_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_upper_internal(self) -> "SnowflakeQueryCompiler":
+        """
         Convert strings to uppercase.
 
         Returns
@@ -18999,6 +19073,17 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         return SnowflakeQueryCompiler(new_internal_frame)
 
     def str_title(self) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _str_title_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._str_title_internal()
+
+        qc = self._str_title_internal()
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _str_title_internal(self) -> "SnowflakeQueryCompiler":
         """
         Titlecase the string
 

--- a/tests/integ/modin/test_faster_pandas.py
+++ b/tests/integ/modin/test_faster_pandas.py
@@ -721,6 +721,42 @@ def test_rename(session):
         assert_frame_equal(snow_result, native_result)
 
 
+@pytest.mark.parametrize(
+    "func", ["isdigit", "islower", "istitle", "isupper", "lower", "upper", "title"]
+)
+@sql_count_checker(query_count=3)
+def test_str_no_params(session, func):
+    with session_parameter_override(
+        session, "dummy_row_pos_optimization_enabled", True
+    ):
+        # create tables
+        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([["abc"], ["DEF"], ["cba"]], columns=["A"])
+        ).write.save_as_table(table_name, table_type="temp")
+
+        # create snow dataframes
+        df = pd.read_snowflake(table_name)
+        snow_result = getattr(df["A"].str, func)()
+
+        # verify that the input dataframe has a populated relaxed query compiler
+        assert df._query_compiler._relaxed_query_compiler is not None
+        assert df._query_compiler._relaxed_query_compiler._dummy_row_pos_mode is True
+        # verify that the output dataframe also has a populated relaxed query compiler
+        assert snow_result._query_compiler._relaxed_query_compiler is not None
+        assert (
+            snow_result._query_compiler._relaxed_query_compiler._dummy_row_pos_mode
+            is True
+        )
+
+        # create pandas dataframes
+        native_df = df.to_pandas()
+        native_result = getattr(native_df["A"].str, func)()
+
+        # compare results
+        assert_series_equal(snow_result, native_result)
+
+
 @sql_count_checker(query_count=3)
 def test_str_contains(session):
     with session_parameter_override(


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2464676

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add support for str.isdigit/islower/isupper/istitle/lower/upper/title in faster pandas.
