### PR TITLE
NO-SNOW: Fix daily test failures caused by alias flattening

### DIFF
--- a/tests/integ/test_multithreading.py
+++ b/tests/integ/test_multithreading.py
@@ -688,7 +688,7 @@ def test_concurrent_update_on_sensitive_configs(
     run=False,
 )
 def test_large_query_breakdown_with_cte(threadsafe_session):
-    bounds = (300, 520) if threadsafe_session.sql_simplifier_enabled else (50, 70)
+    bounds = (300, 520) if threadsafe_session.sql_simplifier_enabled else (30, 60)
     try:
         original_query_compilation_stage_enabled = (
             threadsafe_session._query_compilation_stage_enabled


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Fixes some test failures caused by #4078.

- tests/integ/test_multithreading.py::test_large_query_breakdown_with_cte: The new alias removal reduced the complexity of the generated query; with trial and error in Cursor, the new bounds in this test trigger query breakdown again.
- tests/integ/scala/test_snowflake_plan_suite.py::test_plan_height: Since some of the new alias optimization code exists outside of the SQL simplifier, the depth of generated joins has been reduced. The depth did not decrease when the SQL simplifier is enabled due to the presence of intermediate `SelectStatement` objects.
- tests/integ/compiler/test_query_generator.py::test_select_alias_identity: The specific optimization here relies on the SQL simplifier being enabled, so the generated query is different if it is not.