### PR TITLE
NO-SNOW: use doctest ellipsis on series_util doctest dtype

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py
+++ b/src/snowflake/snowpark/modin/plugin/docstrings/series_utils.py
@@ -2638,11 +2638,11 @@ class CombinedDatetimelikeProperties:
         1   0 days 00:00:02
         2   0 days 00:00:03
         dtype: timedelta64[ns]
-        >>> ser.dt.seconds
+        >>> ser.dt.seconds  # doctest: +ELLIPSIS
         0    1
         1    2
         2    3
-        dtype: int8
+        dtype: ...
 
         For TimedeltaIndex:
 
@@ -2698,11 +2698,11 @@ class CombinedDatetimelikeProperties:
         1   0 days 00:00:00.000002
         2   0 days 00:00:00.000003
         dtype: timedelta64[ns]
-        >>> ser.dt.microseconds
+        >>> ser.dt.microseconds  # doctest: +ELLIPSIS
         0    1
         1    2
         2    3
-        dtype: int8
+        dtype: ...
 
         For TimedeltaIndex:
 
@@ -2730,11 +2730,11 @@ class CombinedDatetimelikeProperties:
         1   0 days 00:00:00.000000002
         2   0 days 00:00:00.000000003
         dtype: timedelta64[ns]
-        >>> ser.dt.nanoseconds
+        >>> ser.dt.nanoseconds  # doctest: +ELLIPSIS
         0    1
         1    2
         2    3
-        dtype: int8
+        dtype: ...
 
         For TimedeltaIndex:
 


### PR DESCRIPTION
flaky modin merge gate: use doctest ellipsis to deal with nondeterministic dtype depending on machine env

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Example merge gate failure for modin: https://github.com/snowflakedb/snowpark-python/actions/runs/19552156495/job/55986336209?pr=4003
```
_ [doctest] snowpark.modin.plugin.docstrings.series_utils.CombinedDatetimelikeProperties.nanoseconds _
2724         --------
2725         For Series:
2726 
2727         >>> ser = pd.Series(pd.to_timedelta([1, 2, 3], unit='ns'))
2728         >>> ser
2729         0   0 days 00:00:00.000000001
2730         1   0 days 00:00:00.000000002
2731         2   0 days 00:00:00.000000003
2732         dtype: timedelta64[ns]
2733         >>> ser.dt.nanoseconds
Differences (unified diff with -expected +actual):
    @@ -2,3 +2,3 @@
     1    2
     2    3
    -dtype: int8
    +dtype: int64
```
Relevant PR that proves series dtype's nondeterministic nature based on platform and env: https://github.com/snowflakedb/snowpark-python/pull/3921 