### PR TITLE
SNOW-3034995: Add cloudpickle automatically when using artifact_repository with packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.46.0 (TBD)
+
+### Snowpark Python API Updates
+
+#### Bug Fixes
+
+- Fixed a bug where `cloudpickle` was not automatically added to the package list when using `artifact_repository` with custom packages, causing `ModuleNotFoundError` at runtime.
+
 ## 1.45.0 (TBD)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 import cloudpickle
+from packaging.requirements import Requirement
 
 import snowflake.snowpark
 from snowflake.connector.options import installed_pandas, pandas
@@ -1234,7 +1235,12 @@ def resolve_imports_and_packages(
                 raise TypeError(
                     "Artifact repository requires that all packages be passed as str."
                 )
-            resolved_packages = packages
+            resolved_packages = list(packages)
+            if not any(
+                Requirement(pkg).name.lower() == "cloudpickle"
+                for pkg in resolved_packages
+            ):
+                resolved_packages.append(f"cloudpickle=={cloudpickle.__version__}")
     else:
         # resolve packages
         if session is None:  # In case of sandbox

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -101,3 +101,81 @@ def test_do_register_udf_sandbox(session_sandbox, cleanup_registration_patch):
         "schema": "some_schema",
         "application_roles": ["app_viewer"],
     }
+
+
+def test_artifact_repository_adds_cloudpickle():
+    """Test that cloudpickle is automatically added when using artifact_repository with packages."""
+    from snowflake.snowpark._internal.udf_utils import resolve_imports_and_packages
+
+    # Test case 1: packages provided without cloudpickle
+    result = resolve_imports_and_packages(
+        session=None,
+        object_type=TempObjectType.FUNCTION,
+        func=lambda: 1,
+        arg_names=[],
+        udf_name="test_udf",
+        stage_location=None,
+        imports=None,
+        packages=["urllib3", "requests", "cloudpickle-non-existing"],
+        artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+    )
+    _, _, _, all_packages, _, _ = result
+
+    # Verify cloudpickle was added
+    assert all_packages is not None
+    package_list = all_packages.split(",") if all_packages else []
+    assert any(
+        pkg.strip().strip("'").startswith("cloudpickle==") for pkg in package_list
+    ), f"cloudpickle not found in packages: {all_packages}"
+
+    # Test case 2: packages already contains cloudpickle
+    result2 = resolve_imports_and_packages(
+        session=None,
+        object_type=TempObjectType.FUNCTION,
+        func=lambda: 1,
+        arg_names=[],
+        udf_name="test_udf2",
+        stage_location=None,
+        imports=None,
+        packages=["urllib3", "cloudpickle>=2.0", "requests"],
+        artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+    )
+    _, _, _, all_packages2, _, _ = result2
+
+    # Verify cloudpickle was not duplicated
+    package_list2 = all_packages2.split(",") if all_packages2 else []
+    cloudpickle_count = sum(
+        1 for pkg in package_list2 if "cloudpickle" in pkg.strip().strip("'").lower()
+    )
+    assert (
+        cloudpickle_count == 1
+    ), f"cloudpickle should appear exactly once, found {cloudpickle_count} times in: {all_packages2}"
+
+    # Test case 3: packages with various version specifiers
+    test_cases = [
+        ["urllib3", "cloudpickle==2.2.1"],
+        ["urllib3", "cloudpickle>=2.0"],
+        ["urllib3", "cloudpickle~=2.2"],
+        ["urllib3", "cloudpickle<=3.0"],
+    ]
+
+    for packages in test_cases:
+        result = resolve_imports_and_packages(
+            session=None,
+            object_type=TempObjectType.FUNCTION,
+            func=lambda: 1,
+            arg_names=[],
+            udf_name="test_udf_versioned",
+            stage_location=None,
+            imports=None,
+            packages=packages,
+            artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+        )
+        _, _, _, all_packages, _, _ = result
+        package_list = all_packages.split(",") if all_packages else []
+        cloudpickle_count = sum(
+            1 for pkg in package_list if "cloudpickle" in pkg.strip().strip("'").lower()
+        )
+        assert (
+            cloudpickle_count == 1
+        ), f"For {packages}, cloudpickle should appear exactly once, found {cloudpickle_count} times"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3034995

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

**Problem**
When using artifact_repository with custom packages, cloudpickle was not automatically added to the package list, causing ModuleNotFoundError: No module named 'cloudpickle' at runtime in UDF execution.
**Root Cause**
In src/snowflake/snowpark/_internal/udf_utils.py (lines 1232-1237), when both artifact_repository and packages were provided, the code directly assigned resolved_packages = packages without calling session._resolve_packages(), which meant cloudpickle was never added to the dependency list.
**Solution**
Added logic to automatically include cloudpickle when using artifact repositories with custom packages:
- Check for cloudpickle: After assigning the packages list, check if cloudpickle is already present using Requirement(pkg).name.lower() to handle all version specifiers (==, >=, <=, ~=, etc.)
- Auto-add if missing: If cloudpickle is not found, append cloudpickle=={version} to the package list
- Preserve user choice: If user already specified cloudpickle with any version constraint, respect it and don't duplicate
