### PR TITLE
NO-SNOW: Fix SQL simplifier test failures

### DIFF
--- a/tests/integ/scala/test_snowflake_plan_suite.py
+++ b/tests/integ/scala/test_snowflake_plan_suite.py
@@ -223,7 +223,11 @@ def test_plan_height(session, temp_table, sql_simplifier_enabled):
     assert filter1._plan.plan_state[PlanState.PLAN_HEIGHT] == 2
 
     join1 = filter1.join(df2, on=["a"])
-    assert join1._plan.plan_state[PlanState.PLAN_HEIGHT] == 4
+    assert (
+        join1._plan.plan_state[PlanState.PLAN_HEIGHT] == 4
+        if sql_simplifier_enabled
+        else 3
+    )
 
     aggregate1 = df3.distinct()
     assert aggregate1._plan.plan_state[PlanState.PLAN_HEIGHT] == (
@@ -231,23 +235,31 @@ def test_plan_height(session, temp_table, sql_simplifier_enabled):
     )
 
     join2 = join1.join(aggregate1, on=["b"])
-    assert join2._plan.plan_state[PlanState.PLAN_HEIGHT] == 6
+    assert (
+        join2._plan.plan_state[PlanState.PLAN_HEIGHT] == 6
+        if sql_simplifier_enabled
+        else 4
+    )
 
     split_to_table = table_function("split_to_table")
     table_function1 = join2.select("a", "b", split_to_table("d", lit(" ")))
-    assert table_function1._plan.plan_state[PlanState.PLAN_HEIGHT] == 8
+    assert (
+        table_function1._plan.plan_state[PlanState.PLAN_HEIGHT] == 8
+        if sql_simplifier_enabled
+        else 6
+    )
 
     filter3 = join2.where(col("a") > 1)
     filter4 = join2.where(col("a") < 1)
     assert (
         filter3._plan.plan_state[PlanState.PLAN_HEIGHT]
         == filter4._plan.plan_state[PlanState.PLAN_HEIGHT]
-        == (6 if sql_simplifier_enabled else 7)
+        == (6 if sql_simplifier_enabled else 5)
     )
 
     union1 = filter3.union_all_by_name(filter4)
     assert union1._plan.plan_state[PlanState.PLAN_HEIGHT] == (
-        8 if sql_simplifier_enabled else 9
+        8 if sql_simplifier_enabled else 7
     )
 
 

--- a/tests/integ/test_df_aggregate.py
+++ b/tests/integ/test_df_aggregate.py
@@ -1191,8 +1191,10 @@ def test_group_by_agg_sort_filter_limit_ordering(session):
     # 5. ORDER BY -> LIMIT -> ORDER BY -> LIMIT
     # The RESEARCH group is dropped by the first ORDER BY + LIMIT.
     # The SALES and HR groups are dropped by the second ORDER BY + LIMIT.
+    # Note that SQL ORDER BY is not stable, and the final result has no ordering guarantees
+    # on the "headcount" column. Spark's DataFrame.orderBy is also unstable.
     result5 = (
-        agg_df.orderBy(col("headcount").asc())
+        agg_df.orderBy(col("headcount").asc(), col("avg_salary").asc())
         .limit(4)
         .orderBy(col("avg_salary").desc())
         .limit(2)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

The final case in `tests/integ/test_df_aggregate.py:: test_group_by_agg_sort_filter_limit_ordering ` was not deterministic, and happened to produce different output with the simplifier disabled.

`tests/integ/scala/test_snowflake_plan_suite.py::test_plan_height` was caused by #4096, which was previously reverted and un-reverted. I forgot to update this test in the un-revert.