### PR TITLE
SNOW-3027686: Fix spark string format for interval year-month

### DIFF
--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -1468,18 +1468,25 @@ def format_year_month_interval_for_display(
     # Default initialization
     years = "0"
     months = "0"
-    is_negative = False
+    is_negative = cell.startswith("-")
+    # Remove the sign prefix and parse the remaining part
+    remaining = cell[1:]  # Remove the "+" or "-" prefix: "1-6"
 
     if has_internal_dash:
         # Format like "+1-03" or "-1-03" or "-1-6" (compound year-month)
-        is_negative = cell.startswith("-")
-
-        # Remove the sign prefix and parse the remaining "year-month" part
-        remaining = cell[1:]  # Remove the "+" or "-" prefix: "1-6"
         if "-" in remaining:
             parts = remaining.split("-", 1)  # Split only on first dash: ["1", "6"]
             years = str(int(parts[0]))
             months = str(int(parts[1]))
+    else:
+        # Format like "+2" or "-3"
+        if (
+            start_field == YearMonthIntervalType.YEAR
+            and end_field == YearMonthIntervalType.YEAR
+        ):
+            years = str(int(remaining))
+        else:
+            months = str(int(remaining))
 
     # Format based on start/end field
     sign_prefix = "-" if is_negative else ""
@@ -1502,9 +1509,7 @@ def format_year_month_interval_for_display(
     ):
         # Months only: MONTH - calculate total months
         total_months = int(years) * 12 + int(months)
-        if is_negative:
-            total_months = -total_months
-        return f"INTERVAL '{total_months}' MONTH"
+        return f"INTERVAL '{sign_prefix}{total_months}' MONTH"
 
 
 def format_day_time_interval_for_display(

--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -3308,13 +3308,13 @@ def test_year_month_interval_type_dataframe(session):
     test_result = df.collect()
 
     assert len(test_result) == 2
-    assert test_result[0][0] == "+3-00"
-    assert test_result[0][1] == "+1-06"
-    assert test_result[0][2] == "+1-03"
+    assert test_result[0][0] == "+3"  # interval year
+    assert test_result[0][1] == "+1-06"  # interval year to month
+    assert test_result[0][2] == "+15"  # interval month
 
-    assert test_result[1][0] == "-1-00"
-    assert test_result[1][1] == "-0-03"
-    assert test_result[1][2] == "+0-07"
+    assert test_result[1][0] == "-1"  # interval year
+    assert test_result[1][1] == "-0-03"  # interval year to month
+    assert test_result[1][2] == "+7"  # interval month
 
     assert isinstance(df.schema.fields[0].datatype, YearMonthIntervalType)
     assert df.schema.fields[0].datatype.start_field == 0

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -2744,6 +2744,18 @@ def test_show_interval_formatting(session):
         """
     )
 
+    # Single negative year intervals (not YEAR TO MONTH)
+    df = session.sql("SELECT INTERVAL '-5' YEAR as single_year")
+    assert df._show_string_spark(truncate=False) == dedent(
+        """\
+        +------------------+
+        |"SINGLE_YEAR"     |
+        +------------------+
+        |INTERVAL '-5' YEAR|
+        +------------------+
+        """
+    )
+
     # Single month intervals (not YEAR TO MONTH)
     df = session.sql("SELECT INTERVAL '8' MONTH as single_month")
     assert df._show_string_spark(truncate=False) == dedent(
@@ -2753,6 +2765,18 @@ def test_show_interval_formatting(session):
         +------------------+
         |INTERVAL '8' MONTH|
         +------------------+
+        """
+    )
+
+    # Single negative month intervals (not YEAR TO MONTH)
+    df = session.sql("SELECT INTERVAL '-8' MONTH as single_month")
+    assert df._show_string_spark(truncate=False) == dedent(
+        """\
+        +-------------------+
+        |"SINGLE_MONTH"     |
+        +-------------------+
+        |INTERVAL '-8' MONTH|
+        +-------------------+
         """
     )
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-3027686
   
  Process year-month Intervals of format '+/-ddd' correctly.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
