### PR TITLE
SNOW-3217482: Fix mock_convert_timezone to handle string timestamp inputs

### DIFF
--- a/.claude/skills/local-testing-bug-fix/SKILL.md
+++ b/.claude/skills/local-testing-bug-fix/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: local-testing-bug-fix
+description: Fix a GitHub Local Testing issue
+---
+
+Fix GitHub issue $ARGUMENTS (provide a GitHub issue URL or number) following our coding standards.
+
+## Prerequisites
+
+Before using this skill, ensure the following are set up:
+
+1. **`gh` CLI** — must be installed and authenticated (`gh auth status`) to fetch issue details
+2. **`tests/parameters.py`** — must exist (gitignored, create it manually) with your Snowflake credentials:
+   ```python
+   CONNECTION_PARAMETERS = {
+       "account": "your_account",
+       "user": "your_user",
+       "password": "your_password",
+       "database": "your_db",
+       "schema": "public",
+   }
+   ```
+   Required only for running live integ tests. Mock-only tests (`tests/mock/`) do not need credentials.
+
+1. Fetch and read the issue description (use `gh issue view <number>` or the URL)
+2. Understand the requirements and reproduce the problem mentally
+3. Determine if the fix is feasible (see Known Limitations below)
+4. Find the relevant code in `src/snowflake/snowpark/_internal/mock/`
+5. Implement the fix
+6. Write or update tests (see Test approach below)
+7. Create a commit with message format: `SNOW-XXXXXXX: <description>`
+
+## Codebase layout
+
+- Local testing implementation: `src/snowflake/snowpark/_internal/mock/`
+- Mock-only tests (local testing exclusive): `tests/mock/`
+- Shared integ tests (run against both live and local): `tests/integ/`
+  - Tests unsupported in local testing are explicitly skipped with the marker below
+
+## Skipping a test for local testing
+
+When a test in `tests/integ/` cannot run in local testing mode, mark it:
+
+```python
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="<explain why it is not supported>",
+)
+def test_something(session):
+    ...
+```
+
+## Test approach
+
+Validate by comparing live session output to local testing session output:
+
+```python
+from snowflake.snowpark import Session
+
+# live session — tries ~/.snowflake/connections.toml first, falls back to tests/parameters.py
+try:
+    session = Session.builder.getOrCreate()
+except Exception:
+    from tests.parameters import CONNECTION_PARAMETERS
+    session = Session.builder.configs(CONNECTION_PARAMETERS).create()
+
+# local testing session
+local_session = Session.builder.config("local_testing", True).create()
+
+df = session...              # DF operation
+local_df = local_session...  # same DF operation
+
+df.print_schema()
+df.show()
+
+local_df.print_schema()
+local_df.show()
+
+# compare the output, fix
+```
+
+Run integ tests in local testing mode:
+```bash
+pytest tests/integ/<test_file>.py --local_testing_mode
+```
+
+Run mock-only tests:
+```bash
+pytest tests/mock/<test_file>.py
+```
+
+## Known Limitations
+
+1. Local Testing does not support raw SQL
+2. If the issue requires a feature that is fundamentally server-side (e.g., raw SQL execution, file stages), it may not be feasible — explain this to the user instead of partially implementing

--- a/src/snowflake/snowpark/mock/_functions.py
+++ b/src/snowflake/snowpark/mock/_functions.py
@@ -2056,7 +2056,10 @@ def mock_convert_timezone(
     else:
         source_timezone, target_timezone, source_time = args
         return_type = TimestampTimeZone.NTZ
-        if source_time.sf_type.datatype.tz is not TimestampTimeZone.NTZ:
+        if (
+            isinstance(source_time.sf_type.datatype, TimestampType)
+            and source_time.sf_type.datatype.tz is not TimestampTimeZone.NTZ
+        ):
             raise ValueError(
                 "[Local Testing] convert_timezone can only convert NTZ timestamps when source_timezone is specified."
             )
@@ -2069,6 +2072,9 @@ def mock_convert_timezone(
         source_timezone, target_timezone, source_time = row
         if source_time is None:
             return None
+
+        if isinstance(source_time, str):
+            source_time = dateutil.parser.parse(source_time)
 
         if source_timezone is not None:
             # Using dateutil because it uses iana timezones while pytz would use Olson tzdb.

--- a/tests/mock/test_functions.py
+++ b/tests/mock/test_functions.py
@@ -19,6 +19,7 @@ from snowflake.snowpark.functions import (
     col,
     concat_ws,
     contains,
+    convert_timezone,
     count,
     current_date,
     current_time,
@@ -871,3 +872,48 @@ def test_save_as_table_column_order_name_array_type(session):
     assert len(result) == 1
     assert result[0]["ID"] == 1
     assert result[0]["TAGS"] is None
+
+
+def test_convert_timezone_with_string_input(session):
+    """Regression test for SNOW-3217482 / GitHub #4110:
+    convert_timezone should parse string timestamps."""
+    df = session.create_dataframe([["2023-03-10T08:00:00+03:00"]], schema=["date"])
+    result = df.select(convert_timezone(lit("UTC"), col("date"))).collect()
+    assert result[0][0] == datetime.datetime(
+        2023, 3, 10, 5, 0, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_convert_timezone_with_string_input_ntz(session):
+    """String input without timezone info should use the session/local timezone."""
+    df = session.create_dataframe([["2023-06-15T12:30:00"]], schema=["date"])
+    result = df.select(convert_timezone(lit("UTC"), col("date"))).collect()
+    assert result[0][0] is not None
+    assert result[0][0].year == 2023
+    assert result[0][0].month == 6
+    assert result[0][0].day == 15
+
+
+def test_convert_timezone_with_string_input_null(session):
+    """String column with None values should return None."""
+    df = session.create_dataframe([[None]], schema=["date"])
+    result = df.select(convert_timezone(lit("UTC"), col("date"))).collect()
+    assert result[0][0] is None
+
+
+def test_convert_timezone_with_string_input_three_args(session):
+    """Three-arg form: convert_timezone(target_tz, source_time, source_tz) with string input."""
+    from snowflake.snowpark.mock._functions import LocalTimezone
+    import pytz
+
+    LocalTimezone.set_local_timezone(pytz.timezone("Etc/GMT+8"))
+    try:
+        df = session.create_dataframe([["2023-03-10T08:00:00"]], schema=["date"])
+        # target=UTC, source_time=date (NTZ string), source_tz=US/Eastern
+        # 08:00 in US/Eastern → 13:00 UTC (EST is UTC-5)
+        result = df.select(
+            convert_timezone(lit("UTC"), col("date"), lit("US/Eastern"))
+        ).collect()
+        assert result[0][0] == datetime.datetime(2023, 3, 10, 13, 0)
+    finally:
+        LocalTimezone.set_local_timezone()


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

Fixes #4110

mock_convert_timezone in local testing mode crashes with AttributeError: 'str' object has no attribute 'tzinfo' when the source timestamp column contains string (varchar) values instead of datetime objects. Snowflake natively handles this by parsing the string, but the mock did not.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
