### PR TITLE
SNOW-2476996: Add support for rolling.min/max/count/sum/mean/std/var/sem/corr in faster pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@
   - `dt.month_name`
   - `dt.day_name`
   - `dt.strftime`  
+  - `rolling.min`
+  - `rolling.max`
+  - `rolling.count`
+  - `rolling.sum`
+  - `rolling.mean`
+  - `rolling.std`
+  - `rolling.var`
+  - `rolling.sem`
+  - `rolling.corr`
 - Make faster pandas disabled by default (opt-in instead of opt-out).
 
 ## 1.42.0 (2025-10-28)

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -16894,6 +16894,35 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_count_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._rolling_count_internal(
+                    fold_axis=fold_axis,
+                    rolling_kwargs=rolling_kwargs,
+                    numeric_only=numeric_only,
+                    **kwargs,
+                )
+            )
+        qc = self._rolling_count_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            numeric_only=numeric_only,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_count_internal(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        numeric_only: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
         return self._window_agg(
             window_func=WindowFunction.ROLLING,
             agg_func="count",
@@ -16902,6 +16931,39 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def rolling_sum(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        numeric_only: bool = False,
+        engine: Optional[Literal["cython", "numba"]] = None,
+        engine_kwargs: Optional[dict[str, bool]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_sum_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._rolling_sum_internal(
+                fold_axis=fold_axis,
+                rolling_kwargs=rolling_kwargs,
+                numeric_only=numeric_only,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
+                **kwargs,
+            )
+        qc = self._rolling_sum_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            numeric_only=numeric_only,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_sum_internal(
         self,
         fold_axis: Union[int, str],
         rolling_kwargs: dict,
@@ -16922,6 +16984,41 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def rolling_mean(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        numeric_only: bool = False,
+        engine: Optional[Literal["cython", "numba"]] = None,
+        engine_kwargs: Optional[dict[str, bool]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_mean_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._rolling_mean_internal(
+                    fold_axis=fold_axis,
+                    rolling_kwargs=rolling_kwargs,
+                    numeric_only=numeric_only,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                    **kwargs,
+                )
+            )
+        qc = self._rolling_mean_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            numeric_only=numeric_only,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_mean_internal(
         self,
         fold_axis: Union[int, str],
         rolling_kwargs: dict,
@@ -16963,6 +17060,42 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_var_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._rolling_var_internal(
+                fold_axis=fold_axis,
+                rolling_kwargs=rolling_kwargs,
+                ddof=ddof,
+                numeric_only=numeric_only,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
+                **kwargs,
+            )
+        qc = self._rolling_var_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            ddof=ddof,
+            numeric_only=numeric_only,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_var_internal(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        ddof: int = 1,
+        numeric_only: bool = False,
+        engine: Optional[Literal["cython", "numba"]] = None,
+        engine_kwargs: Optional[dict[str, bool]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_var", engine, engine_kwargs
         )
@@ -16974,6 +17107,42 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def rolling_std(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        ddof: int = 1,
+        numeric_only: bool = False,
+        engine: Optional[Literal["cython", "numba"]] = None,
+        engine_kwargs: Optional[dict[str, bool]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_std_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._rolling_std_internal(
+                fold_axis=fold_axis,
+                rolling_kwargs=rolling_kwargs,
+                ddof=ddof,
+                numeric_only=numeric_only,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
+                **kwargs,
+            )
+        qc = self._rolling_std_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            ddof=ddof,
+            numeric_only=numeric_only,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_std_internal(
         self,
         fold_axis: Union[int, str],
         rolling_kwargs: dict,
@@ -17004,6 +17173,39 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_min_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._rolling_min_internal(
+                fold_axis=fold_axis,
+                rolling_kwargs=rolling_kwargs,
+                numeric_only=numeric_only,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
+                **kwargs,
+            )
+        qc = self._rolling_min_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            numeric_only=numeric_only,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_min_internal(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        numeric_only: bool = False,
+        engine: Optional[Literal["cython", "numba"]] = None,
+        engine_kwargs: Optional[dict[str, bool]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_min", engine, engine_kwargs
         )
@@ -17024,6 +17226,39 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         *args: Any,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_max_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._rolling_max_internal(
+                fold_axis=fold_axis,
+                rolling_kwargs=rolling_kwargs,
+                numeric_only=numeric_only,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
+                **kwargs,
+            )
+        qc = self._rolling_max_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            numeric_only=numeric_only,
+            engine=engine,
+            engine_kwargs=engine_kwargs,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_max_internal(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        numeric_only: bool = False,
+        engine: Optional[Literal["cython", "numba"]] = None,
+        engine_kwargs: Optional[dict[str, bool]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
         WarningMessage.warning_if_engine_args_is_set(
             "rolling_max", engine, engine_kwargs
         )
@@ -17035,6 +17270,57 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def rolling_corr(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        other: Optional[SnowparkDataFrame] = None,
+        pairwise: Optional[bool] = None,
+        ddof: int = 1,
+        numeric_only: bool = False,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_corr_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None and (
+            not isinstance(other, (Series, DataFrame))
+            or other._query_compiler._relaxed_query_compiler is not None
+        ):
+            if isinstance(other, (Series, DataFrame)):
+                if isinstance(other, Series):
+                    new_other = Series(
+                        query_compiler=other._query_compiler._relaxed_query_compiler
+                    )
+                else:  # DataFrame
+                    new_other = DataFrame(
+                        query_compiler=other._query_compiler._relaxed_query_compiler
+                    )
+            else:
+                new_other = other
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._rolling_corr_internal(
+                    fold_axis=fold_axis,
+                    rolling_kwargs=rolling_kwargs,
+                    other=new_other,
+                    pairwise=pairwise,
+                    ddof=ddof,
+                    numeric_only=numeric_only,
+                    **kwargs,
+                )
+            )
+        qc = self._rolling_corr_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            other=other,
+            pairwise=pairwise,
+            ddof=ddof,
+            numeric_only=numeric_only,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_corr_internal(
         self,
         fold_axis: Union[int, str],
         rolling_kwargs: dict,
@@ -17126,6 +17412,36 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ErrorMessage.method_not_implemented_error(name="quantile", class_="Rolling")
 
     def rolling_sem(
+        self,
+        fold_axis: Union[int, str],
+        rolling_kwargs: dict,
+        ddof: int = 1,
+        numeric_only: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _rolling_sem_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._rolling_sem_internal(
+                fold_axis=fold_axis,
+                rolling_kwargs=rolling_kwargs,
+                ddof=ddof,
+                numeric_only=numeric_only,
+                **kwargs,
+            )
+        qc = self._rolling_sem_internal(
+            fold_axis=fold_axis,
+            rolling_kwargs=rolling_kwargs,
+            ddof=ddof,
+            numeric_only=numeric_only,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _rolling_sem_internal(
         self,
         fold_axis: Union[int, str],
         rolling_kwargs: dict,

--- a/tests/integ/modin/test_faster_pandas.py
+++ b/tests/integ/modin/test_faster_pandas.py
@@ -759,6 +759,95 @@ def test_rename(session):
 @pytest.mark.parametrize(
     "func",
     [
+        "min",
+        "max",
+        "count",
+        "sum",
+        "mean",
+        "std",
+        "var",
+        "sem",
+    ],
+)
+@sql_count_checker(query_count=3)
+def test_rolling(session, func):
+    with session_parameter_override(
+        session, "dummy_row_pos_optimization_enabled", True
+    ):
+        # create tables
+        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([[1, 11], [2, 12], [3, 13]], columns=["A", "B"])
+        ).write.save_as_table(table_name, table_type="temp")
+
+        # create snow dataframes
+        df = pd.read_snowflake(table_name)
+        snow_result = getattr(df.rolling(2), func)()
+
+        # verify that the input dataframe has a populated relaxed query compiler
+        assert df._query_compiler._relaxed_query_compiler is not None
+        assert df._query_compiler._relaxed_query_compiler._dummy_row_pos_mode is True
+        # verify that the output dataframe also has a populated relaxed query compiler
+        assert snow_result._query_compiler._relaxed_query_compiler is not None
+        assert (
+            snow_result._query_compiler._relaxed_query_compiler._dummy_row_pos_mode
+            is True
+        )
+
+        # create pandas dataframes
+        native_df = df.to_pandas()
+        native_result = getattr(native_df.rolling(2), func)()
+
+        # compare results
+        assert_frame_equal(snow_result, native_result)
+
+
+@sql_count_checker(query_count=5, join_count=1)
+def test_rolling_corr(session):
+    with session_parameter_override(
+        session, "dummy_row_pos_optimization_enabled", True
+    ):
+        # create tables
+        table_name1 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([[1, 11], [2, 12], [3, 13]], columns=["A", "C"])
+        ).write.save_as_table(table_name1, table_type="temp")
+        table_name2 = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([[1, 21], [2, 22], [3, 23]], columns=["B", "C"])
+        ).write.save_as_table(table_name2, table_type="temp")
+
+        # create snow dataframes
+        df1 = pd.read_snowflake(table_name1).sort_values("A", ignore_index=True)
+        df2 = pd.read_snowflake(table_name2).sort_values("B", ignore_index=True)
+        snow_result = df1.rolling(2).corr(df2)
+
+        # verify that the input dataframes have a populated relaxed query compiler
+        assert df1._query_compiler._relaxed_query_compiler is not None
+        assert df1._query_compiler._relaxed_query_compiler._dummy_row_pos_mode is True
+        assert df2._query_compiler._relaxed_query_compiler is not None
+        assert df2._query_compiler._relaxed_query_compiler._dummy_row_pos_mode is True
+        # verify that the output dataframe also has a populated relaxed query compiler
+        assert snow_result._query_compiler._relaxed_query_compiler is not None
+        assert (
+            snow_result._query_compiler._relaxed_query_compiler._dummy_row_pos_mode
+            is True
+        )
+
+        # create pandas dataframes
+        native_df1 = df1.to_pandas()
+        native_df2 = df2.to_pandas()
+        native_result = native_df1.rolling(2).corr(native_df2)
+
+        # compare results
+        assert_frame_equal(
+            snow_result, native_result, check_dtype=False, check_index_type=False
+        )
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
         "isdigit",
         "islower",
         "istitle",


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2476996

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add support for rolling.min/max/count/sum/mean/std/var/sem/corr in faster pandas.
