### PR TITLE
SNOW-3166637: allow string data for decimal type when < array binding threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bug Fixes
 
 - Fixed a bug where `Session.udf.register_from_file` did not properly process the `strict` and `secure` parameters.
+- Fixed a bug when create dataframe with small data(< array binding threshold), and error is raised when have string value in a DecimalType column.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -420,7 +420,9 @@ def to_sql(
         else:
             return f"'{value}' :: FLOAT"
 
-    if isinstance(value, Decimal) and isinstance(datatype, DecimalType):
+    if (isinstance(value, Decimal) or isinstance(value, str)) and isinstance(
+        datatype, DecimalType
+    ):
         return f"{value} :: {analyzer_utils.number(datatype.precision, datatype.scale)}"
 
     if isinstance(datatype, DateType):

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -114,6 +114,7 @@ def test_to_sql():
     assert to_sql(1.2, DoubleType()) == "'1.2' :: FLOAT"
 
     assert to_sql(Decimal(0.5), DecimalType(2, 1)) == "0.5 ::  NUMBER (2, 1)"
+    assert to_sql("0.5", DecimalType(2, 1)) == "0.5 ::  NUMBER (2, 1)"
 
     assert to_sql(397, DateType()) == "DATE '1971-02-02'"
     # value type must be int


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
