### PR TITLE
SNOW-3077601: Fix filter on empty dataframe returning schemaless result

### DIFF
--- a/tests/mock/test_empty_dataframe_filter.py
+++ b/tests/mock/test_empty_dataframe_filter.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+"""Tests for issue #4076: Filter on empty dataframe results in schemaless dataframe."""
+
+from snowflake.snowpark.functions import col, lit
+from snowflake.snowpark.types import IntegerType, StringType, StructField, StructType
+
+
+def test_filter_empty_dataframe_preserves_schema(session):
+    """Filter on empty dataframe should preserve schema (issue #4076)."""
+    empty_schema = StructType([
+        StructField("entry", StringType(), True),
+        StructField("file_path", StringType(), True),
+    ])
+    mock_encounters_df = session.create_dataframe([], schema=empty_schema)
+
+    # Before filter: should have 2 columns
+    assert len(mock_encounters_df.schema.fields) == 2
+    assert [f.name for f in mock_encounters_df.schema.fields] == ["ENTRY", "FILE_PATH"]
+
+    # After filter: should preserve the same schema
+    filtered_df = mock_encounters_df.filter(col("entry").is_null())
+    assert len(filtered_df.schema.fields) == 2, (
+        "Filtered empty dataframe should retain schema (ENTRY, FILE_PATH)"
+    )
+    assert [f.name for f in filtered_df.schema.fields] == ["ENTRY", "FILE_PATH"]
+
+    # Both should be empty
+    assert mock_encounters_df.count() == 0
+    assert filtered_df.count() == 0
+
+
+def test_filter_empty_dataframe_various_conditions(session):
+    """Various filter conditions on empty dataframe should all preserve schema."""
+    empty_schema = StructType([
+        StructField("entry", StringType(), True),
+        StructField("file_path", StringType(), True),
+    ])
+    df = session.create_dataframe([], schema=empty_schema)
+
+    # is_null
+    assert len(df.filter(col("entry").is_null()).schema.fields) == 2
+
+    # is_not_null
+    assert len(df.filter(col("entry").is_not_null()).schema.fields) == 2
+
+    # equals
+    assert len(df.filter(col("entry") == lit("x")).schema.fields) == 2
+
+    # not equals
+    assert len(df.filter(col("entry") != lit("x")).schema.fields) == 2
+
+    # Chain filters
+    chained = df.filter(col("entry").is_null()).filter(col("file_path").is_null())
+    assert len(chained.schema.fields) == 2
+
+
+def test_select_lit_filter_preserves_projection_not_source(session):
+    """select(lit(1)).filter() must keep projected columns only, not original schema."""
+    schema = StructType([
+        StructField("a", IntegerType()),
+        StructField("b", StringType()),
+    ])
+    df = session.create_dataframe([], schema=schema)
+    result = df.select(lit(1).alias("x")).filter(col("x") > 0)
+    assert len(result.schema.fields) == 1
+    assert result.schema.fields[0].name == "X"
+
+
+def test_filter_empty_dataframe_with_three_columns(session):
+    """Filter on empty dataframe with more columns preserves schema."""
+    schema = StructType([
+        StructField("a", IntegerType()),
+        StructField("b", StringType()),
+        StructField("c", IntegerType()),
+    ])
+    df = session.create_dataframe([], schema=schema)
+    filtered = df.filter(col("a") > 0)
+    assert len(filtered.schema.fields) == 3
+    assert [f.name for f in filtered.schema.fields] == ["A", "B", "C"]


### PR DESCRIPTION
When filtering an empty DataFrame with an explicit schema in local testing mode, pandas `df[boolean_mask]` can return 0 columns due to an index-alignment edge case. This fix preserves the schema by using `iloc[0:0].copy()` when row filtering incorrectly produces a schemaless result.

Fixes #4076

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3077601

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   **Problem:** When filtering an empty DataFrame in local testing mode, `df.filter(col("entry").is_null())` returns a DataFrame with 0 columns instead of preserving the original schema.

   **Root cause:** Pandas `df[boolean_mask]` on an empty DataFrame can return a schemaless result (0 columns) due to an index-alignment edge case. The boolean mask is correct, but pandas produces invalid output.

   **Solution:** After applying the filter via `df[condition]`, check if the result lost its columns while the input had columns. If so, use `df.iloc[0:0].copy()` to get an empty DataFrame with the correct schema. This fix is applied in two places:
   - `Filter` plan execution path
   - `MockSelectStatement` where clause path

   **Tests added:** 4 test cases in `tests/mock/test_empty_dataframe_filter.py`:
   - Exact reproduction of issue #4076
   - Various filter conditions (is_null, is_not_null, ==, !=, chained)
   - Verification that `select(lit(1)).filter()` correctly keeps only projected columns
   - Multi-column schema preservation