### PR TITLE
[SNOW-3203938] Fix ai_parse_document_basic test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 - Fixed a bug in `Session.client_telemetry` that trace does not have snowflake style trace id.
 - Fixed a bug in `ai_complete` where `model_parameters` and `response_format` values containing single quotes would generate malformed SQL.
-- Fixed a ai_parse_document test that failed with new error handling
 
 ## 1.47.0 (2026-03-05)
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3203938

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

With latest changes related to the new error handling, basic parse document tests started failing because metadata key is mising in the response.
This is expected behaviour, more details can be found [here](https://docs.google.com/document/d/1eG_1tUYopEnBGUBl5AWn26wd-CbgvCEzf2JBfJS9vYA/edit?tab=t.0). 
I've modified tests to use session parameter, to test both legacy and new response without error details (the bcr process lasts ~3 months, so during this time both combinations will be available for clients).
It affects ai_parse_document only, as for other functions the value didn't change. 
New response type is {value:<old response>, error}, but when response error details are disabled, value is extracted.
In case of ai_parse_document, metadata was moved to the root level of the response {value,metadata,error} making it absent in value.
As a follow-up, it would be a good idea to cover new error handling with error details in these tests.
