### PR TITLE
SNOW-2679281: Add missing tests and changelog entries for dt.dayofweek/weekday/dayofyear/isocalendar (already supported in faster pandas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,10 @@
   - `dt.month_name`
   - `dt.day_name`
   - `dt.strftime`  
+  - `dt.dayofweek`  
+  - `dt.weekday`  
+  - `dt.dayofyear`    
+  - `dt.isocalendar`  
   - `rolling.min`
   - `rolling.max`
   - `rolling.count`

--- a/tests/integ/modin/test_faster_pandas.py
+++ b/tests/integ/modin/test_faster_pandas.py
@@ -1249,6 +1249,9 @@ def test_str_translate(session):
         "is_leap_year",
         "days_in_month",
         "daysinmonth",
+        "dayofweek",
+        "weekday",
+        "dayofyear",
     ],
 )
 @sql_count_checker(query_count=3)
@@ -1296,7 +1299,7 @@ def test_dt_properties(session, property_name):
         assert_series_equal(snow_result, native_result)
 
 
-@pytest.mark.parametrize("func", ["normalize", "month_name", "day_name"])
+@pytest.mark.parametrize("func", ["normalize", "month_name", "day_name", "isocalendar"])
 @sql_count_checker(query_count=3)
 def test_dt_functions_no_params(session, func):
     with session_parameter_override(
@@ -1338,7 +1341,10 @@ def test_dt_functions_no_params(session, func):
         native_result = getattr(native_df["A"].dt, func)()
 
         # compare results
-        assert_series_equal(snow_result, native_result)
+        if func == "isocalendar":
+            assert_frame_equal(snow_result, native_result, check_dtype=False)
+        else:
+            assert_series_equal(snow_result, native_result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-2679281

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Add missing tests and changelog entries for dt.dayofweek/weekday/dayofyear/isocalendar in faster pandas.
