### PR TITLE
NO-SNOW: Fix UDF parameter registration error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,6 @@
 - Removed experimental warning from `DataFrame.to_arrow` and `DataFrame.to_arrow_batches`.
 - When both `Session.reduce_describe_query_enabled` and `Session.cte_optimization_enabled` are enabled, fewer DESCRIBE queries are issued when resolving table attributes.
 
-#### Dependency Updates
-
-- Added a dependency on `protobuf<7.35` (was `<6.34`).
-
 ### Snowpark pandas API Updates
 
 #### New Features

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ INSTALL_REQ_LIST = [
     "pyyaml",
     "cloudpickle>=1.6.0,<=3.1.1,!=2.1.0,!=2.2.0",
     # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
-    "protobuf>=3.20, <7.35",  # Snowpark IR
+    "protobuf>=3.20, <6.34",  # Snowpark IR
     "python-dateutil",  # Snowpark IR
     "tzlocal",  # Snowpark IR
 ]

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -1038,8 +1038,6 @@ body {
             }
           }
         }
-        max_batch_size {
-        }
         parallel: 4
         return_type {
           integer_type: true
@@ -1272,8 +1270,6 @@ body {
               v: true
             }
           }
-        }
-        max_batch_size {
         }
         parallel: 4
         return_type {


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3018722
   Fixes #4056

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Bumps the `protobuf` dependency in response to a high-severity CVE. There appear to be no major breaking changes on our end, though a newly-raised TypeError actually uncovered a bug in our UDF registration code.

As protobuf 7.34.0rc1 is still a release candidate, we may need to wait for a full 7.34.0 release to properly test.