### PR TITLE
SNOW-3152139: Create UDF_init_once decorator in python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@
 #### New Features
 
 - Added support for the `array_union_agg` function in the `snowflake.snowpark.functions` module.
+- Added the `udf_init_once` decorator in `snowflake.snowpark.functions` for marking functions to be executed once during pre-fork initialization on Snowflake workers, matching the server-side `_snowflake.udf_init_once` API.
 
 #### Bug Fixes
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -158,6 +158,7 @@ The return type is always ``Column``. The input types tell you the acceptable va
     <BLANKLINE>
 """
 import functools
+import inspect
 import typing
 from functools import reduce
 import json
@@ -10327,6 +10328,61 @@ def vectorized(input: type, max_batch_size: Optional[int] = None) -> Callable:
         return _inner
 
     return _decorator
+
+
+def udf_init_once(func: Callable) -> Callable:
+    """Mark a function to be executed once during pre-fork initialization.
+
+    This decorator has the same signature as the server-side ``_snowflake.udf_init_once``.
+    It is a no-op for local invocation. Functions decorated with ``@udf_init_once`` run in
+    the head worker process before individual workers are forked. The initialized state
+    (e.g., loaded models, computed lookup tables) is shared across all workers via
+    Copy-On-Write.
+
+    The decorated function must:
+        - Accept zero arguments
+        - Be a callable (function, lambda, or callable object)
+
+    Multiple ``@udf_init_once`` functions are executed in the order they are defined.
+
+    Example::
+
+        from snowflake.snowpark.functions import udf_init_once
+
+        model = None
+
+        @udf_init_once
+        def load_model():
+            global model
+            model = 42
+
+    Use this decorator in handler files registered via
+    :meth:`~snowflake.snowpark.udf.UDFRegistration.register_from_file`.
+    On the Snowflake server the ``_snowflake.udf_init_once`` implementation
+    is used instead; this client-side definition provides the same API so
+    that handler files can be tested locally.
+
+    Args:
+        func: The init function to decorate. Must be callable and accept zero arguments.
+
+    Returns:
+        The decorated function, unchanged.
+
+    See Also:
+        - :func:`udf`
+        - :meth:`~snowflake.snowpark.udf.UDFRegistration.register_from_file`
+    """
+    if not callable(func):
+        raise TypeError(
+            f"@udf_init_once target must be callable, got {type(func).__name__}"
+        )
+    sig = inspect.signature(func)
+    if len(sig.parameters) != 0:
+        raise TypeError(
+            f"@udf_init_once function must take 0 arguments, got {len(sig.parameters)}"
+        )
+    func._sf_init_once = True
+    return func
 
 
 @publicapi

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -2726,4 +2726,4 @@ def test_udf_init_once_register_from_file(session):
     )
     df = session.create_dataframe([[1], [2], [3]], schema=["a"])
     res = df.select(multiply_udf("a").alias("result")).collect()
-    assert sorted([row.RESULT for row in res]) == [10, 20, 30]
+    assert sorted(row.RESULT for row in res) == [10, 20, 30]

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -2710,3 +2710,20 @@ def test_udf_with_vectorized_nested_decorators_series(session):
     )
     res = df.select(add_series("a", "b").alias("result")).collect()
     assert [row.RESULT for row in res] == [3, 30, 300, 15]
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="UDF init_once is not supported in Local Testing",
+)
+def test_udf_init_once_register_from_file(session):
+    """Test @udf_init_once in a handler file used with register_from_file."""
+    multiply_udf = session.udf.register_from_file(
+        file_path="tests/resources/test_udf_dir/test_udf_init_once_file.py",
+        func_name="multiply",
+        return_type=IntegerType(),
+        input_types=[IntegerType()],
+    )
+    df = session.create_dataframe([[1], [2], [3]], schema=["a"])
+    res = df.select(multiply_udf("a").alias("result")).collect()
+    assert sorted([row.RESULT for row in res]) == [10, 20, 30]

--- a/tests/resources/test_udf_dir/test_udf_init_once_file.py
+++ b/tests/resources/test_udf_dir/test_udf_init_once_file.py
@@ -1,0 +1,17 @@
+try:
+    from _snowflake import udf_init_once
+except ModuleNotFoundError:
+    from snowflake.snowpark.functions import udf_init_once
+
+
+_multiplier = 1
+
+
+@udf_init_once
+def setup():
+    global _multiplier
+    _multiplier = 10
+
+
+def multiply(x):
+    return x * _multiplier

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -19,6 +19,7 @@ from snowflake.snowpark._internal.utils import (
     get_stage_parts,
     get_temp_type_for_object,
     get_udf_upload_prefix,
+    is_cloud_path,
     is_snowflake_quoted_id_case_insensitive,
     is_snowflake_unquoted_suffix_case_insensitive,
     is_sql_select_statement,
@@ -30,7 +31,6 @@ from snowflake.snowpark._internal.utils import (
     validate_object_name,
     warning,
     zip_file_or_directory_to_stream,
-    is_cloud_path,
 )
 from tests.utils import IS_WINDOWS, TestFiles
 
@@ -114,23 +114,23 @@ def test_calculate_checksum():
     else:
         assert (
             calculate_checksum(test_files.test_udf_directory)
-            == "3a2607ef293801f59e7840f5be423d4a55edfe2ac732775dcfda01205df377f0"
+            == "d472060e6d717517a3f9c7048ac43fc0c646467a6b3772f63355071a65ad8ecf"
         )
         assert (
             calculate_checksum(test_files.test_udf_directory, algorithm="md5")
-            == "b72b61c8d5639fff8aa9a80278dba60f"
+            == "322ad29c4018a1375f61b670196cf902"
         )
         # Validate that hashes are different when reading whole dir.
         # Using a sufficiently small chunk size so that the hashes differ.
         assert (
             calculate_checksum(test_files.test_udf_directory, chunk_size=128)
-            == "c071de824a67c083edad45c2b18729e17c50f1b13be980140437063842ea2469"
+            == "40d4811752a978779518082f0312f8823cb46dd84d12c68a7bb456c388f38df4"
         )
         assert (
             calculate_checksum(
                 test_files.test_udf_directory, chunk_size=128, whole_file_hash=True
             )
-            == "3a2607ef293801f59e7840f5be423d4a55edfe2ac732775dcfda01205df377f0"
+            == "d472060e6d717517a3f9c7048ac43fc0c646467a6b3772f63355071a65ad8ecf"
         )
 
 

--- a/tests/unit/scala/test_utils_suite.py
+++ b/tests/unit/scala/test_utils_suite.py
@@ -256,6 +256,7 @@ def test_zip_file_or_directory_to_stream():
             [
                 "test_udf_dir/",
                 "test_udf_dir/test_another_udf_file.py",
+                "test_udf_dir/test_udf_init_once_file.py",
                 "test_udf_dir/test_pandas_udf_file.py",
                 "test_udf_dir/test_udf_file.py",
             ],
@@ -270,6 +271,7 @@ def test_zip_file_or_directory_to_stream():
             [
                 "test_udf_dir/",
                 "test_udf_dir/test_another_udf_file.py",
+                "test_udf_dir/test_udf_init_once_file.py",
                 "test_udf_dir/test_pandas_udf_file.py",
                 "test_udf_dir/test_udf_file.py",
             ],
@@ -285,6 +287,7 @@ def test_zip_file_or_directory_to_stream():
                 "resources/",
                 "resources/test_udf_dir/",
                 "resources/test_udf_dir/test_another_udf_file.py",
+                "resources/test_udf_dir/test_udf_init_once_file.py",
                 "resources/test_udf_dir/test_pandas_udf_file.py",
                 "resources/test_udf_dir/test_udf_file.py",
             ],
@@ -384,6 +387,7 @@ def test_zip_file_or_directory_to_stream():
                 "resources/test_sp_dir/test_table_sp_file.py",
                 "resources/test_udf_dir/",
                 "resources/test_udf_dir/test_another_udf_file.py",
+                "resources/test_udf_dir/test_udf_init_once_file.py",
                 "resources/test_udf_dir/test_pandas_udf_file.py",
                 "resources/test_udf_dir/test_udf_file.py",
                 "resources/test_udtf_dir/",

--- a/tests/unit/test_udf_utils.py
+++ b/tests/unit/test_udf_utils.py
@@ -82,6 +82,37 @@ def test_generate_python_code_exception():
         assert "Source code comment could not be generated" in generated_code
 
 
+def test_udf_init_once_decorator_simple():
+    """Test @udf_init_once as simple decorator (same API as _snowflake.udf_init_once)."""
+    from snowflake.snowpark.functions import udf_init_once
+
+    @udf_init_once
+    def my_init():
+        pass
+
+    # Sets _sf_init_once = True on the init function itself
+    assert my_init._sf_init_once is True
+    # The function is returned unchanged (not wrapped)
+    assert my_init.__name__ == "my_init"
+
+
+def test_udf_init_once_rejects_non_zero_arg_function():
+    from snowflake.snowpark.functions import udf_init_once
+
+    with pytest.raises(TypeError, match="must take 0 arguments"):
+
+        @udf_init_once
+        def bad_init(x):
+            return x
+
+
+def test_udf_init_once_rejects_non_callable():
+    from snowflake.snowpark.functions import udf_init_once
+
+    with pytest.raises(TypeError, match="must be callable"):
+        udf_init_once("not_a_function")
+
+
 @pytest.mark.parametrize(
     "packages",
     [


### PR DESCRIPTION
SNOW-3152139: Create UDF_init_once decorator in python client

What
Adds the udf_init_once decorator to snowflake.snowpark.functions, providing a client-side definition that matches the server-side _snowflake.udf_init_once API.
Why
The @udf_init_once decorator allows users to mark zero-argument functions for one-time execution during pre-fork initialization on Snowflake workers. Initialized state (e.g., loaded models, computed lookup tables) is shared across all workers via Copy-On-Write. This avoids redundant initialization in each worker process.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
