### PR TITLE
SNOW-2644834: Add support for 11 groupby functions in faster pandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,17 @@
   - `cumsum`
   - `cummin`
   - `cummax`
+  - `groupby.first`
+  - `groupby.last`
+  - `groupby.rank`
+  - `groupby.shift`
+  - `groupby.cumcount`
+  - `groupby.cumsum`
+  - `groupby.cummin`
+  - `groupby.cummax`
+  - `groupby.any`
+  - `groupby.all`
+  - `groupby.unique`
 - Make faster pandas disabled by default (opt-in instead of opt-out).
 - Improve performance of `drop_duplicates` by avoiding joins when `keep!=False` in faster pandas.
 

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -5571,6 +5571,43 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         **kwargs: dict[str, Any],
     ) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _groupby_first_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_first_internal(
+                    by=by,
+                    axis=axis,
+                    groupby_kwargs=groupby_kwargs,
+                    agg_args=agg_args,
+                    agg_kwargs=agg_kwargs,
+                    drop=drop,
+                    **kwargs,
+                )
+            )
+        qc = self._groupby_first_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_first_internal(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict[str, Any],
+        agg_args: tuple[Any],
+        agg_kwargs: dict[str, Any],
+        drop: bool = False,
+        **kwargs: dict[str, Any],
+    ) -> "SnowflakeQueryCompiler":
+        """
         Get the first non-null value for each group.
 
         Args:
@@ -5607,6 +5644,43 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ),
     )
     def groupby_last(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict[str, Any],
+        agg_args: tuple[Any],
+        agg_kwargs: dict[str, Any],
+        drop: bool = False,
+        **kwargs: dict[str, Any],
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_last_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_last_internal(
+                    by=by,
+                    axis=axis,
+                    groupby_kwargs=groupby_kwargs,
+                    agg_args=agg_args,
+                    agg_kwargs=agg_kwargs,
+                    drop=drop,
+                    **kwargs,
+                )
+            )
+        qc = self._groupby_last_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_last_internal(
         self,
         by: Any,
         axis: int,
@@ -6119,6 +6193,43 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ),
     )
     def groupby_shift(
+        self,
+        by: Any,
+        axis: int,
+        level: int,
+        periods: int,
+        freq: str,
+        fill_value: Any,
+        is_series_groupby: bool,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_shift_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_shift_internal(
+                    by=by,
+                    axis=axis,
+                    level=level,
+                    periods=periods,
+                    freq=freq,
+                    fill_value=fill_value,
+                    is_series_groupby=is_series_groupby,
+                )
+            )
+        qc = self._groupby_shift_internal(
+            by=by,
+            axis=axis,
+            level=level,
+            periods=periods,
+            freq=freq,
+            fill_value=fill_value,
+            is_series_groupby=is_series_groupby,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_shift_internal(
         self,
         by: Any,
         axis: int,
@@ -6705,6 +6816,34 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         ascending: bool,
     ) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _groupby_cumcount_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_cumcount_internal(
+                    by=by,
+                    axis=axis,
+                    groupby_kwargs=groupby_kwargs,
+                    ascending=ascending,
+                )
+            )
+        qc = self._groupby_cumcount_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            ascending=ascending,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_cumcount_internal(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict[str, Any],
+        ascending: bool,
+    ) -> "SnowflakeQueryCompiler":
+        """
         Number each item in each group from 0 to the length of that group - 1.
 
         Args:
@@ -6736,6 +6875,34 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def groupby_cummax(
+        self,
+        by: Any,
+        axis: int,
+        numeric_only: bool,
+        groupby_kwargs: dict[str, Any],
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_cummax_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_cummax_internal(
+                    by=by,
+                    axis=axis,
+                    numeric_only=numeric_only,
+                    groupby_kwargs=groupby_kwargs,
+                )
+            )
+        qc = self._groupby_cummax_internal(
+            by=by,
+            axis=axis,
+            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_cummax_internal(
         self,
         by: Any,
         axis: int,
@@ -6780,6 +6947,34 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         groupby_kwargs: dict[str, Any],
     ) -> "SnowflakeQueryCompiler":
         """
+        Wrapper around _groupby_cummin_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_cummin_internal(
+                    by=by,
+                    axis=axis,
+                    numeric_only=numeric_only,
+                    groupby_kwargs=groupby_kwargs,
+                )
+            )
+        qc = self._groupby_cummin_internal(
+            by=by,
+            axis=axis,
+            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_cummin_internal(
+        self,
+        by: Any,
+        axis: int,
+        numeric_only: bool,
+        groupby_kwargs: dict[str, Any],
+    ) -> "SnowflakeQueryCompiler":
+        """
         Cumulative min for each group.
 
         Args:
@@ -6810,6 +7005,31 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def groupby_cumsum(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict[str, Any],
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_cumsum_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_cumsum_internal(
+                    by=by,
+                    axis=axis,
+                    groupby_kwargs=groupby_kwargs,
+                )
+            )
+        qc = self._groupby_cumsum_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_cumsum_internal(
         self,
         by: Any,
         axis: int,
@@ -6913,6 +7133,41 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         drop: bool = False,
         **kwargs: Any,
     ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_any_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._groupby_any_internal(
+                by=by,
+                axis=axis,
+                groupby_kwargs=groupby_kwargs,
+                agg_args=agg_args,
+                agg_kwargs=agg_kwargs,
+                drop=drop,
+                **kwargs,
+            )
+        qc = self._groupby_any_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_any_internal(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict[str, Any],
+        agg_args: Any,
+        agg_kwargs: dict[str, Any],
+        drop: bool = False,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
 
         # We have to override the Modin version of this function because our groupby frontend passes the
         # ignored numeric_only argument to this query compiler method, and BaseQueryCompiler
@@ -6928,6 +7183,41 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def groupby_all(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict[str, Any],
+        agg_args: Any,
+        agg_kwargs: dict[str, Any],
+        drop: bool = False,
+        **kwargs: Any,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_all_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = self._relaxed_query_compiler._groupby_all_internal(
+                by=by,
+                axis=axis,
+                groupby_kwargs=groupby_kwargs,
+                agg_args=agg_args,
+                agg_kwargs=agg_kwargs,
+                drop=drop,
+                **kwargs,
+            )
+        qc = self._groupby_all_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+            **kwargs,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_all_internal(
         self,
         by: Any,
         axis: int,
@@ -24125,6 +24415,46 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         )
 
     def groupby_unique(
+        self,
+        by: Any,
+        axis: int,
+        groupby_kwargs: dict,
+        agg_args: Sequence,
+        agg_kwargs: dict,
+        numeric_only: bool,
+        is_series_groupby: bool,
+        drop: bool = False,
+    ) -> "SnowflakeQueryCompiler":
+        """
+        Wrapper around _groupby_unique_internal to be supported in faster pandas.
+        """
+        relaxed_query_compiler = None
+        if self._relaxed_query_compiler is not None:
+            relaxed_query_compiler = (
+                self._relaxed_query_compiler._groupby_unique_internal(
+                    by=by,
+                    axis=axis,
+                    groupby_kwargs=groupby_kwargs,
+                    agg_args=agg_args,
+                    agg_kwargs=agg_kwargs,
+                    numeric_only=numeric_only,
+                    is_series_groupby=is_series_groupby,
+                    drop=drop,
+                )
+            )
+        qc = self._groupby_unique_internal(
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            numeric_only=numeric_only,
+            is_series_groupby=is_series_groupby,
+            drop=drop,
+        )
+        return self._maybe_set_relaxed_qc(qc, relaxed_query_compiler)
+
+    def _groupby_unique_internal(
         self,
         by: Any,
         axis: int,

--- a/tests/integ/modin/test_faster_pandas.py
+++ b/tests/integ/modin/test_faster_pandas.py
@@ -266,6 +266,49 @@ def test_agg(session, func):
         assert_series_equal(snow_result4, native_result4, check_dtype=False)
 
 
+@pytest.mark.parametrize(
+    "func",
+    [
+        "first",
+        "last",
+        "rank",
+        "shift",
+        "cumcount",
+        "cumsum",
+        "cummin",
+        "cummax",
+        "any",
+        "all",
+        "unique",
+    ],
+)
+@sql_count_checker(query_count=3)
+def test_groupby_no_param_functions(session, func):
+    with session_parameter_override(
+        session, "dummy_row_pos_optimization_enabled", True
+    ):
+        # create tables
+        table_name = Utils.random_name_for_temp_object(TempObjectType.TABLE)
+        session.create_dataframe(
+            native_pd.DataFrame([[2, 12], [2, 11], [3, 13]], columns=["A", "B"])
+        ).write.save_as_table(table_name, table_type="temp")
+
+        # create snow dataframes
+        df = pd.read_snowflake(table_name).sort_values("B", ignore_index=True)
+        snow_result = getattr(df.groupby("A")["B"], func)()
+
+        # verify that the input dataframe has a populated relaxed query compiler
+        assert df._query_compiler._relaxed_query_compiler is not None
+        assert df._query_compiler._relaxed_query_compiler._dummy_row_pos_mode is True
+
+        # create pandas dataframes
+        native_df = df.to_pandas()
+        native_result = getattr(native_df.groupby("A")["B"], func)()
+
+        # compare results
+        assert_series_equal(snow_result, native_result, check_dtype=False)
+
+
 @sql_count_checker(query_count=5, union_count=1)
 def test_concat(session):
     with session_parameter_override(


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2644834

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add support for 11 groupby functions in faster pandas.
    - `groupby.first`
    - `groupby.last`
    - `groupby.rank`
    - `groupby.shift`
    - `groupby.cumcount`
    - `groupby.cumsum`
    - `groupby.cummin`
    - `groupby.cummax`
    - `groupby.any`
    - `groupby.all`
    - `groupby.unique`

