### PR TITLE
Fix/snow 3257427 columnorname inconsistency

### DIFF
--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -3677,7 +3677,7 @@ class DataFrame:
     def join(
         self,
         right: "DataFrame",
-        on: Optional[Union[ColumnOrName, Iterable[ColumnOrName]]] = None,
+        on: Optional[Union[ColumnOrName, Iterable[str]]] = None,
         how: Optional[str] = None,
         *,
         lsuffix: str = "",
@@ -3986,19 +3986,17 @@ class DataFrame:
             elif (
                 isinstance(using_columns, Iterable)
                 and len(using_columns) > 0
+                and not all([isinstance(col, str) for col in using_columns])
             ):
-                converted_using_columns = []
-                for i, c in enumerate(using_columns):
-                    if isinstance(c, str):
-                        converted_using_columns.append(c)
-                    elif isinstance(c, Column) and isinstance(c._expression, NamedExpression):
-                        converted_using_columns.append(c._expression.name)
-                    else:
-                        raise TypeError(
-                            f"All list elements for 'on' or 'using_columns' must be a column name (str) or a Column referencing a named column. "
-                            f"Got: '{type(c)}' at index {i}"
-                        )
-                using_columns = converted_using_columns
+                bad_idx, bad_col = next(
+                    (idx, col)
+                    for idx, col in enumerate(using_columns)
+                    if not isinstance(col, str)
+                )
+                raise TypeError(
+                    f"All list elements for 'on' or 'using_columns' must be string type. "
+                    f"Got: '{type(bad_col)}' at index {bad_idx}"
+                )
             elif not isinstance(using_columns, Iterable):
                 raise TypeError(
                     f"Invalid input type for join column: {type(using_columns)}"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3257427

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [x] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

I updated the API so that its runtime behavior is consistent with the type annotations and the documented behavior.
This patch PR is related to [this](https://github.com/snowflakedb/snowpark-python/issues/4124).