### PR TITLE
NO-SNOW: Suppress snyk warning in connector version

### DIFF
--- a/ci/snyk/requirements.txt
+++ b/ci/snyk/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>=40.6.0
 wheel
 cloudpickle>=1.6.0,<=3.1.1,!=2.1.0,!=2.2.0
-snowflake-connector-python>=3.17.0,<5.0.0
+snowflake-connector-python>=4.0.0,<5.0.0
 typing-extensions>=4.1.0,<5.0.0


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Snyk complains:
https://app.snyk.io/org/snowflakedb-sca-scanning-public-repo/project/773f470d-2a57-4aa9-b797-101b0b098f6c#issue-SNYK-PYTHON-SNOWFLAKECONNECTORPYTHON-13803382

Detailed paths and remediation
Introduced through: root@0.0.0 › snowflake-connector-python@3.17.0
Fix: Upgrade snowflake-connector-python to version 4.0.0 