### PR TITLE
SNOW-3198369: Fix exception from passing SQL SET calls to Streamlit `st.write`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug when saving a fdn table into an iceberg table in overwrite mode, error is raised because `StringType` is saved in wrong length.
 - Fixed a bug in `ai_complete` where `model_parameters` and `response_format` values containing single quotes would generate malformed SQL.
 - Fixed a bug in `DataFrameReader.xml()` where reading XML with a custom schema whose field names contain colons (e.g., `px:name`) raised a `SnowparkColumnException`.
+- Fixed a bug where passing a DataFrame created from a SQL `SET` command to Streamlit's `st.write` method would raise an exception.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/_internal/analyzer/schema_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/schema_utils.py
@@ -77,7 +77,7 @@ def analyze_attributes(
     # SQL commands which cannot be prepared
     # https://docs.snowflake.com/en/user-guide/sql-prepare.html
     if lowercase.startswith(
-        ("alter", "drop", "use", "create", "grant", "revoke", "comment")
+        ("alter", "drop", "use", "create", "grant", "revoke", "comment", "set")
     ):
         return command_attributes()
     if lowercase.startswith(("ls", "list")):

--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -218,3 +218,14 @@ def test_sql_start(session):
         len(df2.queries["queries"]) == 2
     )  # convert to result_scan because sql is non-select
     assert "RESULT_SCAN" in df2.queries["queries"][1]
+
+
+def test_sql_set_variable_to_pandas(session):
+    # Covers SNOW-3198369. Passing the result of a SQL SET operation to Streamlit's
+    # st.write (which calls to_pandas on the result of a session.sql call) should succeed,
+    # but previously errored out with
+    # 000007 (0A000): Statement provided can not be prepared.
+    uncollected = session.sql("set temp_snowpark_test_variable = 100")
+    result = uncollected.to_pandas()
+    assert result['"status"'][0] == "Statement executed successfully."
+    assert session.sql("select $temp_snowpark_test_variable").collect() == [Row(100)]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3198369 (#4102)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Streamlit internally attempts to call `to_pandas` on dataframe-like objects passed to `st.write` ([source](https://github.com/streamlit/streamlit/blob/093814974d2dba8813414cdbb31e300259dc367a/lib/streamlit/dataframe_util.py#L673-L680)). This previously caused issues if the dataframe was created from a SQL `SET` statement, as our internal analyzer inappropriately attempted to issue a DESCRIBE query rather than understanding that the output would always contain a STATUS column.